### PR TITLE
ST6RI-437: Render unnamed actions and states, and remove inappropriate satisfying feature links. (PlantUML)

### DIFF
--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
@@ -67,7 +67,7 @@ public class SysMLInteractiveHelp {
     	    + "   ORTHOLINE\t\tOrthogonal line style\n"
     	    + "   COMPTREE\t\tShow tree structures in compartments\n\n"
     	    + "Example:\n"
-    	    + "  %viz --view Tree --style LR --style ortholine Pkg1::PartDef Pkg1::Pkg2::partUsage\n"
+    	    + "\t%viz --view Tree --style LR --style ortholine Pkg1::PartDef Pkg1::Pkg2::partUsage\n"
     	    + "should visualize Pkg1::PartDef and Pkg1::Pkg2::partUsage with a tree view ordered in the left-to-right direction with orthogonal lines.\n";
 
     private static final String VIEW_HELP_STRING =

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
@@ -54,6 +54,7 @@ public class SysMLInteractiveHelp {
     	    + "   INTERCONNECTION\tShow an interconnection view, like an Internal Block Diagram (IBD)\n"
     	    + "   STATE\t\tShow state machines\n"
     	    + "   ACTION\t\tShow actions like an activity diagram\n"
+    	    + "   SEQUENCE\t\tShow events and messages in a sequence diagram\n"
     	    + "   MIXED\t\tShow multiple views\n\n"
     	    + "<STYLE> is also case insensitive. Multiple --style options are allowed.  The possible style names are:\n"
     	    + "   DEFAULT\t\tStandard B&W format\n"

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
@@ -65,7 +65,10 @@ public class SysMLInteractiveHelp {
     	    + "   LR\t\t\tLeft-to-Right orientation\n"
     	    + "   POLYLINE\t\tPolyline style\n"
     	    + "   ORTHOLINE\t\tOrthogonal line style\n"
-    	    + "   COMPTREE\t\tShow tree structures in compartments\n";
+    	    + "   COMPTREE\t\tShow tree structures in compartments\n\n"
+    	    + "Example:\n"
+    	    + "  %viz --view Tree --style LR --style ortholine Pkg1::PartDef Pkg1::Pkg2::partUsage\n"
+    	    + "should visualize Pkg1::PartDef and Pkg1::Pkg2::partUsage with a tree view ordered in the left-to-right direction with orthogonal lines.\n";
 
     private static final String VIEW_HELP_STRING =
     	      "Usage: %view [--render=<RENDERING>] [--style=<STYLE>...] <NAME>\n\n"

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
@@ -37,10 +37,7 @@ import org.omg.sysml.lang.sysml.Type;
 public class VActionMembers extends VBehavior {
 
     private void addNode(Feature f, String type) {
-        String name = f.getName();
-        if (name == null) {
-            name = "noname";
-        }
+        String name = getNameAnyway(f, true);
         append(type);
         append(' ');
         addNameWithId(f, name, true);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
@@ -139,10 +139,7 @@ public abstract class VBehavior extends VDefault {
         	}
         }
         if (text.length() == 0) {
-            String name = getName(au);
-            if (name == null) {
-                name = "noname";
-            }
+            String name = getNameAnyway(au, true);
             text.append(name);
         }
         addPUMLLine(au, send ? "send " : "accept ", text.toString());

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
@@ -93,7 +93,7 @@ public class VComposite extends VMixed {
 
     @Override
     public String casePortUsage(PortUsage pu) {
-        String name = extractName(pu);
+        String name = extractTitleName(pu);
         if (name == null) return "";
 
         VComposite vc = new VComposite(this);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -51,11 +51,21 @@ public class VDefault extends VTraverser {
         return f.getEffectiveName();
     }
 
-    protected static String getName(Type typ) {
-        if (typ instanceof Feature) {
-            return getFeatureName((Feature) typ);
+    protected static String getName(Element e) {
+        if (e instanceof Feature) {
+            return getFeatureName((Feature) e);
         } else {
-            return typ.getName();
+            return e.getName();
+        }
+    }
+
+    protected static String getNameAnyway(Element e, boolean creole) {
+        String ret = getName(e);
+        if (ret != null) return ret;
+        if (creole) {
+            return "<s>noname</s>";
+        } else {
+            return "noname";
         }
     }
 
@@ -127,8 +137,7 @@ public class VDefault extends VTraverser {
     }
 
     protected boolean addRecLine(Type typ, boolean withStyle) {
-    	String name = getName(typ);
-    	if (name == null) return false;
+    	String name = getNameAnyway(typ, true);
         return addRecLine(name, typ, withStyle);
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMetadata.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMetadata.java
@@ -36,7 +36,7 @@ public class VMetadata extends Visitor {
     public VMetadata(Visitor v) {
     	super(v, true);
 	}
-
+    
     private final String metadataTitle = "«metadata»";
     private void addAnnotatingFeatureInternal(AnnotatingFeature af) {
         if (checkId(af)) return;
@@ -84,7 +84,7 @@ public class VMetadata extends Visitor {
             }
         }
         if (sb.length() > 0) {
-            append("--\n");
+        	append("--\n");
             append(sb.toString());
         }
         append("end note\n");

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
@@ -70,7 +70,7 @@ public class VSequence extends VDefault {
      new StyleSwitch(new StyleRelSwitch() {
 		@Override
 		public String caseConnector(Connector c) {
-            return " -> ";
+            return " ->> ";
 		}
     },
       new StyleStereotypeSwitch() {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
@@ -31,7 +31,7 @@ import org.omg.sysml.lang.sysml.Type;
 
 public class VStateMachine extends VDefault {
     private void addState(Type typ, boolean isParallel, boolean withStyle) {
-        String name = getName(typ);
+        String name = getNameAnyway(typ, true);
         if (isParallel) {
             name = name + "\\n" + "<b>parallel</b>";
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
@@ -63,8 +63,11 @@ public class VStateMembers extends VBehavior {
                 Feature f = ss.getSubsettedFeature();
                 if (f instanceof ActionUsage) {
                     if (!(ss instanceof Redefinition)) {
-                        sb.append(f.getName());
-                        sb.append(' ');
+                        String name2 = getName(f);
+                        if (name2 != null) {
+                            sb.append(name2);
+                            sb.append(' ');
+                        }
                     }
                 }
             }
@@ -115,16 +118,14 @@ public class VStateMembers extends VBehavior {
     public String startStateUsage(Type typ) {
         traverse(typ);
         if (descriptions != null) {
-            String name = getName(typ);
-            if (name != null) {
-                int size = descriptions.size();
-                for (int i = 0; i < size; i++) {
-                    append("desc ");
-                    addNameWithId(typ, name, false);
-                    append(" : ");
-                    append(descriptions.get(i));
-                    append('\n');
-                }
+            String name = getNameAnyway(typ, true);
+            int size = descriptions.size();
+            for (int i = 0; i < size; i++) {
+                append("desc ");
+                addNameWithId(typ, name, false);
+                append(" : ");
+                append(descriptions.get(i));
+                append('\n');
             }
         }
         outputEntryExitTransitions();

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -39,6 +39,7 @@ import org.omg.sysml.lang.sysml.LifeClass;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.PortioningFeature;
 import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
 import org.omg.sysml.lang.sysml.SatisfyRequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
@@ -160,16 +161,11 @@ public abstract class VStructure extends VDefault {
     }
 
 
-    protected String extractName(Element e) {
-        if (!(e instanceof Feature)) {
-            return e.getName();
-        }
+    protected String extractTitleName(Element e) {
+        String name = getNameAnyway(e, true);
+        if (!(e instanceof Feature)) return name;
+
         Feature f = (Feature) e;
-        String name = getFeatureName(f);
-        if (name == null) {
-        	// It should not happen but need to give some name for processing
-        	name = "<s>noname</s>";
-        }
         List<FeatureTyping> tt = f.getOwnedTyping();
         if (tt.isEmpty()) return name;
         StringBuilder sb = new StringBuilder();
@@ -199,7 +195,7 @@ public abstract class VStructure extends VDefault {
     }
 
     protected boolean addType(Type typ, String keyword) {
-        String name = extractName(typ);
+        String name = extractTitleName(typ);
         if (name == null) return false;
         return addType(typ, name, keyword);
     }
@@ -233,9 +229,11 @@ public abstract class VStructure extends VDefault {
 
     @Override
     public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
-        addPRelation(sru.getSatisfiedRequirement(),
-                     sru.getSatisfyingFeature(),
-                     sru, "<<satisfy>>");
+        RequirementUsage ru = sru.getSatisfiedRequirement();
+        Feature target = sru.getSatisfyingFeature();
+        if ((ru != null) && (target != null)) {
+            addPRelation(ru, target, sru, "<<satisfy>>");
+        }
         return "";
     }
     

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -232,7 +232,7 @@ public abstract class VStructure extends VDefault {
         RequirementUsage ru = sru.getSatisfiedRequirement();
         Feature target = sru.getSatisfyingFeature();
         if ((ru != null) && (target != null)) {
-            addPRelation(ru, target, sru, "<<satisfy>>");
+            addPRelation(target, ru, sru, "<<satisfy>>");
         }
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -98,7 +98,7 @@ public class VTree extends VStructure {
 
         String name = vm.getName();
         if (name == null) {
-        	name = extractName(u);
+        	name = extractTitleName(u);
         }
         if (name == null) {
         	name = "variant";
@@ -206,7 +206,7 @@ public class VTree extends VStructure {
 
     private void addReq(String keyword, Type typ, String reqId) {
     	if (checkVisited(typ)) return;
-        String name = extractName(typ);
+        String name = extractTitleName(typ);
         if (name == null) return;
         if (reqId != null) {
             name = " [<b>" + reqId + "</b>] " + name;

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SatisfyRequirementUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SatisfyRequirementUsageImpl.java
@@ -175,17 +175,20 @@ public class SatisfyRequirementUsageImpl extends RequirementUsageImpl implements
 	 * @generated NOT
 	 */
 	public Feature basicGetSatisfyingFeature() {
-		FeatureValue featureValue = FeatureUtil.getValuationFor(this);
-		if (featureValue != null) {
-			Expression value = featureValue.getValue();
-			if (value instanceof PathStepExpression) {
-				List<Expression> operands = ((PathStepExpression)value).getOperand();
-				if (operands.size() > 1) {
-					value = operands.get(1);
+		Feature subjectParameter = this.getSubjectParameter();
+		if (subjectParameter != null) {
+			FeatureValue featureValue = FeatureUtil.getValuationFor(subjectParameter);
+			if (featureValue != null) {
+				Expression value = featureValue.getValue();
+				if (value instanceof PathStepExpression) {
+					List<Expression> operands = ((PathStepExpression)value).getOperand();
+					if (operands.size() > 1) {
+						value = operands.get(1);
+					}
 				}
-			}
-			if (value instanceof FeatureReferenceExpression) {
-				return ((FeatureReferenceExpression)value).getReferent();
+				if (value instanceof FeatureReferenceExpression) {
+					return ((FeatureReferenceExpression)value).getReferent();
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
This PR fixes the visualization problems of:

- Unnamed actions and states are not rendered;
- Wrong `<<satisfy>>` links may appear when SatisfyRequirementUsage is incomplete;
- PlantUML error in sequence view reported in ST6RI-436.

