### PR TITLE
ST6RI-489 OperatorExpression operands are serialized twice in XMI

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/expression/PathExpressions.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/expression/PathExpressions.kerml.xt
@@ -43,10 +43,7 @@ package P {
         
     feature v1_n : Integer = v1.n;
     
-    //* XPECT errors ---
-        "Must be a valid feature" at "S"
-        "Must be a valid feature" at "S"
-        --- */
+    // XPECT errors ---> "Must be a valid feature" at "S"
     feature v1_m : Integer = v1.S;
     
     // XPECT errors ---> "Must be a valid feature" at "V"

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/PathTests_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/PathTests_invalid.kerml.xt
@@ -51,14 +51,8 @@ package P {
     feature v1_n : Integer = v1::n;
     // XPECT warnings --> "Should be an accessible feature (use dot notation for nesting)" at "v1::m"
     feature v1_m : Real = v1::m;
-    //* XPECT warnings ---
-        "Should be an accessible feature (use dot notation for nesting)" at "v2::m"
-        "Should be an accessible feature (use dot notation for nesting)" at "v2::m"
-    	--- */
+    // XPECT warnings ---> "Should be an accessible feature (use dot notation for nesting)" at "v2::m"
     feature v2_m : Real = v1.n + v2::m;
-    //* XPECT errors ---
-        "Must be a valid feature" at "m::mm"
-        "Must be a valid feature" at "m::mm"
-    	--- */
+    // XPECT errors ---> "Must be a valid feature" at "m::mm"
 	feature v2_m_mm = v2.m::mm;
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
@@ -31,15 +31,11 @@ import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMIResource;
-import org.eclipse.emf.ecore.xmi.XMLSave;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
-import org.eclipse.emf.ecore.xmi.impl.XMLSaveImpl;
 import org.omg.kerml.xtext.KerMLStandaloneSetup;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.util.SysMLUtil;
 
 /**
@@ -79,19 +75,6 @@ public class KerML2XMI extends SysMLUtil {
 					setID(eObject, ((Element)eObject).getIdentifier());
 				}
 				super.attachedHelper(eObject);
-			}
-			
-			@Override
-			protected XMLSave createXMLSave()
-			{
-				return new XMLSaveImpl(createXMLHelper()) {
-					@Override
-					protected boolean shouldSaveFeature(EObject o, EStructuralFeature f)
-					{
-						return f != SysMLPackage.eINSTANCE.getOperatorExpression_Operand() && 
-								super.shouldSaveFeature(o, f);
-					}
-				};
 			}
 		};
 		

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
@@ -31,11 +31,15 @@ import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMIResource;
+import org.eclipse.emf.ecore.xmi.XMLSave;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMLSaveImpl;
 import org.omg.kerml.xtext.KerMLStandaloneSetup;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.util.SysMLUtil;
 
 /**
@@ -75,6 +79,19 @@ public class KerML2XMI extends SysMLUtil {
 					setID(eObject, ((Element)eObject).getIdentifier());
 				}
 				super.attachedHelper(eObject);
+			}
+			
+			@Override
+			protected XMLSave createXMLSave()
+			{
+				return new XMLSaveImpl(createXMLHelper()) {
+					@Override
+					protected boolean shouldSaveFeature(EObject o, EStructuralFeature f)
+					{
+						return f != SysMLPackage.eINSTANCE.getOperatorExpression_Operand() && 
+								super.shouldSaveFeature(o, f);
+					}
+				};
 			}
 		};
 		

--- a/org.omg.sysml.uml.ecore.importer/src/org/omg/sysml/uml/ecore/importer/CustomUML2EcoreConverter.java
+++ b/org.omg.sysml.uml.ecore.importer/src/org/omg/sysml/uml/ecore/importer/CustomUML2EcoreConverter.java
@@ -38,26 +38,32 @@ public class CustomUML2EcoreConverter extends UML2EcoreConverter {
 			Element element = entry.getKey();
 			EModelElement modelElement = entry.getValue();
 			if (element instanceof Property && modelElement instanceof EReference
-					&& !((Property)element).isDerived()
-					&& !((EReference)modelElement).isMany()
 					&& AggregationKind.COMPOSITE_LITERAL.equals(((Property) element).getAggregation())) {
-				EList<Property> subsets = ((Property)element).getSubsettedProperties();
-				EList<Property> redefines = ((Property)element).getRedefinedProperties();
-				if (subsets.stream().anyMatch(Property::isComposite) ||
-					redefines.stream().anyMatch(Property::isComposite)) {
-					EReference ref = (EReference)modelElement;
-					System.out.println(ref.getName());
-					
-					ref.setDerived(true);
-					ref.setTransient(true);
-					ref.setVolatile(true);
-					ref.setContainment(false);
-					
-					EReference opRef = ref.getEOpposite();
-					if (opRef != null) {
-						opRef.setDerived(true);
-						opRef.setTransient(true);
-						opRef.setVolatile(true);
+				Property property = (Property)element;
+				EReference ref = (EReference)modelElement;
+				EList<Property> subsets = property.getSubsettedProperties();
+				EList<Property> redefines = property.getRedefinedProperties();
+				if (property.isDerived()) {
+					if (subsets.isEmpty() && redefines.isEmpty()) {
+						ref.setContainment(true);
+						System.out.println("Make containment: " + ref.getName());
+					}
+				} else if (!ref.isMany()) {
+					if (subsets.stream().anyMatch(Property::isComposite) ||
+						redefines.stream().anyMatch(Property::isComposite)) {
+						System.out.println("Make derived: " + ref.getName());
+						
+						ref.setDerived(true);
+						ref.setTransient(true);
+						ref.setVolatile(true);
+						ref.setContainment(false);
+						
+						EReference opRef = ref.getEOpposite();
+						if (opRef != null) {
+							opRef.setDerived(true);
+							opRef.setTransient(true);
+							opRef.setVolatile(true);
+						}
 					}
 				}
 			}

--- a/org.omg.sysml/model/SysML.ecore
+++ b/org.omg.sysml/model/SysML.ecore
@@ -1663,11 +1663,10 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
         lowerBound="1" eType="ecore:EDataType types.ecore#//String"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="operand" upperBound="-1"
-        eType="#//Expression" containment="true">
+        eType="#//Expression" volatile="true" transient="true" derived="true" containment="true">
       <eAnnotations source="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName">
         <details key="body" value="operatorExpression"/>
       </eAnnotations>
-      <eAnnotations source="redefines" references="#//InvocationExpression/argument"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="PathSelectExpression" eSuperTypes="#//OperatorExpression"/>

--- a/org.omg.sysml/model/SysML.uml
+++ b/org.omg.sysml/model/SysML.uml
@@ -1546,7 +1546,7 @@ valueConnector.featuringType = featureWithValue.featuringType</body>
     <ownedAttribute xmi:id="20570f1e-fe68-4660-8050-e8f8e05ce806" name="operator" visibility="public">
       <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
     </ownedAttribute>
-    <ownedAttribute xmi:id="5e317aa3-fe01-4c0d-b580-4e798d36cb83" name="operand" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" aggregation="composite" redefinedProperty="8df13e80-6028-4c00-b26b-10d581ca6fce" association="42eb906b-afc3-4e19-9cf1-3acb2b325108">
+    <ownedAttribute xmi:id="5e317aa3-fe01-4c0d-b580-4e798d36cb83" name="operand" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" aggregation="composite" isDerived="true" association="42eb906b-afc3-4e19-9cf1-3acb2b325108">
       <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fc6509ca-3420-4606-bf23-12c8693c0ca1" name="" visibility="public"/>
       <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8b18ac6c-f136-487e-9a82-53b1263152a4" name="" visibility="public" value="*"/>
     </ownedAttribute>

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/OperatorExpression.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/OperatorExpression.java
@@ -71,12 +71,6 @@ public interface OperatorExpression extends InvocationExpression {
 	/**
 	 * Returns the value of the '<em><b>Operand</b></em>' containment reference list.
 	 * The list contents are of type {@link org.omg.sysml.lang.sysml.Expression}.
-	 * <p>
-	 * This feature redefines the following features:
-	 * </p>
-	 * <ul>
-	 *   <li>'{@link org.omg.sysml.lang.sysml.InvocationExpression#getArgument() <em>Argument</em>}'</li>
-	 * </ul>
 	 * <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Operand</em>' reference list isn't clear, there
@@ -85,9 +79,8 @@ public interface OperatorExpression extends InvocationExpression {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Operand</em>' containment reference list.
 	 * @see org.omg.sysml.lang.sysml.SysMLPackage#getOperatorExpression_Operand()
-	 * @model containment="true"
+	 * @model containment="true" transient="true" volatile="true" derived="true"
 	 *        annotation="http://schema.omg.org/spec/MOF/2.0/emof.xml#Property.oppositeRoleName body='operatorExpression'"
-	 *        annotation="redefines"
 	 * @generated
 	 */
 	EList<Expression> getOperand();

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OperatorExpressionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OperatorExpressionImpl.java
@@ -27,15 +27,18 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
-
 import org.eclipse.emf.common.notify.Notification;
 
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.DelegatingEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.EClassImpl;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EContentsEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.omg.sysml.adapter.OperatorExpressionAdapter;
 import org.omg.sysml.lang.sysml.Expression;
@@ -96,6 +99,22 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 	protected OperatorExpressionImpl() {
 		super();
 	}
+	
+	@Override
+	public EList<EObject> eContents() {
+		EClass eClass = eClass();
+		EStructuralFeature[] containmentFeatures = ((EClassImpl.FeatureSubsetSupplier)eClass.getEAllStructuralFeatures()).containments();
+		EStructuralFeature operandFeature = eClass.getEStructuralFeature(SysMLPackage.OPERATOR_EXPRESSION__OPERAND);
+		EStructuralFeature[] nonOperandFeatures = new EStructuralFeature[containmentFeatures.length - 1];
+		int i = 0;
+		for (EStructuralFeature feature: containmentFeatures) {
+			if (feature != operandFeature) {
+				nonOperandFeatures[i] = feature;
+				i++;
+			}
+		}
+		return new EContentsEList<>(this, nonOperandFeatures);
+	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -126,7 +145,7 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SysMLPackage.OPERATOR_EXPRESSION__OPERATOR, oldOperator, operator));
 	}
-
+	
 	/**
 	 * Use a special OperandEList so that operands inserted into the list are automatically actually added
 	 * as owned features.
@@ -148,6 +167,20 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 	 */
 	public boolean isSetOperand() {
 		return operand != null && !operand.isEmpty();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case SysMLPackage.OPERATOR_EXPRESSION__OPERAND:
+				return ((InternalEList<?>)getOperand()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
 
 	@Override
@@ -177,19 +210,6 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
   		return false;
 	}
 	
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-		switch (featureID) {
-			case SysMLPackage.OPERATOR_EXPRESSION__OPERAND:
-				return ((InternalEList<?>)getOperand()).basicRemove(otherEnd, msgs);
-		}
-		return super.eInverseRemove(otherEnd, featureID, msgs);
-	}
-
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OperatorExpressionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OperatorExpressionImpl.java
@@ -35,7 +35,6 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.EClassImpl;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EContentsEList;
@@ -81,16 +80,6 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 	 * @ordered
 	 */
 	protected String operator = OPERATOR_EDEFAULT;
-
-	/**
-	 * The cached value of the '{@link #getOperand() <em>Operand</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getOperand()
-	 * @generated
-	 * @ordered
-	 */
-	protected EList<Expression> operand;
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -146,6 +135,8 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 			eNotify(new ENotificationImpl(this, Notification.SET, SysMLPackage.OPERATOR_EXPRESSION__OPERATOR, oldOperator, operator));
 	}
 	
+	protected EList<Expression> operand = null;
+	
 	/**
 	 * Use a special OperandEList so that operands inserted into the list are automatically actually added
 	 * as owned features.
@@ -160,54 +151,12 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 		return operand;
 	}
 	
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public boolean isSetOperand() {
-		return operand != null && !operand.isEmpty();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-		switch (featureID) {
-			case SysMLPackage.OPERATOR_EXPRESSION__OPERAND:
-				return ((InternalEList<?>)getOperand()).basicRemove(otherEnd, msgs);
-		}
-		return super.eInverseRemove(otherEnd, featureID, msgs);
-	}
-
 	@Override
 	public Function getFunction() {
 		String operator = getOperator();
 		return operator == null? super.getFunction():
 			   (Function)SysMLLibraryUtil.getLibraryType(this, 
 					   OperatorExpressionAdapter.getOperatorQualifiedNames(getOperator()));
-	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public EList<Expression> getArgument() {
-		return getOperand();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public boolean isSetArgument() {
-  		return false;
 	}
 	
 	/**
@@ -268,12 +217,10 @@ public class OperatorExpressionImpl extends InvocationExpressionImpl implements 
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case SysMLPackage.OPERATOR_EXPRESSION__ARGUMENT:
-				return isSetArgument();
 			case SysMLPackage.OPERATOR_EXPRESSION__OPERATOR:
 				return OPERATOR_EDEFAULT == null ? operator != null : !OPERATOR_EDEFAULT.equals(operator);
 			case SysMLPackage.OPERATOR_EXPRESSION__OPERAND:
-				return isSetOperand();
+				return !getOperand().isEmpty();
 		}
 		return super.eIsSet(featureID);
 	}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SysMLPackageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SysMLPackageImpl.java
@@ -8174,7 +8174,7 @@ public class SysMLPackageImpl extends EPackageImpl implements SysMLPackage {
 
 		initEClass(operatorExpressionEClass, OperatorExpression.class, "OperatorExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getOperatorExpression_Operator(), theTypesPackage.getString(), "operator", null, 1, 1, OperatorExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getOperatorExpression_Operand(), this.getExpression(), null, "operand", null, 0, -1, OperatorExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getOperatorExpression_Operand(), this.getExpression(), null, "operand", null, 0, -1, OperatorExpression.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
 		initEClass(pathSelectExpressionEClass, PathSelectExpression.class, "PathSelectExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -9117,14 +9117,6 @@ public class SysMLPackageImpl extends EPackageImpl implements SysMLPackage {
 		   },
 		   new URI[] {
 			 URI.createURI(eNS_URI).appendFragment("//FeatureMembership/ownedMemberFeature")
-		   });
-		addAnnotation
-		  (getOperatorExpression_Operand(),
-		   source,
-		   new String[] {
-		   },
-		   new URI[] {
-			 URI.createURI(eNS_URI).appendFragment("//InvocationExpression/argument")
 		   });
 		addAnnotation
 		  (getItemFlow_ItemFlowEnd(),


### PR DESCRIPTION
This PR makes the following changes to fix the subject bug:

1. Updated `OperatorExpression::operand` in `SysML.uml` so it is derived and has no redefined properties. (A corresponding update has been made in the MagicDraw abstract syntax model so it will be included in future exports of `SysML.uml`.)
2. Revised the custom Ecore generation so that a composite property that is derived and has no subsetted or redefined properties remains a containment feature in the generated Ecore model.

As a result of above, `operand` is still a containment feature, as required by Xtext, but it is also marked as transient, so that it is not serialized in the XMI.

In addition, the `eContents()` method has been overridden in `OperatorExpressionImpl` to exclude `operand` from the contents traversal. As a result, operands are now longer included twice in the contents, avoiding redundant validation resulting in duplicated messages if there are errors.