### PR TITLE
ST6RI-296 Fix continuous integration builds for tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,8 @@
 		<propertyregex property="bundle-version"
 			       input="${maven-version}"
 			       regexp="-SNAPSHOT"
-			       replace=".qualifier"/>
+			       replace=".qualifier"
+			       defaultValue="${maven-version}"/>
                 <echo> Set the versions to POM: ${maven-version}, Bundle: ${bundle-version} </echo>
                 <!-- Currently no need to change the versions of child poms but left it for future use.
                 <replaceregexp byline="true" flags="i">

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-repository>https://download.eclipse.org/releases/2020-06</eclipse-repository>
     <plantuml-repository>https://github.com/himi/p2-update-puml-sysmlv2/raw/main/updates</plantuml-repository>
-    <xpect-repository>https://ci.eclipse.org/xpect/job/Xpect/job/master/lastBuild/artifact/org.eclipse.xpect.releng/p2-repository/target/repository</xpect-repository>
+    <xpect-repository>
+      https://ci.eclipse.org/xpect/job/Xpect/job/master/lastBuild/artifact/org.eclipse.xpect.releng/p2-repository/target/repository
+    </xpect-repository>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <flatten-maven-plugin.version>1.2.2</flatten-maven-plugin.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
@@ -136,17 +138,17 @@
           <execution>
             <id>set-version</id>
             <phase>validate</phase>
-	    <configuration>
-	      <target>
-		<taskdef resource="net/sf/antcontrib/antcontrib.properties"
-			 classpathref="maven.plugin.classpath"/>
-		<property name="maven-version" value="${project.version}"/>
-		<propertyregex property="bundle-version"
-			       input="${maven-version}"
-			       regexp="-SNAPSHOT"
-			       replace=".qualifier"
-			       defaultValue="${maven-version}"/>
-                <echo> Set the versions to POM: ${maven-version}, Bundle: ${bundle-version} </echo>
+            <configuration>
+              <target>
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                         classpathref="maven.plugin.classpath"/>
+                <property name="maven-version" value="${project.version}"/>
+                <propertyregex property="bundle-version"
+                               input="${maven-version}"
+                               regexp="-SNAPSHOT"
+                               replace=".qualifier"
+                               defaultValue="${maven-version}"/>
+                <echo>Set the versions to POM: ${maven-version}, Bundle: ${bundle-version}</echo>
                 <!-- Currently no need to change the versions of child poms but left it for future use.
                 <replaceregexp byline="true" flags="i">
                   <fileset dir="${basedir}">
@@ -160,7 +162,7 @@
                   <fileset dir="${basedir}">
                     <include name="*/META-INF/MANIFEST.MF"/>
                     <exclude name="org.omg.sysml.uml.ecore.importer*/**/*"/>
-                   </fileset>
+                  </fileset>
                   <regexp pattern="Bundle-Version:\s*(.*)"/>
                   <substitution expression="Bundle-Version: ${bundle-version}"/>
                 </replaceregexp>
@@ -178,10 +180,10 @@
             </goals>
           </execution>
         </executions>
-	<dependencies>
-	  <dependency>
-	    <groupId>ant-contrib</groupId>
-	    <artifactId>ant-contrib</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>ant-contrib</groupId>
+            <artifactId>ant-contrib</artifactId>
             <version>1.0b3</version>
             <exclusions>
               <exclusion>
@@ -271,23 +273,23 @@
   </distributionManagement>
 
   <profiles>
-  	<profile>
+    <profile>
       <id>runTests</id>
       <activation>
-      	<property>
-      	  <name>!xpect.tests.skip</name>
-      	</property>
+        <property>
+          <name>!xpect.tests.skip</name>
+        </property>
       </activation>
       <repositories>
-	    <repository>
-	      <id>xpect</id>
-	      <url>${xpect-repository}</url>
-	      <layout>p2</layout>
-	    </repository>
+        <repository>
+          <id>xpect</id>
+          <url>${xpect-repository}</url>
+          <layout>p2</layout>
+        </repository>
       </repositories>
       <modules>
-      	<module>org.omg.kerml.xpect.tests</module>
-      	<module>org.omg.sysml.xpect.tests</module>
+        <module>org.omg.kerml.xpect.tests</module>
+        <module>org.omg.sysml.xpect.tests</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
# Symptom
TravisCI failing to build tags ([ex](https://travis-ci.com/github/Systems-Modeling/SysML-v2-Pilot-Implementation/builds/220213353)), but not regular commits.

Upon local reproduction with verbose logging, the source of the issue was the following exception:
```
[ERROR] Internal error: org.eclipse.tycho.core.osgitools.OsgiManifestParserException: Exception parsing OSGi MANIFEST /home/i/SysML-v2-Pilot-Implementation/org.omg.sysml/META-INF/MANIFEST.MF: Invalid manifest header Bundle-Version: "${bundle-version}" : invalid version "${bundle-version}": non-numeric "${bundle-version}": For input string: "${bundle-version}" -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: org.eclipse.tycho.core.osgitools.OsgiManifestParserException: Exception parsing OSGi MANIFEST /home/i/SysML-v2-Pilot-Implementation/org.omg.sysml/META-INF/MANIFEST.MF: Invalid manifest header Bundle-Version: "${bundle-version}" : invalid version "${bundle-version}": non-numeric "${bundle-version}"
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
Caused by: org.eclipse.tycho.core.osgitools.OsgiManifestParserException: Exception parsing OSGi MANIFEST /home/i/SysML-v2-Pilot-Implementation/org.omg.sysml/META-INF/MANIFEST.MF: Invalid manifest header Bundle-Version: "${bundle-version}" : invalid version "${bundle-version}": non-numeric "${bundle-version}"
    at org.eclipse.tycho.core.osgitools.OsgiManifest.<init> (OsgiManifest.java:50)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.parse (OsgiManifest.java:152)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFile (DefaultBundleReader.java:99)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFromDirectory (DefaultBundleReader.java:95)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.doLoadManifest (DefaultBundleReader.java:60)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifest (DefaultBundleReader.java:51)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.readArtifactKey (OsgiBundleProject.java:147)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.setupProject (OsgiBundleProject.java:142)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.setupProject (DefaultTychoResolver.java:75)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:90)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
Caused by: org.osgi.framework.BundleException: Invalid manifest header Bundle-Version: "${bundle-version}" : invalid version "${bundle-version}": non-numeric "${bundle-version}"
    at org.eclipse.osgi.internal.resolver.StateBuilder.createBundleDescription (StateBuilder.java:124)
    at org.eclipse.osgi.internal.resolver.StateObjectFactoryImpl.createBundleDescription (StateObjectFactoryImpl.java:35)
    at org.eclipse.osgi.service.resolver.StateObjectFactory$StateObjectFactoryProxy.createBundleDescription (StateObjectFactory.java:562)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.<init> (OsgiManifest.java:46)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.parse (OsgiManifest.java:152)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFile (DefaultBundleReader.java:99)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFromDirectory (DefaultBundleReader.java:95)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.doLoadManifest (DefaultBundleReader.java:60)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifest (DefaultBundleReader.java:51)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.readArtifactKey (OsgiBundleProject.java:147)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.setupProject (OsgiBundleProject.java:142)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.setupProject (DefaultTychoResolver.java:75)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:90)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
Caused by: java.lang.IllegalArgumentException: invalid version "${bundle-version}": non-numeric "${bundle-version}"
    at org.osgi.framework.Version.parseInt (Version.java:169)
    at org.osgi.framework.Version.<init> (Version.java:126)
    at org.osgi.framework.Version.valueOf (Version.java:255)
    at org.osgi.framework.Version.parseVersion (Version.java:226)
    at org.eclipse.osgi.internal.resolver.StateBuilder.createBundleDescription (StateBuilder.java:120)
    at org.eclipse.osgi.internal.resolver.StateObjectFactoryImpl.createBundleDescription (StateObjectFactoryImpl.java:35)
    at org.eclipse.osgi.service.resolver.StateObjectFactory$StateObjectFactoryProxy.createBundleDescription (StateObjectFactory.java:562)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.<init> (OsgiManifest.java:46)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.parse (OsgiManifest.java:152)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFile (DefaultBundleReader.java:99)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFromDirectory (DefaultBundleReader.java:95)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.doLoadManifest (DefaultBundleReader.java:60)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifest (DefaultBundleReader.java:51)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.readArtifactKey (OsgiBundleProject.java:147)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.setupProject (OsgiBundleProject.java:142)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.setupProject (DefaultTychoResolver.java:75)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:90)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
Caused by: java.lang.NumberFormatException: For input string: "${bundle-version}"
    at java.lang.NumberFormatException.forInputString (NumberFormatException.java:65)
    at java.lang.Integer.parseInt (Integer.java:638)
    at java.lang.Integer.parseInt (Integer.java:770)
    at org.osgi.framework.Version.parseInt (Version.java:167)
    at org.osgi.framework.Version.<init> (Version.java:126)
    at org.osgi.framework.Version.valueOf (Version.java:255)
    at org.osgi.framework.Version.parseVersion (Version.java:226)
    at org.eclipse.osgi.internal.resolver.StateBuilder.createBundleDescription (StateBuilder.java:120)
    at org.eclipse.osgi.internal.resolver.StateObjectFactoryImpl.createBundleDescription (StateObjectFactoryImpl.java:35)
    at org.eclipse.osgi.service.resolver.StateObjectFactory$StateObjectFactoryProxy.createBundleDescription (StateObjectFactory.java:562)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.<init> (OsgiManifest.java:46)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.parse (OsgiManifest.java:152)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFile (DefaultBundleReader.java:99)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifestFromDirectory (DefaultBundleReader.java:95)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.doLoadManifest (DefaultBundleReader.java:60)
    at org.eclipse.tycho.core.osgitools.DefaultBundleReader.loadManifest (DefaultBundleReader.java:51)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.readArtifactKey (OsgiBundleProject.java:147)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.setupProject (OsgiBundleProject.java:142)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.setupProject (DefaultTychoResolver.java:75)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:90)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException
```

# Diagnosis
* TravisCI is [instructed](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/.travis.yml#L24-L28) to use [`.ci/release.sh`](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/.ci/release.sh) when building tags instead of just [`.ci/deploy.sh`](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/.ci/deploy.sh)
* `.ci/release.sh` first [removes the snapshot suffix](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/.ci/release.sh#L5), if present, from all projects' versions before delegating to `.ci/deploy.sh`
* Because versioning info can be found in numerous places in our projects, we extended `versions:set` to propagate the version to those, including [`MANIFEST.MF` and `feature.xml` files](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/pom.xml#L158-L172).
* Note that [the declaration for `bundle-version`](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/87d457795fdcfa3548f06795d060c3bcf7f58a1f/pom.xml#L144-L147) includes a regex replacement of `-SNAPSHOT` to `.qualifier` from input `${maven-version}`. PropertyRegex has the *interesting* implementation that when the regex pattern is not found in the input that it leaves the property undefined - [source](http://ant-contrib.sourceforge.net/tasks/tasks/propertyregex.html)! This means that `${bundle-version}` gets included as a literal string, e.g. `version="${bundle-version}"`.
* The exception seen above is the result of OSGi not liking that version of `${bundle-version}` instead of the desired `x.y.z`.

# Solution
Specifying a `defaultValue`for `bundle-version` - [minimal diff](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/commit/9e9f1eeae19ed4a26f4d6976f68c1d11b8f8137c). The remaining changes are to fix the indentation in pom.xml.