### PR TITLE
ST6RI-447 State action validation error message is spuriously placed

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_NestedConnectorConnectingEndsGoodCase.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_NestedConnectorConnectingEndsGoodCase.kerml.xt
@@ -1,0 +1,35 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+package test{
+	feature x;
+	feature y;
+	assoc A {
+		end end1;
+		end end2;
+		
+		feature f {
+			feature z;
+		}
+		
+		connector from end1 to f.z;
+	}
+	
+	connector c:A from x to y;
+}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/StateTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/StateTest.sysml.xt
@@ -92,4 +92,14 @@ package StateTest {
 		state s1;
 		state s2;
 	}
+
+	state s4 {
+		do action a;
+  		action c;
+	}
+	
+	state s5 :> s4 {
+  		do action b :>> c;
+	}
+	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
@@ -38,7 +38,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 	}
 END_SETUP 
 */
-package 'State Decomposition-1' {
+package StateUsage_invalid {
 	
 	part def A;
 	attribute def VT;
@@ -49,5 +49,19 @@ package 'State Decomposition-1' {
 	state s2 : VT;
 	//XPECT errors --> "A state must be typed by state definitions." at "state s3 : ac;"
 	state s3 : ac;
+	
+	state s4 {
+		entry action a1;
+		//XPECT errors --> "A state may have at most one entry action." at "entry action a2;"
+		entry action a2;
+		
+		do action b1;
+		//XPECT errors --> "A state may have at most one do action." at "do action b2;"
+  		do action b2;
+  		
+  		exit action c1;
+		//XPECT errors --> "A state may have at most one exit action." at "exit action c2;"
+  		exit action c2;
+	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -79,6 +79,16 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	
 	// Computed Redefinition
 	
+	/**
+	 *  For state and transition actions, always add implicit redefinition.
+	 */
+	@Override
+	public boolean isComputeRedefinitions() {
+		String redefinedFeature = getRedefinedFeature(getTarget());
+		return redefinedFeature != null? isComputeRedefinitions:
+				super.isComputeRedefinitions();
+	}
+	
 	@Override
 	public List<? extends Feature> getRelevantFeatures() {
 		return TypeUtil.getItemFeaturesOf(getTarget());

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -245,18 +245,22 @@ public class FeatureAdapter extends TypeAdapter {
 		return redefinedFeatures; 
 	}
 	
-	private boolean isComputeRedefinitions = true;
+	protected boolean isComputeRedefinitions = true;
 	
 	public void forceComputeRedefinitions() {
-		isComputeRedefinitions = true;
+		isComputeRedefinitions = isAddImplicitGeneralTypes;
+	}
+	
+	public boolean isComputeRedefinitions() {
+		EList<Redefinition> ownedRedefinitions = getTarget().getOwnedRedefinition();
+		return isComputeRedefinitions && ownedRedefinitions.isEmpty();
 	}
 	
 	/**
 	 * If this Feature has no Redefinitions, compute relevant Redefinitions, as appropriate.
 	 */
 	public void addComputedRedefinitions(Element skip) {
-		EList<Redefinition> ownedRedefinitions = getTarget().getOwnedRedefinition();
-		if (isComputeRedefinitions && ownedRedefinitions.isEmpty()) {
+		if (isComputeRedefinitions()) {
 			removeImplicitGeneralType(SysMLPackage.eINSTANCE.getRedefinition());
 			addRedefinitions(skip);
 			isComputeRedefinitions = false;

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -208,7 +208,7 @@ public class UsageUtil {
 	}
 	
 	public static List<StateSubactionMembership> getStateSubactionMembershipsOf(Type type, StateSubactionKind kind) {
-		return type.getFeatureMembership().stream().
+		return type.getOwnedFeatureMembership().stream().
 				filter(StateSubactionMembership.class::isInstance).
 				map(StateSubactionMembership.class::cast).
 				filter(m->m.getKind() == kind).

--- a/sysml/src/examples/Simple Tests/StateTest.sysml
+++ b/sysml/src/examples/Simple Tests/StateTest.sysml
@@ -43,4 +43,14 @@ package StateTest {
 		state s1;
 		state s2;
 	}
+	
+	state s4 {
+		do action a;
+  		action c;
+	}
+	
+	state s5 :> s4 {
+  		do action b :>> c;
+	}
+	
 }


### PR DESCRIPTION
- Added default redefinition for state entry/do/exit and transition guard/trigger/effect actions, to an otherwise inherited action of the same kind, even if the action has an owned redefinition.

- Changed state action validation to only check owned actions.

- Also blocked adding of implicit general types after unnecessary ones
removed, but removed redefinitions from unnecessary implicit general
types removal.