### PR TITLE
ST6RI-365 Add syntax highlighting generation to automated build

### DIFF
--- a/org.omg.sysml.jupyter.jupyterlab/src/main/mode.ts
+++ b/org.omg.sysml.jupyter.jupyterlab/src/main/mode.ts
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
+ * Source code modifications should be applied to template file:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/jupyter/mode_template.ts
+ */
+
 // tslint:disable-next-line
 import 'codemirror/addon/mode/simple';
 
@@ -29,59 +36,59 @@ const P_MIME = 'text/x-sysml'
 const f_wordify = (h: any, s: string) => ({...h, [s]: true});
 
 export function defineSysMLv2Mode(): void {
-	CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
-		return CodeMirror.getMode(gc_mode, {
-			name: 'clike',
-			keywords: [
-				"about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
-				"analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
-				"comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
-				"do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
-				"flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
-				"instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
-				"nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
-				"protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
-				"return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
-				"subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
-				"variation", "verification", "verify", "view", "viewpoint"
-			].reduce(f_wordify, {}),
-			defKeywords: [
-				"action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
-				"concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
-				"link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
-				"snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
-				"verification", "view", "viewpoint"
-			].reduce(f_wordify, {}),
-			typeFirstDefinitions: true,
-			atoms: ['true', 'false', 'null'].reduce(f_wordify),
-			number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
-			modeProps: {
-				fold: ['brace'],
-			},
-			hooks: {
-				"'": function(stream: CodeMirror.StringStream) {
-					let b_escaped = false;
-					let s_next;
-					while(s_next = stream.next()) {
-						if(s_next === "'" && !b_escaped) break;
-						b_escaped = !b_escaped && s_next === '\\';
-					}
-					return 'variable';
-				},
-				'/': function(stream: CodeMirror.StringStream) {
-					if(stream.match('/*', false)) stream.next();
-					return false;
-				},
-			},
-		});
-	});
+    CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
+        return CodeMirror.getMode(gc_mode, {
+            name: 'clike',
+            keywords: [
+                "about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
+                "analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
+                "comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
+                "do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
+                "flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
+                "instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
+                "nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
+                "protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
+                "return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
+                "subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
+                "variation", "verification", "verify", "view", "viewpoint"
+            ].reduce(f_wordify, {}),
+            defKeywords: [
+                "action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
+                "concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
+                "link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
+                "snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
+                "verification", "view", "viewpoint"
+            ].reduce(f_wordify, {}),
+            typeFirstDefinitions: true,
+            atoms: ['true', 'false', 'null'].reduce(f_wordify),
+            number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+            modeProps: {
+                fold: ['brace'],
+            },
+            hooks: {
+                "'": function(stream: CodeMirror.StringStream) {
+                    let b_escaped = false;
+                    let s_next;
+                    while(s_next = stream.next()) {
+                        if(s_next === "'" && !b_escaped) break;
+                        b_escaped = !b_escaped && s_next === '\\';
+                    }
+                    return 'variable';
+                },
+                '/': function(stream: CodeMirror.StringStream) {
+                    if(stream.match('/*', false)) stream.next();
+                    return false;
+                },
+            },
+        });
+    });
 
-	CodeMirror.defineMIME(P_MIME, SI_MODE);
+    CodeMirror.defineMIME(P_MIME, SI_MODE);
 
-	(CodeMirror as any).modeInfo.push({
-		ext: ['sysml'],
-		mime: P_MIME,
-		mode: SI_MODE,
-		name: 'sysml',
-	});
+    (CodeMirror as any).modeInfo.push({
+        ext: ['sysml'],
+        mime: P_MIME,
+        mode: SI_MODE,
+        name: 'sysml',
+    });
 }

--- a/org.omg.sysml.jupyter.jupyterlab/src/main/mode.ts
+++ b/org.omg.sysml.jupyter.jupyterlab/src/main/mode.ts
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
  * Source code modifications should be applied to template file:

--- a/org.omg.sysml.jupyter.kernel/src/main/resources/kernel/kernel.js
+++ b/org.omg.sysml.jupyter.kernel/src/main/resources/kernel/kernel.js
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
+ * Source code modifications should be applied to template file:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/jupyter/kernel_template.js
+ */
+
 define([
     'codemirror/lib/codemirror',
     'codemirror/mode/clike/clike',
@@ -46,44 +53,46 @@ var enableMode = function (CodeMirror) {
             name: "clike",
             keywords: words([
                 "about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
-				"analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
-				"comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
-				"do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
-				"flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
-				"instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
-				"nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
-				"protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
-				"return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
-				"subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
-				"variation", "verification", "verify", "view", "viewpoint"
-                ]),
+                "analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
+                "comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
+                "do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
+                "flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
+                "instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
+                "nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
+                "protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
+                "return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
+                "subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
+                "variation", "verification", "verify", "view", "viewpoint"
+            ]),
             defKeywords: words([
                 "action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
-				"concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
-				"link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
-				"snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
-				"verification", "view", "viewpoint"
-                ]),
+                "concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
+                "link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
+                "snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
+                "verification", "view", "viewpoint"
+            ]),
             typeFirstDefinitions: true,
             atoms: words("true false null"),
             number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
             modeProps: {fold: ["brace"]},
             hooks: {
-				"'": function(stream) {
-						var escaped = false, next;
-						while ((next = stream.next()) != null) {
-							if (next == "'" && !escaped) { break; }
-							escaped = !escaped && next == "\\";
-						}
-						return "variable";
-				},
-				"/": function(stream) {
-					if (stream.match("/*", false)) {
-						stream.next();
-					}
-					return false;
-				}
-			}
+                "'": function (stream) {
+                    var escaped = false, next;
+                    while ((next = stream.next()) != null) {
+                        if (next == "'" && !escaped) {
+                            break;
+                        }
+                        escaped = !escaped && next == "\\";
+                    }
+                    return "variable";
+                },
+                "/": function (stream) {
+                    if (stream.match("/*", false)) {
+                        stream.next();
+                    }
+                    return false;
+                }
+            }
         });
     });
     CodeMirror.defineMIME("text/x-sysml", "sysml");

--- a/org.omg.sysml.jupyter.kernel/src/main/resources/kernel/kernel.js
+++ b/org.omg.sysml.jupyter.kernel/src/main/resources/kernel/kernel.js
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
  * Source code modifications should be applied to template file:

--- a/tool-support/syntax-highlighting/README.md
+++ b/tool-support/syntax-highlighting/README.md
@@ -1,63 +1,68 @@
-# KerML and SysML language definitions for non-Eclipse IDEs
+# KerML and SysML language definitions for non-Eclipse editors
 
-This project contains language definition files to enable syntax highlighting in IDEs other than Eclipse.
+This project contains language definition files to enable syntax highlighting in other editors than Eclipse.
 
-The language definition files for other IDES are auto-generated. Currently, the following IDEs are supported:
+The language definition files for other editors are auto-generated from the `xtext` source. Currently, the generator
+supports the following environments:
+
 - *Visual Studio Code*
 - *JetBrains* IDEs, e.g. *PyCharm*
 - *JupyterLab* and *Jupyter Notebook* web apps
- 
+
 ## Installation for Visual Studio Code (VS Code)
 
 In order to use the KerML and SysML grammars for syntax highlighting with *VS Code* perform the following steps:
 
 1. Install the latest **VS Code** from https://code.visualstudio.com/
 2. Open the `extensions` installation folder
-   - On Windows: `%localappdata%\Programs\Microsoft VS Code\resources\app\extensions`
-   - On macOS: `/Applications/Visual Studio Code.app/Contents/Resources/app/extensions`
+    - On Windows: `%localappdata%\Programs\Microsoft VS Code\resources\app\extensions`
+    - On macOS: `/Applications/Visual Studio Code.app/Contents/Resources/app/extensions`
 3. Copy the folders `kerml` and `sysml` from the `vscode` folder into the `extensions` installation folder
 4. Start **VS Code**
 
 If you want similar colors as in the SysML training examples, add the following settings to **VS CODE**:
+
 - Select menu *File > Preferences > Settings*
 - Select the tab *User* for global settings or *Workspace* for settings limited to the current project
 - In the *Search Bar* at the top enter `Token Color`
 - In the search results click `Edit in settings.json` under *Token Color Customizations*
 
-Once the `settings.json` file is open, insert the following snippet (please, exclude the outer curly brackets, 
-and insert a comma where needed):
+Once the `settings.json` file is open, insert the following snippet (please, exclude the outer curly brackets, and
+insert a comma where needed):
+
 ```json
 {
   "editor.tokenColorCustomizations": {
-     "comments": "#20a060",
-     "variables": "#0000ff",
-     "strings": "#c00000",
-     "textMateRules": [
-        {
-           "scope": "keyword",
-           "settings": {
-              "foreground": "#7b0050",
-              "fontStyle": "bold"
-           }
-        },
-        {
-           "scope": "keyword.operator",
-           "settings": {
-              "foreground": "#7b0050",
-              "fontStyle": "bold"
-           }
-        },
-        {
-           "scope": "keyword.control",
-           "settings": {
-              "foreground": "#7b0050",
-              "fontStyle": "bold"
-           }
+    "comments": "#20a060",
+    "variables": "#0000ff",
+    "strings": "#c00000",
+    "textMateRules": [
+      {
+        "scope": "keyword",
+        "settings": {
+          "foreground": "#7b0050",
+          "fontStyle": "bold"
         }
-     ]
+      },
+      {
+        "scope": "keyword.operator",
+        "settings": {
+          "foreground": "#7b0050",
+          "fontStyle": "bold"
+        }
+      },
+      {
+        "scope": "keyword.control",
+        "settings": {
+          "foreground": "#7b0050",
+          "fontStyle": "bold"
+        }
+      }
+    ]
   }
 }
 ```
+
 ... and save the file.
 
 Open a `.kerml` source file and a `.sysml` source file to verify that syntax coloring works.
@@ -68,53 +73,58 @@ In order to use the KerML and SysML grammars for syntax highlighting with a *Jet
 
 1. Close any running *JetBrains IDE*.
 2. Open the `filetypes` settings folder:
-   - On Windows: `%APPDATA%\JetBrains\<product><version>\settingsRepository\repository\filetypes`
-   - On macOS: `~/Library/Application Support/JetBrains/<product><version>/settingsRepository/repository/filetypes`
-   - E.g. for *PyCharm version 2020.1* `<product><version>` is `PyCharm2020.1`.
-3. Open `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/jetbrains`.
+    - On Windows: `%APPDATA%\JetBrains\<product><version>\settingsRepository\repository\filetypes`
+    - On macOS: `~/Library/Application Support/JetBrains/<product><version>/settingsRepository/repository/filetypes`
+    - E.g. for *PyCharm version 2020.1* `<product><version>` is `PyCharm2020.1`.
+3. Open `$GIT_REPO_DIR/tool-support/syntax-highlighting/jetbrains`.
 4. Copy the files `KerML.xml` and `SysML.xml` from above `jetbrains` folder into the `filetypes` folder.
 5. Start your *JetBrains IDE*.
 
-If needed, you can experiment with the language settings through menu *File > Settings ... > Editor > File Types*. 
-Look for the *OMG Kernel Modeling Language* or *OMG Systems Modeling Language* settings.
+If needed, you can experiment with the language settings through menu *File > Settings ... > Editor > File Types*. Look
+for the *OMG Kernel Modeling Language* or *OMG Systems Modeling Language* settings.
 
-## Installation for JupyterLab (inside this git repo)
+## Installation for JupyterLab and Jupyter Notebook (inside this git repo)
 
-Copy the generated file `mode.ts` file, like so: 
+In order to prepare for a release of the JupyterLab and Jupyter Notebook modules, just run the generator script, as
+indicated below:
 
-    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation
-    $ cp tool-support/syntax-highlighting/jupyter/mode.ts org.omg.sysml.jupyter.jupyterlab/src/main
-
-## Installation for Jupyter Notebook (inside this git repo)
-
-Copy the generated file `kernel.js` file, like so: 
-
-    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation
-    $ cp tool-support/syntax-highlighting/jupyter/kernel.js org.omg.sysml.jupyter.kernel/src/main/resources/kernel
-
-## Generate up-to-date Language Definition Files from `xtext` source grammars 
-
-To update the language definition files from the `xtext` source grammars in their respective repository folders, 
-run the Python (v3) script `xtext_grammar_converter.py` as follows:
-
-    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting
+    $ cd $GIT_REPO_DIR/tool-support/syntax-highlighting
     $ python xtext_grammar_converter.py
 
-This updates the following language definition files in sub-folders of 
-`MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting`:
+The files `mode.ts` and `kernel.js` are auto-generated from their respective template files:
+
+- `./jupyter/mode_template.ts`
+- `./jupyter/kernel_template.js`
+
+For both templates the `$KEYWORDS` and `$DEF_KEYWORDS` placeholders get replaced with the lists of (def) keywords
+extracted from the `xtext` grammars. The additional data file `.jupyter/additional_def_keywords.txt` is used to manually
+define a collection of definition keywords that should be included in the replacement of `$DEF_KEYWORDS`. See the
+comments inside that data file for instructions.
+
+After generation is completed, the resulting files are copied to their target locations:
+
+- `mode.ts` to `$GIT_REPO_DIR/org.omg.sysml.jupyter.jupyterlab/src/main`
+- `kernel.js` to `$GIT_REPO_DIR/org.omg.sysml.jupyter.kernel/src/main/resources/kernel`
+
+Adaptations to the source code should be made in the respective template files.
+
+## Generate up-to-date Language Definition Files from `xtext` source grammars
+
+To update the language definition files from the `xtext` source grammars in their respective repository folders, run the
+Python (v3) script `xtext_grammar_converter.py` as follows:
+
+    $ cd $GIT_REPO_DIR/tool-support/syntax-highlighting
+    $ python xtext_grammar_converter.py
+
+This updates the following language definition files in sub-folders of
+`$GIT_REPO_DIR/tool-support/syntax-highlighting`:
+
 - `./vscode/kerml/syntaxes/kerml.tmLanguage.json`
 - `./vscode/sysml/syntaxes/sysml.tmLanguage.json`
 - `./jetbrains/KerML.xml`
 - `./jetbrains/SysML.xml`
 - `./jupyter/mode.ts`
 - `./jupyter/kernel.js`
-
-The JupyterLab and Jupyter Notebook generation uses the following template and data files as inputs:
-- `.jupyter/mode_template.ts` for JupyterLab, where the `"$KEYWORDS"` and `"$DEF_KEYWORDS"` placeholders get 
-  replaced with the lists of (def) keywords extracted from the `xtext` grammars.
-- `.jupyter/kernel_template.js` for Jupyter Notebook, with the same `"$KEYWORDS"` and `"$DEF_KEYWORDS"` placeholders. 
-- `.jupyter/additional_def_keywords.txt` to manually define a collection of definition keywords that should be added 
-  in the generated files. See comments inside the file for an explanation.
 
 ## Known Issues
 
@@ -124,8 +134,12 @@ None.
 
 ### Release 2021-05
 
-2021-05-??: ST6RI-365 Added syntax highlighting generation to automated build
+2021-06-07: ST6RI-365 Added syntax highlighting generation for semi-automated builds / preparation for release.
+
 2021-05-14: ST6RI-286 Added support for JupyterLab and Jupyter Notebook and updated for release 2021-04
+
 2021-04-08: Updated for release 2021-03 of the KerML and SysML `xtext` language definitions.
+
 2020-10-15: Updated for release 2020-09 of the KerML and SysML `xtext` language definitions.
+
 2020-06-22: First release, based on the 2020-06 release of the KerML and SysML `xtext` language definitions.

--- a/tool-support/syntax-highlighting/README.md
+++ b/tool-support/syntax-highlighting/README.md
@@ -2,9 +2,10 @@
 
 This project contains language definition files to enable syntax highlighting in IDEs other than Eclipse.
 
-The language definition files for other IDES are auto-generated. Currently the following IDEs are supported:
+The language definition files for other IDES are auto-generated. Currently, the following IDEs are supported:
 - *Visual Studio Code*
 - *JetBrains* IDEs, e.g. *PyCharm*
+- *JupyterLab* and *Jupyter Notebook* web apps
  
 ## Installation for Visual Studio Code (VS Code)
 
@@ -13,7 +14,7 @@ In order to use the KerML and SysML grammars for syntax highlighting with *VS Co
 1. Install the latest **VS Code** from https://code.visualstudio.com/
 2. Open the `extensions` installation folder
    - On Windows: `%localappdata%\Programs\Microsoft VS Code\resources\app\extensions`
-   - On MacOS: `/Applications/Visual Studio Code.app/Contents/Resources/app/extensions`
+   - On macOS: `/Applications/Visual Studio Code.app/Contents/Resources/app/extensions`
 3. Copy the folders `kerml` and `sysml` from the `vscode` folder into the `extensions` installation folder
 4. Start **VS Code**
 
@@ -23,36 +24,39 @@ If you want similar colors as in the SysML training examples, add the following 
 - In the *Search Bar* at the top enter `Token Color`
 - In the search results click `Edit in settings.json` under *Token Color Customizations*
 
-Once the `settings.json` file is open, insert the following snippet:
+Once the `settings.json` file is open, insert the following snippet (please, exclude the outer curly brackets, 
+and insert a comma where needed):
 ```json
+{
   "editor.tokenColorCustomizations": {
-    "comments": "#20a060",
-    "variables": "#0000ff",
-    "strings": "#c00000",
-    "textMateRules": [
-      {
-        "scope": "keyword",
-        "settings": {
-          "foreground": "#7b0050",
-          "fontStyle": "bold"
+     "comments": "#20a060",
+     "variables": "#0000ff",
+     "strings": "#c00000",
+     "textMateRules": [
+        {
+           "scope": "keyword",
+           "settings": {
+              "foreground": "#7b0050",
+              "fontStyle": "bold"
+           }
+        },
+        {
+           "scope": "keyword.operator",
+           "settings": {
+              "foreground": "#7b0050",
+              "fontStyle": "bold"
+           }
+        },
+        {
+           "scope": "keyword.control",
+           "settings": {
+              "foreground": "#7b0050",
+              "fontStyle": "bold"
+           }
         }
-      },
-      {
-        "scope": "keyword.operator",
-        "settings": {
-          "foreground": "#7b0050",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control",
-        "settings": {
-          "foreground": "#7b0050",
-          "fontStyle": "bold"
-        }
-      }
-    ]
-  },
+     ]
+  }
+}
 ```
 ... and save the file.
 
@@ -65,7 +69,7 @@ In order to use the KerML and SysML grammars for syntax highlighting with a *Jet
 1. Close any running *JetBrains IDE*.
 2. Open the `filetypes` settings folder:
    - On Windows: `%APPDATA%\JetBrains\<product><version>\settingsRepository\repository\filetypes`
-   - On MacOS: `~/Library/Application Support/JetBrains/<product><version>/settingsRepository/repository/filetypes`
+   - On macOS: `~/Library/Application Support/JetBrains/<product><version>/settingsRepository/repository/filetypes`
    - E.g. for *PyCharm version 2020.1* `<product><version>` is `PyCharm2020.1`.
 3. Open `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/jetbrains`.
 4. Copy the files `KerML.xml` and `SysML.xml` from above `jetbrains` folder into the `filetypes` folder.
@@ -74,19 +78,43 @@ In order to use the KerML and SysML grammars for syntax highlighting with a *Jet
 If needed, you can experiment with the language settings through menu *File > Settings ... > Editor > File Types*. 
 Look for the *OMG Kernel Modeling Language* or *OMG Systems Modeling Language* settings.
 
-## Update TextMate and JetBrains Language Definition Files
+## Installation for JupyterLab (inside this git repo)
 
-To update the language definition files from the `KerML.xtext` and `SysML.xtext` source grammars 
-in their respective repository folders, run the Python (v3) script `xtext_grammar_converter.py` as follows:
+Copy the generated file `mode.ts` file, like so: 
 
-    $ cd MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting
+    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation
+    $ cp tool-support/syntax-highlighting/jupyter/mode.ts org.omg.sysml.jupyter.jupyterlab/src/main
+
+## Installation for Jupyter Notebook (inside this git repo)
+
+Copy the generated file `kernel.js` file, like so: 
+
+    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation
+    $ cp tool-support/syntax-highlighting/jupyter/kernel.js org.omg.sysml.jupyter.kernel/src/main/resources/kernel
+
+## Generate up-to-date Language Definition Files from `xtext` source grammars 
+
+To update the language definition files from the `xtext` source grammars in their respective repository folders, 
+run the Python (v3) script `xtext_grammar_converter.py` as follows:
+
+    $ cd MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting
     $ python xtext_grammar_converter.py
 
-This updates the following language definition files:
-- `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/vscode/kerml/syntaxes/kerml.tmLanguage.json`
-- `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/vscode/sysml/syntaxes/sysml.tmLanguage.json`
-- `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/jetbrains/KerML.xml`
-- `MY_GIT_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting/jetbrains/SysML.xml`
+This updates the following language definition files in sub-folders of 
+`MY_GIT_REPOS_FOLDER/SysML-v2-Pilot-Implementation/tool-support/syntax-highlighting`:
+- `./vscode/kerml/syntaxes/kerml.tmLanguage.json`
+- `./vscode/sysml/syntaxes/sysml.tmLanguage.json`
+- `./jetbrains/KerML.xml`
+- `./jetbrains/SysML.xml`
+- `./jupyter/mode.ts`
+- `./jupyter/kernel.js`
+
+The JupyterLab and Jupyter Notebook generation uses the following template and data files as inputs:
+- `.jupyter/mode_template.ts` for JupyterLab, where the `"$KEYWORDS"` and `"$DEF_KEYWORDS"` placeholders get 
+  replaced with the lists of (def) keywords extracted from the `xtext` grammars.
+- `.jupyter/kernel_template.js` for Jupyter Notebook, with the same `"$KEYWORDS"` and `"$DEF_KEYWORDS"` placeholders. 
+- `.jupyter/additional_def_keywords.txt` to manually define a collection of definition keywords that should be added 
+  in the generated files. See comments inside the file for an explanation.
 
 ## Known Issues
 
@@ -94,8 +122,10 @@ None.
 
 ## Release Notes
 
-### Release 2021-03
+### Release 2021-05
 
+2021-05-??: ST6RI-365 Added syntax highlighting generation to automated build
+2021-05-14: ST6RI-286 Added support for JupyterLab and Jupyter Notebook and updated for release 2021-04
 2021-04-08: Updated for release 2021-03 of the KerML and SysML `xtext` language definitions.
 2020-10-15: Updated for release 2020-09 of the KerML and SysML `xtext` language definitions.
 2020-06-22: First release, based on the 2020-06 release of the KerML and SysML `xtext` language definitions.

--- a/tool-support/syntax-highlighting/jupyter/kernel.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel.js
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
+ * Source code modifications should be applied to template file:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/jupyter/kernel_template.js
+ */
+
 define([
     'codemirror/lib/codemirror',
     'codemirror/mode/clike/clike',
@@ -56,28 +63,30 @@ var enableMode = function (CodeMirror) {
                 "return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
                 "subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
                 "variation", "verification", "verify", "view", "viewpoint"
-                ]),
+            ]),
             defKeywords: words([
                 "action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
                 "concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
                 "link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
                 "snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
                 "verification", "view", "viewpoint"
-                ]),
+            ]),
             typeFirstDefinitions: true,
             atoms: words("true false null"),
             number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
             modeProps: {fold: ["brace"]},
             hooks: {
-                "'": function(stream) {
-                        var escaped = false, next;
-                        while ((next = stream.next()) != null) {
-                            if (next == "'" && !escaped) { break; }
-                            escaped = !escaped && next == "\\";
+                "'": function (stream) {
+                    var escaped = false, next;
+                    while ((next = stream.next()) != null) {
+                        if (next == "'" && !escaped) {
+                            break;
                         }
-                        return "variable";
+                        escaped = !escaped && next == "\\";
+                    }
+                    return "variable";
                 },
-                "/": function(stream) {
+                "/": function (stream) {
                     if (stream.match("/*", false)) {
                         stream.next();
                     }

--- a/tool-support/syntax-highlighting/jupyter/kernel.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel.js
@@ -46,44 +46,44 @@ var enableMode = function (CodeMirror) {
             name: "clike",
             keywords: words([
                 "about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
-				"analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
-				"comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
-				"do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
-				"flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
-				"instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
-				"nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
-				"protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
-				"return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
-				"subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
-				"variation", "verification", "verify", "view", "viewpoint"
+                "analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
+                "comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
+                "do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
+                "flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
+                "instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
+                "nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
+                "protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
+                "return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
+                "subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
+                "variation", "verification", "verify", "view", "viewpoint"
                 ]),
             defKeywords: words([
                 "action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
-				"concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
-				"link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
-				"snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
-				"verification", "view", "viewpoint"
+                "concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
+                "link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
+                "snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
+                "verification", "view", "viewpoint"
                 ]),
             typeFirstDefinitions: true,
             atoms: words("true false null"),
             number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
             modeProps: {fold: ["brace"]},
             hooks: {
-				"'": function(stream) {
-						var escaped = false, next;
-						while ((next = stream.next()) != null) {
-							if (next == "'" && !escaped) { break; }
-							escaped = !escaped && next == "\\";
-						}
-						return "variable";
-				},
-				"/": function(stream) {
-					if (stream.match("/*", false)) {
-						stream.next();
-					}
-					return false;
-				}
-			}
+                "'": function(stream) {
+                        var escaped = false, next;
+                        while ((next = stream.next()) != null) {
+                            if (next == "'" && !escaped) { break; }
+                            escaped = !escaped && next == "\\";
+                        }
+                        return "variable";
+                },
+                "/": function(stream) {
+                    if (stream.match("/*", false)) {
+                        stream.next();
+                    }
+                    return false;
+                }
+            }
         });
     });
     CodeMirror.defineMIME("text/x-sysml", "sysml");

--- a/tool-support/syntax-highlighting/jupyter/kernel.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel.js
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
  * Source code modifications should be applied to template file:

--- a/tool-support/syntax-highlighting/jupyter/kernel_template.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel_template.js
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $SCRIPT
+ * Source code modifications should be applied to template file:
+ *   $TEMPLATE_FILE
+ */
+
 define([
     'codemirror/lib/codemirror',
     'codemirror/mode/clike/clike',
@@ -46,24 +53,26 @@ var enableMode = function (CodeMirror) {
             name: "clike",
             keywords: words([
                 "$KEYWORDS"
-                ]),
+            ]),
             defKeywords: words([
                 "$DEF_KEYWORDS"
-                ]),
+            ]),
             typeFirstDefinitions: true,
             atoms: words("true false null"),
             number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
             modeProps: {fold: ["brace"]},
             hooks: {
-                "'": function(stream) {
-                        var escaped = false, next;
-                        while ((next = stream.next()) != null) {
-                            if (next == "'" && !escaped) { break; }
-                            escaped = !escaped && next == "\\";
+                "'": function (stream) {
+                    var escaped = false, next;
+                    while ((next = stream.next()) != null) {
+                        if (next == "'" && !escaped) {
+                            break;
                         }
-                        return "variable";
+                        escaped = !escaped && next == "\\";
+                    }
+                    return "variable";
                 },
-                "/": function(stream) {
+                "/": function (stream) {
                     if (stream.match("/*", false)) {
                         stream.next();
                     }

--- a/tool-support/syntax-highlighting/jupyter/kernel_template.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel_template.js
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $SCRIPT
  * Source code modifications should be applied to template file:

--- a/tool-support/syntax-highlighting/jupyter/kernel_template.js
+++ b/tool-support/syntax-highlighting/jupyter/kernel_template.js
@@ -55,21 +55,21 @@ var enableMode = function (CodeMirror) {
             number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
             modeProps: {fold: ["brace"]},
             hooks: {
-				"'": function(stream) {
-						var escaped = false, next;
-						while ((next = stream.next()) != null) {
-							if (next == "'" && !escaped) { break; }
-							escaped = !escaped && next == "\\";
-						}
-						return "variable";
-				},
-				"/": function(stream) {
-					if (stream.match("/*", false)) {
-						stream.next();
-					}
-					return false;
-				}
-			}
+                "'": function(stream) {
+                        var escaped = false, next;
+                        while ((next = stream.next()) != null) {
+                            if (next == "'" && !escaped) { break; }
+                            escaped = !escaped && next == "\\";
+                        }
+                        return "variable";
+                },
+                "/": function(stream) {
+                    if (stream.match("/*", false)) {
+                        stream.next();
+                    }
+                    return false;
+                }
+            }
         });
     });
     CodeMirror.defineMIME("text/x-sysml", "sysml");

--- a/tool-support/syntax-highlighting/jupyter/mode.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode.ts
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
+ * Source code modifications should be applied to template file:
+ *   $GIT_REPO_DIR/tool-support/syntax-highlighting/jupyter/mode_template.ts
+ */
+
 // tslint:disable-next-line
 import 'codemirror/addon/mode/simple';
 

--- a/tool-support/syntax-highlighting/jupyter/mode.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode.ts
@@ -29,59 +29,59 @@ const P_MIME = 'text/x-sysml'
 const f_wordify = (h: any, s: string) => ({...h, [s]: true});
 
 export function defineSysMLv2Mode(): void {
-	CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
-		return CodeMirror.getMode(gc_mode, {
-			name: 'clike',
-			keywords: [
-				"about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
-				"analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
-				"comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
-				"do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
-				"flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
-				"instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
-				"nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
-				"protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
-				"return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
-				"subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
-				"variation", "verification", "verify", "view", "viewpoint"
-			].reduce(f_wordify, {}),
-			defKeywords: [
-				"action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
-				"concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
-				"link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
-				"snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
-				"verification", "view", "viewpoint"
-			].reduce(f_wordify, {}),
-			typeFirstDefinitions: true,
-			atoms: ['true', 'false', 'null'].reduce(f_wordify),
-			number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
-			modeProps: {
-				fold: ['brace'],
-			},
-			hooks: {
-				"'": function(stream: CodeMirror.StringStream) {
-					let b_escaped = false;
-					let s_next;
-					while(s_next = stream.next()) {
-						if(s_next === "'" && !b_escaped) break;
-						b_escaped = !b_escaped && s_next === '\\';
-					}
-					return 'variable';
-				},
-				'/': function(stream: CodeMirror.StringStream) {
-					if(stream.match('/*', false)) stream.next();
-					return false;
-				},
-			},
-		});
-	});
+    CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
+        return CodeMirror.getMode(gc_mode, {
+            name: 'clike',
+            keywords: [
+                "about", "abstract", "accept", "action", "activity", "affect", "alias", "all", "allocate", "allocation",
+                "analysis", "as", "assert", "assoc", "assume", "attribute", "bind", "block", "by", "calc", "case",
+                "comment", "concern", "connect", "connection", "constraint", "decide", "def", "defined", "dependency",
+                "do", "doc", "else", "end", "entry", "enum", "exhibit", "exit", "expose", "feature", "filter", "first",
+                "flow", "for", "fork", "frame", "from", "hastype", "id", "if", "import", "in", "individual", "inout",
+                "instanceof", "interface", "istype", "item", "join", "language", "link", "merge", "metadata",
+                "nonunique", "objective", "of", "ordered", "out", "package", "part", "perform", "port", "private",
+                "protected", "public", "redefines", "ref", "render", "rendering", "rep", "require", "requirement",
+                "return", "satisfy", "send", "snapshot", "specializes", "stakeholder", "state", "stream", "subject",
+                "subsets", "succession", "then", "timeslice", "to", "transition", "type", "value", "variant",
+                "variation", "verification", "verify", "view", "viewpoint"
+            ].reduce(f_wordify, {}),
+            defKeywords: [
+                "action", "activity", "allocation", "analysis", "attribute", "block", "calc", "case", "comment",
+                "concern", "connection", "constraint", "def", "doc", "enum", "id", "individual", "interface", "item",
+                "link", "metadata", "objective", "package", "part", "port", "ref", "rendering", "rep", "requirement",
+                "snapshot", "stakeholder", "state", "subject", "timeslice", "transition", "type", "value",
+                "verification", "view", "viewpoint"
+            ].reduce(f_wordify, {}),
+            typeFirstDefinitions: true,
+            atoms: ['true', 'false', 'null'].reduce(f_wordify),
+            number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+            modeProps: {
+                fold: ['brace'],
+            },
+            hooks: {
+                "'": function(stream: CodeMirror.StringStream) {
+                    let b_escaped = false;
+                    let s_next;
+                    while(s_next = stream.next()) {
+                        if(s_next === "'" && !b_escaped) break;
+                        b_escaped = !b_escaped && s_next === '\\';
+                    }
+                    return 'variable';
+                },
+                '/': function(stream: CodeMirror.StringStream) {
+                    if(stream.match('/*', false)) stream.next();
+                    return false;
+                },
+            },
+        });
+    });
 
-	CodeMirror.defineMIME(P_MIME, SI_MODE);
+    CodeMirror.defineMIME(P_MIME, SI_MODE);
 
-	(CodeMirror as any).modeInfo.push({
-		ext: ['sysml'],
-		mime: P_MIME,
-		mode: SI_MODE,
-		name: 'sysml',
-	});
+    (CodeMirror as any).modeInfo.push({
+        ext: ['sysml'],
+        mime: P_MIME,
+        mode: SI_MODE,
+        name: 'sysml',
+    });
 }

--- a/tool-support/syntax-highlighting/jupyter/mode.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode.ts
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $GIT_REPO_DIR/tool-support/syntax-highlighting/xtext_grammar_converter.py
  * Source code modifications should be applied to template file:

--- a/tool-support/syntax-highlighting/jupyter/mode_template.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode_template.ts
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
- */
-
-/*
+ *
  * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
  *   $SCRIPT
  * Source code modifications should be applied to template file:

--- a/tool-support/syntax-highlighting/jupyter/mode_template.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode_template.ts
@@ -18,6 +18,13 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  */
 
+/*
+ * ATTENTION: This file is auto-generated from the Xtext grammar definitions by script:
+ *   $SCRIPT
+ * Source code modifications should be applied to template file:
+ *   $TEMPLATE_FILE
+ */
+
 // tslint:disable-next-line
 import 'codemirror/addon/mode/simple';
 

--- a/tool-support/syntax-highlighting/jupyter/mode_template.ts
+++ b/tool-support/syntax-highlighting/jupyter/mode_template.ts
@@ -29,45 +29,45 @@ const P_MIME = 'text/x-sysml'
 const f_wordify = (h: any, s: string) => ({...h, [s]: true});
 
 export function defineSysMLv2Mode(): void {
-	CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
-		return CodeMirror.getMode(gc_mode, {
-			name: 'clike',
-			keywords: [
-				"$KEYWORDS"
-			].reduce(f_wordify, {}),
-			defKeywords: [
-				"$DEF_KEYWORDS"
-			].reduce(f_wordify, {}),
-			typeFirstDefinitions: true,
-			atoms: ['true', 'false', 'null'].reduce(f_wordify),
-			number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
-			modeProps: {
-				fold: ['brace'],
-			},
-			hooks: {
-				"'": function(stream: CodeMirror.StringStream) {
-					let b_escaped = false;
-					let s_next;
-					while(s_next = stream.next()) {
-						if(s_next === "'" && !b_escaped) break;
-						b_escaped = !b_escaped && s_next === '\\';
-					}
-					return 'variable';
-				},
-				'/': function(stream: CodeMirror.StringStream) {
-					if(stream.match('/*', false)) stream.next();
-					return false;
-				},
-			},
-		});
-	});
+    CodeMirror.defineMode(SI_MODE, (gc_mode, gc_parser) => {
+        return CodeMirror.getMode(gc_mode, {
+            name: 'clike',
+            keywords: [
+                "$KEYWORDS"
+            ].reduce(f_wordify, {}),
+            defKeywords: [
+                "$DEF_KEYWORDS"
+            ].reduce(f_wordify, {}),
+            typeFirstDefinitions: true,
+            atoms: ['true', 'false', 'null'].reduce(f_wordify),
+            number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+            modeProps: {
+                fold: ['brace'],
+            },
+            hooks: {
+                "'": function(stream: CodeMirror.StringStream) {
+                    let b_escaped = false;
+                    let s_next;
+                    while(s_next = stream.next()) {
+                        if(s_next === "'" && !b_escaped) break;
+                        b_escaped = !b_escaped && s_next === '\\';
+                    }
+                    return 'variable';
+                },
+                '/': function(stream: CodeMirror.StringStream) {
+                    if(stream.match('/*', false)) stream.next();
+                    return false;
+                },
+            },
+        });
+    });
 
-	CodeMirror.defineMIME(P_MIME, SI_MODE);
+    CodeMirror.defineMIME(P_MIME, SI_MODE);
 
-	(CodeMirror as any).modeInfo.push({
-		ext: ['sysml'],
-		mime: P_MIME,
-		mode: SI_MODE,
-		name: 'sysml',
-	});
+    (CodeMirror as any).modeInfo.push({
+        ext: ['sysml'],
+        mime: P_MIME,
+        mode: SI_MODE,
+        name: 'sysml',
+    });
 }

--- a/tool-support/syntax-highlighting/xtext_grammar_converter.py
+++ b/tool-support/syntax-highlighting/xtext_grammar_converter.py
@@ -1,9 +1,8 @@
 """
-Basic TextMate grammar for kerml and sysml language as part of SysML 2 Pilot Implementation
+Converter/generator of syntax highlighting definitions for the kerml and sysml languages from their xtext grammars
+for various non-Eclipse editors as part of the SysML 2 Pilot Implementation
 
-Copyright (c) 2020 DEKonsult
-
-Purpose: Syntax highlighting in VS Code  editor similar to Jupyter Notebook
+Copyright (c) 2020-2021 DEKonsult
 
 Contributor(s):
 - Hans Peter de Koning (DEKonsult)
@@ -15,8 +14,6 @@ import re
 import textwrap
 from typing import List, Set, Dict
 import logging
-
-NEW_LINE = "\n"
 
 
 class DATA:
@@ -351,7 +348,8 @@ class Converter(object):
                 logging.error(f"def keyword '{def_keyword}' "
                               f"is not in the list of keywords obtained from the xtext grammar")
 
-        indent = 4 * "\t"
+        four_spaces = "    "
+        indent = 4 * four_spaces
         keywords_block = f"\n{indent}".join(textwrap.wrap('"' + '", "'.join(keywords_minus_atoms) + '"', 104))
         def_keywords_block = f"\n{indent}".join(textwrap.wrap('"' + '", "'.join(self.def_keywords) + '"', 104))
 


### PR DESCRIPTION
In the end we decided to make this semi-automated: the generator script `xtext_grammar_converter.py` can be run on demand, after changes to the `xtext` grammars have been made, to automatically prepare for an intermediate or complete release.

The script is not included as part of CI, because that would potentially cause mutual dependencies as the generator replaces source code in the `jupyterLab` and `jupyter.kernel` modules.