### PR TITLE
ST6RI-491 Complete SI and USCustomaryUnits libraries (continued)

### DIFF
--- a/sysml.library/Domain Libraries/Quantities and Units/ISQ.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQ.sysml
@@ -18,4 +18,24 @@ package ISQ {
     import ISQCharacteristicNumbers::*; // ISO 80000-11 "Characteristic numbers"
     import ISQCondensedMatter::*;       // ISO 80000-12 "Condensed matter physics"
     import ISQInformation::*;           // IEC 80000-13 "Information science and technology"
+
+    /* Additional quantity declarations */
+
+    /** 
+     * temperature difference
+     * 
+     * A separate temperature difference quantity and unit are needed in order to support °C, °F and centrigrade temperature differences
+     */
+    attribute def TemperatureDifferenceUnit :> SimpleUnit {
+        private attribute thermodynamicTemperaturePF: QuantityPowerFactor[1] { :>> quantity = isq.'Θ'; :>> exponent = 1; }
+        attribute :>> quantityDimension { :>> quantityPowerFactors = thermodynamicTemperaturePF; }
+    }
+
+    attribute def TemperatureDifferenceValue :> ScalarQuantityValue {
+        attribute :>> num: Real;
+        attribute :>> mRef: TemperatureDifferenceUnit[1];
+    }
+    
+    attribute temperatureDifference: TemperatureDifferenceValue [*] nonunique :> scalarQuantities;
+
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQBase.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQBase.sysml
@@ -178,8 +178,7 @@ package ISQBase {
      * Declaration of the International System of Quantities (ISQ), 
      * including its base quantities and symbols as specified in ISO 80000-1:2009.
      */
-    attribute isq: SystemOfQuantities {
-        attribute :>> longName = "International System of Quantities";
+    attribute <isq> 'International System of Quantities': SystemOfQuantities {
         attribute :>> baseQuantities = ( L, M, T, I, 'Θ', N, J );
         
         attribute L: LengthValue[1];

--- a/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_CGS.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_CGS.sysml
@@ -1,0 +1,62 @@
+package <CGS> 'Centimetre-Gram-Second System of Units' {
+    doc /*
+    Library package with measurement unit declarations generated from NIST SP811 Appendix B
+    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+    Generated at 2022-02-11T23:27:48Z
+    */
+
+    private import UnitsAndScales::*;
+    import ISQ::*;
+    import SI::*;
+
+    attribute 'abampere' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
+    attribute 'abcoulomb' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 1.0E+01; } }
+    attribute 'abfarad' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.0E+09; } }
+    //attribute 'abhenry' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 1.0E-09; } }
+    attribute 'abmho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.0E+09; } }
+    attribute 'abohm' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 1.0E-09; } }
+    attribute 'abvolt' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 1.0E-08; } }
+    attribute <Bi> 'biot' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
+    attribute <cP> 'centipoise' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.0E-03; } }
+    attribute <cSt> 'centistokes' : KinematicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2/s; :>> conversionFactor = 1.0E-06; } }
+    attribute <D> 'debye' : ElectricDipoleMomentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C*m; :>> conversionFactor = 3.335641E-30; :>> isExact = false; } }
+    attribute <dyn> 'dyne' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 1.0E-05; } }
+    attribute <'dyn⋅cm'> 'dyne centimeter' : MomentOfForceUnit = dyn*cm;
+    attribute <'dyn/cm²'> 'dyne per square centimeter' : PressureUnit = dyn/cm^2;
+    attribute 'EMU of capacitance' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.0E+09; } }
+    attribute 'EMU of current' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
+    attribute 'EMU of electric potential' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 1.0E-08; } }
+    //attribute 'EMU of inductance' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 1.0E-09; } }
+    attribute 'EMU of resistance' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 1.0E-09; } }
+    attribute <erg> 'erg' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.0E-07; } }
+    attribute <'erg/s'> 'erg per second' : PowerUnit = erg/s;
+    attribute <'erg/(cm²⋅s)'> 'erg per square centimeter second' : DensityOfHeatFlowRateUnit = erg/(cm^2*s);
+    attribute 'ESU of capacitance' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.112650E-12; :>> isExact = false; } }
+    attribute 'ESU of current' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 3.335641E-10; :>> isExact = false; } }
+    attribute 'ESU of electric potential' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 2.997925E+02; :>> isExact = false; } }
+    //attribute 'ESU of inductance' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 8.987552E+11; :>> isExact = false; } }
+    attribute 'ESU of resistance' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 8.987552E+11; :>> isExact = false; } }
+    attribute <Fr> 'franklin' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 3.335641E-10; :>> isExact = false; } }
+    attribute <Gal> 'gal (acceleration)' : AccelerationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s^2; :>> conversionFactor = 1.0E-02; } }
+    attribute <'γ'> 'gamma' : MagneticFluxDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = T; :>> conversionFactor = 1.0E-09; } }
+    attribute <Gs> 'gauss' : MagneticFluxDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = T; :>> conversionFactor = 1.0E-04; } }
+    alias G for Gs;
+    attribute <Gi> 'gilbert' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 7.957747E-01; :>> isExact = false; } }
+    attribute <K> 'kayser' : CurvatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^-1; :>> conversionFactor = 1.0E+02; } }
+    attribute <Mx> 'maxwell' : MagneticFluxUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Wb; :>> conversionFactor = 1.0E-08; } }
+    attribute <Oe> 'oersted' : LinearElectricCurrentDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A/m; :>> conversionFactor = 7.957747E+01; :>> isExact = false; } }
+    attribute <ph> 'phot' : IlluminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = lx; :>> conversionFactor = 1.0E+04; } }
+    attribute <P> 'poise' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.0E-01; } }
+    attribute <rad> 'rad (absorbed dose)' : AbsorbedDoseUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Gy; :>> conversionFactor = 1.0E-02; } }
+    attribute <rem> 'rem' : DoseEquivalentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Sv; :>> conversionFactor = 1.0E-02; } }
+    attribute 'statampere' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 3.335641E-10; :>> isExact = false; } }
+    attribute 'statcoulomb' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 3.335641E-10; :>> isExact = false; } }
+    attribute 'statfarad' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.112650E-12; :>> isExact = false; } }
+    //attribute 'stathenry' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 8.987552E+11; :>> isExact = false; } }
+    attribute 'statmho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.112650E-12; :>> isExact = false; } }
+    attribute 'statohm' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 8.987552E+11; :>> isExact = false; } }
+    attribute 'statvolt' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 2.997925E+02; :>> isExact = false; } }
+    attribute <sb> 'stilb' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 1.0E+04; } }
+    attribute <St> 'stokes' : KinematicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2/s; :>> conversionFactor = 1.0E-04; } }
+
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_Imp.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_Imp.sysml
@@ -1,0 +1,25 @@
+package <Imp> 'Imperial (Canadian and UK) Units' {
+    doc /*
+    Library package with measurement unit declarations generated from NIST SP811 Appendix B
+    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+    Generated at 2022-02-11T23:27:48Z
+    */
+
+    private import UnitsAndScales::*;
+    import ISQ::*;
+    import SI::*;
+
+    attribute <gal> 'gallon (Canadian and UK (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.54609E-03; } }
+    attribute <gi> 'gill (Canadian and UK (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.420653E-04; :>> isExact = false; } }
+    attribute 'horsepower (UK)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.4570E+02; :>> isExact = false; } }
+    attribute <oz> 'ounce (troy or apothecary)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 3.110348E-02; :>> isExact = false; } }
+    attribute <floz> 'ounce (Canadian and UK fluid (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.841306E-05; :>> isExact = false; } }
+    attribute <'oz/gal'> 'ounce (avoirdupois) per gallon (Canadian and UK (Imperial))' : MassDensityUnit = oz/gal;
+    attribute <dwt> 'pennyweight' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.555174E-03; :>> isExact = false; } }
+    attribute <lb> 'pound (troy or apothecary)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 3.732417E-01; :>> isExact = false; } }
+    attribute 'poundal' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 1.382550E-01; :>> isExact = false; } }
+    attribute 'poundal per square foot' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.488164E+00; :>> isExact = false; } }
+    attribute 'poundal second per square foot' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.488164E+00; :>> isExact = false; } }
+    attribute <'lb/gal'> 'pound per gallon (Canadian and UK (Imperial))' : MassDensityUnit = lb/gal;
+
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_SI_deprecated.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_SI_deprecated.sysml
@@ -1,0 +1,56 @@
+package <SI_deprecated> 'International System of Units - Deprecated units' {
+    doc /*
+    Library package with measurement unit declarations generated from NIST SP811 Appendix B
+    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+    Generated at 2022-02-11T23:27:48Z
+    */
+
+    private import UnitsAndScales::*;
+    import ISQ::*;
+    import SI::*;
+
+    attribute <'at'> 'atmosphere, technical' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+04; } }
+    attribute <cal_th> 'calorie (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+00; } }
+    attribute <cal_mean> 'calorie (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+00; :>> isExact = false; } }
+    attribute <cal_15> 'calorie (15 °C)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.18580E+00; :>> isExact = false; } }
+    attribute <cal_20> 'calorie (20 °C)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.18190E+00; :>> isExact = false; } }
+    attribute <cal_nutrition_th> 'calorie (th), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+03; } }
+    attribute <cal_nutrition_mean> 'calorie (mean), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+03; :>> isExact = false; } }
+    attribute <'cal_th/(cm⋅s⋅°C)'> 'calorie (th) per centimeter second degree Celsius' : ThermalConductivityUnit = cal_th/(cm*s*'°C');
+    attribute <'cal_th/g'> 'calorie (th) per gram' : SpecificEnergyUnit = cal_th/g;
+    attribute <'cal_th/(g⋅°C)'> 'calorie (th) per gram degree Celsius' : SpecificHeatCapacityUnit = cal_th/(g*'°C');
+    attribute <'cal_th/(g·K)'> 'calorie (th) per gram kelvin' : SpecificHeatCapacityUnit = cal_th/(g*K);
+    attribute <'cal_th/min'> 'calorie (th) per minute' : PowerUnit = cal_th/min;
+    attribute <'cal_th/s'> 'calorie (th) per second' : PowerUnit = cal_th/s;
+    //attribute <'cal_th/cm²'> 'calorie (th) per square centimeter' : SurfaceHeatDensityUnit = cal_th/cm^2;
+    attribute <'cal_th/(cm²⋅min)'> 'calorie (th) per square centimeter minute' : DensityOfHeatFlowRateUnit = cal_th/(cm^2*min);
+    attribute <'cal_th/(cm²⋅s)'> 'calorie (th) per square centimeter second' : DensityOfHeatFlowRateUnit = cal_th/(cm^2*s);
+    attribute 'centimeter of mercury (0 °C)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.33322E+03; :>> isExact = false; } }
+    attribute <cmHg> 'centimeter of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+03; :>> isExact = false; } }
+    attribute 'centimeter of water (4 °C)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80638E+01; :>> isExact = false; } }
+    attribute <cmH2O> 'centimeter of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+01; } }
+    attribute <Ci> 'curie' : NuclearActivityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Bq; :>> conversionFactor = 3.7E+10; } }
+    //attribute 'degree centigrade (temperature)' : ThermodynamicTemperatureUnit; // conversion TBD
+    //attribute 'degree centigrade (temperature interval)' : TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = '°C'; :>> conversionFactor = 1.0E+00; :>> isExact = false; } }
+    attribute <gf> 'gram-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 9.80665E-03; } }
+    attribute <'gf/cm²'> 'gram-force per square centimeter' : PressureUnit = gf/cm^2;
+    attribute <hp_metric> 'horsepower (metric)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.354988E+02; :>> isExact = false; } }
+    attribute <kcal_th> 'kilocalorie (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+03; } }
+    attribute <kcal_mean> 'kilocalorie (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+03; :>> isExact = false; } }
+    attribute <'kcal_th/min'> 'kilocalorie (th) per minute' : PowerUnit = kcal_th/min;
+    attribute <'kcal_th/s'> 'kilocalorie (th) per second' : PowerUnit = kcal_th/s;
+    attribute <kgf> 'kilogram-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 9.80665E+00; } }
+    attribute <'kgf⋅m'> 'kilogram-force meter' : MomentOfForceUnit = kgf*m;
+    attribute <'kgf/cm²'> 'kilogram-force per square centimeter' : PressureUnit = kgf/cm^2;
+    attribute <'kgf/m²'> 'kilogram-force per square meter' : PressureUnit = kgf/m^2;
+    attribute <'kgf/mm²'> 'kilogram-force per square millimeter' : PressureUnit = kgf/mm^2;
+    attribute <'kgf⋅s²/m'> 'kilogram-force second squared per meter' : MassUnit = kgf*s^2/m;
+    attribute <kp> 'kilopond (kilogram-force)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 9.80665E+00; } }
+    attribute 'mho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.0E+00; } }
+    attribute <'μ'> 'micron' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-06; } }
+    attribute <mmH2O> 'millimeter of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+00; } }
+    //attribute 'rhe' : ReciprocalDynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa^-1*s^-1; :>> conversionFactor = 1.0E+01; } }
+    attribute <R> 'roentgen' : ExposureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C/kg; :>> conversionFactor = 2.58E-04; } }
+    attribute <Torr> 'torr' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+02; :>> isExact = false; } }
+
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_SI_recognized.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/NIST_SP811_SI_recognized.sysml
@@ -1,0 +1,76 @@
+package <SI_recognized> 'International System of Units - Units recognized in SI' {
+    doc /*
+    Library package with measurement unit declarations generated from NIST SP811 Appendix B
+    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+    Generated at 2022-02-11T23:27:48Z
+    */
+
+    private import UnitsAndScales::*;
+    import ISQ::*;
+    import SI::*;
+
+    attribute <g_n> 'acceleration of free fall, standard' : AccelerationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s^2; :>> conversionFactor = 9.80665E+00; } }
+    attribute <'A⋅h'> 'ampere hour' : ElectricChargeUnit = A*h;
+    attribute <'Å'> 'ångström' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-10; } }
+    attribute <a> 'are' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E+02; } }
+    attribute <au> 'astronomical unit' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.495979E+11; :>> isExact = false; } }
+    attribute <atm> 'atmosphere, standard' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.01325E+05; } }
+    attribute <bar> 'bar' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.0E+05; } }
+    attribute <b> 'barn' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E-28; } }
+    attribute <cal_IT> 'calorie (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+00; } }
+    alias cal for cal_IT;
+    attribute <cal_nutrition_IT> 'calorie (IT), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+03; } }
+    alias cal_nutrition for cal_nutrition_IT;
+    attribute <'cal_IT/g'> 'calorie (IT) per gram' : SpecificEnergyUnit = cal_IT/g;
+    attribute <'cal_IT/(g⋅°C)'> 'calorie (IT) per gram degree Celsius' : SpecificHeatCapacityUnit = cal_IT/(g*'°C');
+    attribute <'cal_IT/(g⋅K)'> 'calorie (IT) per gram kelvin' : SpecificHeatCapacityUnit = cal_IT/(g*K);
+    attribute 'carat, metric' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.0E-04; } }
+    attribute 'darcy' : PermeabilityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 9.869233E-13; :>> isExact = false; } }
+    attribute <d> 'day' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 8.64E+04; } }
+    attribute 'day (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 8.616409E+04; :>> isExact = false; } }
+    attribute <'°'> 'degree (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 1.745329E-02; :>> isExact = false; } }
+    attribute <'°C'> 'degree Celsius (temperature)' : ThermodynamicTemperatureUnit; // conversion TBD
+    //attribute 'degree Celsius (temperature interval)' : TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 1.0E+00; } }
+    attribute 'denier' : LinearMassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m; :>> conversionFactor = 1.111111E-07; :>> isExact = false; } }
+    attribute <eV> 'electronvolt' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.602177E-19; :>> isExact = false; } }
+    attribute 'faraday (based on carbon 12)' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 9.648531E+04; :>> isExact = false; } }
+    attribute 'fermi' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-15; } }
+    attribute <gon> 'gon (also called grade)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 1.570796E-02; :>> isExact = false; } }
+    attribute <'g/cm³'> 'gram per cubic centimeter' : MassDensityUnit = g/cm^3;
+    attribute <ha> 'hectare' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E+04; } }
+    attribute <h> 'hour' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.6E+03; } }
+    attribute 'hour (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.590170E+03; :>> isExact = false; } }
+    attribute <kcal_IT> 'kilocalorie (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+03; } }
+    alias kcal for kcal_IT;
+    attribute <'km/h'> 'kilometer per hour' : SpeedUnit = km/h;
+    attribute <'kW⋅h'> 'kilowatt hour' : EnergyUnit = kW*h;
+    attribute 'lambert' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 3.183099E+03; :>> isExact = false; } }
+    attribute <'l.y.'> 'light year' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 9.46073E+15; :>> isExact = false; } }
+    attribute <L> 'liter' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.0E-03; } }
+    attribute <mil_NATO> 'mil (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 9.817477E-04; :>> isExact = false; } }
+    attribute <mbar> 'millibar' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.0E+02; } }
+    attribute <mmHg> 'millimeter of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+02; :>> isExact = false; } }
+    attribute <'′'> 'minute (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 2.908882E-04; :>> isExact = false; } }
+    attribute <min> 'minute' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 6.0E+01; } }
+    attribute 'minute (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 5.983617E+01; :>> isExact = false; } }
+    attribute <'Ω⋅cm'> 'ohm centimeter' : ResistivityUnit = 'Ω'*cm;
+    attribute <pc> 'parsec' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.085678E+16; :>> isExact = false; } }
+    attribute <r> 'revolution' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 6.283185E+00; :>> isExact = false; } }
+    attribute <'r/min'> 'revolution per minute (rpm)' : AngularVelocityUnit = r/min;
+    attribute 'rpm (revolution per minute)' : AngularVelocityUnit = r/min;
+    attribute <'″'> 'second (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 4.848137E-06; :>> isExact = false; } }
+    attribute 'second (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 9.972696E-01; :>> isExact = false; } }
+    attribute 'shake' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 1.0E-08; } }
+    attribute <st> 'stere' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.0E+00; } }
+    attribute 'tex' : LinearMassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m; :>> conversionFactor = 1.0E-06; } }
+    attribute <t> 'ton, metric' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.0E+03; } }
+    attribute 'tonne (called "metric ton" in US)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.0E+03; } }
+    attribute 'ton of TNT (energy equivalent)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+09; } }
+    attribute <'W⋅h'> 'watt hour' : EnergyUnit = W*h;
+    attribute <'W/cm²'> 'watt per square centimeter' : DensityOfHeatFlowRateUnit = W/cm^2;
+    attribute <'W⋅s'> 'watt second' : EnergyUnit = W*s;
+    attribute 'year (365 days)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.1536E+07; } }
+    attribute 'year (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.155815E+07; :>> isExact = false; } }
+    attribute 'year (tropical)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.155693E+07; :>> isExact = false; } }
+
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -48,6 +48,12 @@ package Quantities {
 	abstract attribute vectorQuantities: VectorQuantityValue[*] nonunique :> tensorQuantities;
 	abstract attribute scalarQuantities: ScalarQuantityValue[*] nonunique :> vectorQuantities;
 
+    /*
+     * Define generic aliases QuantityValue and quantities for the top level quantity attribute def and attribute.
+     */
+	alias QuantityValue for TensorQuantityValue;
+	alias quantities for tensorQuantities;
+	
 	/**
 	 * A SystemOfQuantities represents the essentials of [VIM] concept "system of quantities" (https://jcgm.bipm.org/vim/en/1.3.html), defined as a
 	 * "set of quantities together with a set of noncontradictory equations relating those quantities".

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -44,12 +44,6 @@ package Quantities {
 	abstract attribute vectorQuantities: VectorQuantityValue[*] nonunique :> tensorQuantities;
 	abstract attribute scalarQuantities: ScalarQuantityValue[*] nonunique :> vectorQuantities;
 
-    /*
-     * Define generic aliases QuantityValue and quantities for the top level quantity attribute def and attribute.
-     */
-	alias QuantityValue for TensorQuantityValue;
-	alias quantities for tensorQuantities;
-	
 	/**
 	 * A SystemOfQuantities represents the essentials of [VIM] concept "system of quantities" (https://jcgm.bipm.org/vim/en/1.3.html), defined as a
 	 * "set of quantities together with a set of noncontradictory equations relating those quantities".

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -17,7 +17,6 @@ package Quantities {
 		attribute isBound: ScalarValues::Boolean;
 		attribute num: ScalarValues::Number[1..*] ordered nonunique :>> elements;
 		attribute mRef: UnitsAndScales::TensorMeasurementReference;
-		attribute measure: UnitsAndScales::TensorMeasurementReference;
         attribute :>> dimensions = mRef.dimensions;
 		attribute order :>> rank = mRef.order;
         attribute contravariantOrder: ScalarValues::Natural;

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -3,7 +3,12 @@
  */
 package Quantities {
 	private import Collections::*;
-	private import ScalarValues::ScalarValue;
+	private import ScalarValues::NumericalValue;
+	private import ScalarValues::Number;
+	private import ScalarValues::Real;
+	private import ScalarValues::Natural;
+	private import ScalarValues::Boolean;
+	private import ScalarValues::String;
 	
 	/**
 	 * The value of a quantity is a tuple of one or more numbers (i.e. mathematical number values) and a reference to a measurement reference.
@@ -14,13 +19,13 @@ package Quantities {
 	 * and a ScalarQuantityValue a ScalarMeasurementReference. See package UnitsAndScales for details.
 	 */
 	abstract attribute def TensorQuantityValue :> Array {
-		attribute isBound: ScalarValues::Boolean;
-		attribute num: ScalarValues::Number[1..*] ordered nonunique :>> elements;
+		attribute isBound: Boolean;
+		attribute num: Number[1..*] ordered nonunique :>> elements;
 		attribute mRef: UnitsAndScales::TensorMeasurementReference;
         attribute :>> dimensions = mRef.dimensions;
 		attribute order :>> rank = mRef.order;
-        attribute contravariantOrder: ScalarValues::Natural;
-        attribute covariantOrder: ScalarValues::Natural;
+        attribute contravariantOrder: Natural;
+        attribute covariantOrder: Natural;
 
         assert constraint orderSum { contravariantOrder + covariantOrder == order }
         assert constraint boundMatch { (isBound == mRef.isBound) || (!isBound && mRef.isBound) }
@@ -30,7 +35,7 @@ package Quantities {
 		attribute :>> mRef: UnitsAndScales::VectorMeasurementReference;
 	}
 	
-	abstract attribute def ScalarQuantityValue :> VectorQuantityValue, ScalarValue {
+	abstract attribute def ScalarQuantityValue :> VectorQuantityValue, NumericalValue {
 		attribute :>> mRef: UnitsAndScales::ScalarMeasurementReference;
 	}
 	
@@ -50,7 +55,6 @@ package Quantities {
 	 * completed by adding derived quantities which are products of powers of the base quantities.
 	 */
 	attribute def SystemOfQuantities {
-		attribute longName: ScalarValues::String;
 		attribute baseQuantities: ScalarQuantityValue[*] ordered :> scalarQuantities;
 	}
 
@@ -61,7 +65,7 @@ package Quantities {
 	 */
 	attribute def QuantityPowerFactor {
 		attribute quantity: ScalarQuantityValue[1];
-		attribute exponent: ScalarValues::Real[1];
+		attribute exponent: Real[1];
 	}
 	
 	/**

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -1,6 +1,6 @@
 package QuantityCalculations {
 	import ScalarValues::*;
-    import Quantities::*;
+    import Quantities::ScalarQuantityValue;
     import UnitsAndScales::ScalarMeasurementReference;
     import UnitsAndScales::DimensionOneValue;
     

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -2,7 +2,6 @@ package QuantityCalculations {
 	import ScalarValues::*;
     import Quantities::*;
     import UnitsAndScales::ScalarMeasurementReference;
-    import UnitsAndScales::MeasurementReference;
     import UnitsAndScales::DimensionOneValue;
     
     calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): ScalarQuantityValue;

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -5,7 +5,7 @@ package QuantityCalculations {
     import UnitsAndScales::MeasurementReference;
     import UnitsAndScales::DimensionOneValue;
     
-    calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): QuantityValue;
+    calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): ScalarQuantityValue;
 
 	calc def Abs specializes NumericalFunctions::Abs (x: ScalarQuantityValue): ScalarQuantityValue;
 

--- a/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
@@ -1,7 +1,7 @@
 /**
  * International System of (Measurement) Units -- Système International d'Unités (SI), as defined in ISO/IEC 80000
  *
- * Note 1: In accordance with ISO/IEC 80000 en-GB spelling is used for the longNames and definitions of the units.
+ * Note 1: In accordance with ISO/IEC 80000 en-GB spelling is used for the names and definitions of the units.
  * Note 2: This is a representative but not yet complete list of measurement units.
  */
 package SI {
@@ -11,7 +11,7 @@ package SI {
     import QuantityCalculations::*;
 
     /*
-     * SI simple units needed before creation of base units
+     * SI simple unit needed in support of creation of the base units
      */
     attribute <g> gram : MassUnit;
 
@@ -22,7 +22,7 @@ package SI {
     attribute <kg> kilogram : MassUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = kilo; :>> referenceUnit = g; } }
     attribute <s> second : DurationUnit;
     attribute <A> ampere : ElectricCurrentUnit;
-    attribute <K> kelvin : ThermodynamicTemperatureUnit {
+    attribute <K> kelvin : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit {
         attribute temperatureOfWaterAtTriplePointInK: DefinitionalQuantityValue {
             :>> num = 27316/100;
             :>> definition = "temperature in kelvin of pure water at the triple point";
@@ -34,8 +34,10 @@ package SI {
 
     /*
      * Declare the SI system of units with its explicit base units
+     * and its associated system of quantities, the ISQ.
      */
 	attribute <si> 'ISO/IEC 80000 International System of Units' : SystemOfUnits {
+		:>> systemOfQuantities = isq;
 		:>> baseUnits = (m, kg, s, A, K, mol, cd);
 	}
 
@@ -56,6 +58,7 @@ package SI {
     attribute <Hart> hartley : InformationContentUnit = one;
     attribute <Hz> hertz : FrequencyUnit = s^-1;
     attribute <J> joule : EnergyUnit = N*m;
+    //attribute <kat> katal : CatalyticActivityUnit = mol/s;
     attribute <lm> lumen : LuminousFluxUnit = cd*sr;
     attribute <lx> lux : IlluminanceUnit = lm/m^2;
     attribute <N> newton : ForceUnit = kg*m/s^2;
@@ -75,19 +78,26 @@ package SI {
     attribute <'Ω'> ohm : ResistanceUnit = V/A;
 
     /*
-     * Units recognized in SI
+     * Units recognized in SI as specified in ISO 80000-1:2009
      */
-    attribute <b> barn : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'm²'; :>> conversionFactor = 1.0e-28; } }
-    attribute <Da> dalton : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.66053906660e-27; } }
-    attribute <eV> electronvolt : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.602176487e-19; } }
-    attribute <u> 'atomic mass unit' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Da; :>> conversionFactor = 1.0; } }
-    attribute <ua> 'astronomical unit' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 149597870691e11; } }
-    attribute <var> 'volt ampere reactive' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V*A; :>> conversionFactor = 1.0; } }
-    attribute <'°'> degree : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 3.141592653589793/180; } } // conversionFactor should become pi/180
     attribute <'Å'> 'ångström' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0e-10; } }
-
+    attribute <b> barn : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'm²'; :>> conversionFactor = 1.0e-28; } }
+    attribute <d> day: DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = hour; :>> conversionFactor = 24; } }
+    attribute <Da> dalton : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.66053906660e-27; :>> isExact = false; } }
+    attribute <eV> electronvolt : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.602176487e-19; :>> isExact = false; } }
+    attribute <h> hour: DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = min; :>> conversionFactor = 60; } }
+    attribute <min> minute : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 60; } }
     attribute <L> litre : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'm³'; :>> conversionFactor = 1.0e-3; } }
-    attribute <mL> millilitre : VolumeUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = milli; :>> referenceUnit = L; } }
+    attribute tonne : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.0e-3; } }
+    alias 'metric ton' for tonne;
+    attribute <u> 'atomic mass unit' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Da; :>> conversionFactor = 1.0; } }
+    attribute <ua> 'astronomical unit' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 149597870691e11; :>> isExact = false; } }
+    attribute <var> 'volt ampere reactive' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V*A; :>> conversionFactor = 1.0; } }
+    attribute <'°'> degree : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 1.745329E-02; :>> isExact = false; } } // conversionFactor should become pi/180
+    attribute <'′'> 'minute (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 2.908882E-04; :>> isExact = false; } }
+    alias arcmin for '′';
+    attribute <'″'> 'second (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 4.848137E-06; :>> isExact = false; } }
+    alias arcsec for '″';
 
     /*
      * Derived units used in parts 3 to 12 of ISO/IEC 80000
@@ -287,37 +297,44 @@ package SI {
     /*
      * Prefixed units
      */
+    
+    /* Length */
     attribute <nm> nanometre : LengthUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = nano; :>> referenceUnit = m; } }
     attribute <mm> millimetre : LengthUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = milli; :>> referenceUnit = m; } }
     attribute <cm> centimetre : LengthUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = centi; :>> referenceUnit = m; } }
     attribute <km> kilometre : LengthUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = kilo; :>> referenceUnit = m; } }
+
+    /* Volume */
+    attribute <mL> millilitre : VolumeUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = milli; :>> referenceUnit = L; } }
+
+    /* Force */
     attribute <mN> millinewton : ForceUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = milli; :>> referenceUnit = N; } }
+
+    /* Energy */
     attribute <kJ> kilojoule : EnergyUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = kilo; :>> referenceUnit = J; } }
     attribute <MJ> megajoule : EnergyUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = mega; :>> referenceUnit = J; } }
     attribute <GJ> gigajoule : EnergyUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = giga; :>> referenceUnit = J; } }
+    
+    /* Power */
     attribute <kW> kilowatt : PowerUnit { :>> unitConversion: ConversionByPrefix { :>> prefix = kilo; :>> referenceUnit = W; } }
 
-    /*
-     * Non-standard conversion based units that are accepted in SI
-     */
-    attribute <min> minute : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 60; } }
-    attribute <h> hour: DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = min; :>> conversionFactor = 60; } }
+    /* Speed */
     attribute <'km/h'> 'kilometre per hour': SpeedUnit = km/h;
 
     /*
-     * degree Celsius unit for temperature difference quantities
+     * degree Celsius unit for temperature interval (i.e. temperature difference) quantities
      */
-    attribute <'°C_unit'> 'degree celsius (unit)' : TemperatureUnit {
+    attribute <'°C'> 'degree celsius (temperature interval)' : TemperatureDifferenceUnit {
         attribute :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 1; }
    	}
 
     /*
      * degree Celsius interval scale for absolute temperature quantities
      *
-     * The interval scale is defined with an explicit mapping to the kelvin ratio scale from which the offset between the scales can be computed.
+     * The interval scale is defined with an explicit mapping to the kelvin thermodynamic temperature ratio scale from which the offset between the scales can be computed.
      */
-    attribute <'°C_scale'> 'degree celsius scale' : IntervalScale {
-        attribute :>> unit = '°C_unit';
+    attribute <'°C_abs'> 'degree celsius (temperature scale)' : IntervalScale {
+        attribute :>> unit = '°C';
         attribute temperatureWaterAtFreezingPointInC: DefinitionalQuantityValue {
             :>> num = 0; :>> definition = "temperature in degree Celsius of pure water at freezing point";
         }
@@ -329,11 +346,10 @@ package SI {
         }
         attribute :>> definitionalQuantityValues = (temperatureWaterAtTriplePointInC, temperatureWaterAtFreezingPointInC);
         attribute :>> quantityValueMapping = celsiusToKelvinScaleMapping;
-        // Experimental zero shift w.r.t. to K (kelvin) thermodynamic temperature ratio scale
-        // Such CoordinateTransformation can be used instead of the celsiusToKelvinScaleMapping
+
+        /* CoordinateTransformation (zero shift) w.r.t. thermodynamic temperature in kelvin */ 
         private attribute zeroDegreeCelsiusInKelvin: ThermodynamicTemperatureValue = 273.15 [K];
-        attribute zeroShift : CoordinateTransformation { :>> source = K; :>> target = self; :>> origin = zeroDegreeCelsiusInKelvin; }
+        attribute zeroShift : CoordinateTransformation { :>> source = K; :>> target = self; :>> origin = zeroDegreeCelsiusInKelvin; :>> basisDirections = 1 [K]; }
         attribute :>> placement = zeroShift;
     }
-    alias '°C' for '°C_scale';
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
@@ -8,7 +8,6 @@ package SI {
     private import UnitsAndScales::*;
     import ISQ::*;
     import SIPrefixes::*;
-    import QuantityCalculations::*;
 
     /*
      * SI simple unit needed in support of creation of the base units

--- a/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
@@ -1,10 +1,9 @@
+/**
+ * Measurement unit declarations generated from NIST SP811 Appendix B
+ *
+ * See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+ */
 package <USCU> USCustomaryUnits {
-    doc /*
-    Library package with measurement unit declarations generated from NIST SP811 Appendix B
-    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
-    Generated at 2022-02-11T22:37:06Z
-    */
-
     private import UnitsAndScales::*;
     import ISQ::*;
     import SI::*;

--- a/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
@@ -1,100 +1,24 @@
-/**
- * US customary units defined w.r.t. SI units
- * Conversion factors are taken from NIST SP 811 Appendix B
- * See https://www.nist.gov/physical-measurement-laboratory/nist-guide-si-appendix-b
- */
-package USCustomaryUnits {
-	private import UnitsAndScales::*;
-	import ISQ::*;
-	private import SI::*;
+package <USCU> USCustomaryUnits {
+    doc /*
+    Library package with measurement unit declarations generated from NIST SP811 Appendix B
+    See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
+    Generated at 2022-02-11T22:37:06Z
+    */
 
-	attribute <ft> foot : LengthUnit {
-		:>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3048/10000; }
-	}
+    private import UnitsAndScales::*;
+    import ISQ::*;
+    import SI::*;
 
-	attribute <'in'> inch : LengthUnit {
-		:>> unitConversion: ConversionByConvention { :>> referenceUnit = ft; :>> conversionFactor = 1/12; }
-	}
-
-    attribute <mi> mile : LengthUnit {
-    	:>> unitConversion: ConversionByConvention { :>> referenceUnit = ft; :>> conversionFactor = 5280; }
-    }
-
-    attribute <lb> 'pound  (avoirdupois)' : MassUnit {
-    	:>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 4535924/10000000; }
-    }
-
-    attribute <'mi/h'> 'mile per hour' : SpeedUnit = mi/h;
-
-    attribute <lbf> 'pound-force' : ForceUnit {
-		:>> unitConversion: ConversionByConvention { :>> referenceUnit = SI::N; :>> conversionFactor = 4448222/1000000; }
-	}
-
-    /*
-     * Definition of an alias for 'mi/h' ("mile per hour")
-     */
-    alias mph for 'mi/h';
-
-	/*
-	 * degree Fahrenheit unit for relative temperature (i.e. temperature difference) quantities
-	 */
-	attribute <'°F_unit'> 'degree fahrenheit (relative)' : TemperatureUnit {
-		:>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; }
-	}
-
-	/*
-	 * degree Fahrenheit interval scale for absolute temperature quantities
-	 *
-	 * The interval scale is defined with an explicit mapping to the degree Celsius interval scale from which the offset between the scales can be computed.
-	 */
-	attribute <'°F_scale'> 'degree fahrenheit (absolute)' : IntervalScale {
-		:>> unit = '°F_unit';
-		private attribute temperatureWaterAtFreezingPointInF: DefinitionalQuantityValue {
-			:>> num = 32.0;
-			:>> definition = "temperature in degree Fahrenheit of pure water at freezing point";
-		}
-		private attribute fahrenheitToCelsiusScaleMapping: QuantityValueMapping {
-			:>> mappedQuantityValue = temperatureWaterAtFreezingPointInF;
-			:>> referenceQuantityValue = '°C_scale'.temperatureWaterAtFreezingPointInC;
-
-		}
-		attribute :>> definitionalQuantityValues = temperatureWaterAtFreezingPointInF;
-		attribute :>> quantityValueMapping = fahrenheitToCelsiusScaleMapping;
-	}
-	//alias '°F' for '°F_scale';
-
-    /*
-     * US Customary Units generated after transformation from NIST SP811 Appendix B
-     * See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
-     * Generated at 2022-01-10T00:45:14Z
-     */
-
-    attribute 'abampere' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
-    attribute 'abcoulomb' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 1.0E+01; } }
-    attribute 'abfarad' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.0E+09; } }
-    attribute 'abhenry' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 1.0E-09; } }
-    attribute 'abmho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.0E+09; } }
-    attribute 'abohm' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 1.0E-09; } }
-    attribute 'abvolt' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 1.0E-08; } }
-    attribute <g_n> 'acceleration of free fall, standard' : AccelerationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s^2; :>> conversionFactor = 9.80665E+00; } }
-    attribute 'acre (based on US survey foot)' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 4.046873E+03; } }
-    attribute 'acre foot (based on US survey foot)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.233489E+03; } }
-    attribute <'A⋅h'> 'ampere hour' : ElectricChargeUnit = A*h;
-    attribute <'Å'> 'ångström' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-10; } }
-    attribute <a> 'are' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E+02; } }
-    attribute <au> 'astronomical unit' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.495979E+11; } }
-    attribute <atm> 'atmosphere, standard' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.01325E+05; } }
-    attribute <at> 'atmosphere, technical' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+04; } }
-    attribute <bar> 'bar' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.0E+05; } }
-    attribute <b> 'barn' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E-28; } }
-    attribute <bbl> 'barrel (for petroleum, 42 gallons (US))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.589873E-01; } }
-    attribute <Bi> 'biot' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
-    attribute <Btu_IT> 'British thermal unit (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.055056E+03; } }
-    attribute <Btu_th> 'British thermal unit (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.054350E+03; } }
-    attribute <Btu> 'British thermal unit (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05587E+03; } }
-    attribute 'British thermal unit (39 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05967E+03; } }
-    attribute 'British thermal unit (59 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05480E+03; } }
-    attribute 'British thermal unit (60 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05468E+03; } }
+    attribute 'acre (based on US survey foot)' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 4.046873E+03; :>> isExact = false; } }
+    attribute 'acre foot (based on US survey foot)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.233489E+03; :>> isExact = false; } }
+    attribute <bbl> 'barrel (for petroleum, 42 gallons (US))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.589873E-01; :>> isExact = false; } }
+    attribute <Btu_IT> 'British thermal unit (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.055056E+03; :>> isExact = false; } }
+    alias Btu for Btu_IT;
+    attribute <Btu_th> 'British thermal unit (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.054350E+03; :>> isExact = false; } }
+    attribute <Btu_mean> 'British thermal unit (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05587E+03; :>> isExact = false; } }
+    attribute <'Btu_39°F'> 'British thermal unit (39 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05967E+03; :>> isExact = false; } }
+    attribute <'Btu_59°F'> 'British thermal unit (59 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05480E+03; :>> isExact = false; } }
+    attribute <'Btu_60°F'> 'British thermal unit (60 °F)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05468E+03; :>> isExact = false; } }
     attribute <'Btu_IT⋅ft/(h⋅ft²⋅°F)'> 'British thermal unit (IT) foot per hour square foot degree Fahrenheit' : ThermalConductivityUnit = Btu_IT*ft/(h*ft^2*'°F');
     attribute <'Btu_th⋅ft/(h⋅ft²⋅°F)'> 'British thermal unit (th) foot per hour square foot degree Fahrenheit' : ThermalConductivityUnit = Btu_th*ft/(h*ft^2*'°F');
     attribute <'Btu_IT⋅in/(h⋅ft²⋅°F)'> 'British thermal unit (IT) inch per hour square foot degree Fahrenheit' : ThermalConductivityUnit = Btu_IT*'in'/(h*ft^2*'°F');
@@ -130,39 +54,12 @@ package USCustomaryUnits {
     attribute <'Btu_IT/(ft²⋅s)'> 'British thermal unit (IT) per square foot second' : DensityOfHeatFlowRateUnit = Btu_IT/(ft^2*s);
     attribute <'Btu_th/(ft²⋅s)'> 'British thermal unit (th) per square foot second' : DensityOfHeatFlowRateUnit = Btu_th/(ft^2*s);
     attribute <'Btu_th/(in²⋅s)'> 'British thermal unit (th) per square inch second' : DensityOfHeatFlowRateUnit = Btu_th/('in'^2*s);
-    attribute <bu> 'bushel (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.523907E-02; } }
-    attribute <cal_IT> 'calorie (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+00; } }
-    attribute <cal_th> 'calorie (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+00; } }
-    attribute <cal> 'calorie (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+00; } }
-    attribute <cal_15> 'calorie (15 °C)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.18580E+00; } }
-    attribute <cal_20> 'calorie (20 °C)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.18190E+00; } }
-    attribute 'calorie (IT), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+03; } }
-    attribute 'calorie (th), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+03; } }
-    attribute 'calorie (mean), kilogram (nutrition)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+03; } }
-    attribute <'cal_th/(cm⋅s⋅°C)'> 'calorie (th) per centimeter second degree Celsius' : ThermalConductivityUnit = cal_th/(cm*s*'°C');
-    attribute <'cal_IT/g'> 'calorie (IT) per gram' : SpecificEnergyUnit = cal_IT/g;
-    attribute <'cal_th/g'> 'calorie (th) per gram' : SpecificEnergyUnit = cal_th/g;
-    attribute <'cal_IT/(g⋅°C)'> 'calorie (IT) per gram degree Celsius' : SpecificHeatCapacityUnit = cal_IT/(g*'°C');
-    attribute <'cal_th/(g⋅°C)'> 'calorie (th) per gram degree Celsius' : SpecificHeatCapacityUnit = cal_th/(g*'°C');
-    attribute <'cal_IT/(g⋅K)'> 'calorie (IT) per gram kelvin' : SpecificHeatCapacityUnit = cal_IT/(g*K);
-    //attribute <'cal_th/(g·K)'> 'calorie (th) per gram kelvin' : SpecificHeatCapacityUnit = cal_th/('g·K');
-    attribute <'cal_th/min'> 'calorie (th) per minute' : PowerUnit = cal_th/min;
-    attribute <'cal_th/s'> 'calorie (th) per second' : PowerUnit = cal_th/s;
-    //attribute <'cal_th/cm²'> 'calorie (th) per square centimeter' : SurfaceHeatDensityUnit = cal_th/cm^2;
-    attribute <'cal_th/(cm²⋅min)'> 'calorie (th) per square centimeter minute' : DensityOfHeatFlowRateUnit = cal_th/(cm^2*min);
-    attribute <'cal_th/(cm²⋅s)'> 'calorie (th) per square centimeter second' : DensityOfHeatFlowRateUnit = cal_th/(cm^2*s);
+    attribute <bu> 'bushel (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.523907E-02; :>> isExact = false; } }
     attribute <'cd/in²'> 'candela per square inch' : LuminanceUnit = cd/'in'^2;
-    attribute 'carat, metric' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.0E-04; } }
-    attribute 'centimeter of mercury (0 °C)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.33322E+03; } }
-    attribute <cmHg> 'centimeter of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+03; } }
-    attribute 'centimeter of water (4 °C)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80638E+01; } }
-    attribute <cmH2O> 'centimeter of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+01; } }
-    attribute <cP> 'centipoise' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.0E-03; } }
-    attribute <cSt> 'centistokes' : KinematicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2/s; :>> conversionFactor = 1.0E-06; } }
-    attribute <ch> 'chain (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.011684E+01; } }
-    attribute 'circular mil' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 5.067075E-10; } }
-    attribute 'clo' : ThermalInsulanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2*K/W; :>> conversionFactor = 1.55E-01; } }
-    attribute 'cord (128 ft^3)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.624556E+00; } }
+    attribute <ch> 'chain (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.011684E+01; :>> isExact = false; } }
+    attribute 'circular mil' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 5.067075E-10; :>> isExact = false; } }
+    attribute 'clo' : ThermalInsulanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2*K/W; :>> conversionFactor = 1.55E-01; :>> isExact = false; } }
+    attribute 'cord (128 ft^3)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.624556E+00; :>> isExact = false; } }
     attribute <'ft³'> 'cubic foot' : VolumeUnit = ft^3;
     attribute <'ft³/min'> 'cubic foot per minute' : VolumeFlowRateUnit = ft^3/min;
     attribute <'ft³/s'> 'cubic foot per second' : VolumeFlowRateUnit = ft^3/s;
@@ -171,19 +68,8 @@ package USCustomaryUnits {
     attribute <'mi³'> 'cubic mile' : VolumeUnit = mi^3;
     attribute <'yd³'> 'cubic yard' : VolumeUnit = yd^3;
     attribute <'yd³/min'> 'cubic yard per minute' : VolumeFlowRateUnit = yd^3/min;
-    attribute 'cup (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.365882E-04; } }
-    attribute <Ci> 'curie' : NuclearActivityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Bq; :>> conversionFactor = 3.7E+10; } }
-    attribute 'darcy' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 9.869233E-13; } }
-    attribute <d> 'day' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 8.64E+04; } }
-    attribute 'day (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 8.616409E+04; } }
-    attribute <D> 'debye' : ElectricDipoleMomentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C*m; :>> conversionFactor = 3.335641E-30; } }
-    attribute <'°'> 'degree (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 1.745329E-02; } }
-    attribute <'°C'> 'degree Celsius (temperature)' : TemperatureUnit; // conversion TBD
-    attribute 'degree Celsius (temperature interval)' : TemperatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 1.0E+00; } }
-    attribute 'degree centigrade (temperature)' : TemperatureUnit; // conversion TBD
-    attribute 'degree centigrade (temperature interval)' : TemperatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = '°C'; :>> conversionFactor = 1.0E+00; } }
-    attribute <'°F'> 'degree Fahrenheit (temperature)' : TemperatureUnit; // conversion TBD
-    attribute 'degree Fahrenheit (temperature interval)' : TemperatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = '°C'; :>> conversionFactor = 5.555556E-01; } }
+    attribute 'cup (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.365882E-04; :>> isExact = false; } }
+    attribute <'°F'> 'degree Fahrenheit (temperature interval)' : TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; } }
     attribute <'°F⋅h/Btu_IT'> 'degree Fahrenheit hour per British thermal unit (IT)' : ThermalResistanceUnit = '°F'*h/Btu_IT;
     attribute <'°F⋅h/Btu_th'> 'degree Fahrenheit hour per British thermal unit (th)' : ThermalResistanceUnit = '°F'*h/Btu_th;
     attribute <'°F⋅h⋅ft²/Btu_IT'> 'degree Fahrenheit hour square foot per British thermal unit (IT)' : ThermalInsulanceUnit = '°F'*h*ft^2/Btu_IT;
@@ -192,165 +78,90 @@ package USCustomaryUnits {
     //attribute <'°F⋅h⋅ft²/(Btu_th⋅in)'> 'degree Fahrenheit hour square foot per British thermal unit (th) inch' : ThermalResistivityUnit = '°F'*h*ft^2/(Btu_th*'in');
     attribute <'°F⋅s/Btu_IT'> 'degree Fahrenheit second per British thermal unit (IT)' : ThermalResistanceUnit = '°F'*s/Btu_IT;
     attribute <'°F⋅s/Btu_th'> 'degree Fahrenheit second per British thermal unit (th)' : ThermalResistanceUnit = '°F'*s/Btu_th;
-    attribute <'°R'> 'degree Rankine' : TemperatureUnit; // conversion TBD
-    attribute 'degree Rankine (temperature interval)' : TemperatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5.555556E-01; } }
-    attribute 'denier' : LinearMassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m; :>> conversionFactor = 1.111111E-07; } }
-    attribute <dyn> 'dyne' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 1.0E-05; } }
-    attribute <'dyn⋅cm'> 'dyne centimeter' : MomentOfForceUnit = dyn*cm;
-    attribute <'dyn/cm²'> 'dyne per square centimeter' : PressureUnit = dyn/cm^2;
-    attribute <eV> 'electronvolt' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.602177E-19; } }
-    //attribute <abfarad> 'EMU of capacitance' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.0E+09; } }
-    //attribute <abampere> 'EMU of current' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 1.0E+01; } }
-    //attribute <abvolt> 'EMU of electric potential' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 1.0E-08; } }
-    //attribute <abhenry> 'EMU of inductance' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 1.0E-09; } }
-    //attribute <abohm> 'EMU of resistance' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 1.0E-09; } }
-    attribute <erg> 'erg' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.0E-07; } }
-    attribute <'erg/s'> 'erg per second' : PowerUnit = erg/s;
-    attribute <'erg/(cm²⋅s)'> 'erg per square centimeter second' : DensityOfHeatFlowRateUnit = erg/(cm^2*s);
-    attribute <statfarad> 'ESU of capacitance' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.112650E-12; } }
-    attribute <statampere> 'ESU of current' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 3.335641E-10; } }
-    attribute <statvolt> 'ESU of electric potential' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 2.997925E+02; } }
-    attribute <stathenry> 'ESU of inductance' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 8.987552E+11; } }
-    attribute <statohm> 'ESU of resistance' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 8.987552E+11; } }
-    attribute 'faraday (based on carbon 12)' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 9.648531E+04; } }
-    attribute 'fathom (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.828804E+00; } }
-    attribute 'fermi' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-15; } }
-    attribute <floz> 'fluid ounce (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; } }
-    //attribute <ft> 'foot' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048E-01; } }
-    attribute 'foot (US survey)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048006E-01; } }
-    attribute 'footcandle' : IlluminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = lx; :>> conversionFactor = 1.076391E+01; } }
-    attribute 'footlambert' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 3.426259E+00; } }
-    attribute <ftHg> 'foot of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 4.063666E+04; } }
-    attribute 'foot of water (39.2 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.98898E+03; } }
-    attribute <ftH2O> 'foot of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.989067E+03; } }
+    attribute <'°R'> 'degree Rankine' : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; } }
+    attribute 'fathom (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.828804E+00; :>> isExact = false; } }
+    attribute <floz> 'fluid ounce (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; :>> isExact = false; } }
+    attribute <ft> 'foot' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048E-01; } }
+    attribute 'foot (US survey)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048006E-01; :>> isExact = false; } }
+    attribute 'footcandle' : IlluminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = lx; :>> conversionFactor = 1.076391E+01; :>> isExact = false; } }
+    attribute 'footlambert' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 3.426259E+00; :>> isExact = false; } }
+    attribute <ftHg> 'foot of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 4.063666E+04; :>> isExact = false; } }
+    attribute 'foot of water (39.2 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.98898E+03; :>> isExact = false; } }
+    attribute <ftH2O> 'foot of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.989067E+03; :>> isExact = false; } }
     attribute <'ft/h'> 'foot per hour' : SpeedUnit = ft/h;
     attribute <'ft/min'> 'foot per minute' : SpeedUnit = ft/min;
     attribute <'ft/s'> 'foot per second' : SpeedUnit = ft/s;
     attribute <'ft/s²'> 'foot per second squared' : AccelerationUnit = ft/s^2;
-    attribute 'foot poundal' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.214011E-02; } }
+    attribute 'foot poundal' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.214011E-02; :>> isExact = false; } }
     attribute <'ft⋅lbf'> 'foot pound-force' : EnergyUnit = ft*lbf;
     attribute <'ft⋅lbf/h'> 'foot pound-force per hour' : PowerUnit = ft*lbf/h;
     attribute <'ft⋅lbf/min'> 'foot pound-force per minute' : PowerUnit = ft*lbf/min;
     attribute <'ft⋅lbf/s'> 'foot pound-force per second' : PowerUnit = ft*lbf/s;
     attribute <'ft⁴'> 'foot to the fourth power' : SecondAxialMomentOfAreaUnit = ft^4;
-    attribute <Fr> 'franklin' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 3.335641E-10; } }
-    //attribute <Gal> 'gal' : AccelerationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s^2; :>> conversionFactor = 1.0E-02; } }
-    attribute <gal_imp> 'gallon (Canadian and UK (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.54609E-03; } }
-    attribute <gal> 'gallon (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.785412E-03; } }
+    attribute <gal> 'gallon (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 3.785412E-03; :>> isExact = false; } }
     attribute <'gal/d'> 'gallon (US) per day' : VolumeFlowRateUnit = gal/d;
     //attribute <'gal/(hp⋅h)'> 'gallon (US) per horsepower hour' : EnergySpecificVolumeUnit = gal/(hp*h);
     attribute <'gal/min'> 'gallon (US) per minute (gpm)' : VolumeFlowRateUnit = gal/min;
-    attribute <'γ'> 'gamma' : MagneticFluxDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = T; :>> conversionFactor = 1.0E-09; } }
-    attribute <Gs> 'gauss' : MagneticFluxDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = T; :>> conversionFactor = 1.0E-04; } }
-    attribute <Gi> 'gilbert' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 7.957747E-01; } }
-    attribute <gi> 'gill (Canadian and UK (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.420653E-04; } }
-    attribute 'gill (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.182941E-04; } }
-    attribute <gon> 'gon (also called grade)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 1.570796E-02; } }
+    attribute <gi> 'gill (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.182941E-04; :>> isExact = false; } }
     attribute <gr> 'grain' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 6.479891E-05; } }
     attribute <'gr/gal'> 'grain per gallon (US)' : MassDensityUnit = gr/gal;
-    //attribute <'gf/cm²'> 'gram-force per square centimeter' : PressureUnit = gf/cm^2;
-    attribute <'g/cm³'> 'gram per cubic centimeter' : MassDensityUnit = g/cm^3;
-    attribute <ha> 'hectare' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 1.0E+04; } }
-    attribute <hp> 'horsepower (550 ft*lbf/s)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.456999E+02; } }
-    attribute 'horsepower (boiler)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 9.80950E+03; } }
+    attribute <hp> 'horsepower (550 ft*lbf/s)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.456999E+02; :>> isExact = false; } }
+    attribute 'horsepower (boiler)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 9.80950E+03; :>> isExact = false; } }
     attribute 'horsepower (electric)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.46E+02; } }
-    attribute 'horsepower (metric)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.354988E+02; } }
-    attribute 'horsepower (UK)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.4570E+02; } }
-    attribute 'horsepower (water)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.46043E+02; } }
-    attribute <h> 'hour' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.6E+03; } }
-    attribute 'hour (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.590170E+03; } }
-    attribute 'hundredweight (long, 112 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 5.080235E+01; } }
-    attribute 'hundredweight (short, 100 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 4.535924E+01; } }
-    //attribute <'in'> 'inch' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.54E-02; } }
-    attribute 'inch of mercury (32 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.38638E+03; } }
-    attribute 'inch of mercury (60 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.37685E+03; } }
-    attribute <inHg> 'inch of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.386389E+03; } }
-    attribute 'inch of water (39.2 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.49082E+02; } }
-    attribute 'inch of water (60 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.4884E+02; } }
-    attribute <inH2O> 'inch of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.490889E+02; } }
+    attribute 'horsepower (water)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 7.46043E+02; :>> isExact = false; } }
+    attribute 'hundredweight (long, 112 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 5.080235E+01; :>> isExact = false; } }
+    attribute 'hundredweight (short, 100 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 4.535924E+01; :>> isExact = false; } }
+    attribute <'in'> 'inch' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.54E-02; } }
+    attribute 'inch of mercury (32 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.38638E+03; :>> isExact = false; } }
+    attribute 'inch of mercury (60 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.37685E+03; :>> isExact = false; } }
+    attribute <inHg> 'inch of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 3.386389E+03; :>> isExact = false; } }
+    attribute 'inch of water (39.2 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.49082E+02; :>> isExact = false; } }
+    attribute 'inch of water (60 °F)' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.4884E+02; :>> isExact = false; } }
+    attribute <inH2O> 'inch of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 2.490889E+02; :>> isExact = false; } }
     attribute <'in/s'> 'inch per second' : SpeedUnit = 'in'/s;
     attribute <'in/s²'> 'inch per second squared' : AccelerationUnit = 'in'/s^2;
     attribute <'in⁴'> 'inch to the fourth power' : SecondAxialMomentOfAreaUnit = 'in'^4;
-    attribute <K> 'kayser' : CurvatureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^-1; :>> conversionFactor = 1.0E+02; } }
-    attribute 'kelvin' : TemperatureUnit; // conversion TBD
-    attribute <kcal_IT> 'kilocalorie (IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.1868E+03; } }
-    attribute <kcal_th> 'kilocalorie (th)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+03; } }
-    attribute <kcal> 'kilocalorie (mean)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.19002E+03; } }
-    attribute <'kcal_th/min'> 'kilocalorie (th) per minute' : PowerUnit = kcal_th/min;
-    attribute <'kcal_th/s'> 'kilocalorie (th) per second' : PowerUnit = kcal_th/s;
-    attribute <kgf> 'kilogram-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 9.80665E+00; } }
-    attribute <'kgf⋅m'> 'kilogram-force meter' : MomentOfForceUnit = kgf*m;
-    attribute <'kgf/cm²'> 'kilogram-force per square centimeter' : PressureUnit = kgf/cm^2;
-    attribute <'kgf/m²'> 'kilogram-force per square meter' : PressureUnit = kgf/m^2;
-    attribute <'kgf/mm²'> 'kilogram-force per square millimeter' : PressureUnit = kgf/mm^2;
-    attribute <'kgf⋅s²/m'> 'kilogram-force second squared per meter' : MassUnit = kgf*s^2/m;
-    attribute <'km/h'> 'kilometer per hour' : SpeedUnit = km/h;
-    attribute <kp> 'kilopond (kilogram-force)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 9.80665E+00; } }
-    attribute <'kW⋅h'> 'kilowatt hour' : EnergyUnit = kW*h;
-    attribute <kip> 'kip (1 kip = 1000 lbf)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 4.448222E+03; } }
+    attribute <kip> 'kip (1 kip = 1000 lbf)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 4.448222E+03; :>> isExact = false; } }
     attribute <'kip/in²'> 'kip per square inch (ksi)' : PressureUnit = kip/'in'^2;
-    attribute 'knot (nautical mile per hour)' : SpeedUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s; :>> conversionFactor = 5.144444E-01; } }
-    attribute 'lambert' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 3.183099E+03; } }
-    //attribute 'langley' : SurfaceHeatDensityUnit = cal_th/cm^2;
-    attribute <'l.y.'> 'light year' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 9.46073E+15; } }
-    attribute <L> 'liter' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.0E-03; } }
+    attribute <knot> 'knot (nautical mile per hour)' : SpeedUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m/s; :>> conversionFactor = 5.144444E-01; :>> isExact = false; } }
+    //attribute <'cal_th/cm²'> 'langley' : SurfaceHeatDensityUnit = cal_th/cm^2;
     attribute <'lm/ft²'> 'lumen per square foot' : IlluminanceUnit = lm/ft^2;
-    attribute <Mx> 'maxwell' : MagneticFluxUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Wb; :>> conversionFactor = 1.0E-08; } }
-    attribute 'mho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.0E+00; } }
     attribute 'microinch' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.54E-08; } }
-    attribute <'μ'> 'micron' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.0E-06; } }
-    attribute 'mil (0.001 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.54E-05; } }
-    attribute 'mil (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 9.817477E-04; } }
-    //attribute <mi> 'mile' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.609344E+03; } }
-    attribute 'mile (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.609347E+03; } }
-    attribute 'mile, nautical' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.852E+03; } }
-    //attribute <'mi/gal'> 'mile per gallon (US) (mpg)' : FuelEconomyUnit = mi/gal;
-    //attribute <'mi/h'> 'mile per hour' : SpeedUnit = mi/h;
+    attribute <mil> 'mil (0.001 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 2.54E-05; } }
+    attribute <mi> 'mile' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.609344E+03; } }
+    attribute 'mile (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.609347E+03; :>> isExact = false; } }
+    attribute <nmi> 'mile, nautical' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.852E+03; } }
+    alias NM for nmi;
+    //attribute <'mi/gal'> 'mile per gallon (US)' : FuelEconomyUnit = mi/gal;
+    //alias mpg for 'mi/gal';
+    attribute <'mi/h'> 'mile per hour' : SpeedUnit = mi/h;
+    alias mph for 'mi/h';
     attribute <'mi/min'> 'mile per minute' : SpeedUnit = mi/min;
     attribute <'mi/s'> 'mile per second' : SpeedUnit = mi/s;
-    attribute <mbar> 'millibar' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.0E+02; } }
-    attribute <mmHg> 'millimeter of mercury, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+02; } }
-    attribute <mmH2O> 'millimeter of water, conventional' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 9.80665E+00; } }
-    attribute <'′'> 'minute (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 2.908882E-04; } }
-    attribute <min> 'minute' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 6.0E+01; } }
-    attribute 'minute (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 5.983617E+01; } }
-    attribute <Oe> 'oersted' : LinearElectricCurrentDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A/m; :>> conversionFactor = 7.957747E+01; } }
-    attribute <'Ω⋅cm'> 'ohm centimeter' : ResistivityUnit = 'Ω'*cm;
-    attribute 'ohm circular-mil per foot' : ResistivityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'*m; :>> conversionFactor = 1.662426E-09; } }
-    attribute <oz> 'ounce (avoirdupois)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.834952E-02; } }
-    attribute 'ounce (troy or apothecary)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 3.110348E-02; } }
-    attribute 'ounce (Canadian and UK fluid (Imperial))' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.841306E-05; } }
-    attribute 'ounce (US fluid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; } }
-    attribute <ozf> 'ounce (avoirdupois)-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 2.780139E-01; } }
+    attribute 'ohm circular-mil per foot' : ResistivityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'*m; :>> conversionFactor = 1.662426E-09; :>> isExact = false; } }
+    attribute <oz> 'ounce (avoirdupois)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.834952E-02; :>> isExact = false; } }
+    attribute 'ounce (US fluid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; :>> isExact = false; } }
+    attribute <ozf> 'ounce (avoirdupois)-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 2.780139E-01; :>> isExact = false; } }
     attribute <'ozf⋅in'> 'ounce (avoirdupois)-force inch' : MomentOfForceUnit = ozf*'in';
     attribute <'oz/in³'> 'ounce (avoirdupois) per cubic inch' : MassDensityUnit = oz/'in'^3;
-    attribute <'oz/gal'> 'ounce (avoirdupois) per gallon (Canadian and UK (Imperial))' : MassDensityUnit = oz/gal;
-    attribute 'ounce (avoirdupois) per gallon (US)' : MassDensityUnit = oz/gal;
+    attribute <'oz/gal'> 'ounce (avoirdupois) per gallon (US)' : MassDensityUnit = oz/gal;
     attribute <'oz/ft²'> 'ounce (avoirdupois) per square foot' : SurfaceMassDensityUnit = oz/ft^2;
     attribute <'oz/in²'> 'ounce (avoirdupois) per square inch' : SurfaceMassDensityUnit = oz/'in'^2;
     attribute <'oz/yd²'> 'ounce (avoirdupois) per square yard' : SurfaceMassDensityUnit = oz/yd^2;
-    attribute <pc> 'parsec' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.085678E+16; } }
-    attribute <pk> 'peck (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 8.809768E-03; } }
-    attribute <dwt> 'pennyweight' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.555174E-03; } }
-    //attribute 'perm (0 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/(Pa*s*m^2); :>> conversionFactor = 5.72135E-11; } }
-    //attribute 'perm (23 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/(Pa*s*m^2); :>> conversionFactor = 5.74525E-11; } }
-    //attribute 'perm inch (0 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/('Pa·s·m'); :>> conversionFactor = 1.45322E-12; } }
-    //attribute 'perm inch (23 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/('Pa·s·m'); :>> conversionFactor = 1.45929E-12; } }
-    attribute <ph> 'phot' : IlluminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = lx; :>> conversionFactor = 1.0E+04; } }
-    attribute 'pica (computer) (1/6 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 4.233333E-03; } }
-    attribute 'pica (printers)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 4.217518E-03; } }
-    attribute <drypt> 'pint (US dry)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 5.506105E-04; } }
-    attribute <liqpt> 'pint (US liquid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.731765E-04; } }
-    attribute 'point (computer) (1/72 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.527778E-04; } }
-    //attribute 'point (printer's)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.514598E-04; } }
-    attribute <P> 'poise' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.0E-01; } }
-    //attribute <lb> 'pound (avoirdupois)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 4.535924E-01; } }
-    attribute 'pound (troy or apothecary)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 3.732417E-01; } }
-    attribute 'poundal' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 1.382550E-01; } }
-    attribute 'poundal per square foot' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.488164E+00; } }
-    attribute 'poundal second per square foot' : DynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa*s; :>> conversionFactor = 1.488164E+00; } }
+    attribute <pk> 'peck (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 8.809768E-03; :>> isExact = false; } }
+    //attribute 'perm (0 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/(Pa*s*m^2); :>> conversionFactor = 5.72135E-11; :>> isExact = false; } }
+    //attribute 'perm (23 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/(Pa*s*m^2); :>> conversionFactor = 5.74525E-11; :>> isExact = false; } }
+    //attribute 'perm inch (0 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/('Pa·s·m'); :>> conversionFactor = 1.45322E-12; :>> isExact = false; } }
+    //attribute 'perm inch (23 °C)' : VapourTransmissionUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/('Pa·s·m'); :>> conversionFactor = 1.45929E-12; :>> isExact = false; } }
+    attribute <pica> 'pica (computer) (1/6 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 4.233333E-03; :>> isExact = false; } }
+    attribute 'pica (printer′s)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 4.217518E-03; :>> isExact = false; } }
+    attribute <drypt> 'pint (US dry)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 5.506105E-04; :>> isExact = false; } }
+    attribute <liqpt> 'pint (US liquid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.731765E-04; :>> isExact = false; } }
+    attribute <pt> 'point (computer) (1/72 in)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.527778E-04; :>> isExact = false; } }
+    attribute 'point (printer′s)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.514598E-04; :>> isExact = false; } }
+    attribute <lb> 'pound (avoirdupois)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 4.535924E-01; :>> isExact = false; } }
     attribute <'lb⋅ft²'> 'pound foot squared' : MomentOfInertiaUnit = lb*ft^2;
-    //attribute <lbf> 'pound-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 4.448222E+00; } }
+    attribute <lbf> 'pound-force' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 4.448222E+00; :>> isExact = false; } }
     attribute <'lbf⋅ft'> 'pound-force foot' : MomentOfForceUnit = lbf*ft;
     attribute <'lbf⋅ft/in'> 'pound-force foot per inch' : ForceUnit = lbf*ft/'in';
     attribute <'lbf⋅in'> 'pound-force inch' : MomentOfForceUnit = lbf*'in';
@@ -359,7 +170,8 @@ package USCustomaryUnits {
     attribute <'lbf/in'> 'pound-force per inch' : SurfaceTensionUnit = lbf/'in';
     //attribute 'pound-force per pound (lbf/lb) (thrust to mass ratio)' : ThrustToMassRatioUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N/kg; :>> conversionFactor = 9.80665E+00; } }
     attribute <'lbf/ft²'> 'pound-force per square foot' : PressureUnit = lbf/ft^2;
-    attribute <'lbf/in²'> 'pound-force per square inch (psi)' : PressureUnit = lbf/'in'^2;
+    attribute <'lbf/in²'> 'pound-force per square inch' : PressureUnit = lbf/'in'^2;
+    alias psi for 'lbf/in²';
     attribute <'lbf⋅s/ft²'> 'pound-force second per square foot' : DynamicViscosityUnit = lbf*s/ft^2;
     attribute <'lbf⋅s/in²'> 'pound-force second per square inch' : DynamicViscosityUnit = lbf*s/'in'^2;
     attribute <'lb⋅in²'> 'pound inch squared' : MomentOfInertiaUnit = lb*'in'^2;
@@ -369,8 +181,7 @@ package USCustomaryUnits {
     attribute <'lb/ft'> 'pound per foot' : LinearMassDensityUnit = lb/ft;
     attribute <'lb/(ft⋅h)'> 'pound per foot hour' : DynamicViscosityUnit = lb/(ft*h);
     attribute <'lb/(ft⋅s)'> 'pound per foot second' : DynamicViscosityUnit = lb/(ft*s);
-    attribute <'lb/gal'> 'pound per gallon (Canadian and UK (Imperial))' : MassDensityUnit = lb/gal;
-    attribute 'pound per gallon (US)' : MassDensityUnit = lb/gal;
+    attribute <'lb/gal'> 'pound per gallon (US)' : MassDensityUnit = lb/gal;
     //attribute <'lb/(hp⋅h)'> 'pound per horsepower hour' : FuelConsumptionUnit = lb/(hp*h);
     attribute <'lb/h'> 'pound per hour' : MassFlowRateUnit = lb/h;
     attribute <'lb/in'> 'pound per inch' : LinearMassDensityUnit = lb/'in';
@@ -379,22 +190,12 @@ package USCustomaryUnits {
     attribute <'lb/ft²'> 'pound per square foot' : SurfaceMassDensityUnit = lb/ft^2;
     attribute <'lb/in²'> 'pound per square inch (not pound-force)' : SurfaceMassDensityUnit = lb/'in'^2;
     attribute <'lb/yd'> 'pound per yard' : LinearMassDensityUnit = lb/yd;
-    attribute 'psi (pound-force per square inch)' : PressureUnit = lbf/'in'^2;
-    attribute 'quad (10^15 Btu_IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.055056E+18; } }
-    attribute <dryqt> 'quart (US dry)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.101221E-03; } }
-    attribute <liqqt> 'quart (US liquid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 9.463529E-04; } }
-    attribute <rad> 'rad (absorbed dose)' : AbsorbedDoseUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Gy; :>> conversionFactor = 1.0E-02; } }
-    attribute <rem> 'rem' : DoseEquivalentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Sv; :>> conversionFactor = 1.0E-02; } }
-    attribute <r> 'revolution' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 6.283185E+00; } }
-    attribute <'r/min'> 'revolution per minute (rpm)' : AngularVelocityUnit = r/min;
-    //attribute 'rhe' : ReciprocalDynamicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa^-1*s^-1; :>> conversionFactor = 1.0E+01; } }
-    attribute <rd> 'rod (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 5.029210E+00; } }
-    attribute <R> 'roentgen' : ExposureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C/kg; :>> conversionFactor = 2.58E-04; } }
-    attribute 'rpm (revolution per minute)' : AngularVelocityUnit = r/min;
-    attribute <'″'> 'second (angle)' : AngularMeasureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = rad; :>> conversionFactor = 4.848137E-06; } }
-    attribute 'second (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 9.972696E-01; } }
-    attribute 'shake' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 1.0E-08; } }
-    attribute <slug> 'slug' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.459390E+01; } }
+    attribute 'pound-force per square inch (psi)' : PressureUnit = lbf/'in'^2;
+    attribute 'quad (10^15 Btu_IT)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.055056E+18; :>> isExact = false; } }
+    attribute <dryqt> 'quart (US dry)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.101221E-03; :>> isExact = false; } }
+    attribute <liqqt> 'quart (US liquid)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 9.463529E-04; :>> isExact = false; } }
+    attribute <rd> 'rod (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 5.029210E+00; :>> isExact = false; } }
+    attribute <slug> 'slug' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.459390E+01; :>> isExact = false; } }
     attribute <'slug/ft³'> 'slug per cubic foot' : MassDensityUnit = slug/ft^3;
     attribute <'slug/(ft⋅s)'> 'slug per foot second' : DynamicViscosityUnit = slug/(ft*s);
     attribute <'ft²'> 'square foot' : AreaUnit = ft^2;
@@ -402,44 +203,49 @@ package USCustomaryUnits {
     attribute <'ft²/s'> 'square foot per second' : KinematicViscosityUnit = ft^2/s;
     attribute <'in²'> 'square inch' : AreaUnit = 'in'^2;
     attribute <'mi²'> 'square mile' : AreaUnit = mi^2;
-    attribute 'square mile (based on US survey foot)' : AreaUnit = mi^2;
+    attribute 'square mile (based on US survey foot)' : AreaUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2; :>> conversionFactor = 2.589998E+06; :>> isExact = false; } }
     attribute <'yd²'> 'square yard' : AreaUnit = yd^2;
-    //attribute 'statampere' : ElectricCurrentUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = A; :>> conversionFactor = 3.335641E-10; } }
-    attribute 'statcoulomb' : ElectricChargeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = C; :>> conversionFactor = 3.335641E-10; } }
-    //attribute 'statfarad' : CapacitanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = F; :>> conversionFactor = 1.112650E-12; } }
-    //attribute 'stathenry' : InductanceUnit, PermeanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = H; :>> conversionFactor = 8.987552E+11; } }
-    attribute 'statmho' : ConductanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = S; :>> conversionFactor = 1.112650E-12; } }
-    //attribute 'statohm' : ResistanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = 'Ω'; :>> conversionFactor = 8.987552E+11; } }
-    //attribute 'statvolt' : ElectricPotentialUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = V; :>> conversionFactor = 2.997925E+02; } }
-    attribute <st> 'stere' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.0E+00; } }
-    attribute <sb> 'stilb' : LuminanceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = cd/m^2; :>> conversionFactor = 1.0E+04; } }
-    attribute <St> 'stokes' : KinematicViscosityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^2/s; :>> conversionFactor = 1.0E-04; } }
-    attribute 'tablespoon' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.478676E-05; } }
-    attribute 'teaspoon' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.928922E-06; } }
-    attribute 'tex' : LinearMassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m; :>> conversionFactor = 1.0E-06; } }
+    attribute 'tablespoon' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 1.478676E-05; :>> isExact = false; } }
+    attribute 'teaspoon' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 4.928922E-06; :>> isExact = false; } }
     attribute 'therm (EC)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.05506E+08; } }
     attribute 'therm (US)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 1.054804E+08; } }
-    attribute <AT> 'ton, assay' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.916667E-02; } }
-    attribute 'ton-force (2000 lbf)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 8.896443E+03; } }
-    attribute 'ton, long (2240 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.016047E+03; } }
-    attribute 'ton, long, per cubic yard' : MassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m^3; :>> conversionFactor = 1.328939E+03; } }
-    attribute <t> 'ton, metric' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.0E+03; } }
-    attribute 'tonne (called "metric ton" in US)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.0E+03; } }
-    attribute 'ton of refrigeration (12 000 Btu_IT/h)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 3.516853E+03; } }
-    attribute 'ton of TNT (energy equivalent)' : EnergyUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = J; :>> conversionFactor = 4.184E+09; } }
-    attribute 'ton, register' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.831685E+00; } }
-    attribute 'ton, short (2000 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 9.071847E+02; } }
-    attribute 'ton, short, per cubic yard' : MassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m^3; :>> conversionFactor = 1.186553E+03; } }
-    attribute 'ton, short, per hour' : MassFlowRateUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/s; :>> conversionFactor = 2.519958E-01; } }
-    attribute <Torr> 'torr' : PressureUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Pa; :>> conversionFactor = 1.333224E+02; } }
-    attribute 'unit pole' : MagneticFluxUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Wb; :>> conversionFactor = 1.256637E-07; } }
-    attribute <'W⋅h'> 'watt hour' : EnergyUnit = W*h;
-    attribute <'W/cm²'> 'watt per square centimeter' : DensityOfHeatFlowRateUnit = W/cm^2;
+    attribute <AT> 'ton, assay' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 2.916667E-02; :>> isExact = false; } }
+    attribute 'ton-force (2000 lbf)' : ForceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = N; :>> conversionFactor = 8.896443E+03; :>> isExact = false; } }
+    attribute 'ton, long (2240 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 1.016047E+03; :>> isExact = false; } }
+    attribute 'ton, long, per cubic yard' : MassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m^3; :>> conversionFactor = 1.328939E+03; :>> isExact = false; } }
+    attribute 'ton of refrigeration (12 000 Btu_IT/h)' : PowerUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = W; :>> conversionFactor = 3.516853E+03; :>> isExact = false; } }
+    attribute 'ton, register' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.831685E+00; :>> isExact = false; } }
+    attribute 'ton, short (2000 lb)' : MassUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg; :>> conversionFactor = 9.071847E+02; :>> isExact = false; } }
+    attribute 'ton, short, per cubic yard' : MassDensityUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/m^3; :>> conversionFactor = 1.186553E+03; :>> isExact = false; } }
+    attribute 'ton, short, per hour' : MassFlowRateUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = kg/s; :>> conversionFactor = 2.519958E-01; :>> isExact = false; } }
+    attribute 'unit pole' : MagneticFluxUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = Wb; :>> conversionFactor = 1.256637E-07; :>> isExact = false; } }
     attribute <'W/in²'> 'watt per square inch' : DensityOfHeatFlowRateUnit = W/'in'^2;
-    attribute <'W⋅s'> 'watt second' : EnergyUnit = W*s;
     attribute <yd> 'yard' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 9.144E-01; } }
-    attribute 'year (365 days)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.1536E+07; } }
-    attribute 'year (sidereal)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.155815E+07; } }
-    attribute 'year (tropical)' : DurationUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = s; :>> conversionFactor = 3.155693E+07; } }
+
+
+	/*
+	 * degree Fahrenheit interval scale for absolute (thermodynamic) temperature quantities
+	 *
+	 * The scale is defined with an explicit mapping to the degree Celsius interval scale and a coordinate transformation w.r.t. the kelvin scale
+	 */
+	attribute <'°F_abs'> 'degree fahrenheit (absolute)' : IntervalScale {
+		:>> unit = '°F';
+		private attribute temperatureWaterAtFreezingPointInF: DefinitionalQuantityValue {
+			:>> num = 32.0;
+			:>> definition = "temperature in degree Fahrenheit of pure water at freezing point";
+		}
+		private attribute fahrenheitToCelsiusScaleMapping: QuantityValueMapping {
+			:>> mappedQuantityValue = temperatureWaterAtFreezingPointInF;
+			:>> referenceQuantityValue = '°C_abs'.temperatureWaterAtFreezingPointInC;
+
+		}
+		attribute :>> definitionalQuantityValues = temperatureWaterAtFreezingPointInF;
+		attribute :>> quantityValueMapping = fahrenheitToCelsiusScaleMapping;
+
+        /* CoordinateTransformation (zero shift) w.r.t. thermodynamic temperature in kelvin */ 
+        private attribute zeroDegreeFahrenheitInKelvin: ThermodynamicTemperatureValue = 229835/900 [K];
+        attribute zeroShift : CoordinateTransformation { :>> source = K; :>> target = self; :>> origin = zeroDegreeFahrenheitInKelvin; :>> basisDirections = 1 [K]; }
+        attribute :>> placement = zeroShift;
+	}
 
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
@@ -22,14 +22,15 @@ package UnitsAndScales {
 	 * to a single dimensional measurement reference for a scalar quantity. The measurement references for all dimensions of a
 	 * quantity are specified through the mRefs attribute. Each element of mRefs is a ScalarMeasurementReference.
 	 *
-	 * The longName of a TensorMeasurementReference is the spelled-out human readable name of the measurement reference.
-	 * For example, typical measurement units for the speed quantity would have the longName "metre per second", "kilometre per hour",
-	 * "mile per hour".
+	 * The humanId of a TensorMeasurementReference is the unique symbol by which the measurement reference is known.
+	 * The name of a TensorMeasurementReference is spelled-out human readable name of the measurement reference.
+	 * For example, typical measurement units for the speed quantity would have the respective humanId and name: 
+	 * <'m/s'> and 'metre per second',
+	 * <'km/h'> and 'kilometre per hour',
+	 * <'mi/h'> and 'mile per hour'.
 	 *
 	 * A measurement reference can have zero or more definitionalQuantityValues that allows to specify
 	 * quantity values that carry a particular meaning or relevance for the measurement reference.
-     *
-	 * To stress the generality of the TensorMeasurementReference the alias MeasurementReference is defined.
 	 */
 	attribute def TensorMeasurementReference :> Array {
 		attribute isBound: Boolean[1] default false;

--- a/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
@@ -38,7 +38,6 @@ package UnitsAndScales {
 		attribute mRefs: ScalarMeasurementReference[1..*] :>> elements;
 		attribute definitionalQuantityValues: DefinitionalQuantityValue[0..*];
 	}
-	alias MeasurementReference for TensorMeasurementReference;
 
 	/**
 	 * A VectorMeasurementReference is a specialization of TensorMeasurementReference for vector quantities that are
@@ -46,8 +45,8 @@ package UnitsAndScales {
 	 * The `n` basis unit vectors that span the vector space are defined by the mRefs which each are
 	 * a ScalarMeasurementReference, typically a MeasurementUnit or an IntervalScale.
 	 *
-	 * Pairwise VectorQuantityValue and VectorMeasurementReference specializations can also be used to define a vector space
-	 * for state vectors as used in state-space representation models.
+	 * A pair of a specialization of VectorQuantityValue and a specialization of VectorMeasurementReference can also be used to 
+	 * define a vector space for state vectors as used in state-space representation models.
 	 *
 	 * Attribute isOrthogonal declares whether the basis vectors of the vector space are orthogonal, i.e. whether the
 	 * inner products of any pair of basis vectors yield zero.
@@ -141,10 +140,13 @@ package UnitsAndScales {
 
 	/**
 	 * Representation of the linear conversion relationship between one measurement unit and another measurement unit, that acts as a reference.
+	 * 
+	 * Attribute isExact asserts whether the conversionFactor is exact or not. By default it is set true.
 	 */
 	abstract attribute def UnitConversion {
 		attribute referenceUnit: MeasurementUnit;
 		attribute conversionFactor: Real;
+		attribute isExact: Boolean default true;
 	}
 
 	/**
@@ -250,7 +252,7 @@ package UnitsAndScales {
 	}
 
 	/**
-	 * Representation of a particular quantity value that is used in the definition of a MeasurementReference
+	 * Representation of a particular quantity value that is used in the definition of a TensorMeasurementReference
 	 *
 	 * Typically such a particular value is defined by convention. It can be used to define a selected reference value,
 	 * such as the meaning of zero on a measurement scale or the origin of a top-level coordinate system.
@@ -293,9 +295,12 @@ package UnitsAndScales {
 	 * for a given system of quantities".
 	 * The base units are a particular selection of measurement units for each of the base quantities of a system of quantities,
 	 * that form the basis on top of which all other (derived) units are defined.
+	 * 
+	 * Attribute systemOfQuantities speficies the associated SystemOfQuantities.
 	 */
 	attribute def SystemOfUnits {
 		attribute longName: String[1];
+		attribute systemOfQuantities : SystemOfQuantities[1];
 		attribute baseUnits: SimpleUnit[1..*] ordered;
 	}
 

--- a/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
@@ -1,6 +1,6 @@
 package VectorCalculations {
 	import ScalarValues::*;
-    import Quantities::*;
+    import Quantities::VectorQuantityValue;
 
     /* Vector addition and subtraction */
 	calc def '+' specializes NumericalFunctions::'+' (x: VectorQuantityValue, y: VectorQuantityValue): VectorQuantityValue;

--- a/sysml/src/examples/Analysis Examples/Vehicle Analysis Demo.sysml
+++ b/sysml/src/examples/Analysis Examples/Vehicle Analysis Demo.sysml
@@ -12,7 +12,7 @@ package 'Vehicle Analysis Demo' {
 	        attribute :>> quantityDimension { :>> quantityPowerFactors = (distancePF, volumePF); }
 	    }
 
-	    attribute def DistancePerVolumeValue :> QuantityValue {
+	    attribute def DistancePerVolumeValue :> ScalarQuantityValue {
 	        :>> num : Real;
 	        :>> mRef : DistancePerVolumeUnit;
 	    }

--- a/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
+++ b/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
@@ -12,7 +12,7 @@ package AnalysisIndividualExample {
 	        attribute :>> quantityDimension { :>> quantityPowerFactors = (distancePF, volumePF); }
 	    }
 
-	    attribute def DistancePerVolumeValue :> QuantityValue {
+	    attribute def DistancePerVolumeValue :> ScalarQuantityValue {
 	        :>> num : Real;
 	        :>> mRef : DistancePerVolumeUnit;
 	    }

--- a/sysml/src/examples/Simple Tests/AliasTest.sysml
+++ b/sysml/src/examples/Simple Tests/AliasTest.sysml
@@ -1,6 +1,6 @@
 package AliasTest {
-	import Quantities::quantities; // import of an alias	
-	attribute q :> quantities;
+	import ISQSpaceTime::breadth; // import of an alias
+	attribute b :> breadth;
 	
     part def P1 {
         port porig1;

--- a/sysml/src/validation/10-Analysis and Trades/10c-Fuel Economy Analysis.sysml
+++ b/sysml/src/validation/10-Analysis and Trades/10c-Fuel Economy Analysis.sysml
@@ -5,7 +5,7 @@ package '10c-Fuel Economy Analysis' {
 	import ISQ::*;
 	import USCustomaryUnits::*;
 	
-	attribute distancePerVolume : QuantityValue = length / volume;	
+	attribute distancePerVolume : ScalarQuantityValue = length / volume;	
 	attribute gallon : MeasurementUnit = 231.0 * 'in'^3;
 	
 	package FuelEconomyRequirementsModel {
@@ -76,7 +76,7 @@ package '10c-Fuel Economy Analysis' {
 			subject vehicle : Vehicle;
 			in calc scenario : NominalScenario;
 			in requirement fuelEconomyRequirement : FuelEconomyRequirement;
-			return calculatedFuelEconomy : QuantityValue;
+			return calculatedFuelEconomy : ScalarQuantityValue;
 			
 			objective fuelEconomyAnalysisObjective {
 				doc /*


### PR DESCRIPTION
The upgrade for generating the Q&U library packages from NIST SP811 is now reasonably complete. The generator splits the units defined in SP811 as follows:

- USCustomaryUnits.sysml (humanId `<USCU>`) only containing US Customary Units, This is the main package to be used by end-users.
- NIST_SP811_CGS (humanId `<CGS>`) 'Centimetre-Gram-Second System of Units' library
- NIST_SP811_Imp  (humanId `<Imp>`) 'Imperial (Canadian and UK) Units' library
- NIST_SP811_SI_recognized (humanId `<SI_recognized>`) 'International System of Units - Units recognized in SI' library
- NIST_SP811_SI_deprecated (humanId `<SI_deprecated>`) 'International System of Units - Deprecated units' library.

The last four provide complete coverage of all units and conversion factors defined in SP811, but are of limited value to end-users, with the possible exception of the `<Imp>` library, that could provide a basis for extension with more Canadian/UK Imperial units, if needed. Since the last four files are completely auto-generated they can also be left out of the 2022-01 release.

A number of units are still commented out, due the unavailability (in ISO/IEC 80000) of their corresponding quantity attribute defs. These quantities will need to be provided in a next sprint.

In addition to Thermodynamic Temperature now also Temperature Difference is properly modeled, which finally enabled proper specifications of the degree Celsius and Fahrenheit scales, as well as the degree Celsius and Fahrenheit units.

The remaining work will be explicitly documented in issue [ST6RI-491](https://openmbee.atlassian.net/browse/ST6RI-491).