### PR TITLE
ST6RI-193 Exceptions thrown during name resolution

### DIFF
--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/KerMLRuntimeModule.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/KerMLRuntimeModule.xtend
@@ -11,6 +11,7 @@ import org.omg.sysml.lang.sysml.util.IModelLibraryProvider
 import org.omg.kerml.xtext.library.KerMLLibraryProvider
 import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.omg.kerml.xtext.naming.KerMLQualifiedNameProvider
+import org.omg.kerml.xtext.scoping.KerMLLinker
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -31,5 +32,9 @@ class KerMLRuntimeModule extends AbstractKerMLRuntimeModule {
 
 	override Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {
 		KerMLQualifiedNameProvider
+	}
+
+	override Class<? extends org.eclipse.xtext.linking.ILinker> bindILinker() {
+		KerMLLinker
 	}
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2020 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * 
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Zoltan Ujhelyi, MDS
+ * 
+ *****************************************************************************/
+package org.omg.kerml.xtext.scoping;
+
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.xtext.linking.lazy.LazyLinker;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class KerMLLinker extends LazyLinker {
+
+	protected void clearReference(EObject obj, EReference ref) {
+		if (Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__SOURCE)
+		 || Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__TARGET)) {
+			// The Relationship#source and #target features are overridden
+			// in each subtype to provide specific derived implementations that
+			// are regenerated each time they are accessed so there is no need to
+			// delete them; and as of May 2020, generic references as not supported
+			// in concrete syntax, making it a safe to not clear them during linking.
+			return;
+		}
+		super.clearReference(obj, ref);
+	}
+}

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/SysMLRuntimeModule.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/SysMLRuntimeModule.xtend
@@ -11,6 +11,7 @@ import org.omg.sysml.xtext.scoping.SysMLGlobalScopeProvider
 import org.omg.kerml.xtext.naming.KerMLQualifiedNameConverter
 import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.omg.kerml.xtext.naming.KerMLQualifiedNameProvider
+import org.omg.kerml.xtext.scoping.KerMLLinker
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -31,5 +32,9 @@ class SysMLRuntimeModule extends AbstractSysMLRuntimeModule {
 
 	override Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {
 		KerMLQualifiedNameProvider
+	}
+		
+	override Class<? extends org.eclipse.xtext.linking.ILinker> bindILinker() {
+		KerMLLinker
 	}
 }


### PR DESCRIPTION
Each time the linker implementation tries to resolve references in a
resource it starts by clearing existing proxies. However, in some cases
it gets confused by the SysML metamodel implementations that are derived
but not marked as such, e.g. in case of `Relationship`#`source` and
`Relationship`#`target`. Furthermore, removing these references can result
in reentrant resolution that confuses Xtext even more.

This change updates the linker implementation of Xtext to not to clear
these features, as it is unnecessary (the superclass implementation is
not used for now, while the subclasses always build new lists each time
they are called).

In addition to the version we have reviewed with @seidewitz I have also added the `Relationship`#`source` feature to the ignore list as it behaves exactly the same way as `target` so it made more sense to me to keep it consistent in the linker as well.