### PR TITLE
Fix pattern matches in angle bracket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,8 @@
                   <fileset dir="${basedir}">
                     <include name="*/feature.xml"/>
                   </fileset>
-                  <regexp pattern="&lt;feature([^>]+)(version\s*=\s*&quot;[^&quot;]*&quot;)([^>]+)>"/>
-                  <substitution expression="&lt;feature\1version=&quot;${bundle-version}&quot;\3>"/>
+                  <regexp pattern="&lt;feature([^&gt;]+)(version\s*=\s*&quot;[^&quot;]*&quot;)([^&gt;]+)&gt;"/>
+                  <substitution expression="&lt;feature\1version=&quot;${bundle-version}&quot;\3&gt;"/>
                 </replaceregexp>
               </target>
             </configuration>


### PR DESCRIPTION
Fixes an error reported by maven:
```
This Pom pom.xml is in the Wrong Format: Line 217, column 50: Illegal character in attribute value: '>' -> 
```