### PR TITLE
ST6RI-321: Spurious "(T,blue)" shown in header of various def elements (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.omg.sysml.plantuml
 Import-Package: com.google.inject;version="1.3.0",
- net.sourceforge.plantuml;version="1.2020.14.himi5",
+ net.sourceforge.plantuml;version="1.2020.14.himi6",
  org.eclipse.emf.common,
  org.eclipse.emf.common.util,
  org.eclipse.emf.ecore,

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -183,7 +183,7 @@ public class SysML2PlantUMLStyle {
         }
     }
 
-    public final boolean isPrimary;
+    private final boolean isPrimary;
     public final String name;
     public final String title;
     public final String commandStr;
@@ -235,8 +235,8 @@ public class SysML2PlantUMLStyle {
         add(false, name, title, commandStr, null, options);
     }
 
-    public boolean isEntitled() {
-        return title != null;
+    public boolean isPrimary() {
+        return isPrimary;
     }
 
     public static Collection<String> getStyleTitles() {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLSvc.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLSvc.java
@@ -71,7 +71,7 @@ public class SysML2PlantUMLSvc {
         if (styles != null) {
             for (String style: styles) {
                 SysML2PlantUMLStyle s = SysML2PlantUMLStyle.get(style);
-                if (s.isEntitled()) addDefault = false;
+                if (s.isPrimary()) addDefault = false;
                 s2Text.addStyle(s);
             }
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -73,12 +73,12 @@ public class SysML2PlantUMLText {
     }
 
     private void resetStyle(SysML2PlantUMLStyle style) {
-        if (!style.isPrimary) return;
+        if (!style.isPrimary()) return;
         SysML2PlantUMLStyle[] ss = new SysML2PlantUMLStyle[styles.size()];
         ss = styles.toArray(ss);
         for (int i = 0; i < ss.length; i++) {
             SysML2PlantUMLStyle s = ss[i];
-            if (s.isPrimary) {
+            if (s.isPrimary()) {
                 styles.remove(i);
             }
         }


### PR DESCRIPTION
To ensure to use the fixed version of PlantUML, set the dependent version to the latest one.

I also fixed the default style is not properly chosen in Jupyter environment when we specify --style comptree with 
9d60bf2