### PR TITLE
ST6RI-386 Kernel libraries for feature access and control performances

### DIFF
--- a/kerml/src/examples/Simple Tests/Expressions.kerml
+++ b/kerml/src/examples/Simple Tests/Expressions.kerml
@@ -12,11 +12,22 @@ package Expressions {
 	
 	b = x > y? x-y: y-x;
 	c = x->collect {in xx; xx + 1}; 
-	d = x->while({in q; q > 3}, {in r; r - 1})->reduce {in s; in t; s + t}->reduce '+';
+	d = x->reduce {in s; in t; s + t}->reduce '+';
 	
-	function w specializes while (initial) result {
-		expr condition redefines while::condition (v){v > 3}
-		expr body redefines while::body (u){u - 1}
+	behavior w specializes ControlPerformances::LoopPerformance (inout v: Integer)  {
+		in expr redefines whileTest {v > 3}
+		in step redefines body : Performances::Performance {
+			step decrement {
+				out v_decr : Integer = v - 1;			
+			}
+			succession decrement then update;
+			step update : FeatureAccessPerformances::FeatureWritePerformance {
+				inout replacementValues = decrement.v_decr;
+				feature redefines onOccurrence = w::self {
+					feature redefines accessedFeature redefines v;
+				}
+			}
+		}
 	}
 	
 	xx = x == 1 && y == 2? a:

--- a/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
@@ -67,6 +67,7 @@ public class ExpressionUtil {
 		return expression.getOwnedMembership().stream().
 				filter(mem->!(mem instanceof ParameterMembership)).
 				map(Membership::getMemberElement).
+				filter(el->el != null).
 				findFirst().orElse(null);
 	}
 

--- a/sysml.library/Kernel Library/ControlFunctions.kerml
+++ b/sysml.library/Kernel Library/ControlFunctions.kerml
@@ -36,11 +36,6 @@ package ControlFunctions {
 		composite abstract expr secondValue[0..1] (): Boolean[1];
 	}
 	
-	abstract function while('initial': Anything[0..*]): Anything[0..*] {
-		composite abstract expr condition[1..*] (argument: Anything[0..*]): Boolean[1];
-		composite abstract expr body[0..*] (argument: Anything[0..*]): Anything[0..*];
-	}
-	
 	abstract function collect(collection: Anything[0..*]): Anything[0..*] {
 		composite abstract expr mapper[0..*] (argument: Anything[1]): Anything[0..*];
 	}

--- a/sysml.library/Kernel Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Library/ControlPerformances.kerml
@@ -1,19 +1,101 @@
 package ControlPerformances {
+	private import ScalarValues::Boolean;
+	private import SequenceFunctions::size;
+	private import Occurrences::Occurrence;
 	private import Occurrences::HappensBefore;
+	private import Occurrences::SelfSameLifeLink;
+	private import Performances::Performance;
+	private import Performances::BooleanEvaluation;
 	
-	behavior DecisionPerformance {
+	/**
+	 * A DecisionPerformance is a Performance that represents the selection of one of the Successions
+	 * that have the DecisionPerforance behavior as their source. All such Successions must subset the 
+	 * outgoingHBLink feature of the source DecisionPerformance. For each instance of DecisionPerformance, 
+	 * the outgoingHBLink is an instance of exactly one of the Successions, ordering the DecisionPerformance
+	 * as happening before an instance of the target of that Succcession.
+	 */
+	behavior DecisionPerformance specializes Performance {
 		/**
-		 * Specializations subset this (via SelfLink) by all
+		 * Specializations subset this by all
 		 * successions going out of a decision step.
 		 */
 		feature outgoingHBLink: HappensBefore[1];
 	}
 	
-	behavior MergePerformance {
+	/**
+	 * A MergePerformance is a Performance that represents the merging of all Successions that
+	 * target the MergePerforance behavior. All such Successions must subset the incomingHBLink
+	 * feature of the target MergePerformance. For each instance of MergePerformance, the
+	 * incomingHBLink is an instance of exactly one of the Successions, ordering the
+	 * MergePerformance as happening after an instance of the source of that Succcession.
+	 */
+	behavior MergePerformance specializes Performance {
 		/**
-		 * Specializations subset this (via SelfLink) by all
+		 * Specializations subset this by all
 		 * successions coming into a merge step.
 		 */
 		feature incomingHBLink: HappensBefore[1];
+	}
+
+	/**
+	 * An IfPerformance is a Performance that determines whether the ifTest evaluation result is true 
+	 * (by whether ifTrue has a value).
+	 */	
+	abstract behavior IfPerformance specializes Performance {
+		in ifTest : BooleanEvaluation[1];
+		feature trueLiteral : Boolean[1] = true;
+		binding all ifTrue of ifTest.result[0..1] = trueLiteral[0..1];
+	}
+	
+	/**
+	 * An IfThenPerformance is an IfPerformance where the thenClause occurs after and only after the 
+	 * ifTest evaluation result is true.
+	 */
+	behavior IfThenPerformance specializes IfPerformance {
+		in redefines ifTest;
+		in thenClause : Occurrence[0..1];
+		succession ifTest[1] then thenClause[0..1];
+		inv { ifTrue->size() == thenClause->size() }
+	}
+	
+	/**
+	 * An IfElsePerformance is an IfPerformance where the elseCaluse occurs  occurs after and only 
+	 * after the ifTest evaluation result is not true.
+	 */
+	behavior IfElsePerformance specializes IfPerformance {
+		in redefines ifTest;
+		in elseClause : Occurrence[0..1];
+		succession ifTest[1] then elseClause[0..1];
+		inv { !ifTrue->size() == elseClause->size() }
+	}
+	
+	/**
+	 * An IfThenElsePerformance is an IfThenPerformance and an IfElsePerformance.
+	 */
+	behavior IfThenElsePerformance specializes IfThenPerformance, IfElsePerformance;
+	
+	/**
+	 * A LoopPerformance is a Performance where the body occurs repeatedly in sequence (iterates) 
+	 * as long as the whileTest evaluation result is true before each iteration (and after the 
+	 * previous one, except the first time) and the untilTest evaluation result is not true after 
+	 * each iteration and before the next one (except the last one).
+	 */
+	behavior LoopPerformance specializes Performance {
+		in whileTest : BooleanEvaluation[1..*];
+		in untilTest : BooleanEvaluation[0..*];
+		in body : Occurrence[0..*];
+		
+		step whileDecision : IfThenPerformance[1..*];
+		step untilDecision : IfElsePerformance[1..*];
+		
+		binding whileDecision.ifTest[1] = whileTest[1];
+		binding whileDecision.thenClause[1] = body[1];
+		
+		succession body then untilDecision;
+		
+		binding untilDecision.ifTest[1] = untilTest[1];
+		binding loopBack of untilDecision.elseClause[0..1] = whileDecision[1];
+		
+		inv { loopBack->size() == whileDecision->size() - 1 }
 	}
 }

--- a/sysml.library/Kernel Library/FeatureAccessPerformances.kerml
+++ b/sysml.library/Kernel Library/FeatureAccessPerformances.kerml
@@ -1,0 +1,64 @@
+package FeatureAccessPerformances {
+	private import Base::Anything;
+	private import Base::things;
+	private import Occurrences::Occurrence;
+	private import Occurrences::SelfSameLifeLink;
+	private import Performances::Performance;
+	private import Performances::Evaluation;
+
+	/**
+	 * A FeatureReferencingPerformance is the base Performance for specialized behaviors related 
+	 * to values of one more more referenced Features, as identified in specializations of this 
+	 * Behavior.
+	 */
+	abstract behavior FeatureReferencingPerformance specializes Performance {
+		
+		/**
+		 * Occurrence with values for the referenced feature in specializations of this behavior.
+		 */
+		in abstract feature onOccurrence: Occurrence [1];
+		 
+		/**
+		 * Values of the referenced feature, as specified in specializations of this behavior.
+		 */
+		inout feature values : Anything [*] nonunique;		
+	}
+
+	/**
+	 * A FeatureAccessPerformance is a FeatureReferencingPerformance where the result values
+	 * are all the values of a feature of onOccurrence at the time the Performance ends. The
+	 * feature is specified by restricting things in specializations or usages.
+	 */
+    abstract behavior FeatureAccessPerformance specializes FeatureReferencingPerformance {
+     	
+		in abstract feature onOccurrence : Occurrence {
+			abstract feature accessedFeature;
+			feature startingAt : Occurrence [1] subsets timeSlices, onOccurrence;
+		}
+
+		/**
+		 * Requires some time slice of onOccurrence to start when this performance
+		 * ends (first binding), with particular feature values (second binding).
+		 * The feature is specified by restricting the onOccurrence::accessedFeature 
+		 * on usages of this behavior.
+		 */
+	  	 binding onOccurrence.startingAt.startShot = endShot;
+	  	 connector :SelfSameLifeLink from onOccurrence.startingAt.accessedFeature to values;
+	}
+
+	/**
+	 * A FeatureReadEvaluation is a FeatureAccessPerformance that is a function providing as
+	 * its result the values of a feature on an occurrence at the time its evaluation ends.
+	 */
+	abstract function FeatureReadEvaluation specializes FeatureAccessPerformance, Evaluation 
+		(OnOccurrence: Occurrence[1]) 
+		resultValues : Anything[*] nonunique redefines result redefines values;
+
+	/**
+	 * A FeatureWritePerformance is a FeatureAccessPerformance that assigns the values of a 
+	 * feature on an occurrence to the given replacementValues at time its performance ends.
+	 */
+	abstract function FeatureWritePerformance specializes FeatureAccessPerformance {
+		 inout feature replacementValues : Anything redefines values [*] nonunique;
+	}
+}

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -6,6 +6,7 @@
 package Occurrences {
 	private import Base::Anything;
 	private import Base::things;
+	private import Base::DataValue;
 	private import Links::*;
 	
 	/**
@@ -22,6 +23,7 @@ package Occurrences {
 		feature portionOfLife : Life[1] subsets portionOf;
 		
 		feature self : Occurrence[1] redefines Anything::self subsets timeSlices;
+		feature sameLifeOccurrences : Occurrence[1..*] subsets things;
 		
 		/**
 		 * Occurrences that end before this occurrence starts.
@@ -147,6 +149,28 @@ package Occurrences {
 	
 	abstract feature occurrences: Occurrence[0..*] subsets things;
 	
+	/**
+	 * SelfSameLifeLink is a binary association that is equivalent to SelfLink it the
+	 * linked things are DataValues, but asserts that the link things are portions of
+	 * the same Life if they are Occurrences. A SelfSameLink is not itself an Occurrence
+	 * (SelfSameLifeLink is disjoint with LinkObject).
+	 */
+	assoc all SelfSameLifeLink specializes BinaryLink {
+	 
+		end feature selfSameLife: Anything[1..*] redefines source;
+		end feature myselfSameLife: Anything[1..*] redefines target;
+
+	 	feature all sourceOccurrence : Occurrence [1..*] subsets selfSameLife redefines Occurrence::sameLifeOccurrences;
+	 	feature all targetOccurrence : Occurrence [1..*] subsets myselfSameLife;
+		binding sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
+
+		feature all sourceDataValue : DataValue [0..1] subsets selfSameLife;
+		feature all targetDataValue : DataValue [0..1] subsets myselfSameLife;
+		binding sourceDataValue = targetDataValue;
+	}
+	
+	subclass SelfLink specializes SelfSameLifeLink;
+
 	/**
 	 * HappensLink is the base of the associations that assert temporal relationships 
 	 * between a sourceOccurrence and a targetOccurrence. Because HappensLinks assert 

--- a/sysml.library/Kernel Library/Performances.kerml
+++ b/sysml.library/Kernel Library/Performances.kerml
@@ -54,7 +54,7 @@ package Performances {
 	 * Evaluation is the most general class of functions that may be evaluated to compute
 	 * a result.
 	 */
-	abstract function Evaluation specializes Performance (): Anything[0..*];
+	abstract function Evaluation specializes Performance () result: Anything[0..*];
 	
 	/**
 	 * BooleanEvaluation is a specialization of Evaluation that is the most general class of


### PR DESCRIPTION
This pull request updates the Kernel Library for the 2021-05 baseline.

1. A new association `SelfSameLifeLink` has been added to the Occurrences package.

2. A new `FeatureAccessPerformances` package has been added, with the following behaviors in it:
   - `FeatureReferencingPerformance`
   - `FeatureAccessingPerformance`
   - `FeatureReadEvaluation`
   - `FeatureWritePerformance`

3. The following new behaviors have been added to the `ControlPerformances` package:
   - `IfPerformance`
   - `IfThenPerformance`
   - `IfElsePerformance`
   - `IfThenElsePeformance`
   - `LoopPerformance`

**Note:** There has been no update to the abstract syntax to make it convenient to use these new behaviors. That will done during the implementation of [ST6RI-387](https://openmbee.atlassian.net/browse/ST6RI-387), which has been deferred to the 2021-06 release.