### PR TITLE
ST6RI-467 Include Use Case names could not be resolved

### DIFF
--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/UseCaseTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/UseCaseTest.sysml.xt
@@ -84,7 +84,7 @@ package UseCaseTest {
 	use case u : UseSystem;
 	
 	part system : System {
-		include u;
+		include uc2;
 		perform u;
 	}
 	

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/IncludeUseCaseUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/IncludeUseCaseUsageImpl.java
@@ -7,6 +7,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.EventOccurrenceUsage;
+import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.IncludeUseCaseUsage;
 import org.omg.sysml.lang.sysml.OccurrenceUsage;
 import org.omg.sysml.lang.sysml.PerformActionUsage;
@@ -167,6 +168,11 @@ public class IncludeUseCaseUsageImpl extends UseCaseUsageImpl implements Include
 	}
 
 	// Additional overrides
+	
+	@Override
+	public Feature namingFeature() {
+		return getUseCaseIncluded();
+	}
 	
 	@Override
 	public boolean isReference() {

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -242,9 +242,9 @@ package Occurrences {
   		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
 		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
 
-  		private feature all betweenOccurrence: Occurrence[0..*];
-  		private succession earlierOccurrence[1] then betweenOccurrence[0];
-		private succession betweenOccurrence[0] then laterOccurrence[1];
+  		private feature all betweenOccurrence: Occurrence[0];
+  		private succession earlierOccurrence[1] then betweenOccurrence[0..*];
+		private succession betweenOccurrence[0..*] then laterOccurrence[1];
 	}
 
 	/**

--- a/sysml/src/examples/Simple Tests/UseCaseTest.sysml
+++ b/sysml/src/examples/Simple Tests/UseCaseTest.sysml
@@ -29,7 +29,7 @@ package UseCaseTest {
 	use case u : UseSystem;
 	
 	part system : System {
-		include u;
+		include uc2;
 		perform u;
 	}
 	


### PR DESCRIPTION
Note: The commit related to ST6RI-461 should have been pushed separately, but now that it is accidentally included in this PR, it is not worth the trouble to change it. The second commit contains the resolution to ST6RI-467.