### PR TITLE
ST6RI-476 Feature values resolve in scope of feature namespace

### DIFF
--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/EnumerationTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/EnumerationTest.sysml.xt
@@ -46,8 +46,8 @@ package EnumerationTest {
 	}
 	
 	enum color : ColorKind;
-	attribute color1 : ColorKind = ColorKind::blue;
-	attribute color2 : ColorKind = blue;
+	enum color1 = ColorKind::blue;	// Implicitly typed by ColorKind.
+	attribute color2 : ColorKind = color1;
 	
 	enum def E1 { a; b; c; }
 	enum def E2;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -408,7 +408,11 @@ public class FeatureAdapter extends TypeAdapter {
 	protected BindingConnector addValueBinding(Expression sourceExpression) {
 		Feature target = getTarget();
 		ElementUtil.transform(sourceExpression);
-		return addBindingConnector(target.getFeaturingType(), sourceExpression.getResult(), target);
+		Feature result = sourceExpression.getResult();
+		if (target.getOwnedSpecialization().isEmpty()) {
+			addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), result);
+		}
+		return addBindingConnector(target.getFeaturingType(), result, target);
 	}
 		
 	public BindingConnector computeAssertionConnector(Feature result) {
@@ -433,9 +437,9 @@ public class FeatureAdapter extends TypeAdapter {
 	
 	@Override
 	public void doTransform() {
+		computeValueConnector();
 		forceComputeRedefinitions();
 		super.doTransform();
-		computeValueConnector();
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
@@ -62,6 +62,12 @@ public class ConnectorUtil {
 
 	// Connector ends
 	
+	public static boolean isConnectorEndSubsettingOf(Connector connector, Subsetting subsetting) {
+		Feature feature = subsetting.getSubsettingFeature();
+    	return connector.getConnectorEnd().contains(feature) &&
+	    	   FeatureUtil.getFirstOwnedSubsettingOf(feature).orElse(null) == subsetting;
+	}
+	
 	public static Feature addConnectorEndTo(Connector connector, Feature relatedFeature) {
 		Feature endFeature = SysMLFactory.eINSTANCE.createFeature();
 		Subsetting subsetting = SysMLFactory.eINSTANCE.createSubsetting();

--- a/org.omg.sysml/src/org/omg/sysml/util/NamespaceUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/NamespaceUtil.java
@@ -30,6 +30,7 @@ import org.omg.sysml.adapter.NamespaceAdapter;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
+import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
@@ -80,10 +81,12 @@ public class NamespaceUtil {
 			return null;
 		} else {
 			Namespace namespace = getParentNamespaceOf(element);
-			while (namespace instanceof InvocationExpression || 
+			while (element instanceof FeatureValue || 
+				   namespace instanceof InvocationExpression || 
 				   namespace instanceof FeatureReferenceExpression
 			) {
-				namespace = getParentNamespaceOf(namespace);
+				element = namespace.getOwningMembership();
+				namespace = getParentNamespaceOf(element);
 			}
 			return namespace;
 		}

--- a/sysml/src/examples/Metadata Examples/VerificationMetadataExample.sysml
+++ b/sysml/src/examples/Metadata Examples/VerificationMetadataExample.sysml
@@ -1,5 +1,6 @@
 package VerificationMetadataExample {
 	import VerificationCases::*;
+	import VerificationMethodKind::*;
 	
     verification def MassTest;
     verification massTests:MassTest {

--- a/sysml/src/examples/Simple Tests/EnumerationTest.sysml
+++ b/sysml/src/examples/Simple Tests/EnumerationTest.sysml
@@ -22,15 +22,8 @@ package EnumerationTest {
 	}
 	
 	enum color : ColorKind;
-	attribute color1 : ColorKind = ColorKind::blue;
-	
-	/** 
-	 * Note that "blue" can be used without qualification here because,
-	 * currently, names in the expression on the right-hand side are
-	 * resolved in the scope of the feature being declared, which inherits
-	 * the members of its type.
-	 */
-	attribute color2 : ColorKind = ColorKind::blue;
+	enum color1 = ColorKind::blue;	// Implicitly typed by ColorKind.
+	attribute color2 : ColorKind = color1;
 	
 	/**
 	 * The "enum" keyword is optional for EnumerationUsages used to define the

--- a/sysml/src/examples/Simple Tests/EnumerationTest.sysml
+++ b/sysml/src/examples/Simple Tests/EnumerationTest.sysml
@@ -30,7 +30,7 @@ package EnumerationTest {
 	 * resolved in the scope of the feature being declared, which inherits
 	 * the members of its type.
 	 */
-	attribute color2 : ColorKind = blue;
+	attribute color2 : ColorKind = ColorKind::blue;
 	
 	/**
 	 * The "enum" keyword is optional for EnumerationUsages used to define the

--- a/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified_06_20_21.sysml
+++ b/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified_06_20_21.sysml
@@ -541,7 +541,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                     // parts in bodyAssy and interioer are marked as safety or security features
                     part bodyAssy:BodyAssy{
                         part body:Body{
-                            attribute :>> color = red;  
+                            attribute :>> color = Colors::red;
                         }
                         part bumper {@Safety{isMandatory = true;}}
                         part keylessEntry {@Security;}
@@ -1122,7 +1122,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                     out massMeasured:>ISQ::mass);
                 //return :>> verdict = PassIf(vehicleSpecification::vehicleMassRequirement(vehicle_b));
                 // the following statement is not intended to be part of the model, but just confirm VerdictKind
-                return :>> verdict:VerdictKind = pass;
+                return :>> verdict:VerdictKind = VerdictKind::pass;
             }
         }
         package VerificationSystem{

--- a/sysml/src/validation/10-Analysis and Trades/10b-Trade-off Among Alternative Configurations.sysml
+++ b/sysml/src/validation/10-Analysis and Trades/10b-Trade-off Among Alternative Configurations.sysml
@@ -50,7 +50,7 @@ package '10b-Trade-off Among Alternative Configurations' {
 		}
 		
 		part vehicle : Vehicle {
-			part engine[1] :> engineChoice = '6cylEngine' {
+			part engine[1] :> engineChoice = engineChoice::'6cylEngine' {
 				assert constraint engineSelectionRational { 
 					doc /* Selected the best engine based on the 'engineTradeStudy'. */
 					engine == Analysis::engineTradeStudy.selectedAlternative

--- a/sysml/src/validation/14-Language Extensions/14a-Language Extensions.sysml
+++ b/sysml/src/validation/14-Language Extensions/14a-Language Extensions.sysml
@@ -18,14 +18,14 @@ package '14a-Language Extensions' {
 	
 	part part_X {
 		metadata Classified {
-			classificationLevel = conf;
+			classificationLevel = ClassificationLevel::conf;
 		}
 	}
 	
 	// Alternative shorthand notation
 	part part_Y {
 		@Classified {
-			classificationLevel = conf;
+			classificationLevel = ClassificationLevel::conf;
 		}
 	}
 		

--- a/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
+++ b/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
@@ -83,11 +83,11 @@ package '14c-Language-Extensions' {
 		}
 		
 		requirement req3: RequirementWithSIL {
-			@StatusHolder { status = Approved; }
+			@StatusHolder { status = Status::Approved; }
 			
 			doc /* Alarm when battery has sank */
 			
-			:>> sil = A;
+			:>> sil = SIL::A;
 		}
 		
 		connection :Violates connect 'Glucose FMEA Item' to req2;


### PR DESCRIPTION
This pull request includes the following changes:

1. Names in the value Expression of a FeatureValue resolve in the scope of the parent of the Feature with the FeatureValue, rather than in the scope of the Feature itself (resolves the bug as originally reported for ST6RI-476).
2. The initial Feature name in a FeatureChain used to specify a Connector related Feature is resolved in the scope of the parent of the Connector, rather than in the scope of the Connector itself.
3. If a Feature with a FeatureValue has no explicit owned Specializations, then an implicit Subsetting is added to the result of the value Expression of the FeatureValue.