### PR TITLE
ST6RI-406 Dot notation for feature chains

### DIFF
--- a/org.omg.kerml.xpect.tests/library/Objects.kerml
+++ b/org.omg.kerml.xpect.tests/library/Objects.kerml
@@ -36,10 +36,7 @@ package Objects {
 	 * BinaryLinkObject is the most general binary association structure, being both a 
 	 * BinaryLink and a LinkObject.
 	 */
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
-		end feature source: Anything[0..*] nonunique subsets BinaryLink::source;
-	    end feature target: Anything[0..*] nonunique subsets BinaryLink::target;
-	}
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject;
 	
 	/**
 	 * objects is a specialization of occurrences restricted to type Object.

--- a/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
@@ -36,10 +36,7 @@ package Objects {
 	 * BinaryLinkObject is the most general binary association structure, being both a 
 	 * BinaryLink and a LinkObject.
 	 */
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
-		end feature source: Anything[0..*] nonunique subsets BinaryLink::source;
-	    end feature target: Anything[0..*] nonunique subsets BinaryLink::target;
-	}
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject;
 	
 	/**
 	 * objects is a specialization of occurrences restricted to type Object.

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -36,10 +36,7 @@ package Objects {
 	 * BinaryLinkObject is the most general binary association structure, being both a 
 	 * BinaryLink and a LinkObject.
 	 */
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
-		end feature source: Anything[0..*] nonunique subsets BinaryLink::source;
-	    end feature target: Anything[0..*] nonunique subsets BinaryLink::target;
-	}
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject;
 	
 	/**
 	 * objects is a specialization of occurrences restricted to type Object.


### PR DESCRIPTION
Formerly, dot notation of the form `f_1.f_2. ... .f_n`, for _n > 1_, mapped to a hierarchy of (left associative) PathStepExpressions, one for each dot. This notation could be used in two ways:

1. As an evaluable Expression in its own right, either directly as an owned Expression or as a sub-Expression of some other Expression. In this case, `f_1` can be any Expression for which `f_2` is a Feature accessible from the result. All the other `f_i` must be Feature names.
2. To specify an end feature of a Connector (including ItemFlows). In this case, all the `f_i` must be feature names.

This PR replaces the use of PathStepExpressions in the second case with the new FeatureChaining construct available in the 2021-06 baseline. No change is being made at this time to the use of PathStepExpressions for the first case. This case will be addressed further as part of the implementation of [ST6RI-387 Concrete syntax for assignment and control structures](https://openmbee.atlassian.net/browse/ST6RI-387). Dot notation will also now be usable in a third way:

3. As the target of a Subsetting or Redefinition relationship.

A _chained Feature_ is a Feature that represents the relational composition of a sequence of two more more other _chaining Features_. The chained Feature is related to its chaining Features using FeatureChaining relationships. FeatureChainings are always owned by the (source) chained feature.
* The operation `Feature.getOwnedFeatureChaining` returns a list of the FeatureChainings for a Feature (if any), ordered from first chaining Feature to last. 
* The operation `Feature.getChainingFeature` returns a list of the chaining Features, also ordered from first to last. 
* The `Feature.getFeaturingType` operation has been updated to include all the `featuringTypes` of the first chaining Feature.
* The `Feature.getType` operation has been updated to include all the `types` of the last chaining Feature. 
* The static utility operations `FeatureUtil.getFirstChainingFeatureOf` and `FeatureUtil.getLastChainingFeatureOf` can be used to get the first and last chaining Features of a Feature (they avoid doing the full derivation of the `getChainingFeature` list). They return `null` if the Feature has no FeatureChainings.
* Features that subset or redefine a chained Feature inherit members from the last chaining Feature.

The dot notation is implemented as follows using feature chaining:

1. Notation of the form `f_1.f_2. ... .f_n` is normally parsed to a single Feature that owns FeatureChainings that reference each of the `f_i`, in order (but see the special case for ItemFlows below).
2. A chained Feature that is the target of a Subsetting or Redefinition is parsed as an `ownedRelatedElement` of the relationship, as well as being the `subsettedFeature` or `redefinedFeature`. 
   * The end of a Connector is parsed (as usual) as the `subsettedFeature` of a redefining end Feature of the Connector, so a chained Feature used to specify the end of a Connector is owned by the relevant Subsetting relationship for that end.
   * When used to specify the source or target end of an ItemFlow (other than a message), `f_n` is taken to specify the source input or target output feature, and, so, is not included in the chained Feature for the end. If _n = 2_, then the ItemFlow end is parsed as a reference to the Feature named by `f_1`, without chaining. Otherwise, the end Feature is parsed as the chained Feature given by `f_1.f_2. ... .f_m`, for _m = n - 1_.
3. There is a KerML-specific notation **`feature`**_`memberName`_**`is`**_`f_1.f_2. ... .f_n`_`;` that can be used to give a chained Feature a name. It is parsed to a Membership (_not_ a FeatureMembership) with the given `memberName` and the chained Feature as its `ownedMemberElement`.