### PR TITLE
ST6RI-483: Show feature chains in metadata

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMetadata.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMetadata.java
@@ -38,6 +38,7 @@ public class VMetadata extends Visitor {
 	}
     
     private final String metadataTitle = "«metadata»";
+
     private void addAnnotatingFeatureInternal(AnnotatingFeature af) {
         if (checkId(af)) return;
         append("note as ");
@@ -48,11 +49,16 @@ public class VMetadata extends Visitor {
         StringBuilder sb = new StringBuilder();
         for (MetadataFeature mf: af.getOwnedMetadata()) {
             int sLen = sb.length();
-            sb.append(mf.getEffectiveName());
-            MetadataFeatureValue mfv = mf.getMetadataFeatureValue();
-            if (mfv == null) continue;
-            sb.append(" = ");
-            sb.append(getText(mfv.getMetadataValue()));
+            String name = getFeatureChainName(mf);
+            if (name == null) {
+                sb.append(getText(mf));
+            } else {
+                sb.append(name);
+                MetadataFeatureValue mfv = mf.getMetadataFeatureValue();
+                if (mfv == null) continue;
+                sb.append(" = ");
+                sb.append(getText(mfv.getMetadataValue()));
+            }
             int eLen = sb.length();
             int width = eLen - sLen;
             if (width > maxWidth) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.eclipse.emf.ecore.EObject;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureChaining;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;
@@ -323,6 +324,25 @@ public abstract class Visitor extends SysMLSwitch<String> {
 
     protected static String getFeatureName(Feature f) {
         return f.getEffectiveName();
+    }
+
+    protected static String getFeatureChainName(Feature f) {
+        String name = f.getEffectiveName();
+        if (name != null) return name;
+        for (Subsetting ss: f.getOwnedSubsetting()) {
+            Feature sf = ss.getSubsettedFeature();
+            List<FeatureChaining> fcs = sf.getOwnedFeatureChaining();
+            if (fcs.isEmpty()) continue;
+            StringBuilder sb = new StringBuilder();
+            for (FeatureChaining fc : fcs) {
+                if (sb.length() > 0) {
+                    sb.append('.');
+                }
+                sb.append(fc.getChainingFeature().getEffectiveName());
+            }
+            return sb.toString();
+        }
+        return null;
     }
 
     protected static String getNameWithNamespace(Feature f) {


### PR DESCRIPTION
Feature chains in metadata had been wrongly shown with "null".  By this fix, we can show RiskMetadataExample.