### PR TITLE
ST6RI-345: In OpenJDK11, maven build failed due to the lack of javascript support

### DIFF
--- a/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.expressions.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.owl
 Bundle-Vendor: My Company
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xpect.tests
 Bundle-SymbolicName: org.omg.kerml.xpect.tests;singleton:=true
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml.feature/feature.xml
+++ b/org.omg.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.feature"
       label="SysML v2 Feature"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.omg.sysml.interactive.tests;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Automatic-Module-Name: org.omg.sysml.interactive.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/org.omg.sysml.interactive/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.interactive
 Bundle-SymbolicName: org.omg.sysml.interactive
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.omg.sysml.interactive
 Require-Bundle: org.eclipse.emf.ecore,
  com.google.inject,

--- a/org.omg.sysml.jupyter.jupyterlab/package.json
+++ b/org.omg.sysml.jupyter.jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sysml",
-  "version": "0.9.0-SNAPSHOT",
+  "version": "0.10.0-SNAPSHOT",
   "description": "A JupyterLab extension for system modeling using SysML",
   "repository": "github:Systems-Modeling/SysML-v2-Pilot-Implementation",
   "author": "SysML v2 Submission Team",

--- a/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.plantuml
 Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization for Eclipse
 Bundle-SymbolicName: org.omg.sysml.plantuml.eclipse;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.google.common.collect;version="10.0.1",
  com.google.inject;version="1.3.0",

--- a/org.omg.sysml.plantuml.feature/feature.xml
+++ b/org.omg.sysml.plantuml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.plantuml.feature"
       label="SysML v2 PlantUML Visualization Feature"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization
 Bundle-SymbolicName: org.omg.sysml.plantuml
 Automatic-Module-Name: org.omg.sysml.plantuml
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.omg.sysml.plantuml
 Import-Package: com.google.inject;version="1.3.0",

--- a/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xpect.tests
 Bundle-SymbolicName: org.omg.sysml.xpect.tests;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.xtext,

--- a/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.sysml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ui
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-ClassPath: .,
  lib/sysml-v2-api-client-2020-05-all.jar
 Bundle-SymbolicName: org.omg.sysml;singleton:=true

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>
-    <revision>0.9.0-SNAPSHOT</revision>
+    <revision>0.10.0-SNAPSHOT</revision>
     <tycho-version>1.6.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-repository>https://download.eclipse.org/releases/2020-06</eclipse-repository>

--- a/pom.xml
+++ b/pom.xml
@@ -135,13 +135,15 @@
           <execution>
             <id>set-version</id>
             <phase>validate</phase>
-            <configuration>
-              <target>
-                <property name="maven-version" value="${project.version}"/>
-                <script language="javascript">
-                  project.setProperty('bundle-version', project.getProperty('maven-version').
-                  replace("-SNAPSHOT", ".qualifier"));
-                </script>
+	    <configuration>
+	      <target>
+		<taskdef resource="net/sf/antcontrib/antcontrib.properties"
+			 classpathref="maven.plugin.classpath"/>
+		<property name="maven-version" value="${project.version}"/>
+		<propertyregex property="bundle-version"
+			       input="${maven-version}"
+			       regexp="-SNAPSHOT"
+			       replace=".qualifier"/>
                 <echo> Set the versions to POM: ${maven-version}, Bundle: ${bundle-version} </echo>
                 <!-- Currently no need to change the versions of child poms but left it for future use.
                 <replaceregexp byline="true" flags="i">
@@ -174,6 +176,19 @@
             </goals>
           </execution>
         </executions>
+	<dependencies>
+	  <dependency>
+	    <groupId>ant-contrib</groupId>
+	    <artifactId>ant-contrib</artifactId>
+            <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Use propertyregex task in ant-contrib instead of using Javascript.