### PR TITLE
ST6RI-461 Added HappensJustBefore to the Occurrences library model.

### DIFF
--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -36,7 +36,7 @@ package Occurrences {
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
 	  	/**
-	   	 * Occurrences that end just before this occcurrence starts, with no
+	   	 * Occurrences that end just before this occurrence starts, with no
 	     * possibility of other occurrences happening in the time between them.
 	     */
 		feature immediatePredecessors: Occurrence[0..*] subsets predecessors;


### PR DESCRIPTION
Add `HappensJustBefore` to the Occurrences library in order to implement the “meets” temporal relation, as discussed in [ST4MD-355](https://openmbee.atlassian.net/browse/ST4MD-355).