### PR TITLE
ST6RI-389 Update XMI export to use UUIDs for XMI IDs

### DIFF
--- a/org.omg.sysml.xtext/.launch/Save SysML2XMI without Libraries.launch
+++ b/org.omg.sysml.xtext/.launch/Save SysML2XMI without Libraries.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <stringAttribute key="bad_container_name" value="/SySML-v2-Pilot-Implementation/org.omg.sysml.xte/.launch"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysML2XMI.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.xtext.util.SysML2XMI"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml.xtext"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${selected_resource_loc}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml.xtext"/>
+</launchConfiguration>

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysML2XMI.java
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysML2XMI.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2019-2020 Model Driven Solutions, Inc.
+ * Copyright (c) 2019-2021 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,8 +24,6 @@
 
 package org.omg.sysml.xtext.util;
 
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.omg.kerml.xtext.util.KerML2XMI;
 import org.omg.sysml.xtext.SysMLStandaloneSetup;
 
@@ -47,7 +45,6 @@ public class SysML2XMI extends KerML2XMI {
 	
 	public SysML2XMI() {
 		super();
-	    Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put(SYSML_XMI_EXTENSION, new XMIResourceFactoryImpl());
 		SysMLStandaloneSetup.doSetup();
 		this.addExtension("." + SYSML_EXTENSION);
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
@@ -237,6 +237,11 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseMembership(Membership element) {
+			return new MembershipAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseNamespace(Namespace element) {
 			return new NamespaceAdapter(element);
 		}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/MembershipAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/MembershipAdapter.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2021 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.omg.sysml.lang.sysml.Membership;
+
+public class MembershipAdapter extends ElementAdapter {
+
+	public MembershipAdapter(Membership element) {
+		super(element);
+	}
+	
+	@Override
+	public Membership getTarget() {
+		return (Membership)super.getTarget();
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		getTarget().getMemberName();
+	}
+
+}


### PR DESCRIPTION
This PR updates the `KerML2XMI` and `SysML2XMI` utilities to generate XMI that uses the UUID `identifier` of an Element as its XMI ID. These IDs are then used for cross-references, rather than the default Xpaths.

It also includes a fix for the bug reported in [ST6RI-402 Member names are sometimes not written to XMI](https://openmbee.atlassian.net/browse/ST6RI-402).