### PR TITLE
ST6RI-308 Adds Xtend compiler to the maven build configuration

### DIFF
--- a/org.omg.kerml.xtext.ide/pom.xml
+++ b/org.omg.kerml.xtext.ide/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.kerml.xtext.ide</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.kerml.xtext.ui/pom.xml
+++ b/org.omg.kerml.xtext.ui/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.kerml.xtext.ui</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.kerml.xtext/pom.xml
+++ b/org.omg.kerml.xtext/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.kerml.xtext</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLGlobalScope.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLGlobalScope.xtend
@@ -105,7 +105,7 @@ class KerMLGlobalScope extends AbstractScope {
 			val element = root.EObjectOrProxy
 			if (element instanceof Package) {
 				allElements = Iterables.concat(allElements, 
-					scopeFor(element as Package).allElements.map[addQualification(root.name.firstSegment)]
+					scopeFor(element).allElements.map[addQualification(root.name.firstSegment)]
 				)
 			}
 		}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
@@ -82,7 +82,7 @@ class KerMLScopeProvider extends AbstractKerMLScopeProvider {
 		    var subsettingFeature = context.subsettingFeature
 		    var owningType = subsettingFeature?.owningType
 		    if (owningType instanceof QueryPathExpression) {
-			    return subsettingFeature.scope_QueryPathExpression(owningType as QueryPathExpression, context, reference)
+			    return subsettingFeature.scope_QueryPathExpression(owningType, context, reference)
 		    } else if (owningType instanceof Connector) {
 		    	if (owningType.connectorEnd.contains(subsettingFeature)) {
 		    		return owningType.scope_owningNamespace(context, reference)

--- a/org.omg.sysml.xtext.ide/pom.xml
+++ b/org.omg.sysml.xtext.ide/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.sysml.xtext.ide</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.sysml.xtext.ui/pom.xml
+++ b/org.omg.sysml.xtext.ui/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.sysml.xtext.ui</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.sysml.xtext/pom.xml
+++ b/org.omg.sysml.xtext/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.sysml.xtext</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.omg.sysml/pom.xml
+++ b/org.omg.sysml/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.omg.sysml</groupId>
+		<artifactId>org.omg.sysml.parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>org.omg.sysml</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,6 @@
             <execution>
               <goals>
                 <goal>compile</goal>
-                <goal>xtend-install-debug-info</goal>
               </goals>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <yarn.version>1.22.5</yarn.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <xtext.version>2.22.0</xtext.version>
   </properties>
 
 
@@ -194,5 +195,48 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.xtend</groupId>
+          <artifactId>xtend-maven-plugin</artifactId>
+          <version>${xtext.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>compile</goal>
+                <goal>xtend-install-debug-info</goal>
+                <goal>testCompile</goal>
+                <goal>xtend-test-install-debug-info</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <outputDirectory>xtend-gen</outputDirectory>
+          </configuration>
+        </plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>2.5</version>
+					<executions>
+						<execution>
+							<id>gen-clean</id>
+							<goals>
+								<goal>clean</goal>
+							</goals>
+							<configuration>
+								<filesets>
+									<fileset>
+										<directory>${basedir}/xtend-gen</directory>
+										<excludes>**/.gitignore</excludes>
+									</fileset>
+								</filesets>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -206,8 +206,6 @@
               <goals>
                 <goal>compile</goal>
                 <goal>xtend-install-debug-info</goal>
-                <goal>testCompile</goal>
-                <goal>xtend-test-install-debug-info</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
This change adds required configuration to the maven build to generate
Java files to the xtend-gen folders. This required adding extra pom.xml
files to the projects, as it is not possible for the previously used
tycho-pomless to add this project-specific configuration otherwise.