### PR TITLE
ST6RI-410 Name resolution can fail for PathStepExpression

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/expression/PathExpressions.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/expression/PathExpressions.kerml.xt
@@ -6,6 +6,7 @@
                 File {from ="/library/Occurrences.kerml"}
                 File {from ="/library/Objects.kerml"}
                 File {from ="/library/Performances.kerml"}
+                File {from ="/library/Transfers.kerml"}
                 File {from ="/library/ScalarValues.kerml"}
                 File {from ="/library/BaseFunctions.kerml"}
                 File {from ="/library/DataFunctions.kerml"}
@@ -20,6 +21,7 @@
                                 File {from ="/library/Occurrences.kerml"}
                  				File {from ="/library/Objects.kerml"}
                 				File {from ="/library/Performances.kerml"}
+                				File {from ="/library/Transfers.kerml"}
                                 File {from ="/library/ScalarValues.kerml"}
                                 File {from ="/library/BaseFunctions.kerml"}
                                 File {from ="/library/DataFunctions.kerml"}
@@ -39,6 +41,7 @@ package P {
     }
     
     feature v1 : V;
+    feature v2 : V;
         
     feature v1_n : Integer = v1.n;
     
@@ -51,4 +54,20 @@ package P {
     // XPECT errors ---> "Must be a valid feature" at "V"
     feature v2_m : Integer = V;
     
+    binding v1.n = v2.n;
+    
+    behavior B {
+    	out feature a : Integer;
+    	step b {
+    		step c {
+    			feature d : Integer;
+    		}
+    	}
+    }
+    
+    feature b1 : B;
+    feature b2 : B;
+    
+    // Testing deeply nested item flow connection.
+    stream b1.a to b2.b.c.d;
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
@@ -150,9 +150,9 @@ class KerMLScopeProvider extends AbstractKerMLScopeProvider {
 	def static Namespace featureRefNamespace(PathStepExpression qps) {
 		var ops = qps.operand
 		if (ops.size() >= 2) {
-			var op1 = ops.get(1)
-			if (op1 instanceof FeatureReferenceExpression) {
-				return op1.result
+			var op2 = ops.get(1)
+			if (op2 instanceof FeatureReferenceExpression) {
+				return op2.referent
 			}
 		}
 		return null;

--- a/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
+++ b/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
@@ -1,0 +1,140 @@
+package '14c-Language-Extensions' {
+	import ScalarValues::*;
+	
+	package FMEALibrary {
+		
+		abstract occurrence def Situation;
+		
+		occurrence def Cause :> Situation {
+			attribute 'occurrence'[0..1]: Real;
+		}
+		
+		occurrence def FailureMode :> Situation {
+			attribute detectibility[0..1]: Real;
+		}
+		
+		occurrence def Effect :> Situation {
+			attribute severity[0..1]: String;
+		}
+		
+		item def FMEAItem :> Situation {
+			attribute RPN: Real;
+			
+			occurrence causes[*]: Cause;
+			occurrence failureModes[*]: FailureMode;
+			occurrence effects[*]: Effect;
+		}
+				
+		requirement def FMEARequirement;
+		
+		requirement def RequirementWithSIL :> FMEARequirement {
+			attribute sil: SIL;
+		}
+		
+		enum def SIL {
+			A;
+			B;
+			C;
+		}
+		
+		connection def Causes :> Occurrences::HappensBefore {
+			end cause[*]: Situation;
+			end effect[*]: Situation;
+		}
+		
+		connection def Violates {
+			end sit[*]: Situation;
+			end req[*]: FMEARequirement;
+		}
+		
+		abstract connection def ControllingMeasure {
+			end sit[*]: Situation;
+			end req[*]: FMEARequirement;
+		}
+		
+		connection def Prevents :> ControllingMeasure;
+		connection def Mitigates :> ControllingMeasure;
+		
+	}
+	
+	package Annotations {
+
+		enum def Status {
+			Approved;
+			NotApproved;
+		}
+		
+		attribute def StatusHolder {
+			status: Status;
+		}
+		
+	}
+	
+	package UserModel {
+		import FMEALibrary::*;
+		import Annotations::*;
+		
+		requirement req1: FMEARequirement {
+			doc /* Meter designed according to ISO00124 */
+		}
+		
+		requirement req2: FMEARequirement {
+			doc /* Device working for 1 week without the need to replace batteries */
+		}
+		
+		requirement req3: RequirementWithSIL {
+			@StatusHolder { status = Approved; }
+			
+			doc /* Alarm when battery has sank */
+			
+			:>> sil = A;
+		}
+		
+		connection :Violates connect 'Glucose FMEA Item' to req2;
+		connection :Mitigates connect 'Glucose FMEA Item' to req3;
+			
+		item 'Glucose FMEA Item': FMEAItem {
+
+			connection :Prevents connect 'battery depleted' to req1;
+			
+			occurrence 'battery depleted' :> causes {
+				:>> 'occurrence' = 0.005;
+			}
+			
+			connection :Causes connect 'battery depleted' to 'battery cannot be charged';
+			
+			occurrence 'battery cannot be charged' :> failureModes {
+				:>> detectibility = 0.013;
+			}
+			
+			connection :Causes connect 'battery cannot be charged' to 'glucose level undetected';
+			
+			occurrence 'glucose level undetected' :> effects;
+			
+			connection :Causes connect 'glucose level undetected' to 'therapy delay';
+			
+			occurrence 'therapy delay' :> effects {
+				:>> severity = "High";
+			}
+
+		}
+		
+		item 'Glucose Meter in Use' :> 'Glucose FMEA Item' {
+			
+			part 'glucose meter' {
+				event 'glucose level undetected'[*];
+				part battery {
+					event 'battery depleted'[*];
+					event 'battery cannot be charged'[*];
+				}
+				part pump;
+				part reservoir;
+			}
+			
+			part patient {
+				event 'therapy delay'[*];
+			}
+		}
+		
+	}
+}


### PR DESCRIPTION
Updated `KerMLScopeProvider.featureRefNamespace` to return the `referent` of FeatureReferenceExpression as the relative namespace, rather than the `result`. The `result` should nominally subset the `referent`, giving it implicitly the same typing. But that implicit subsetting is only set when the `result` is transformed, which my not have happened yet during name resolution.