### PR TITLE
ST6RI-452 Special scoping for connector ends should only apply to first subsetted element

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_ConnectorEndSubsettingBadCase.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_ConnectorEndSubsettingBadCase.kerml.xt
@@ -1,0 +1,30 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+package test{
+	feature x;
+	feature y;
+	
+	connector c {
+		feature f;
+		end a :> x :> f;
+		//XPECT errors --> "Couldn't resolve reference to Feature 'f'." at "f"
+		end b :> f;
+	}
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScopeProvider.xtend
@@ -47,6 +47,7 @@ import org.omg.sysml.lang.sysml.Redefinition
 import org.omg.sysml.lang.sysml.Specialization
 import org.omg.sysml.lang.sysml.FeatureChaining
 import org.omg.sysml.util.NamespaceUtil
+import org.omg.sysml.util.FeatureUtil
 
 class KerMLScopeProvider extends AbstractKerMLScopeProvider {
 
@@ -83,7 +84,8 @@ class KerMLScopeProvider extends AbstractKerMLScopeProvider {
 		    if (!(context instanceof Redefinition)) {
 			    var owningType = subsettingFeature?.owningType
 				if (owningType instanceof Connector) {
-			    	if (owningType.connectorEnd.contains(subsettingFeature)) {
+			    	if (owningType.connectorEnd.contains(subsettingFeature) &&
+			    		FeatureUtil.getFirstOwnedSubsettingOf(subsettingFeature).orElse(null) === context) {
 			    		return owningType.scope_owningNamespace(context, reference)
 			    	}
 			    }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
@@ -62,4 +62,10 @@ package ConnectionTest {
 	part d4;
 	
 	connection bus : C connect (d1, d2, d3, d4);
+	
+	connection {
+		part q;
+		end end1 :> d1 :> q;
+		end end2 :> d2;
+	}
 }

--- a/sysml/src/examples/Simple Tests/ConnectionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConnectionTest.sysml
@@ -18,6 +18,7 @@ package ConnectionTest {
 	}
 
 	abstract connection def C {
+		part p;
 		end end1;
 		end end2;
 		end end3;
@@ -29,4 +30,10 @@ package ConnectionTest {
 	part d4;
 	
 	connection bus : C connect (d1, d2, d3, d4);
+	
+	connection {
+		part q;
+		end end1 :> d1 :> q;
+		end end2 :> d2;
+	}
 }


### PR DESCRIPTION
Updated scope provider handling of connector end subsetting to only use special scoping if context is the first owned subsetting of the connector end.