### PR TITLE
ST6RI-468 Variation cases cause an error of "A variation must only have variant owned members."

### DIFF
--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/VariabilityTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/VariabilityTest.sysml.xt
@@ -10,6 +10,14 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
  		File {from ="/library.systems/Items.sysml"}
  		File {from ="/library.systems/Parts.sysml"}
  		File {from ="/library.systems/Ports.sysml"}
+		File {from ="/library.systems/Actions.sysml"}
+		File {from ="/library.systems/Calculations.sysml"}
+		File {from ="/library.systems/Cases.sysml"}
+		File {from ="/library.systems/UseCases.sysml"}
+		File {from ="/library.systems/AnalysisCases.sysml"}
+		File {from ="/library.systems/VerificationCases.sysml"}
+		File {from ="/library.systems/Constraints.sysml"}
+		File {from ="/library.systems/Requirements.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -23,6 +31,15 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
 				File {from ="/library.systems/Items.sysml"}
 				File {from ="/library.systems/Parts.sysml"}
  				File {from ="/library.systems/Ports.sysml"}
+				File {from ="/library.systems/Actions.sysml"}
+				File {from ="/library.systems/Calculations.sysml"}
+				File {from ="/library.systems/Cases.sysml"}
+				File {from ="/library.systems/UseCases.sysml"}
+				File {from ="/library.systems/AnalysisCases.sysml"}
+				File {from ="/library.systems/VerificationCases.sysml"}
+				File {from ="/library.systems/UseCases.sysml"}
+				File {from ="/library.systems/Constraints.sysml"}
+				File {from ="/library.systems/Requirements.sysml"}
 			}
 		}
 	}
@@ -50,4 +67,23 @@ package VariabilityTest {
 	}
 	
 	part y : P = v::q;
+	
+	variation action def A {
+		variant action a1;
+		variant action a2;
+	}
+	
+	variation case uc1 {
+    	variant use case uc11;
+    	variant use case uc12;
+    }
+
+    variation analysis a1;
+    
+    variation verification v1;
+    
+    variation requirement r {
+    	variant requirement r1;
+    }
+	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/Variability.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/Variability.sysml.xt
@@ -14,6 +14,10 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 		File {from ="/library.systems/Parts.sysml"}
 		File {from ="/library.systems/Ports.sysml"}
 		File {from ="/library.systems/Actions.sysml"}
+		File {from ="/library.systems/Calculations.sysml"}
+		File {from ="/library.systems/Cases.sysml"}
+		File {from ="/library.systems/Constraints.sysml"}
+		File {from ="/library.systems/Requirements.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -31,6 +35,10 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 				File {from ="/library.systems/Parts.sysml"}
 				File {from ="/library.systems/Ports.sysml"}
 				File {from ="/library.systems/Actions.sysml"}
+				File {from ="/library.systems/Calculations.sysml"}
+				File {from ="/library.systems/Cases.sysml"}
+				File {from ="/library.systems/Constraints.sysml"}
+				File {from ="/library.systems/Requirements.sysml"}
 			}
 		}
 	}
@@ -78,4 +86,14 @@ package VariabilityModel {
         	variant action f2;
         }       
     }
+    
+	variation case caseChoices {
+    	variant case c1;
+    	variant case c2;
+    }
+
+    variation requirement r {
+    	variant requirement r1;
+    }
+
 }

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -194,7 +194,7 @@ class SysMLValidator extends KerMLValidator {
 				error(SysMLValidator.INVALID_USAGE_VARIANT_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIANT)				
 			}
 		// A variation must not own non-variant Usages (except for parameters)
-		} else if (owningNamespace.isVariation && !(owningMembership instanceof ParameterMembership)) {
+		} else if (owningNamespace.isVariation && !(owningMembership instanceof ParameterMembership) && !(owningMembership instanceof ObjectiveMembership)) {
 				error(INVALID_USAGE_VARIATION_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIATION)							
 		}
 	}

--- a/sysml/src/examples/Simple Tests/VariabilityTest.sysml
+++ b/sysml/src/examples/Simple Tests/VariabilityTest.sysml
@@ -19,4 +19,23 @@ package VariabilityTest {
 	}
 	
 	part y : P = v::q;
+	
+	variation action def A {
+		variant action a1;
+		variant action a2;
+	}
+	
+	variation use case uc1 {
+    	variant use case uc11;
+    	variant use case uc12;
+    }
+
+    variation analysis a1;
+    
+    variation verification v1;
+    
+    variation requirement r {
+    	variant requirement r1;
+    }
+	
 }


### PR DESCRIPTION
Updated the validation check for variants to ignore objective memberships.