### PR TITLE
ST6RI-453 Derived values are no longer being written when a model is saved using %publish

### DIFF
--- a/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.expressions.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.owl
 Bundle-Vendor: My Company
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xpect.tests
 Bundle-SymbolicName: org.omg.kerml.xpect.tests;singleton:=true
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext/.launch/Save KerML with Library.launch
+++ b/org.omg.kerml.xtext/.launch/Save KerML with Library.launch
@@ -13,6 +13,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.kerml.xtext.util.KerMLRepositorySaveUtil"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.kerml.xtext"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 &#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${selected_resource_loc}&quot;&#10;&quot;Kernel Library&quot;&#10;&quot;Systems Library&quot; &#10;&quot;Domain Libraries&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 -d&#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${selected_resource_loc}&quot;&#10;&quot;Kernel Library&quot;&#10;&quot;Systems Library&quot; &#10;&quot;Domain Libraries&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.kerml.xtext"/>
 </launchConfiguration>

--- a/org.omg.kerml.xtext/.launch/Save KerML.launch
+++ b/org.omg.kerml.xtext/.launch/Save KerML.launch
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="bad_container_name" value="/SySML-v2-Pilot-Implementation/org.omg.kerml.xte/.launch"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.kerml.xtext.util.KerMLRepositorySaveUtil"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 &quot;${selected_resource_loc}&quot;"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.kerml.xtext"/>
+    <stringAttribute key="bad_container_name" value="/SySML-v2-Pilot-Implementation/org.omg.kerml.xte/.launch"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.kerml.xtext.util.KerMLRepositorySaveUtil"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.kerml.xtext"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 -d &quot;${selected_resource_loc}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.kerml.xtext"/>
 </launchConfiguration>

--- a/org.omg.kerml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java
@@ -43,6 +43,7 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 	
 	private String basePath = ApiElementProcessingFacade.DEFAULT_BASE_PATH;
 	private String libraryPath = null;
+	private boolean isAddDerivedElements = false;
 	private boolean isAddImplicitElements = false;
 	private String projectName;
 	
@@ -109,7 +110,8 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 		int n = args.length;
 		if (n > 0) {
 			int i = 0;
-			while(("-b".equals(args[i]) || "-l".equals(args[i]) || "-g".equals(args[i]) || "-v".equals(args[i])) && 
+			while(("-b".equals(args[i]) || "-l".equals(args[i]) || "-d".equals(args[i]) ||
+				   "-g".equals(args[i]) || "-v".equals(args[i])) && 
 					i + 1 < n) {
 				if ("-b".equals(args[i])) {
 					this.basePath = args[++i];
@@ -118,6 +120,8 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 					if (!libraryPath.endsWith("/")) {
 						libraryPath += "/";
 					}
+				} else if ("-d".equals(args[i])) {
+					this.isAddDerivedElements = true;
 				} else if ("-g".equals(args[i])) {
 					this.isAddImplicitElements = true;
 				} else if ("-v".equals(args[i])) {
@@ -163,6 +167,7 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 		ApiElementProcessingFacade processingFacade = new ApiElementProcessingFacade(this.projectName, this.getBasePath());	
 		processingFacade.setTraversal(this.initialize(processingFacade));
 		processingFacade.setIsVerbose(this.isVerbose);
+		processingFacade.setIsIncludeDerived(this.isAddDerivedElements);
 	}
 	
 	/**
@@ -209,13 +214,14 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 	 * 
 	 * <p>Usage:
 	 * 
-	 * <p>KerMLRepositorySaveUtil [-b base-path-url] [-l library-base-path] [-g] [-v] input-path [library-path library-path...]
+	 * <p>KerMLRepositorySaveUtil [-b base-path-url] [-l library-base-path] [-d] [-g] [-v] input-path [library-path library-path...]
 	 * 
 	 * <p>where:
 	 * 
 	 * <ul>
 	 * <li>-b base-path-url       gives the URL for the base path to be used for the API endpoint (if none is given, the default is used)</li>
 	 * <li>-l library-base-path   gives the base path to used for reading model library resources</li>
+	 * <li>-d                     specifies that derived attributes should be included (the default is not to)</li>
 	 * <li>-g                     specifies that implicit elements should be generated (the default is not to)</li>
 	 * <li>-v                     specifies verbose mode (the default is non-verbose)</li>
 	 * <li>input-path             is a path for reading input resources</li>

--- a/org.omg.sysml.feature/feature.xml
+++ b/org.omg.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.feature"
       label="SysML v2 Feature"
-      version="0.15.1.qualifier"
+      version="0.15.2.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.omg.sysml.interactive.tests;singleton:=true
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Automatic-Module-Name: org.omg.sysml.interactive.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.interactive;bundle-version="0.3.2",

--- a/org.omg.sysml.interactive/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.interactive
 Bundle-SymbolicName: org.omg.sysml.interactive
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Export-Package: org.omg.sysml.interactive
 Require-Bundle: org.eclipse.emf.ecore,
  com.google.inject,

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
@@ -346,12 +346,14 @@ public class SysMLInteractive extends SysMLUtil {
 	protected ApiElementProcessingFacade getApiElementProcessingFacade(String modelName) {
 		System.out.println("API base path: " + this.apiBasePath);
 		ApiElementProcessingFacade processingFacade = new ApiElementProcessingFacade(modelName, this.apiBasePath);	
+		processingFacade.setIsIncludeDerived(true);
 		processingFacade.setTraversal(new Traversal(processingFacade));
 		return processingFacade;
 	}
 	
 	protected JsonElementProcessingFacade getJsonElementProcessingFacade() {
 		JsonElementProcessingFacade processingFacade = new JsonElementProcessingFacade();	
+		processingFacade.setIsIncludeDerived(true);
 		processingFacade.setTraversal(new Traversal(processingFacade));
 		return processingFacade;
 	}

--- a/org.omg.sysml.jupyter.jupyterlab/package.json
+++ b/org.omg.sysml.jupyter.jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@systems-modeling/jupyterlab-sysml",
-  "version": "0.15.1-SNAPSHOT",
+  "version": "0.15.2-SNAPSHOT",
   "description": "A JupyterLab extension for system modeling using SysML",
   "repository": "github:Systems-Modeling/SysML-v2-Pilot-Implementation",
   "author": "SysML v2 Submission Team",

--- a/org.omg.sysml.jupyter.kernel/gradle.properties
+++ b/org.omg.sysml.jupyter.kernel/gradle.properties
@@ -1,2 +1,2 @@
 group=org.omg.sysml
-version=0.15.0-SNAPSHOT
+version=0.15.2-SNAPSHOT

--- a/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.plantuml
 Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization for Eclipse
 Bundle-SymbolicName: org.omg.sysml.plantuml.eclipse;singleton:=true
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Import-Package: com.google.common.collect;version="10.0.1",
  com.google.inject;version="1.3.0",
  net.sourceforge.plantuml.eclipse.utils;version="1.1.25.himi1",

--- a/org.omg.sysml.plantuml.feature/feature.xml
+++ b/org.omg.sysml.plantuml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.plantuml.feature"
       label="SysML v2 PlantUML Visualization Feature"
-      version="0.15.1.qualifier"
+      version="0.15.2.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization
 Bundle-SymbolicName: org.omg.sysml.plantuml
 Automatic-Module-Name: org.omg.sysml.plantuml
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Export-Package: org.omg.sysml.plantuml
 Import-Package: com.google.common.collect,
  com.google.inject;version="1.3.0",

--- a/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xpect.tests
 Bundle-SymbolicName: org.omg.sysml.xpect.tests;singleton:=true
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.xtext,

--- a/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.sysml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ui
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext/.launch/Save SysML Test.launch
+++ b/org.omg.sysml.xtext/.launch/Save SysML Test.launch
@@ -13,6 +13,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.xtext.util.SysMLRepositorySaveTest"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml.xtext"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2.intercax.com:9000 &#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml/src/validation}&quot;&#10;&quot;Kernel Library&quot; &#10;&quot;Systems Library&quot; &#10;&quot;Domain Libraries&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 -d&#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml/src/validation}&quot;&#10;&quot;Kernel Library&quot; &#10;&quot;Systems Library&quot; &#10;&quot;Domain Libraries&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml.xtext"/>
 </launchConfiguration>

--- a/org.omg.sysml.xtext/.launch/Save SysML with Library.launch
+++ b/org.omg.sysml.xtext/.launch/Save SysML with Library.launch
@@ -13,6 +13,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.xtext.util.SysMLRepositorySaveUtil"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml.xtext"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000&#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${selected_resource_loc}&quot;&#10;&quot;Kernel Library&quot;&#10;&quot;Systems Library&quot;&#10;&quot;Domain Library&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 -d&#10;-l &quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}&quot; &#10;&quot;${selected_resource_loc}&quot;&#10;&quot;Kernel Library&quot;&#10;&quot;Systems Library&quot;&#10;&quot;Domain Library&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml.xtext"/>
 </launchConfiguration>

--- a/org.omg.sysml.xtext/.launch/Save SysML.launch
+++ b/org.omg.sysml.xtext/.launch/Save SysML.launch
@@ -13,6 +13,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.xtext.util.SysMLRepositorySaveUtil"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml.xtext"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 &quot;${selected_resource_loc}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-b http://sysml2-dev.intercax.com:9000 -d &quot;${selected_resource_loc}&quot;"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml.xtext"/>
 </launchConfiguration>

--- a/org.omg.sysml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysMLRepositorySaveUtil.java
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysMLRepositorySaveUtil.java
@@ -41,13 +41,14 @@ public class SysMLRepositorySaveUtil extends KerMLRepositorySaveUtil {
 	 * 
 	 * <p>Usage:
 	 * 
-	 * <p>SysMLRepositorySaveUtil [-b base-path-url] [-l library-base-path] [-g] input-path [library-path library-path...]
+	 * <p>SysMLRepositorySaveUtil [-b base-path-url] [-l library-base-path] [-d] [-g] [-v] input-path [library-path library-path...]
 	 * 
 	 * <p>where:
 	 * 
 	 * <ul>
 	 * <li>-b base-path-url       gives the URL for the base path to be used for the API endpoint (if none is given, the default is used)</li>
 	 * <li>-l library-base-path   gives the base path to used for reading model library resources</li>
+	 * <li>-d                     specifies that derived attributes should be included (the default is not to)</li>
 	 * <li>-g                     specifies that implicit generalizations should be generated (the default is not to)</li>
 	 * <li>input-path             is a path for reading input resources</li>
 	 * <li>library-paths          are paths for reading library resources, relative to the library-base-path (if one is given)</li>

--- a/org.omg.sysml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 0.15.1.qualifier
+Bundle-Version: 0.15.2.qualifier
 Bundle-ClassPath: .,
  lib/sysml-v2-api-client-all.jar
 Bundle-SymbolicName: org.omg.sysml;singleton:=true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <properties>
-    <revision>0.15.1-SNAPSHOT</revision>
+    <revision>0.15.2-SNAPSHOT</revision>
     <tycho-version>2.3.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-repository>https://download.eclipse.org/releases/2021-03</eclipse-repository>


### PR DESCRIPTION
For 2021-08, a flag was added to the `JSONElementProcessingFacade` to control whether derived property values are included when generating the JSON representation of a model. This was to allow more compact export of JSON for file-based interchange. However, the default for the flag is false, but the `SysMLInteractive` implementations of `%publish` and `%show` were not updated to set the flag to true when writing to the repository or otherwise generating JSON.

This PR fixes `SysMLInteractive` so that it works as before. It also updates the repository save utilities to add a `-d` flag for including derived property values, as had been previously added to the JSON file export utility (the XMI utility still exports without derived values, at it always has). The Eclipse launchers for the save utilities have been updated to add the `-d` flag, so they also operate as before.

**This is a critical fix to be included in a 2021-08.1 maintenance release.**