### PR TITLE
ST6RI-496 Library model for clocks and triggers

### DIFF
--- a/org.omg.kerml.xpect.tests/library/BaseFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/BaseFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines a basic set of functions defined on all kinds of values. 
+ * Most correspond to similarly named operators in the KerML expression syntax.
+ */
 package BaseFunctions {
 	private import Base::Anything;
 	private import Objects::Object;

--- a/org.omg.kerml.xpect.tests/library/BooleanFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/BooleanFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Boolean values, including those corresponding to 
+ * (non-conditional) logical operators in the KerML expression notation.
+ */
 package BooleanFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/Clocks.kerml
+++ b/org.omg.kerml.xpect.tests/library/Clocks.kerml
@@ -1,0 +1,106 @@
+/*
+ * This package models Clocks that provide an advancing numerical reference 
+ * usable for quantifying the time of an Occurrence.
+ */
+package Clocks {
+	private import ScalarValues::ScalarValue;
+	private import ScalarValues::Real;
+	private import Occurrences::Occurrence;
+	private import ControlFunctions::forAll;
+	private import ISQ::DurationValue;
+	
+	/**
+	 * defaultClock is a single Clock that can be used as a default.
+	 */
+	readonly feature defaultClock : Clock[1];
+	
+	/**
+	 * A Clock provides a scalar currentTime that advances montonically
+	 * over its lifetime. Clock is an abstract base Structure that can be
+	 * specialized for different kinds of time quantification (e.g., discrete
+	 * time, continuous time, time with units, etc.).
+	 */
+	abstract struct Clock {
+		private thisClock : Clock :>> self;
+		/**
+		 * A numerical time reference that advances over the lifetime of the Clock. 
+		 */
+		readonly feature currentTime : ScalarValue[1];
+						
+		/**
+		 * The currentTime of a snapshot of a Clock is equal to
+		 * the TimeOf the snapshot relative to that Clock.
+		 */
+		inv timeFlowConstraint {
+			snapshots->forAll{in s : Clock; 
+				TimeOf(s, thisClock) == s.currentTime
+			}
+		}		
+	}
+	
+	/**
+	 * TimeOf returns a scalar timeValue for a given Occurrence relative to
+	 * a given Clock. The timeValue is the time of the start of the Occurrence,
+	 * which is considered to be synchronized with the snapshot of the Clock 
+	 * with a currentTime equal to the returned timeValue.
+	 */
+	abstract function TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : ScalarValue[1] {
+		/**
+		 * The TimeOf an Occurrence is equal to the time of its start snapshot.
+		 */
+		 inv startTimeConstraint { 
+		 	timeValue == TimeOf(o.startShot, clock)
+		 }	 
+
+		/**
+		 * If one Occurrence happens before another, then the TimeOf the end
+		 * snapshot of the first Occurrence is no greater than the TimeOf the 
+		 * second Occurrence.
+		 */
+		inv timeOrderingConstraint {
+			o.predecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) <= timeValue
+			}
+		}
+				
+		/**
+		 * If one Occurrence happens immediately before another, then the TimeOf 
+		 * the end snapshot of the first Occurrence equals the TimeOf the second
+		 * Occurrence.
+		 */
+		inv timeContinuityConstraint {
+			o.immediatePredecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) == timeValue
+			}
+		}				
+	}
+	
+	/**
+	 * DurationOf returns the duration of a given Occurrence relative to a
+	 * given Clock, which is equal to the TimeOf the end snapshot of the
+	 * Occurrence minus the TimeOf its start snapshot.
+	 */
+	function DurationOf(o : Occurrence[1], clock : Clock[1]) duration : ScalarValue {
+		TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock)
+	}
+	
+	/**
+	 * A BasicClock is a Clock whose currentTime is a Real number.
+	 */
+	struct BasicClock :> Clock {
+		readonly feature :>> currentTime : Real;
+	}
+	
+	/**
+	 * BasicTimeOf returns the TimeOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicTimeOf :> TimeOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];	
+	
+	/**
+	 * BasicDurationOf returns the DurationOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicDurationOf :> DurationOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];
+
+}

--- a/org.omg.kerml.xpect.tests/library/CollectionFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/CollectionFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Collections (as defined in the Collections package). 
+ * For functions on general sequences of values, see the SequenceFunctions package.
+ */
 package CollectionFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;

--- a/org.omg.kerml.xpect.tests/library/Collections.kerml
+++ b/org.omg.kerml.xpect.tests/library/Collections.kerml
@@ -1,3 +1,8 @@
+/**
+ * This package defines a standard set of Collection data types. Unlike sequences of values 
+ * defined directly using multiplicity, these data types allow for the possibility of collections 
+ * as elements of collections.
+ */
 package Collections {
 	private import Base::*;
 	private import ScalarValues::*;

--- a/org.omg.kerml.xpect.tests/library/ComplexFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ComplexFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Complex values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package ComplexFunctions {
 	import ScalarValues::*;
 		

--- a/org.omg.kerml.xpect.tests/library/ControlFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions that correspond to operators in the KerML expression notation 
+ * for which one or more operands are expressions whose evaluation is determined by another operand.
+ */
 package ControlFunctions {
 	private import Base::Anything;
 	private import ScalarValues::ScalarValue;

--- a/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Behaviors to be used to type Steps that control the sequencing of performance
+ * of other Steps. 
+ */
 package ControlPerformances {
 	private import ScalarValues::Boolean;
 	private import SequenceFunctions::size;
@@ -28,7 +32,7 @@ package ControlPerformances {
 	 * target the MergePerforance behavior. All such Successions must subset the incomingHBLink
 	 * feature of the target MergePerformance. For each instance of MergePerformance, the
 	 * incomingHBLink is an instance of exactly one of the Successions, ordering the
-	 * MergePerformance as happening after an instance of the source of that Succcession.
+	 * MergePerformance as happening after an instance of the source of that Succession.
 	 */
 	behavior MergePerformance specializes Performance {
 		/**
@@ -58,7 +62,7 @@ package ControlPerformances {
 	}
 	
 	/**
-	 * An IfElsePerformance is an IfPerformance where the elseCaluse occurs after and only 
+	 * An IfElsePerformance is an IfPerformance where the elseClause occurs after and only 
 	 * after the ifTest evaluation result is not true.
 	 */
 	behavior IfElsePerformance specializes IfPerformance {

--- a/org.omg.kerml.xpect.tests/library/DataFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/DataFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines the abstract base functions corresponding to all the unary and binary operators 
+ * in the KerML expression notation that might be defined on various kinds of DataValues.
+ */
 package DataFunctions {
 	private import Base::DataValue;
 	private import ScalarValues::Boolean;

--- a/org.omg.kerml.xpect.tests/library/IntegerFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/IntegerFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Integer values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package IntegerFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/KerML.kerml
+++ b/org.omg.kerml.xpect.tests/library/KerML.kerml
@@ -1,3 +1,9 @@
+/**
+ * This package contains a reflective KerML model of the KerML abstract syntax.
+ * 
+ * NOTE: This model is currently incomplete. It includes all KerML abstract syntax metaclasses,
+ * but none of their properties.
+ */
 package KerML {
 	
 	struct Element;

--- a/org.omg.kerml.xpect.tests/library/NaturalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/NaturalFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Natural values, including concrete specialization of the 
+ * general arithmetic and comparison operations.
+ */
 package NaturalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/NumericalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/NumericalFunctions.kerml
@@ -1,3 +1,6 @@
+/**
+ * This package defines abstract functions on Numerical values for general arithmetic and comparison operations.
+ */
 package NumericalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/Objects.kerml
+++ b/org.omg.kerml.xpect.tests/library/Objects.kerml
@@ -1,5 +1,5 @@
 /**
- * This package defines classifiers and features that are related to the typing of objects and links.
+ * This package defines classifiers and features that are related to the typing of objects, including link objects.
  */
 package Objects {
 	private import Base::Anything;

--- a/org.omg.kerml.xpect.tests/library/Observation.kerml
+++ b/org.omg.kerml.xpect.tests/library/Observation.kerml
@@ -1,0 +1,125 @@
+
+/*
+ * This package models a framework for monitoring Boolean conditions and notifying
+ * registered observers when they change from false to true.
+ */
+package Observation {
+	private import ScalarValues::Boolean;
+	private import Occurrences::Occurrence;
+	private import SequenceFunctions::including;
+	private import SequenceFunctions::excluding;
+	private import ControlFunctions::select;
+	private import ControlPerformances::DecisionPerformance;
+	private import ControlPerformances::IfThenPerformance;
+	private import FeatureReferencingPerformances::FeatureWritePerformance;
+	private import FeatureReferencingPerformances::BooleanEvaluationResultToMonitorPerformance;
+	private import Transfers::TransferBefore;
+
+	/**
+	 * defaultMonitor is a single ChangeMonitor that can be used as a default.
+	 */
+	readonly feature defaultMonitor[1] : ChangeMonitor;
+
+	/**
+	 * A ChangeSignal is a signal to be sent when the Boolean result of its
+	 * changeCondition Expression changes from false to true.
+	 */
+	struct ChangeSignal {
+		/**
+		 * A BooleanExpression whose result is being monitored.
+		 */
+		bool signalCondition;
+		
+		/**
+		 * The ChangeMonitor responsible for monitoring the signalCondition.
+		 */
+		feature signalMonitor : ChangeMonitor;
+	}
+	
+	/**
+	 * Each Performance of ObserveChange waits for the result of the Boolean 
+	 * condition of a given ChangeSignal to change from false to true, and, when 
+	 * it does, sends the ChangeSignal to a given observer Occurrence.
+	 */
+	private behavior ObserveChange {
+		in feature changeObserver : Occurrence[1];
+		in feature changeSignal : ChangeSignal[1];
+		
+		/**
+		 * If the result of the changeSignal.signalCondition is false, then wait for 
+		 * it to become true.
+		 */
+		composite step wait : IfThenPerformance {
+			in bool redefines ifTest {
+				not changeSignal.signalCondition()
+			}
+			in step redefines thenClause : BooleanEvaluationResultToMonitorPerformance {
+				in bool onOccurrence = changeSignal.signalCondition;
+			}
+		}		
+		
+		succession wait then transfer;
+		
+		/**
+		 * Then send changeSignal to changeObserver.
+		 */
+	    step transfer : TransferBefore[1] 
+	    	redefines outgoingTransfersFromSelf 
+	    	subsets changeObserver.incomingTransfers {
+	    	feature redefines source {
+	    		feature redefines sourceOutput = changeSignal;
+	    	}
+	    }
+	}
+	
+	/**
+	 * A ChangeMonitor is a collection of ongoing ChangeSignal observations 
+	 * for various observer Occurrences. It provides convenient operations for 
+	 * starting and canceling the observations it manages.
+	 */
+	struct ChangeMonitor {
+		private thisMonitor : ChangeMonitor redefines self;
+		private composite feature observations[0..*] : ObserveChange;
+		
+		/**
+		 * Assign a replacement set of observations as those being managed by a
+		 * given ChangeMonitor.
+		 */
+		private behavior AssignObservations specializes FeatureWritePerformance {
+			in feature monitor : ChangeMonitor redefines onOccurrence {
+				feature redefines startingAt {
+					feature redefines accessedFeature, observations;
+				}
+			}
+			inout feature redefines replacementValues[0..*] : ObserveChange;
+		}
+		
+		/**
+		 * Start an observation of a given ChangeSignal for a given Occurrence.
+		 */
+		step startObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private composite step observation : ObserveChange {
+				in changeObserver = observer;
+				in changeSignal = signal;
+			}
+			private composite step addObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->including(observation);	
+			}
+		}
+		
+		/**
+		 * Cancel all observations of a given ChangeSignal for a given Occurrence. 
+		 */
+		step cancelObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private feature observations[0..*] : ObserveChange = 
+				observations->select{in observation : ObserveChange; 
+					observation.changeObserver == observer and observation.changeSignal == signal
+				};
+			private composite step removeObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->excluding(observations);
+			}
+		}
+	}	
+}

--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -35,6 +35,18 @@ package Occurrences {
 		 */
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
+	  	/**
+	   	 * Occurrences that end just before this occurrence starts, with no
+	     * possibility of other occurrences happening in the time between them.
+	     */
+		feature immediatePredecessors: Occurrence[0..*] subsets predecessors;
+
+  		/**
+   		 * Occurrences that start just after this occurrence ends, with no
+   		 * possibility of other occurrences happening in the time between them.
+   		 */
+		feature immediateSuccessors: Occurrence[0..*] subsets successors;
+
 		/**
 		 * Occurrences that start no earlier than and end no later than
 		 * this occurrence, including at least this occurrence.
@@ -160,13 +172,13 @@ package Occurrences {
 		end feature myselfSameLife: Anything[1..*] redefines source;
 		end feature selfSameLife: Anything[1..*] redefines target;
 
-	 	feature all sourceOccurrence : Occurrence [1..*] subsets myselfSameLife;
-	 	feature all targetOccurrence : Occurrence [1..*] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
-		binding sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
+	 	feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
+	 	feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
+		binding oSelf of sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
 
 		feature all sourceDataValue : DataValue [0..1] subsets myselfSameLife;
 		feature all targetDataValue : DataValue [0..1] subsets selfSameLife;
-		binding sourceDataValue = targetDataValue;
+		binding dSelf of sourceDataValue = targetDataValue;
 	}
 	
 	subclassifier SelfLink specializes SelfSameLifeLink; 
@@ -187,12 +199,24 @@ package Occurrences {
 	 * HappensDuring asserts that the shorterOccurrence happens during the longerOccurrence.
 	 * That is, the time interval of the shorterOccurrence is completely within that of the
 	 * longerOccurrence, or every snapshot of the shorterOccurrence happens while (at the
-	 * same time as) some snapshot of the longerOccurrence. Note that this means every
-	 *  occurrence happens during itself.
+	 * same time as) some snapshot of the longerOccurrence. Note that this means every 
+	 * occurrence happens during itself.
 	 */
 	assoc HappensDuring specializes HappensLink {
 		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.suboccurrences;
 		end feature longerOccurrence: Occurrence[1..*] redefines targetOccurrence;
+		
+		/*
+		 * HappensDuring and HappensBefore constrain each other. All predecessors of 
+		 * (occurrences happening before) a HappenDuring's longerOccurrence are also 
+		 * predecessors of its shorterOccurrence. Inversely, all successors (occurrences 
+		 * happening after) its longerOccurrence are also successors of its shorterOccurrence.
+		 */
+		
+		subset longerOccurrence.predecessors subsets shorterOccurrence.predecessors;
+		subset longerOccurrence.successors subsets shorterOccurrence.successors;
+		
+		subset shorterOccurrence.suboccurrences subsets longerOccurrence.suboccurrences;
 	}
 	
 	/**
@@ -218,9 +242,23 @@ package Occurrences {
 		end feature earlierOccurrence: Occurrence[0..*] redefines BinaryLink::source subsets laterOccurrence.predecessors;
 		end feature laterOccurrence: Occurrence[0..*] redefines BinaryLink::target subsets earlierOccurrence.successors;
 		
+		subset laterOccurrence.successors subsets earlierOccurrence.successors;
+		
 		inv { earlierOccurrence != laterOccurrence }
 	}
 	
+	/**
+	 * HappensJustBefore is HappensBefore asserting that the earlierOccurrence happens just 
+	 * before the laterOccurrence, with with no possibility of other occurrences happening in the 
+	 * time between them.
+	 */
+	assoc HappensJustBefore specializes HappensBefore {
+  		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
+		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
+
+  		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	}
+
 	/**
 	 * PortionOf asserts one occurrence is a portion of another, including at least itself. 
 	 */
@@ -253,4 +291,5 @@ package Occurrences {
 	 	end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
 	 	end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
 	 }
+	 
 }

--- a/org.omg.kerml.xpect.tests/library/RationalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/RationalFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Functions on Rational values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package RationalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/RealFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/RealFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Functions on Real values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package RealFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.kerml.xpect.tests/library/ScalarFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ScalarFunctions.kerml
@@ -1,3 +1,6 @@
+/**
+ * This package defines abstract functions that specialize the DataFunctions for use with ScalarValues. 
+ */
 package ScalarFunctions {
 	import ScalarValues::*;
 	private import ControlFunctions::reduce;

--- a/org.omg.kerml.xpect.tests/library/ScalarValues.kerml
+++ b/org.omg.kerml.xpect.tests/library/ScalarValues.kerml
@@ -1,3 +1,8 @@
+/**
+ * This package contains a basic set of primitive scalar (non-collection) data types. 
+ * These include Boolean and String types and a hierarchy of concrete Number types, from 
+ * the most general type of Complex numbers to the most specific type of Positive integers.</p>
+ */
 package ScalarValues {
 	private import Base::DataValue;
 	

--- a/org.omg.kerml.xpect.tests/library/SequenceFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/SequenceFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions that operate on general sequences of values. (For functions that
+ * operate on Collection values, see CollectionFunctions.)
+ */
 package SequenceFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;
@@ -17,19 +21,13 @@ package SequenceFunctions {
 	function notEmpty(seq: Anything[0..*] nonunique): Boolean[1] {
 		!isEmpty(seq)
 	}
-	function includes(seq: Anything[0..*] nonunique, value: Anything[1]): Boolean[1] {
-		seq->exists {in x; x == value}
-	}
-	function includesAll(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
+	function includes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq2->forAll {in x; seq1->includes(x)}
 	}
 	function includesOnly(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
-		seq1->includesAll(seq2) && seq2->includesAll(seq1)
+		seq1->includes(seq2) && seq2->includes(seq1)
 	}
-	function excludes(seq: Anything[0..*] nonunique, value: Anything[1]): Boolean[1] {
-		!seq->includes(value)
-	}
-	function excludesAll(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
+	function excludes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq2->forAll {in x; seq1->excludes(x)}
 	}
 	
@@ -39,11 +37,11 @@ package SequenceFunctions {
 	function intersection(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
 		seq1->select {in x; seq2->includes(x)}
 	}
-	function including(seq: Anything[0..*] ordered nonunique, value : Anything[1]): Anything[0..*] ordered nonunique {
-		(seq, value)
+	function including(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
+		union(seq1, seq2)
 	}
-	function excluding(seq: Anything[0..*] ordered nonunique, value : Anything[1]): Anything[0..*] ordered nonunique {
-		seq->reject {in x; x == value}
+	function excluding(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
+		seq1->reject {in x; seq2->includes(x)}
 	}
 	
 	function subsequence(seq: Anything[0..*] ordered nonunique, startIndex: Positive[1], endIndex: Positive[1]): Anything[0..*] {

--- a/org.omg.kerml.xpect.tests/library/StatePerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/StatePerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package contains a library model of the semantics of state-based behavior,
+ * including the performance of (behavioral) states and the transitions between them.
+ */
 package StatePerformances {
 	private import ScalarValues::Boolean;
 	private import TransitionPerformances::TransitionPerformance;

--- a/org.omg.kerml.xpect.tests/library/StringFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/StringFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on String values, including those corresponding to string concatenation 
+ * and comparison operators in the KerML expression notation.
+ */
 package StringFunctions {
 	import ScalarValues::*;
 	
@@ -13,5 +17,7 @@ package StringFunctions {
 
 	function '==' specializes DataFunctions::'==' (x: String[0..1], y: String[0..1]): Boolean[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: String[1]): String[1];	
+	function ToString specializes BaseFunctions::ToString (x: String[1]): String[1] {
+		x
+	}
 }

--- a/org.omg.kerml.xpect.tests/library/TransitionPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/TransitionPerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package contains a library model of the semantics of conditional transitions between occurrences, 
+ * including the performance of specified Behaviors when the transition occurs.
+ */
 package TransitionPerformances {
 	private import ScalarValues::Boolean;
 	private import Occurrences::HappensBefore;

--- a/org.omg.kerml.xpect.tests/library/Triggers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Triggers.kerml
@@ -1,0 +1,138 @@
+/**
+ * This package contains functions that return ChangeSignals for triggering
+ * when a Boolean condition changes from false to true, at a specific time
+ * or after a specific time delay.
+ */
+package Triggers {
+	private import ScalarValues::Boolean;
+	private import ScalarValues::NumericalValue;
+	private import Occurrences::Occurrence;
+	
+	import Clocks::*;
+	import Observation::*;
+	
+	/**
+	 * A TimeSignal is a ChangeSignal whose condition is the currentTime
+	 * of a given Clock reaching a specific signalTime.
+	 */
+	struct TimeSignal :> ChangeSignal {
+		/**
+		 * The time at which the TimeSignal should be sent.
+		 */
+		feature signalTime : NumericalValue[1];
+		
+		/**
+		 * The Clock whose currentTime is being monitored.
+		 */
+		feature signalClock : Clock[1];
+		
+		/**
+		 * The Boolean condition of the currentTime of the signalClock being
+		 * equal to the signalTime.
+		 */
+		private bool :>> signalCondition {
+			signalClock.currentTime == signalTime
+		}
+	}
+	
+	/**
+	 * TriggerWhen returns a monitored ChangeSignal for a given condition,
+	 * to be sent to a given receiver when the condition occurs.
+	 */
+	function TriggerWhen {
+		/**
+		 * The BooleanExpression to be monitored for changing from 
+		 * false to true.
+		 */
+		in bool condition[1];
+		
+		/**
+		 * The Occurrence to which the ChangeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence [1];
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the ChangeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The ChangeSignal for the condition, as monitored by the monitor.
+		 */
+		out feature signal : ChangeSignal[1] = ChangeSignal(condition, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);			
+	}
+	
+	/**
+	 * TriggerAt returns a monitored TimeSignal to be sent to a receiver when
+	 * the currentTime of a given Clock reaches a specific time. 
+	 */
+	function TriggerAt {
+		/**
+		 * The time instant, relative to the clock, at which the TimeSignal should be sent. 
+		 */
+		in feature time : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time. The default is
+		 * the Clocks::defaultClock. 
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */		
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the given time, as monitored by the monitor.
+		 */
+		out feature signal : TimeSignal[1] = TimeSignal(time, clock, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);
+	}
+	
+	/**
+	 * TriggerAfter returns a monitored TimeSignal to be sent to a receiver after
+	 * a certain time delay relative to a given Clock.
+	 */
+	function TriggerAfter {
+		/**
+		 * The time duration, relative to the clock, after which the TimeSignal is sent.
+		 */
+		in feature delay : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time delay. The default is
+		 * the Clocks::defaultClock.
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the currentTime of the clock when the function is invoked
+		 * plus the given time delay, as monitored by the monitor.
+		 */
+		out signal : TimeSignal[1] = 
+			TriggerAt(clock.currentTime + delay, receiver, clock, monitor);
+	}	
+	
+}

--- a/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/SI.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/SI.sysml
@@ -52,7 +52,7 @@ package SI {
     attribute <E> erlang : TrafficIntensityUnit = one;
     attribute <F> farad : CapacitanceUnit = C/V;
     attribute <Gy> gray : AbsorbedDoseUnit = J/kg;
-    attribute <H> henry : PermeanceUnit = Wb/A;
+    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A;
     attribute <Hart> hartley : InformationContentUnit = one;
     attribute <Hz> hertz : FrequencyUnit = s^-1;
     attribute <J> joule : EnergyUnit = N*m;
@@ -235,7 +235,7 @@ package SI {
     attribute <'mol/kg'> 'mole per kilogram' : MolalityUnit = mol/kg;
     attribute <'mol/L'> 'mole per l' : AmountOfSubstanceConcentrationUnit = mol/L;
     attribute <'mol/m³'> 'mole per cubic metre' : EquilibriumConstantOnConcentrationBasisUnit = mol/m^3;
-    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit = N*m;
+    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m;
     attribute <'N⋅m⋅s'> 'newton metre second' : AngularImpulseUnit = N*m*s;
     attribute <'N⋅m⋅s⁻¹'> 'newton metre second to the power minus 1' : PowerUnit = N*m*s^-1;
     attribute <'N⋅m⁻¹'> 'newton metre to the power minus 1' : SurfaceTensionUnit = N*m^-1;

--- a/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/Time.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/Time.sysml
@@ -1,22 +1,48 @@
 /**
- * Specifications for time instant and various time scales
+ * This package specifies concepts to support time-related quantities and metrology, beyond 
+ * the quantities duration and time as defined in [ISO 80000-3]. Representations of the 
+ * Gregorian calendar date and time of day as specified by the [ISO 8601-1] standard are used.
  */
-
 package Time {
-	import ScalarValues::Real;
-	import ScalarValues::Integer;
-	import ScalarValues::Natural;
-	import ScalarValues::String;
-	import Quantities::ScalarQuantityValue;
-	import Quantities::scalarQuantities;
-    import UnitsAndScales::*;
+	private import Occurrences::Occurrence;
+	private import ScalarValues::Real;
+	private import ScalarValues::Integer;
+	private import ScalarValues::Natural;
+	private import ScalarValues::String;
+	private import Quantities::ScalarQuantityValue;
+	private import Quantities::scalarQuantities;
+    private import UnitsAndScales::*;
     import ISQBase::DurationValue;
     import ISQBase::DurationUnit;
     import ISQBase::duration;
     import ISQSpaceTime::TimeValue;
     import ISQSpaceTime::TimeUnit;
     import ISQSpaceTime::time;
+    
+    /**
+     * defaultClock is a single Clock that can be used as a default.
+     */
+    readonly part defaultClock : Clock[1];
 
+	/**
+	 * A Clock provides a currentTime as a TimeInstantValue that advances montonically over its lifetime.
+	 */
+	part def Clock :> Clocks::Clock {
+		attribute :>> currentTime : TimeInstantValue;
+	}
+	
+	/**
+	 * TimeOf returns a TimeInstantValue for a given Occurrence relative to a given Clock. This TimeInstantValue is the 
+	 * time of the start of the Occurrence, which is considered to be synchronized with the snapshot of the Clock with a 
+	 * currentTime equal to the returned imeValue
+	 */
+	calc def TimeOf :> Clocks::TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : TimeInstantValue[1];
+
+	/**
+	 * DurationOf returns the duration of a given Occurrence relative to a given Clock, which is equal to the TimeOf 
+	 * the end snapshot of the Occurrence minus the TimeOf its start snapshot.
+	 */
+	calc def DurationOf :> Clocks::DurationOf(o : Occurrence[1], clock : Clock[1]) duration : DurationValue;
 
 	/**
 	 * Generic time scale to express a time instant, including a textual definition of the meaning of zero time instant value
@@ -81,7 +107,7 @@ package Time {
 	 * Representation of a time instant expressed on the Coordinated Universal Time (UTC) time scale
 	 */
 	attribute def UtcTimeInstantValue :> DateTime { :>> mRef = UTC; }
-	attribute utcTimeInstant: UtcTimeInstantValue;
+	attribute utcTimeInstant: UtcTimeInstantValue :> timeInstant;
 
 	/**
 	 * Representations of a Gregorian calendar date and time of day as specified by the ISO 8601-1 standard.

--- a/org.omg.sysml.xpect.tests/library.kernel/BaseFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/BaseFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines a basic set of functions defined on all kinds of values. 
+ * Most correspond to similarly named operators in the KerML expression syntax.
+ */
 package BaseFunctions {
 	private import Base::Anything;
 	private import Objects::Object;

--- a/org.omg.sysml.xpect.tests/library.kernel/BooleanFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/BooleanFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Boolean values, including those corresponding to 
+ * (non-conditional) logical operators in the KerML expression notation.
+ */
 package BooleanFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/Clocks.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Clocks.kerml
@@ -1,0 +1,106 @@
+/*
+ * This package models Clocks that provide an advancing numerical reference 
+ * usable for quantifying the time of an Occurrence.
+ */
+package Clocks {
+	private import ScalarValues::ScalarValue;
+	private import ScalarValues::Real;
+	private import Occurrences::Occurrence;
+	private import ControlFunctions::forAll;
+	private import ISQ::DurationValue;
+	
+	/**
+	 * defaultClock is a single Clock that can be used as a default.
+	 */
+	readonly feature defaultClock : Clock[1];
+	
+	/**
+	 * A Clock provides a scalar currentTime that advances montonically
+	 * over its lifetime. Clock is an abstract base Structure that can be
+	 * specialized for different kinds of time quantification (e.g., discrete
+	 * time, continuous time, time with units, etc.).
+	 */
+	abstract struct Clock {
+		private thisClock : Clock :>> self;
+		/**
+		 * A numerical time reference that advances over the lifetime of the Clock. 
+		 */
+		readonly feature currentTime : ScalarValue[1];
+						
+		/**
+		 * The currentTime of a snapshot of a Clock is equal to
+		 * the TimeOf the snapshot relative to that Clock.
+		 */
+		inv timeFlowConstraint {
+			snapshots->forAll{in s : Clock; 
+				TimeOf(s, thisClock) == s.currentTime
+			}
+		}		
+	}
+	
+	/**
+	 * TimeOf returns a scalar timeValue for a given Occurrence relative to
+	 * a given Clock. The timeValue is the time of the start of the Occurrence,
+	 * which is considered to be synchronized with the snapshot of the Clock 
+	 * with a currentTime equal to the returned timeValue.
+	 */
+	abstract function TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : ScalarValue[1] {
+		/**
+		 * The TimeOf an Occurrence is equal to the time of its start snapshot.
+		 */
+		 inv startTimeConstraint { 
+		 	timeValue == TimeOf(o.startShot, clock)
+		 }	 
+
+		/**
+		 * If one Occurrence happens before another, then the TimeOf the end
+		 * snapshot of the first Occurrence is no greater than the TimeOf the 
+		 * second Occurrence.
+		 */
+		inv timeOrderingConstraint {
+			o.predecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) <= timeValue
+			}
+		}
+				
+		/**
+		 * If one Occurrence happens immediately before another, then the TimeOf 
+		 * the end snapshot of the first Occurrence equals the TimeOf the second
+		 * Occurrence.
+		 */
+		inv timeContinuityConstraint {
+			o.immediatePredecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) == timeValue
+			}
+		}				
+	}
+	
+	/**
+	 * DurationOf returns the duration of a given Occurrence relative to a
+	 * given Clock, which is equal to the TimeOf the end snapshot of the
+	 * Occurrence minus the TimeOf its start snapshot.
+	 */
+	function DurationOf(o : Occurrence[1], clock : Clock[1]) duration : ScalarValue {
+		TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock)
+	}
+	
+	/**
+	 * A BasicClock is a Clock whose currentTime is a Real number.
+	 */
+	struct BasicClock :> Clock {
+		readonly feature :>> currentTime : Real;
+	}
+	
+	/**
+	 * BasicTimeOf returns the TimeOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicTimeOf :> TimeOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];	
+	
+	/**
+	 * BasicDurationOf returns the DurationOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicDurationOf :> DurationOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];
+
+}

--- a/org.omg.sysml.xpect.tests/library.kernel/CollectionFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/CollectionFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Collections (as defined in the Collections package). 
+ * For functions on general sequences of values, see the SequenceFunctions package.
+ */
 package CollectionFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;

--- a/org.omg.sysml.xpect.tests/library.kernel/Collections.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Collections.kerml
@@ -1,3 +1,8 @@
+/**
+ * This package defines a standard set of Collection data types. Unlike sequences of values 
+ * defined directly using multiplicity, these data types allow for the possibility of collections 
+ * as elements of collections.
+ */
 package Collections {
 	private import Base::*;
 	private import ScalarValues::*;

--- a/org.omg.sysml.xpect.tests/library.kernel/ComplexFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ComplexFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Complex values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package ComplexFunctions {
 	import ScalarValues::*;
 		

--- a/org.omg.sysml.xpect.tests/library.kernel/ControlFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ControlFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions that correspond to operators in the KerML expression notation 
+ * for which one or more operands are expressions whose evaluation is determined by another operand.
+ */
 package ControlFunctions {
 	private import Base::Anything;
 	private import ScalarValues::ScalarValue;

--- a/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Behaviors to be used to type Steps that control the sequencing of performance
+ * of other Steps. 
+ */
 package ControlPerformances {
 	private import ScalarValues::Boolean;
 	private import SequenceFunctions::size;
@@ -28,7 +32,7 @@ package ControlPerformances {
 	 * target the MergePerforance behavior. All such Successions must subset the incomingHBLink
 	 * feature of the target MergePerformance. For each instance of MergePerformance, the
 	 * incomingHBLink is an instance of exactly one of the Successions, ordering the
-	 * MergePerformance as happening after an instance of the source of that Succcession.
+	 * MergePerformance as happening after an instance of the source of that Succession.
 	 */
 	behavior MergePerformance specializes Performance {
 		/**
@@ -58,7 +62,7 @@ package ControlPerformances {
 	}
 	
 	/**
-	 * An IfElsePerformance is an IfPerformance where the elseCaluse occurs after and only 
+	 * An IfElsePerformance is an IfPerformance where the elseClause occurs after and only 
 	 * after the ifTest evaluation result is not true.
 	 */
 	behavior IfElsePerformance specializes IfPerformance {

--- a/org.omg.sysml.xpect.tests/library.kernel/DataFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/DataFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines the abstract base functions corresponding to all the unary and binary operators 
+ * in the KerML expression notation that might be defined on various kinds of DataValues.
+ */
 package DataFunctions {
 	private import Base::DataValue;
 	private import ScalarValues::Boolean;

--- a/org.omg.sysml.xpect.tests/library.kernel/IntegerFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/IntegerFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Integer values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package IntegerFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
@@ -1,3 +1,9 @@
+/**
+ * This package contains a reflective KerML model of the KerML abstract syntax.
+ * 
+ * NOTE: This model is currently incomplete. It includes all KerML abstract syntax metaclasses,
+ * but none of their properties.
+ */
 package KerML {
 	
 	struct Element;

--- a/org.omg.sysml.xpect.tests/library.kernel/NaturalFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/NaturalFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on Natural values, including concrete specialization of the 
+ * general arithmetic and comparison operations.
+ */
 package NaturalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/NumericalFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/NumericalFunctions.kerml
@@ -1,3 +1,6 @@
+/**
+ * This package defines abstract functions on Numerical values for general arithmetic and comparison operations.
+ */
 package NumericalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
@@ -1,5 +1,5 @@
 /**
- * This package defines classifiers and features that are related to the typing of objects and links.
+ * This package defines classifiers and features that are related to the typing of objects, including link objects.
  */
 package Objects {
 	private import Base::Anything;

--- a/org.omg.sysml.xpect.tests/library.kernel/Observation.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Observation.kerml
@@ -1,0 +1,125 @@
+
+/*
+ * This package models a framework for monitoring Boolean conditions and notifying
+ * registered observers when they change from false to true.
+ */
+package Observation {
+	private import ScalarValues::Boolean;
+	private import Occurrences::Occurrence;
+	private import SequenceFunctions::including;
+	private import SequenceFunctions::excluding;
+	private import ControlFunctions::select;
+	private import ControlPerformances::DecisionPerformance;
+	private import ControlPerformances::IfThenPerformance;
+	private import FeatureReferencingPerformances::FeatureWritePerformance;
+	private import FeatureReferencingPerformances::BooleanEvaluationResultToMonitorPerformance;
+	private import Transfers::TransferBefore;
+
+	/**
+	 * defaultMonitor is a single ChangeMonitor that can be used as a default.
+	 */
+	readonly feature defaultMonitor[1] : ChangeMonitor;
+
+	/**
+	 * A ChangeSignal is a signal to be sent when the Boolean result of its
+	 * changeCondition Expression changes from false to true.
+	 */
+	struct ChangeSignal {
+		/**
+		 * A BooleanExpression whose result is being monitored.
+		 */
+		bool signalCondition;
+		
+		/**
+		 * The ChangeMonitor responsible for monitoring the signalCondition.
+		 */
+		feature signalMonitor : ChangeMonitor;
+	}
+	
+	/**
+	 * Each Performance of ObserveChange waits for the result of the Boolean 
+	 * condition of a given ChangeSignal to change from false to true, and, when 
+	 * it does, sends the ChangeSignal to a given observer Occurrence.
+	 */
+	private behavior ObserveChange {
+		in feature changeObserver : Occurrence[1];
+		in feature changeSignal : ChangeSignal[1];
+		
+		/**
+		 * If the result of the changeSignal.signalCondition is false, then wait for 
+		 * it to become true.
+		 */
+		composite step wait : IfThenPerformance {
+			in bool redefines ifTest {
+				not changeSignal.signalCondition()
+			}
+			in step redefines thenClause : BooleanEvaluationResultToMonitorPerformance {
+				in bool onOccurrence = changeSignal.signalCondition;
+			}
+		}		
+		
+		succession wait then transfer;
+		
+		/**
+		 * Then send changeSignal to changeObserver.
+		 */
+	    step transfer : TransferBefore[1] 
+	    	redefines outgoingTransfersFromSelf 
+	    	subsets changeObserver.incomingTransfers {
+	    	feature redefines source {
+	    		feature redefines sourceOutput = changeSignal;
+	    	}
+	    }
+	}
+	
+	/**
+	 * A ChangeMonitor is a collection of ongoing ChangeSignal observations 
+	 * for various observer Occurrences. It provides convenient operations for 
+	 * starting and canceling the observations it manages.
+	 */
+	struct ChangeMonitor {
+		private thisMonitor : ChangeMonitor redefines self;
+		private composite feature observations[0..*] : ObserveChange;
+		
+		/**
+		 * Assign a replacement set of observations as those being managed by a
+		 * given ChangeMonitor.
+		 */
+		private behavior AssignObservations specializes FeatureWritePerformance {
+			in feature monitor : ChangeMonitor redefines onOccurrence {
+				feature redefines startingAt {
+					feature redefines accessedFeature, observations;
+				}
+			}
+			inout feature redefines replacementValues[0..*] : ObserveChange;
+		}
+		
+		/**
+		 * Start an observation of a given ChangeSignal for a given Occurrence.
+		 */
+		step startObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private composite step observation : ObserveChange {
+				in changeObserver = observer;
+				in changeSignal = signal;
+			}
+			private composite step addObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->including(observation);	
+			}
+		}
+		
+		/**
+		 * Cancel all observations of a given ChangeSignal for a given Occurrence. 
+		 */
+		step cancelObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private feature observations[0..*] : ObserveChange = 
+				observations->select{in observation : ObserveChange; 
+					observation.changeObserver == observer and observation.changeSignal == signal
+				};
+			private composite step removeObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->excluding(observations);
+			}
+		}
+	}	
+}

--- a/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
@@ -35,6 +35,18 @@ package Occurrences {
 		 */
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
+	  	/**
+	   	 * Occurrences that end just before this occurrence starts, with no
+	     * possibility of other occurrences happening in the time between them.
+	     */
+		feature immediatePredecessors: Occurrence[0..*] subsets predecessors;
+
+  		/**
+   		 * Occurrences that start just after this occurrence ends, with no
+   		 * possibility of other occurrences happening in the time between them.
+   		 */
+		feature immediateSuccessors: Occurrence[0..*] subsets successors;
+
 		/**
 		 * Occurrences that start no earlier than and end no later than
 		 * this occurrence, including at least this occurrence.
@@ -160,13 +172,13 @@ package Occurrences {
 		end feature myselfSameLife: Anything[1..*] redefines source;
 		end feature selfSameLife: Anything[1..*] redefines target;
 
-	 	feature all sourceOccurrence : Occurrence [1..*] subsets myselfSameLife;
-	 	feature all targetOccurrence : Occurrence [1..*] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
-		binding sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
+	 	feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
+	 	feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
+		binding oSelf of sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
 
 		feature all sourceDataValue : DataValue [0..1] subsets myselfSameLife;
 		feature all targetDataValue : DataValue [0..1] subsets selfSameLife;
-		binding sourceDataValue = targetDataValue;
+		binding dSelf of sourceDataValue = targetDataValue;
 	}
 	
 	subclassifier SelfLink specializes SelfSameLifeLink; 
@@ -187,12 +199,24 @@ package Occurrences {
 	 * HappensDuring asserts that the shorterOccurrence happens during the longerOccurrence.
 	 * That is, the time interval of the shorterOccurrence is completely within that of the
 	 * longerOccurrence, or every snapshot of the shorterOccurrence happens while (at the
-	 * same time as) some snapshot of the longerOccurrence. Note that this means every
-	 *  occurrence happens during itself.
+	 * same time as) some snapshot of the longerOccurrence. Note that this means every 
+	 * occurrence happens during itself.
 	 */
 	assoc HappensDuring specializes HappensLink {
 		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.suboccurrences;
 		end feature longerOccurrence: Occurrence[1..*] redefines targetOccurrence;
+		
+		/*
+		 * HappensDuring and HappensBefore constrain each other. All predecessors of 
+		 * (occurrences happening before) a HappenDuring's longerOccurrence are also 
+		 * predecessors of its shorterOccurrence. Inversely, all successors (occurrences 
+		 * happening after) its longerOccurrence are also successors of its shorterOccurrence.
+		 */
+		
+		subset longerOccurrence.predecessors subsets shorterOccurrence.predecessors;
+		subset longerOccurrence.successors subsets shorterOccurrence.successors;
+		
+		subset shorterOccurrence.suboccurrences subsets longerOccurrence.suboccurrences;
 	}
 	
 	/**
@@ -218,9 +242,23 @@ package Occurrences {
 		end feature earlierOccurrence: Occurrence[0..*] redefines BinaryLink::source subsets laterOccurrence.predecessors;
 		end feature laterOccurrence: Occurrence[0..*] redefines BinaryLink::target subsets earlierOccurrence.successors;
 		
+		subset laterOccurrence.successors subsets earlierOccurrence.successors;
+		
 		inv { earlierOccurrence != laterOccurrence }
 	}
 	
+	/**
+	 * HappensJustBefore is HappensBefore asserting that the earlierOccurrence happens just 
+	 * before the laterOccurrence, with with no possibility of other occurrences happening in the 
+	 * time between them.
+	 */
+	assoc HappensJustBefore specializes HappensBefore {
+  		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
+		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
+
+  		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	}
+
 	/**
 	 * PortionOf asserts one occurrence is a portion of another, including at least itself. 
 	 */
@@ -253,4 +291,5 @@ package Occurrences {
 	 	end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
 	 	end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
 	 }
+	 
 }

--- a/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
@@ -147,7 +147,7 @@ package Performances {
 	abstract expr literalEvaluations: LiteralEvaluation[0..*] nonunique subsets evaluations;
 	
 	/**
-	 * literalBooleanEvaluations is a specialization of literalEvaluations and booleanEvaluations restricted 
+	 * literaBooleanlEvaluations is a specialization of literalEvaluations and booleanEvaluations restricted 
 	 * to type LiteralBooleanEvaluation.
 	 */
 	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations;

--- a/org.omg.sysml.xpect.tests/library.kernel/RationalFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/RationalFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Functions on Rational values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package RationalFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/RealFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/RealFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines Functions on Real values, including concrete specializations of the 
+ * general arithmetic and comparison operations.
+ */
 package RealFunctions {
 	import ScalarValues::*;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/ScalarFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ScalarFunctions.kerml
@@ -1,3 +1,6 @@
+/**
+ * This package defines abstract functions that specialize the DataFunctions for use with ScalarValues. 
+ */
 package ScalarFunctions {
 	import ScalarValues::*;
 	private import ControlFunctions::reduce;

--- a/org.omg.sysml.xpect.tests/library.kernel/ScalarValues.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ScalarValues.kerml
@@ -1,3 +1,8 @@
+/**
+ * This package contains a basic set of primitive scalar (non-collection) data types. 
+ * These include Boolean and String types and a hierarchy of concrete Number types, from 
+ * the most general type of Complex numbers to the most specific type of Positive integers.</p>
+ */
 package ScalarValues {
 	private import Base::DataValue;
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/SequenceFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/SequenceFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions that operate on general sequences of values. (For functions that
+ * operate on Collection values, see CollectionFunctions.)
+ */
 package SequenceFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;
@@ -17,19 +21,13 @@ package SequenceFunctions {
 	function notEmpty(seq: Anything[0..*] nonunique): Boolean[1] {
 		!isEmpty(seq)
 	}
-	function includes(seq: Anything[0..*] nonunique, value: Anything[1]): Boolean[1] {
-		seq->exists {in x; x == value}
-	}
-	function includesAll(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
+	function includes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq2->forAll {in x; seq1->includes(x)}
 	}
 	function includesOnly(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
-		seq1->includesAll(seq2) && seq2->includesAll(seq1)
+		seq1->includes(seq2) && seq2->includes(seq1)
 	}
-	function excludes(seq: Anything[0..*] nonunique, value: Anything[1]): Boolean[1] {
-		!seq->includes(value)
-	}
-	function excludesAll(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
+	function excludes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq2->forAll {in x; seq1->excludes(x)}
 	}
 	
@@ -39,11 +37,11 @@ package SequenceFunctions {
 	function intersection(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
 		seq1->select {in x; seq2->includes(x)}
 	}
-	function including(seq: Anything[0..*] ordered nonunique, value : Anything[1]): Anything[0..*] ordered nonunique {
-		(seq, value)
+	function including(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
+		union(seq1, seq2)
 	}
-	function excluding(seq: Anything[0..*] ordered nonunique, value : Anything[1]): Anything[0..*] ordered nonunique {
-		seq->reject {in x; x == value}
+	function excluding(seq1: Anything[0..*] ordered nonunique, seq2: Anything[0..*] ordered nonunique): Anything[0..*] ordered nonunique {
+		seq1->reject {in x; seq2->includes(x)}
 	}
 	
 	function subsequence(seq: Anything[0..*] ordered nonunique, startIndex: Positive[1], endIndex: Positive[1]): Anything[0..*] {

--- a/org.omg.sysml.xpect.tests/library.kernel/StatePerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/StatePerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package contains a library model of the semantics of state-based behavior,
+ * including the performance of (behavioral) states and the transitions between them.
+ */
 package StatePerformances {
 	private import ScalarValues::Boolean;
 	private import TransitionPerformances::TransitionPerformance;

--- a/org.omg.sysml.xpect.tests/library.kernel/StringFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/StringFunctions.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package defines functions on String values, including those corresponding to string concatenation 
+ * and comparison operators in the KerML expression notation.
+ */
 package StringFunctions {
 	import ScalarValues::*;
 	
@@ -13,5 +17,7 @@ package StringFunctions {
 
 	function '==' specializes DataFunctions::'==' (x: String[0..1], y: String[0..1]): Boolean[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: String[1]): String[1];	
+	function ToString specializes BaseFunctions::ToString (x: String[1]): String[1] {
+		x
+	}
 }

--- a/org.omg.sysml.xpect.tests/library.kernel/TransitionPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/TransitionPerformances.kerml
@@ -1,3 +1,7 @@
+/**
+ * This package contains a library model of the semantics of conditional transitions between occurrences, 
+ * including the performance of specified Behaviors when the transition occurs.
+ */
 package TransitionPerformances {
 	private import ScalarValues::Boolean;
 	private import Occurrences::HappensBefore;

--- a/org.omg.sysml.xpect.tests/library.kernel/Triggers.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Triggers.kerml
@@ -1,0 +1,138 @@
+/**
+ * This package contains functions that return ChangeSignals for triggering
+ * when a Boolean condition changes from false to true, at a specific time
+ * or after a specific time delay.
+ */
+package Triggers {
+	private import ScalarValues::Boolean;
+	private import ScalarValues::NumericalValue;
+	private import Occurrences::Occurrence;
+	
+	import Clocks::*;
+	import Observation::*;
+	
+	/**
+	 * A TimeSignal is a ChangeSignal whose condition is the currentTime
+	 * of a given Clock reaching a specific signalTime.
+	 */
+	struct TimeSignal :> ChangeSignal {
+		/**
+		 * The time at which the TimeSignal should be sent.
+		 */
+		feature signalTime : NumericalValue[1];
+		
+		/**
+		 * The Clock whose currentTime is being monitored.
+		 */
+		feature signalClock : Clock[1];
+		
+		/**
+		 * The Boolean condition of the currentTime of the signalClock being
+		 * equal to the signalTime.
+		 */
+		private bool :>> signalCondition {
+			signalClock.currentTime == signalTime
+		}
+	}
+	
+	/**
+	 * TriggerWhen returns a monitored ChangeSignal for a given condition,
+	 * to be sent to a given receiver when the condition occurs.
+	 */
+	function TriggerWhen {
+		/**
+		 * The BooleanExpression to be monitored for changing from 
+		 * false to true.
+		 */
+		in bool condition[1];
+		
+		/**
+		 * The Occurrence to which the ChangeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence [1];
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the ChangeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The ChangeSignal for the condition, as monitored by the monitor.
+		 */
+		out feature signal : ChangeSignal[1] = ChangeSignal(condition, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);			
+	}
+	
+	/**
+	 * TriggerAt returns a monitored TimeSignal to be sent to a receiver when
+	 * the currentTime of a given Clock reaches a specific time. 
+	 */
+	function TriggerAt {
+		/**
+		 * The time instant, relative to the clock, at which the TimeSignal should be sent. 
+		 */
+		in feature time : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time. The default is
+		 * the Clocks::defaultClock. 
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */		
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the given time, as monitored by the monitor.
+		 */
+		out feature signal : TimeSignal[1] = TimeSignal(time, clock, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);
+	}
+	
+	/**
+	 * TriggerAfter returns a monitored TimeSignal to be sent to a receiver after
+	 * a certain time delay relative to a given Clock.
+	 */
+	function TriggerAfter {
+		/**
+		 * The time duration, relative to the clock, after which the TimeSignal is sent.
+		 */
+		in feature delay : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time delay. The default is
+		 * the Clocks::defaultClock.
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the currentTime of the clock when the function is invoked
+		 * plus the given time delay, as monitored by the monitor.
+		 */
+		out signal : TimeSignal[1] = 
+			TriggerAt(clock.currentTime + delay, receiver, clock, monitor);
+	}	
+	
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -1,22 +1,48 @@
 /**
- * Specifications for time instant and various time scales
+ * This package specifies concepts to support time-related quantities and metrology, beyond 
+ * the quantities duration and time as defined in [ISO 80000-3]. Representations of the 
+ * Gregorian calendar date and time of day as specified by the [ISO 8601-1] standard are used.
  */
-
 package Time {
-	import ScalarValues::Real;
-	import ScalarValues::Integer;
-	import ScalarValues::Natural;
-	import ScalarValues::String;
-	import Quantities::ScalarQuantityValue;
-	import Quantities::scalarQuantities;
-    import UnitsAndScales::*;
+	private import Occurrences::Occurrence;
+	private import ScalarValues::Real;
+	private import ScalarValues::Integer;
+	private import ScalarValues::Natural;
+	private import ScalarValues::String;
+	private import Quantities::ScalarQuantityValue;
+	private import Quantities::scalarQuantities;
+    private import UnitsAndScales::*;
     import ISQBase::DurationValue;
     import ISQBase::DurationUnit;
     import ISQBase::duration;
     import ISQSpaceTime::TimeValue;
     import ISQSpaceTime::TimeUnit;
     import ISQSpaceTime::time;
+    
+    /**
+     * defaultClock is a single Clock that can be used as a default.
+     */
+    readonly part defaultClock : Clock[1];
 
+	/**
+	 * A Clock provides a currentTime as a TimeInstantValue that advances montonically over its lifetime.
+	 */
+	part def Clock :> Clocks::Clock {
+		attribute :>> currentTime : TimeInstantValue;
+	}
+	
+	/**
+	 * TimeOf returns a TimeInstantValue for a given Occurrence relative to a given Clock. This TimeInstantValue is the 
+	 * time of the start of the Occurrence, which is considered to be synchronized with the snapshot of the Clock with a 
+	 * currentTime equal to the returned imeValue
+	 */
+	calc def TimeOf :> Clocks::TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : TimeInstantValue[1];
+
+	/**
+	 * DurationOf returns the duration of a given Occurrence relative to a given Clock, which is equal to the TimeOf 
+	 * the end snapshot of the Occurrence minus the TimeOf its start snapshot.
+	 */
+	calc def DurationOf :> Clocks::DurationOf(o : Occurrence[1], clock : Clock[1]) duration : DurationValue;
 
 	/**
 	 * Generic time scale to express a time instant, including a textual definition of the meaning of zero time instant value
@@ -81,7 +107,7 @@ package Time {
 	 * Representation of a time instant expressed on the Coordinated Universal Time (UTC) time scale
 	 */
 	attribute def UtcTimeInstantValue :> DateTime { :>> mRef = UTC; }
-	attribute utcTimeInstant: UtcTimeInstantValue;
+	attribute utcTimeInstant: UtcTimeInstantValue :> timeInstant;
 
 	/**
 	 * Representations of a Gregorian calendar date and time of day as specified by the ISO 8601-1 standard.

--- a/sysml.library/Kernel Library/Clocks.kerml
+++ b/sysml.library/Kernel Library/Clocks.kerml
@@ -1,0 +1,106 @@
+/*
+ * This package models Clocks that provide an advancing numerical reference 
+ * usable for quantifying the time of an Occurrence.
+ */
+package Clocks {
+	private import ScalarValues::ScalarValue;
+	private import ScalarValues::Real;
+	private import Occurrences::Occurrence;
+	private import ControlFunctions::forAll;
+	private import ISQ::DurationValue;
+	
+	/**
+	 * defaultClock is a single Clock that can be used as a default.
+	 */
+	readonly feature defaultClock : Clock[1];
+	
+	/**
+	 * A Clock provides a scalar currentTime that advances montonically
+	 * over its lifetime. Clock is an abstract base Structure that can be
+	 * specialized for different kinds of time quantification (e.g., discrete
+	 * time, continuous time, time with units, etc.).
+	 */
+	abstract struct Clock {
+		private thisClock : Clock :>> self;
+		/**
+		 * A numerical time reference that advances over the lifetime of the Clock. 
+		 */
+		readonly feature currentTime : ScalarValue[1];
+						
+		/**
+		 * The currentTime of a snapshot of a Clock is equal to
+		 * the TimeOf the snapshot relative to that Clock.
+		 */
+		inv timeFlowConstraint {
+			snapshots->forAll{in s : Clock; 
+				TimeOf(s, thisClock) == s.currentTime
+			}
+		}		
+	}
+	
+	/**
+	 * TimeOf returns a scalar timeValue for a given Occurrence relative to
+	 * a given Clock. The timeValue is the time of the start of the Occurrence,
+	 * which is considered to be synchronized with the snapshot of the Clock 
+	 * with a currentTime equal to the returned timeValue.
+	 */
+	abstract function TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : ScalarValue[1] {
+		/**
+		 * The TimeOf an Occurrence is equal to the time of its start snapshot.
+		 */
+		 inv startTimeConstraint { 
+		 	timeValue == TimeOf(o.startShot, clock)
+		 }	 
+
+		/**
+		 * If one Occurrence happens before another, then the TimeOf the end
+		 * snapshot of the first Occurrence is no greater than the TimeOf the 
+		 * second Occurrence.
+		 */
+		inv timeOrderingConstraint {
+			o.predecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) <= timeValue
+			}
+		}
+				
+		/**
+		 * If one Occurrence happens immediately before another, then the TimeOf 
+		 * the end snapshot of the first Occurrence equals the TimeOf the second
+		 * Occurrence.
+		 */
+		inv timeContinuityConstraint {
+			o.immediatePredecessors->forAll{in p : Occurrence; 
+				TimeOf(p.endShot, clock) == timeValue
+			}
+		}				
+	}
+	
+	/**
+	 * DurationOf returns the duration of a given Occurrence relative to a
+	 * given Clock, which is equal to the TimeOf the end snapshot of the
+	 * Occurrence minus the TimeOf its start snapshot.
+	 */
+	function DurationOf(o : Occurrence[1], clock : Clock[1]) duration : ScalarValue {
+		TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock)
+	}
+	
+	/**
+	 * A BasicClock is a Clock whose currentTime is a Real number.
+	 */
+	struct BasicClock :> Clock {
+		readonly feature :>> currentTime : Real;
+	}
+	
+	/**
+	 * BasicTimeOf returns the TimeOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicTimeOf :> TimeOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];	
+	
+	/**
+	 * BasicDurationOf returns the DurationOf an Occurrence as a Real number relative
+	 * to a BasicClock.
+	 */
+	function BasicDurationOf :> DurationOf(o : Occurrence[1], clock : BasicClock[1]) : Real[1];
+
+}

--- a/sysml.library/Kernel Library/Observation.kerml
+++ b/sysml.library/Kernel Library/Observation.kerml
@@ -1,0 +1,125 @@
+
+/*
+ * This package models a framework for monitoring Boolean conditions and notifying
+ * registered observers when they change from false to true.
+ */
+package Observation {
+	private import ScalarValues::Boolean;
+	private import Occurrences::Occurrence;
+	private import SequenceFunctions::including;
+	private import SequenceFunctions::excluding;
+	private import ControlFunctions::select;
+	private import ControlPerformances::DecisionPerformance;
+	private import ControlPerformances::IfThenPerformance;
+	private import FeatureReferencingPerformances::FeatureWritePerformance;
+	private import FeatureReferencingPerformances::BooleanEvaluationResultToMonitorPerformance;
+	private import Transfers::TransferBefore;
+
+	/**
+	 * defaultMonitor is a single ChangeMonitor that can be used as a default.
+	 */
+	readonly feature defaultMonitor[1] : ChangeMonitor;
+
+	/**
+	 * A ChangeSignal is a signal to be sent when the Boolean result of its
+	 * changeCondition Expression changes from false to true.
+	 */
+	struct ChangeSignal {
+		/**
+		 * A BooleanExpression whose result is being monitored.
+		 */
+		bool signalCondition;
+		
+		/**
+		 * The ChangeMonitor responsible for monitoring the signalCondition.
+		 */
+		feature signalMonitor : ChangeMonitor;
+	}
+	
+	/**
+	 * Each Performance of ObserveChange waits for the result of the Boolean 
+	 * condition of a given ChangeSignal to change from false to true, and, when 
+	 * it does, sends the ChangeSignal to a given observer Occurrence.
+	 */
+	private behavior ObserveChange {
+		in feature changeObserver : Occurrence[1];
+		in feature changeSignal : ChangeSignal[1];
+		
+		/**
+		 * If the result of the changeSignal.signalCondition is false, then wait for 
+		 * it to become true.
+		 */
+		composite step wait : IfThenPerformance {
+			in bool redefines ifTest {
+				not changeSignal.signalCondition()
+			}
+			in step redefines thenClause : BooleanEvaluationResultToMonitorPerformance {
+				in bool onOccurrence = changeSignal.signalCondition;
+			}
+		}		
+		
+		succession wait then transfer;
+		
+		/**
+		 * Then send changeSignal to changeObserver.
+		 */
+	    step transfer : TransferBefore[1] 
+	    	redefines outgoingTransfersFromSelf 
+	    	subsets changeObserver.incomingTransfers {
+	    	feature redefines source {
+	    		feature redefines sourceOutput = changeSignal;
+	    	}
+	    }
+	}
+	
+	/**
+	 * A ChangeMonitor is a collection of ongoing ChangeSignal observations 
+	 * for various observer Occurrences. It provides convenient operations for 
+	 * starting and canceling the observations it manages.
+	 */
+	struct ChangeMonitor {
+		private thisMonitor : ChangeMonitor redefines self;
+		private composite feature observations[0..*] : ObserveChange;
+		
+		/**
+		 * Assign a replacement set of observations as those being managed by a
+		 * given ChangeMonitor.
+		 */
+		private behavior AssignObservations specializes FeatureWritePerformance {
+			in feature monitor : ChangeMonitor redefines onOccurrence {
+				feature redefines startingAt {
+					feature redefines accessedFeature, observations;
+				}
+			}
+			inout feature redefines replacementValues[0..*] : ObserveChange;
+		}
+		
+		/**
+		 * Start an observation of a given ChangeSignal for a given Occurrence.
+		 */
+		step startObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private composite step observation : ObserveChange {
+				in changeObserver = observer;
+				in changeSignal = signal;
+			}
+			private composite step addObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->including(observation);	
+			}
+		}
+		
+		/**
+		 * Cancel all observations of a given ChangeSignal for a given Occurrence. 
+		 */
+		step cancelObservation(in observer : Occurrence[1], in signal : ChangeSignal[1]) {
+			private feature observations[0..*] : ObserveChange = 
+				observations->select{in observation : ObserveChange; 
+					observation.changeObserver == observer and observation.changeSignal == signal
+				};
+			private composite step removeObservation : AssignObservations[1] {
+				in monitor = thisMonitor; 
+				inout replacementValues = observations->excluding(observations);
+			}
+		}
+	}	
+}

--- a/sysml.library/Kernel Library/Triggers.kerml
+++ b/sysml.library/Kernel Library/Triggers.kerml
@@ -1,0 +1,138 @@
+/**
+ * This package contains functions that return ChangeSignals for triggering
+ * when a Boolean condition changes from false to true, at a specific time
+ * or after a specific time delay.
+ */
+package Triggers {
+	private import ScalarValues::Boolean;
+	private import ScalarValues::NumericalValue;
+	private import Occurrences::Occurrence;
+	
+	import Clocks::*;
+	import Observation::*;
+	
+	/**
+	 * A TimeSignal is a ChangeSignal whose condition is the currentTime
+	 * of a given Clock reaching a specific signalTime.
+	 */
+	struct TimeSignal :> ChangeSignal {
+		/**
+		 * The time at which the TimeSignal should be sent.
+		 */
+		feature signalTime : NumericalValue[1];
+		
+		/**
+		 * The Clock whose currentTime is being monitored.
+		 */
+		feature signalClock : Clock[1];
+		
+		/**
+		 * The Boolean condition of the currentTime of the signalClock being
+		 * equal to the signalTime.
+		 */
+		private bool :>> signalCondition {
+			signalClock.currentTime == signalTime
+		}
+	}
+	
+	/**
+	 * TriggerWhen returns a monitored ChangeSignal for a given condition,
+	 * to be sent to a given receiver when the condition occurs.
+	 */
+	function TriggerWhen {
+		/**
+		 * The BooleanExpression to be monitored for changing from 
+		 * false to true.
+		 */
+		in bool condition[1];
+		
+		/**
+		 * The Occurrence to which the ChangeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence [1];
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the ChangeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The ChangeSignal for the condition, as monitored by the monitor.
+		 */
+		out feature signal : ChangeSignal[1] = ChangeSignal(condition, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);			
+	}
+	
+	/**
+	 * TriggerAt returns a monitored TimeSignal to be sent to a receiver when
+	 * the currentTime of a given Clock reaches a specific time. 
+	 */
+	function TriggerAt {
+		/**
+		 * The time instant, relative to the clock, at which the TimeSignal should be sent. 
+		 */
+		in feature time : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time. The default is
+		 * the Clocks::defaultClock. 
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */		
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the given time, as monitored by the monitor.
+		 */
+		out feature signal : TimeSignal[1] = TimeSignal(time, clock, monitor);
+		
+		step :> monitor.startObservation(receiver, signal);
+	}
+	
+	/**
+	 * TriggerAfter returns a monitored TimeSignal to be sent to a receiver after
+	 * a certain time delay relative to a given Clock.
+	 */
+	function TriggerAfter {
+		/**
+		 * The time duration, relative to the clock, after which the TimeSignal is sent.
+		 */
+		in feature delay : NumericalValue[1];
+		
+		/**
+		 * The Occurrence to which the TimeSignal is to be sent.
+		 */
+		in feature receiver : Occurrence[1];
+		
+		/**
+		 * The Clock to be used as the reference for the time delay. The default is
+		 * the Clocks::defaultClock.
+		 */
+		in feature clock : Clock[1] default defaultClock;
+		
+		/**
+		 * The ChangeMonitor to be used to monitor the TimeSignal condition.
+		 * The default is the Observation::defaultMonitor.
+		 */
+		in feature monitor : ChangeMonitor[1] default defaultMonitor;
+		
+		/**
+		 * The TimeSignal for the currentTime of the clock when the function is invoked
+		 * plus the given time delay, as monitored by the monitor.
+		 */
+		out signal : TimeSignal[1] = 
+			TriggerAt(clock.currentTime + delay, receiver, clock, monitor);
+	}	
+	
+}


### PR DESCRIPTION
**Kernel Model Library**

Added the following packages:

1. `Observation` – models monitoring for change and notifying registered observers.
2. `Clocks` – models clocks that provide a current time reference, with functions for getting the time and duration of an Occurrence relative to a clock.
3. `Triggers` – provides convenience functions for creating monitored change signals for change triggers, absolute time triggers and relative time triggers.

**Quantities and Units Domain Library**

Added to the `Time` package: a specialization of the clock model that uses time instant and duration quantity values.