### PR TITLE
ST6RI-416 Complete SI and USCustomaryUnits libraries - Update: Applied manual corrections (from ST6RI-414) in SI.sysml

### DIFF
--- a/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
@@ -52,7 +52,7 @@ package SI {
     attribute <E> erlang : TrafficIntensityUnit = one;
     attribute <F> farad : CapacitanceUnit = C/V;
     attribute <Gy> gray : AbsorbedDoseUnit = J/kg;
-    attribute <H> henry : PermeanceUnit = Wb/A;
+    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A;
     attribute <Hart> hartley : InformationContentUnit = one;
     attribute <Hz> hertz : FrequencyUnit = s^-1;
     attribute <J> joule : EnergyUnit = N*m;
@@ -235,7 +235,7 @@ package SI {
     attribute <'mol/kg'> 'mole per kilogram' : MolalityUnit = mol/kg;
     attribute <'mol/L'> 'mole per l' : AmountOfSubstanceConcentrationUnit = mol/L;
     attribute <'mol/m³'> 'mole per cubic metre' : EquilibriumConstantOnConcentrationBasisUnit = mol/m^3;
-    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit = N*m;
+    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m;
     attribute <'N⋅m⋅s'> 'newton metre second' : AngularImpulseUnit = N*m*s;
     attribute <'N⋅m⋅s⁻¹'> 'newton metre second to the power minus 1' : PowerUnit = N*m*s^-1;
     attribute <'N⋅m⁻¹'> 'newton metre to the power minus 1' : SurfaceTensionUnit = N*m^-1;


### PR DESCRIPTION
Applied manual corrections (from ST6RI-414) in SI.sysml for Henry and newton metre

When waking up I realized I had overlooked the manual correction from bug fix [ST6RI-414](https://openmbee.atlassian.net/browse/ST6RI-414). This problem will be fully resolved via issue [ST6RI-415](https://openmbee.atlassian.net/browse/ST6RI-415).


