### PR TITLE
ST6RI-398 Implicit specializations may be needed even if there are explicit ones

### DIFF
--- a/kerml/src/examples/Simple Tests/Features.kerml
+++ b/kerml/src/examples/Simple Tests/Features.kerml
@@ -1,61 +1,61 @@
 package Features {
-classifier A;
-classifier B;
-
-feature f;
-feature g;
-
-feature x typed by A, B subsets f redefines g;
-
-// Equivalent declaration:
-feature x1 redefines g typed by A subsets f typed by B;
-
-classifier C;
-
-feature y;
-featuring F of y by C;
-
-feature y1 : A :> x featured by C;
-
-classifier Person;
-
-abstract feature person : Person; // Default subsets Base::things.
-feature child subsets person;
-
-classifier Fuel;
-
-classifier Tanks {
-    feature fuelInPort {
-        in feature fuelFlow : Fuel;
-    }
-    feature fuelOutPort ~ fuelInPort;
-}
-
-feature parent[2] : Person;
-feature mother : Person[1] :> parent;
-
-generalization t1 typing f typed by B;
-generalization t2 typing g : A;
-
-specialization Sub subset parent subsets person;
-specialization subset mother subsets parent;
-
-classifier LegalRecord {
-	feature guardian[0..1] = null;
-}
-
-classifier RegisteredAsset {
-	feature identifier[1];
-}
-
-classifier Vehicle :> RegisteredAsset {
-	feature vin;	
-}
-
-feature legalIdentification;
-
-specialization Redef redefinition LegalRecord::guardian redefines parent;
-specialization redefinition Vehicle::vin redefines RegisteredAsset::identifier;
-
-redefinition Vehicle::vin redefines legalIdentification; 
+	classifier A;
+	classifier B;
+	
+	feature f;
+	feature g;
+	
+	feature x typed by A, B subsets f redefines g;
+	
+	// Equivalent declaration:
+	feature x1 redefines g typed by A subsets f typed by B;
+	
+	classifier C;
+	
+	feature y;
+	featuring F of y by C;
+	
+	feature y1 : A :> x featured by C;
+	
+	classifier Person;
+	
+	abstract feature person : Person; // Default subsets Base::things.
+	feature child subsets person;
+	
+	classifier Fuel;
+	
+	classifier Tanks {
+	    feature fuelInPort {
+	        in feature fuelFlow : Fuel;
+	    }
+	    feature fuelOutPort ~ fuelInPort;
+	}
+	
+	feature parent[2] : Person;
+	feature mother : Person[1] :> parent;
+	
+	generalization t1 typing f typed by B;
+	generalization t2 typing g : A;
+	
+	specialization Sub subset parent subsets person;
+	specialization subset mother subsets parent;
+	
+	classifier LegalRecord {
+		feature guardian[0..1] = null;
+	}
+	
+	classifier RegisteredAsset {
+		feature identifier[1];
+	}
+	
+	classifier Vehicle :> RegisteredAsset {
+		feature vin;	
+	}
+	
+	feature legalIdentification;
+	
+	specialization Redef redefinition LegalRecord::guardian redefines parent;
+	specialization redefinition Vehicle::vin redefines RegisteredAsset::identifier;
+	
+	redefinition Vehicle::vin redefines legalIdentification; 
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_CircleProblem4_FT.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_CircleProblem4_FT.kerml.xt
@@ -22,14 +22,14 @@ package Test1{
 	//XPECT linkedName at A::B --> Test1.A.B
 	//* XPECT scope at A::B ---
 	   	   A.B.B, Test1.A.B.B, A.B.B.b, A.B.B.b.b, Test1.A.B.B.b, Test1.A.B.B.b.b,
-	       A.B.b, A.B.b.B.b, A.B.b.b, A.b, 
+	       A.B.b, A.B.b.B.b, A.B.b.b, A.b, Test1.A.b,
 	   	   A.B.b.B, Test1.A.B.b.B,
-		   A, A.B, Test1.A, Test1.A.B, Test1.A.B.b, Test1.A.B.b.B.b, Test1.A.B.b.b, Test1.A.b, OuterPackage.B.b,
+		   A, A.B, Test1.A, Test1.A.B, Test1.A.B.b, Test1.A.B.b.B.b, Test1.A.B.b.b, OuterPackage.B.b,
 		   OuterPackage.A, OuterPackage.A.a1, OuterPackage.B, OuterPackage.B.b.a1,
-		   	   	   A.B.B.self,  Test1.A.B.B.self,  A.B.B.b.self,  A.B.B.b.b.self,  Test1.A.B.B.b.self,  Test1.A.B.B.b.b.self, 
-	       A.B.b.self,  A.B.b.B.b.self,  A.B.b.b.self,  A.b.self,  
-	   	   A.B.b.B.self,  Test1.A.B.b.B.self, 
-		   A.self,  A.B.self,  Test1.A.self,  Test1.A.B.self,  Test1.A.B.b.self,  Test1.A.B.b.B.b.self,  Test1.A.B.b.b.self,  Test1.A.b.self,  OuterPackage.B.b.self, 
+		   A.B.B.self,  Test1.A.B.B.self,  A.B.B.b.self, Test1.A.B.B.b.self,
+	       A.B.b.self,  
+	   	   A.B.b.B.self, Test1.A.B.b.B.self, 
+		   A.self, Test1.A.self, A.B.self, Test1.A.B.self, Test1.A.B.b.self, OuterPackage.B.b.self, 
 		   OuterPackage.A.self,  OuterPackage.A.a1.self,  OuterPackage.B.self,  OuterPackage.B.b.a1.self, 
 	--- */
 	feature A : A::B {
@@ -42,11 +42,11 @@ package Test1{
 			   	A, A.B, A.B.b, A.b, B, B.b, 
 			   	Test1.A, Test1.A.B, Test1.A.B.b, Test1.A.b, b,
 			   	OuterPackage.A, OuterPackage.A.a1, OuterPackage.B,OuterPackage.B.b, OuterPackage.B.b.a1,
-							    A.B.B.self,  A.B.B.b.self,  A.B.B.b.b.self,  Test1.A.B.B.self,  Test1.A.B.B.b.self,  Test1.A.B.B.b.b.self, 
-			    b.b.self,  b.B.self,  b.B.b.self, 
-			    A.B.b.B.self,  A.B.b.B.b.self,  A.B.b.b.self,  B.b.b.self,  Test1.A.B.b.B.self,  Test1.A.B.b.B.b.self,  Test1.A.B.b.b.self,  
-			   	A.self,  A.B.self,  A.B.b.self,  A.b.self,  B.self,  B.b.self,  
-			   	Test1.A.self,  Test1.A.B.self,  Test1.A.B.b.self,  Test1.A.b.self,  b.self, 
+				A.B.B.self,  A.B.B.b.self,  Test1.A.B.B.self,  Test1.A.B.B.b.self,
+			    b.B.self, 
+			    A.B.b.B.self,  Test1.A.B.b.B.self,
+			   	A.self,  A.B.self,  A.B.b.self,  B.self,  B.b.self,  
+			   	Test1.A.self,  Test1.A.B.self,  Test1.A.B.b.self, b.self, 
 			   	OuterPackage.A.self,  OuterPackage.A.a1.self,  OuterPackage.B.self, OuterPackage.B.b.self,  OuterPackage.B.b.a1.self, self
 			--- */
 			feature b : B; //added this line to see the scope of B

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase1_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase1_Rdef.kerml.xt
@@ -22,9 +22,6 @@ package test{
 	feature A{
 		feature a2{}
 	}
-	//* XPECT errors --- 
-	"Couldn't resolve reference to Feature 'A::a1'." at "A::a1"
-	"Features must have at least one type" at "feature B redefines A::a1 {}"
-	--- */
+	// XPECT errors --> "Couldn't resolve reference to Feature 'A::a1'." at "A::a1"
 	feature B redefines A::a1 {} 
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase2_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase2_Rdef.kerml.xt
@@ -23,10 +23,7 @@ package test{
 		feature a2{}
 	}
 	feature B redefines A {
-		//* XPECT errors --- 
-		   "Couldn't resolve reference to Feature 'a1'." at "a1"
-		   "Features must have at least one type" at "feature b redefines a1{}"
-		--- */
+		// XPECT errors --> "Couldn't resolve reference to Feature 'a1'." at "a1"
 		feature b redefines a1{}
 	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesImportAsFeature_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesImportAsFeature_Rdef.kerml.xt
@@ -24,9 +24,6 @@ END_SETUP
 package test{
 	import SamePackage::container;
 	feature something1 redefines container::A{}
-	//* XPECT errors ---
-	"Couldn't resolve reference to Feature 'container::B'." at "container::B"
-	"Features must have at least one type" at "feature something2 redefines container::B{}"
-	--- */
+	// XPECT errors --> "Couldn't resolve reference to Feature 'container::B'." at "container::B"
 	feature something2 redefines container::B{}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesImport_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesImport_Rdef.kerml.xt
@@ -24,10 +24,7 @@ package test{
 	import SamePackage::container::*;
 	feature something1 redefines A{}
 	//pass junit test
-	//* XPECT errors at A ---
-	   "Couldn't resolve reference to Feature 'B'." at "B"
-	   "Features must have at least one type" at "feature something2 redefines B{}"
-	   --- */
+	// XPECT errors at A --> "Couldn't resolve reference to Feature 'B'." at "B"
 	feature something2 redefines B{}
 }
 

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClassWithAlias_FT.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClassWithAlias_FT.kerml.xt
@@ -25,7 +25,6 @@ package test{
 			A.B.B, A1.A.B.B, B.B, test.A.A.B.B, test.A1.A.B.B,
 		    A, A.B, A1, A1.A, A1.A.B, B, 
 		    test.A, test.A.A, test.A.A.B, test.A1, test.A1.A, test.A1.A.B,
-						A.B.B.self,  A1.A.B.B.self,  B.B.self,  test.A.A.B.B.self,  test.A1.A.B.B.self, 
 		    A.self,  A.B.self,  A1.self,  A1.A.self,  A1.A.B.self,  B.self,  
 		    test.A.self,  test.A.A.self,  test.A.A.B.self,  test.A1.self,  test.A1.A.self,  test.A1.A.B.self, self
 		--- */

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClass_FT.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClass_FT.kerml.xt
@@ -24,7 +24,6 @@ package test{
 			A.B.B, B.B, test.A.A.B.B,
 		    A, A.B, B, 
 		    test.A, test.A.A, test.A.A.B,
-						A.B.B.self,  B.B.self,  test.A.A.B.B.self, 
 		    A.self,  A.B.self,  B.self,  
 		    test.A.self,  test.A.A.self,  test.A.A.B.self, self
 		--- */

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClass_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_SameNamesInnerClassAndOuterClass_Rdef.kerml.xt
@@ -24,7 +24,6 @@ package test{
 			A.B.B, B.B, test.A.A.B.B,
 		    A, A.B, B, 
 		    test.A, test.A.A, test.A.A.B,
-			A.B.B.self,  B.B.self,  test.A.A.B.B.self, 
 		    A.self,  A.B.self,  B.self,  
 		    test.A.self,  test.A.A.self,  test.A.A.B.self, self
 		--- */

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/SimpleImportTests_ImportPackageAndInheritanceFromContainer_FT.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/SimpleImportTests_ImportPackageAndInheritanceFromContainer_FT.kerml.xt
@@ -25,9 +25,9 @@ package test{
 		   a.A, a.A.a, a.a,
  		   a, A, A.a,  A.a.a, test.A.a.a, test.A.a.A, test.A.a.A.a,
  		   test.A, test.A.a, 
-		      test.A.A.self,  test.A.A.a.self,  test.A.A.a.a.self, 
-		   a.A.self,  a.A.a.self,  a.a.self, 
- 		   a.self,  A.self,  A.a.self,   A.a.a.self,  test.A.a.a.self,  test.A.a.A.self,  test.A.a.A.a.self, 
+		   test.A.A.self,  test.A.A.a.self, 
+		   a.A.self,
+ 		   a.self,  A.self,  A.a.self, test.A.a.A.self,
  		   test.A.self,  test.A.a.self,  self
 		   --- */
 		feature a : A;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
@@ -39,15 +39,12 @@ package pkg {
 	occurrence def A {
 		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence areal: Real;"
 		occurrence areal: Real;
-		/* XPECT errors ---
-		 "An occurrence must be typed by occurrence definitions." at "occurrence avalue :> aValue;"
-		 "Features must have at least one type" at "occurrence avalue :> aValue;"
-		--- */
+		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence avalue :> aValue;"
 		occurrence avalue:> aValue;
-		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence twoTypes: ABlock, Real;"
-		occurrence twoTypes: ABlock, Real;
+		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence twoTypes: PartDef, Real;"
+		occurrence twoTypes: PartDef, Real;
 	}
 	attribute aValue: Real;
-	part def ABlock;
-	part aPart: ABlock;	
+	part def PartDef;
+	part aPart: PartDef;	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/PartUsage.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/PartUsage.sysml.xt
@@ -32,12 +32,21 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 END_SETUP 
 */
 // XPECT noErrors ---> ""
-package 'Blocks Example' {
-	part def Vehicle {
-		part eng : Engine;
-		ref driver : Person; 
-		part driver2; //typed by Block (named Part)
+package PartUsage {
+	part def A {
+		part b : B;
+		ref c : C; 
+		part d : D;
+		part e; //typed by library part def Part
+		part f :> i; // also typed by part def Part
 	}
-	part def Engine;	
-	part def Person;
+	part def B;	
+	part def C;
+	
+	item def I;
+	part def D :> I { // also specializes library part def Part
+		port p :> portsOnPart;
+	}
+	
+	item i : I;
 }


### PR DESCRIPTION
This PR updates the algorithm for adding a default general type so that it is added even if the type being declared already has an owned specialization of the same kind, unless the specialization is of a type that is already a subtype of the default type. See issue [ST6RI-398](https://openmbee.atlassian.net/browse/ST6RI-398) for the description of why this is necessary.

Actually, `TypeAdapter.addDefaultType` has been revised to add the default type unconditionally. But `TypeAdapter.doTransform` has also been revised to remove any unnecessary implicit general types, that is, any implicit types for which there is an owned specialization with a general type that conforms to the implicit type. This approach ensures that default types are always added as necessary for the purposes of inheritance during name resolution, but avoids cyclic name resolution errors that can occur if conformance testing of owned specializations is done within `addDefaultType`.