### PR TITLE
ST6RI-506 Reference frame Kernel Library model

### DIFF
--- a/kerml/src/examples/Mass Roll-up Example/MassRollup_1.kerml
+++ b/kerml/src/examples/Mass Roll-up Example/MassRollup_1.kerml
@@ -1,5 +1,5 @@
 package MassRollup_1 {
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 
 	class MassedThing {
 		feature mass subsets ISQ::mass;	

--- a/kerml/src/examples/Mass Roll-up Example/MassRollup_2.kerml
+++ b/kerml/src/examples/Mass Roll-up Example/MassRollup_2.kerml
@@ -1,5 +1,5 @@
 package MassRollup_2 {
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	import ISQ::*;
 	
 	class MassedThing {

--- a/org.omg.kerml.xpect.tests/library/ComplexFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ComplexFunctions.kerml
@@ -5,16 +5,23 @@
 package ComplexFunctions {
 	import ScalarValues::*;
 		
-	feature i: Complex[1] = Rect(0.0, 1.0);
+	feature i: Complex[1] = rect(0.0, 1.0);
 	
-	function Rect(re: Real[1], im: Real[1]): Complex[1];
-	function Polar(abs: Real[1], arg: Real[1]): Complex[1];
+	function rect(re: Real[1], im: Real[1]): Complex[1];
+	function polar(abs: Real[1], arg: Real[1]): Complex[1];
 	
-	function Re(x: Complex[1]): Real[1];
-	function Im(x: Complex[1]): Real[1];
+	function re(x: Complex[1]): Real[1];
+	function im(x: Complex[1]): Real[1];
 	
-	function Abs specializes NumericalFunctions::Abs (x: Complex[1]): Real[1];
-	function Arg(x: Complex[1]): Real[1];
+	function isZero specializes NumericalFunctions::isZero (x : Complex) {
+		re(x) == 0.0 and im(x) == 0.0
+	}
+	function isUnit specializes NumericalFunctions::isUnit (x : Complex) {
+		re(x) == 1.0 and im(x) == 0.0
+	}
+	
+	function abs specializes NumericalFunctions::abs (x: Complex[1]): Real[1];
+	function arg(x: Complex[1]): Real[1];
 	
 	function '+' specializes NumericalFunctions::'+' (x: Complex[1], y: Complex[0..1]): Complex[1];
 	function '-' specializes NumericalFunctions::'-' (x: Complex[1], y: Complex[0..1]): Complex[1];
@@ -28,11 +35,11 @@ package ComplexFunctions {
 	function ToString specializes BaseFunctions::ToString (x: Complex[1]): String[1];
 	function ToComplex(x: String[1]): Complex[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Complex[0..*]): Complex[1] {
-		ScalarFunctions::sum0(collection, Rect(0.0, 0.0))
+	function sum specializes NumericalFunctions::sum (collection: Complex[0..*]): Complex[1] {
+		NumericalFunctions::sum0(collection, rect(0.0, 0.0))
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Complex[0..*]): Complex[1] {
-		ScalarFunctions::product1(collection, Rect(1.0, 0.0))
+	function product specializes NumericalFunctions::product (collection: Complex[0..*]): Complex[1] {
+		NumericalFunctions::product1(collection, rect(1.0, 0.0))
 	}	
 }

--- a/org.omg.kerml.xpect.tests/library/ControlFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlFunctions.kerml
@@ -6,8 +6,8 @@ package ControlFunctions {
 	private import Base::Anything;
 	private import ScalarValues::ScalarValue;
 	private import ScalarValues::Boolean;
-	private import ScalarFunctions::Min;
-	private import ScalarFunctions::Max;
+	private import ScalarFunctions::min;
+	private import ScalarFunctions::max;
 	
 	abstract function '.' {
 		in feature source : Anything[0..*] nonunique {
@@ -92,12 +92,12 @@ package ControlFunctions {
 	
 	function minimize(collection: ScalarValue[1..*]): ScalarValue[1] {
 		abstract composite expr fn[0..*] (argument: ScalarValue[1]): ScalarValue[1];
-		collection->collect {in x; fn(x)}->reduce Min
+		collection->collect {in x; fn(x)}->reduce min
 	}
 	
 	function maximize(collection: ScalarValue[1..*]): ScalarValue {
 		abstract composite expr fn[0..*] (argument: ScalarValue[1]): ScalarValue[1];
-		collection->collect {in x; fn(x)}->reduce Max
+		collection->collect {in x; fn(x)}->reduce max
 	}
 	
 }

--- a/org.omg.kerml.xpect.tests/library/DataFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/DataFunctions.kerml
@@ -34,16 +34,5 @@ package DataFunctions {
 	
 	abstract function '==' specializes BaseFunctions::'=='(x: DataValue[0..1], y: DataValue[0..1]): Boolean[1];
 	
-	abstract function '..'(lower: DataValue[1], upper: DataValue[1]): DataValue[0..*] ordered;
-	
-	abstract function sum(collection: DataValue[0..*] ordered): DataValue[1];
-	abstract function product(collection: DataValue[0..*] ordered): DataValue[1];
-	
-	function sum0(collection: DataValue[0..*] ordered, zero: DataValue[1]): DataValue[1] {
-		collection->reduce '+' ?? zero
-	}
-	
-	function product1(collection: DataValue[0..*] ordered, one: DataValue[1]): DataValue[1] {
-		collection->reduce '*' ?? one
-	}
+	abstract function '..'(lower: DataValue[1], upper: DataValue[1]): DataValue[0..*] ordered;	
 }

--- a/org.omg.kerml.xpect.tests/library/IntegerFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/IntegerFunctions.kerml
@@ -5,37 +5,37 @@
 package IntegerFunctions {
 	import ScalarValues::*;
 	
-	function Abs specializes NumericalFunctions::Abs (x: Integer[1]): Natural[1];
+	function abs specializes RationalFunctions::abs (x: Integer[1]): Natural[1];
 	
-	function '+' specializes NumericalFunctions::'+' (x: Integer[1], y: Integer[0..1]): Integer[1];
-	function '-' specializes NumericalFunctions::'-' (x: Integer[1], y: Integer[0..1]): Integer[1];
-	function '*' specializes NumericalFunctions::'*' (x: Integer[1], y: Integer[1]): Integer[1];
-	function '/' specializes NumericalFunctions::'/' (x: Integer[1], y: Integer[1]): Rational;
-	function '**' specializes NumericalFunctions::'**' (x: Integer[1], y: Natural): Integer[1];
-	function '^' specializes NumericalFunctions::'^' (x: Integer[1], y: Natural): Integer[1];
+	function '+' specializes RationalFunctions::'+' (x: Integer[1], y: Integer[0..1]): Integer[1];
+	function '-' specializes RationalFunctions::'-' (x: Integer[1], y: Integer[0..1]): Integer[1];
+	function '*' specializes RationalFunctions::'*' (x: Integer[1], y: Integer[1]): Integer[1];
+	function '/' specializes RationalFunctions::'/' (x: Integer[1], y: Integer[1]): Rational;
+	function '**' specializes RationalFunctions::'**' (x: Integer[1], y: Natural): Integer[1];
+	function '^' specializes RationalFunctions::'^' (x: Integer[1], y: Natural): Integer[1];
 	function '%' specializes NumericalFunctions::'%' (x: Integer[1], y: Integer[1]): Integer[1];
 	
-	function '<' specializes NumericalFunctions::'<' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '>' specializes NumericalFunctions::'>' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '<=' specializes NumericalFunctions::'<=' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '>=' specializes NumericalFunctions::'>=' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '<' specializes RationalFunctions::'<' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '>' specializes RationalFunctions::'>' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '<=' specializes RationalFunctions::'<=' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '>=' specializes RationalFunctions::'>=' (x: Integer[1], y: Integer[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Integer[1], y: Integer[1]): Integer[1];
-	function Min specializes NumericalFunctions::Min (x: Integer[1], y: Integer[1]): Integer[1];
+	function max specializes RationalFunctions::max (x: Integer[1], y: Integer[1]): Integer[1];
+	function min specializes RationalFunctions::min (x: Integer[1], y: Integer[1]): Integer[1];
 
 	function '==' specializes DataFunctions::'==' (x: Integer[0..1], y: Integer[0..1]): Boolean[1];
 	
 	function '..' specializes ScalarFunctions::'..' (lower: Integer[1], upper: Integer[1]): Integer[0..*];	
 	
-	function ToString specializes BaseFunctions::ToString (x: Integer[1]): String[1];
+	function ToString specializes RationalFunctions::ToString (x: Integer[1]): String[1];
 	function ToNatural(x: Integer[1]): Natural[1];
 	function ToInteger(x: String[1]): Integer[1];
 	
-	function sum specializes ScalarFunctions::sum(collection: Integer[0..*]): Integer[1] {
-		ScalarFunctions::sum0(collection, 0)
+	function sum specializes RationalFunctions::sum(collection: Integer[0..*]): Integer[1] {
+		NumericalFunctions::sum0(collection, 0)
 	}
 	
-	function product specializes ScalarFunctions::product(collection: Integer[0..*]): Integer[1] {
-		ScalarFunctions::product1(collection, 1)
+	function product specializes RationalFunctions::product(collection: Integer[0..*]): Integer[1] {
+		NumericalFunctions::product1(collection, 1)
 	}
 }	

--- a/org.omg.kerml.xpect.tests/library/NaturalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/NaturalFunctions.kerml
@@ -15,7 +15,8 @@ package NaturalFunctions {
 	function '<=' specializes IntegerFunctions::'<=' (x: Natural[1], y: Natural[1]): Boolean[1];
 	function '>=' specializes IntegerFunctions::'>=' (x: Natural[1], y: Natural[1]): Boolean[1];	
 
-	function Max specializes IntegerFunctions::Max (x: Natural[1], y: Natural[1]): Natural[1];
+	function max specializes IntegerFunctions::max (x: Natural[1], y: Natural[1]): Natural[1];
+	function min specializes IntegerFunctions::min (x: Natural[1], y: Natural[1]): Natural[1];
 
 	function '==' specializes IntegerFunctions::'==' (x: Natural[0..1], y: Natural[0..1]): Boolean[1];
 	

--- a/org.omg.kerml.xpect.tests/library/NumericalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/NumericalFunctions.kerml
@@ -3,8 +3,12 @@
  */
 package NumericalFunctions {
 	import ScalarValues::*;
+	private import ControlFunctions::reduce;
 	
-	abstract function Abs(x: NumericalValue[1]): NumericalValue[1];
+	abstract function isZero(x: NumericalValue[1]): Boolean;
+	abstract function isUnit(x : NumericalValue[1]): Boolean;
+	
+	abstract function abs(x: NumericalValue[1]): NumericalValue[1];
 		
 	abstract function '+' specializes ScalarFunctions::'+' (x: NumericalValue[1], y: NumericalValue[0..1]): NumericalValue[1];
 	abstract function '-' specializes ScalarFunctions::'-' (x: NumericalValue[1], y: NumericalValue[0..1]): NumericalValue[1];
@@ -19,6 +23,19 @@ package NumericalFunctions {
 	abstract function '<=' specializes ScalarFunctions::'<=' (x: NumericalValue[1], y: NumericalValue[1]): Boolean[1];
 	abstract function '>=' specializes ScalarFunctions::'>=' (x: NumericalValue[1], y: NumericalValue[1]): Boolean[1];
 	
-	abstract function Max specializes ScalarFunctions::Max (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
-	abstract function Min specializes ScalarFunctions::Min (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	abstract function max specializes ScalarFunctions::max (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	abstract function min specializes ScalarFunctions::min (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	
+	abstract function sum (collection: ScalarValue[0..*]): ScalarValue[1];	
+	abstract function product (collection: ScalarValue[0..*]): ScalarValue[1];
+	
+	function sum0 (collection: NumericalValue[0..*], zero: ScalarValue[1]): ScalarValue {
+		inv { isZero(zero) }
+		collection->reduce '+' ?? zero
+	}
+	
+	function product1 (collection: ScalarValue[0..*], one: ScalarValue[1]): ScalarValue {
+		inv { isUnit(one) }
+		collection->reduce '*' ?? one
+	}
 }

--- a/org.omg.kerml.xpect.tests/library/RationalFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/RationalFunctions.kerml
@@ -5,43 +5,43 @@
 package RationalFunctions {
 	import ScalarValues::*;
 	
-	function Rat(numer: Integer[1], denum: Integer[1]): Rational[1];
-	function Numer(rat: Rational[1]): Integer[1];
-	function Denom(rat: Rational[1]): Integer[1];
+	function rat(numer: Integer[1], denum: Integer[1]): Rational[1];
+	function numer(rat: Rational[1]): Integer[1];
+	function denom(rat: Rational[1]): Integer[1];
 	
-	function Abs specializes NumericalFunctions::Abs (x: Rational[1]): Rational[1];
+	function abs specializes RealFunctions::abs (x: Rational[1]): Rational[1];
 
-	function '+' specializes NumericalFunctions::'+' (x: Rational[1], y: Rational[0..1]): Rational[1];
-	function '-' specializes NumericalFunctions::'-' (x: Rational[1], y: Rational[0..1]): Rational[1];
-	function '*' specializes NumericalFunctions::'*' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '/' specializes NumericalFunctions::'/' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '**' specializes NumericalFunctions::'**' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '^' specializes NumericalFunctions::'^' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '+' specializes RealFunctions::'+' (x: Rational[1], y: Rational[0..1]): Rational[1];
+	function '-' specializes RealFunctions::'-' (x: Rational[1], y: Rational[0..1]): Rational[1];
+	function '*' specializes RealFunctions::'*' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '/' specializes RealFunctions::'/' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '**' specializes RealFunctions::'**' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '^' specializes RealFunctions::'^' (x: Rational[1], y: Rational[1]): Rational[1];
 	
-	function '<' specializes NumericalFunctions::'<' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '>' specializes NumericalFunctions::'>' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '<=' specializes NumericalFunctions::'<=' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '>=' specializes NumericalFunctions::'>=' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '<' specializes RealFunctions::'<' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '>' specializes RealFunctions::'>' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '<=' specializes RealFunctions::'<=' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '>=' specializes RealFunctions::'>=' (x: Rational[1], y: Rational[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Rational[1], y: Rational[1]): Rational[1];
-	function Min specializes NumericalFunctions::Min (x: Rational[1], y: Rational[1]): Rational[1];
+	function max specializes RealFunctions::max (x: Rational[1], y: Rational[1]): Rational[1];
+	function min specializes RealFunctions::min (x: Rational[1], y: Rational[1]): Rational[1];
 
-	function '==' specializes DataFunctions::'==' (x: Rational[0..1], y: Rational[0..1]): Boolean[1];
+	function '==' specializes RealFunctions::'==' (x: Rational[0..1], y: Rational[0..1]): Boolean[1];
 	
-	function GCD(x: Rational[1], y: Rational[1]): Integer[1];
+	function gcd(x: Rational[1], y: Rational[1]): Integer[1];
 		
-	function Floor(x: Rational[1]): Integer[1];
-	function Round(x: Rational[1]): Integer[1];
+	function floor specializes RealFunctions::floor (x: Rational[1]): Integer[1];
+	function round specializes RealFunctions::round (x: Rational[1]): Integer[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: Rational[1]): String[1];
+	function ToString specializes RealFunctions::ToString (x: Rational[1]): String[1];
 	function ToInteger(x: Rational[1]): Integer[1];
 	function ToRational(x: String[1]): Rational[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Rational[0..*]): Rational[1] {
-		ScalarFunctions::sum0(collection, Rat(0, 1))
+	function sum specializes RealFunctions::sum (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::sum0(collection, rat(0, 1))
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Rational[0..*]): Rational[1] {
-		ScalarFunctions::product1(collection, Rat(1, 1))
+	function product specializes RealFunctions::product (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::product1(collection, rat(1, 1))
 	}	
 }

--- a/org.omg.kerml.xpect.tests/library/RealFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/RealFunctions.kerml
@@ -5,40 +5,50 @@
 package RealFunctions {
 	import ScalarValues::*;
 	
-	function Abs specializes NumericalFunctions::Abs (x: Real[1]): Real[1];
+	function re :> ComplexFunctions::re(x: Real[1]): Real[1] {
+		x
+	}
+	function im :> ComplexFunctions::im(x: Real[1]): Real[1] {
+		0.0
+	}
+	
+	function abs specializes ComplexFunctions::abs (x: Real[1]): Real[1];
+	function arg specializes ComplexFunctions::arg (x: Real[1]): Real[1] {
+		0.0
+	}
 
-	function '+' specializes NumericalFunctions::'+' (x: Real[1], y: Real[0..1]): Real[1];
-	function '-' specializes NumericalFunctions::'-' (x: Real[1], y: Real[0..1]): Real[1];
-	function '*' specializes NumericalFunctions::'*' (x: Real[1], y: Real[1]): Real[1];
-	function '/' specializes NumericalFunctions::'/' (x: Real[1], y: Real[1]): Real[1];
-	function '**' specializes NumericalFunctions::'**' (x: Real[1], y: Real[1]): Real[1];
-	function '^' specializes NumericalFunctions::'^' (x: Real[1], y: Real[1]): Real[1];
+	function '+' specializes ComplexFunctions::'+' (x: Real[1], y: Real[0..1]): Real[1];
+	function '-' specializes ComplexFunctions::'-' (x: Real[1], y: Real[0..1]): Real[1];
+	function '*' specializes ComplexFunctions::'*' (x: Real[1], y: Real[1]): Real[1];
+	function '/' specializes ComplexFunctions::'/' (x: Real[1], y: Real[1]): Real[1];
+	function '**' specializes ComplexFunctions::'**' (x: Real[1], y: Real[1]): Real[1];
+	function '^' specializes ComplexFunctions::'^' (x: Real[1], y: Real[1]): Real[1];
 	
 	function '<' specializes NumericalFunctions::'<' (x: Real[1], y: Real[1]): Boolean[1];
 	function '>' specializes NumericalFunctions::'>' (x: Real[1], y: Real[1]): Boolean[1];
 	function '<=' specializes NumericalFunctions::'<=' (x: Real[1], y: Real[1]): Boolean[1];
 	function '>=' specializes NumericalFunctions::'>=' (x: Real[1], y: Real[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Real[1], y: Real[1]): Real[1];
-	function Min specializes NumericalFunctions::Min (x: Real[1], y: Real[1]): Real[1];
+	function max specializes NumericalFunctions::max (x: Real[1], y: Real[1]): Real[1];
+	function min specializes NumericalFunctions::min (x: Real[1], y: Real[1]): Real[1];
 
-	function '==' specializes DataFunctions::'==' (x: Real[0..1], y: Real[0..1]): Boolean[1];
+	function '==' specializes ComplexFunctions::'==' (x: Real[0..1], y: Real[0..1]): Boolean[1];
 			
-	function Sqrt(x: Real[1]): Real[1];
+	function sqrt(x: Real[1]): Real[1];
 
-	function Floor(x: Real[1]): Integer[1];
-	function Round(x: Real[1]): Integer[1];
+	function floor(x: Real[1]): Integer[1];
+	function round(x: Real[1]): Integer[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: Real[1]): String[1];
+	function ToString specializes ComplexFunctions::ToString (x: Real[1]): String[1];
 	function ToInteger(x: Real[1]): Integer[1];
 	function ToRational(x: Real[1]): Rational[1];
 	function ToReal(x: String[1]): Real[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Real[0..*]): Real {
-		ScalarFunctions::sum0(collection, 0.0)
+	function sum specializes ComplexFunctions::sum (collection: Real[0..*]): Real {
+		NumericalFunctions::sum0(collection, 0.0)
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Real[0..*]): Real {
-		ScalarFunctions::product1(collection, 1.0)
+	function product specializes ComplexFunctions::product (collection: Real[0..*]): Real {
+		NumericalFunctions::product1(collection, 1.0)
 	}	
 }

--- a/org.omg.kerml.xpect.tests/library/ScalarFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/ScalarFunctions.kerml
@@ -3,7 +3,6 @@
  */
 package ScalarFunctions {
 	import ScalarValues::*;
-	private import ControlFunctions::reduce;
 	
 	abstract function '+' specializes DataFunctions::'+' (x: ScalarValue[1], y: ScalarValue[0..1]): ScalarValue[1];
 	abstract function '-' specializes DataFunctions::'-' (x: ScalarValue[1], y: ScalarValue[0..1]): ScalarValue[1];
@@ -27,19 +26,8 @@ package ScalarFunctions {
 	abstract function '<=' specializes DataFunctions::'<=' (x: ScalarValue[1], y: ScalarValue[1]): Boolean[1];
 	abstract function '>=' specializes DataFunctions::'>=' (x: ScalarValue[1], y: ScalarValue[1]): Boolean[1];
 	
-	abstract function Max specializes DataFunctions::Max (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
-	abstract function Min specializes DataFunctions::Min (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
+	abstract function max specializes DataFunctions::Max (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
+	abstract function min specializes DataFunctions::Min (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
 	
 	abstract function '..' specializes DataFunctions::'..' (lower: ScalarValue[1], upper: ScalarValue[1]): ScalarValue[0..*];
-	
-	abstract function sum specializes DataFunctions::sum (collection: ScalarValue[0..*]): ScalarValue[1];
-	abstract function product specializes DataFunctions::product (collection: ScalarValue[0..*]): ScalarValue[1];
-	
-	function sum0 specializes DataFunctions::sum0 (collection: ScalarValue[0..*], zero: ScalarValue[1]): ScalarValue {
-		collection->reduce '+' ?? zero
-	}
-	
-	function product1 specializes DataFunctions::product1 (collection: ScalarValue[0..*], one: ScalarValue[1]): ScalarValue {
-		collection->reduce '*' ?? one
-	}
 }

--- a/org.omg.kerml.xpect.tests/library/SpatialFrames.kerml
+++ b/org.omg.kerml.xpect.tests/library/SpatialFrames.kerml
@@ -1,0 +1,160 @@
+/**
+ * This package models spatial frames of reference for quantifying the position of points 
+ * in a three-dimensional space. 
+ */
+package SpatialFrames {
+	private import Clocks::*;
+	private import ScalarValues::NumericalValue;
+	private import VectorValues::ThreeVectorValue;
+	private import VectorValues::CartesianThreeVectorValue;
+	private import VectorFunctions::isZeroVector;
+	private import Objects::Body;
+	private import Objects::Point;
+	private import ControlFunctions::forAll;
+	private import SequenceFunctions::includes;
+	
+	/**
+	 * defaultFrame is a fixed SpatialFrame used as a universal default.
+	 */
+	readonly feature defaultFrame : SpatialFrame[1];
+	
+	/**
+	 * A SpatialFrame is a three-dimensional Body that provides a spatial extent that 
+	 * acts as a frame of reference for defining the phyiscal position and displacement 
+	 * vectors of Points over time.
+	 */
+	abstract struct SpatialFrame specializes Body;
+	
+	/**
+	 * The PositionOf a Point relative to a SpatialFrame, at a specific time relative to a given
+	 * clock, as a positionVector that is a ThreeVectorValue.
+	 */
+	abstract function PositionOf {
+		in point : Point[1];
+		in time : NumericalValue[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return positionVector : ThreeVectorValue[1];
+		
+		/**
+		 * The given point must exist at the given time.
+		 */
+		inv positionTimePrecondition {
+			TimeOf(point.startShot) <= time and
+			time <= TimeOf(point.endShot)
+		}
+		
+		/**
+		 * If the given point occurs within the extent of a Point that is a spaceShot of the given frame,
+		 * then the result positionVector is equal to the PositionOf the enclosing frame Point at
+		 * the given time.
+		 */
+		inv spacePositionConstraint {
+			(frame.spaceSlices as Point)->forAll{in p : Point;
+				p.spaceTimeEnclosedOccurrences->includes(point) implies
+					positionVector == PositionOf(p, time, frame)
+			}
+		}
+	}
+	
+	/**
+	 * The CurrentPositionOf a Point relative to a SpatialFrame and a Clock is the PositionOf
+	 * the Point relative to the SpatialFrame at the currentTime of the Clock.
+	 */
+	abstract function CurrentPositionOf {
+		in point : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return positionVector : ThreeVectorValue[1] =
+			PositionOf(point, clock.currentTime, frame, clock);
+	}
+		
+	/**
+	 * The DisplacementOf two Points relative to a SpatialFrame, at a specific time relative to a
+	 * given clock, is the displacementVector computed as the difference between the PositionOf the 
+	 * first point and PositionOf the second point, relative to that SpatialFrame, at that time.
+	 */
+	function DisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in time : NumericalValue;
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : ThreeVectorValue[1] =
+			PositionOf(point2, time, frame, clock) - PositionOf(point1, time, frame, clock);
+			
+		/**
+		 * If either point1 or point2 occurs within the other, then the displacementVector is
+		 * the zero vector.
+		 */
+		inv zeroDisplacementConstraint {
+			(point1.spaceTimeEnclosedOccurrences->includes(point2) or
+			point2.spaceTimeEnclosedOccurrences->includes(point1)) implies
+				isZeroVector(displacementVector)
+		}
+	}
+	
+	/**
+	 * The CurrentDisplacementOf two points relative to a SpatialFrame and Clock is the DisplacementOf
+	 * the Points realtive to the SpacialFrame at the currentTime of the Clock.
+	 */
+	function CurrentDisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : ThreeVectorValue[1] =
+			DisplacementOf(point1, point2, clock.currentTime, frame, clock);
+	}
+	
+	/**
+	 * A CartesianSpatialFrame is a SpatialFrame relative to which all position and displacement
+	 * vectors can be represented as CartesianThreeVectorValues.
+	 */
+	abstract struct CartesianSpatialFrame :> SpatialFrame;
+	
+	/**
+	 * The PositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	abstract function CartesianPositionOf :> PositionOf {
+		in point : Point[1];
+		in time : NumericalValue[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return positionVector : CartesianThreeVectorValue[1];
+	}
+	
+	/**
+	 * The CurrentPositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	abstract function CartesianCurrentPositionOf :> CurrentPositionOf {
+		in point : Point[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return positionVector : CartesianThreeVectorValue[1];
+	}
+	
+	/**
+	 * The DisplacementOf two points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	function CartesianDisplacementOf :> DisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in time : NumericalValue[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : CartesianThreeVectorValue[1];
+	}
+		
+	/**
+	 * The CurrentDisplacementOf two points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	function CartesianCurrentDisplacementOf :> CurrentDisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : CartesianThreeVectorValue[1];
+	}
+		
+}

--- a/org.omg.kerml.xpect.tests/library/TrigFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/TrigFunctions.kerml
@@ -1,0 +1,34 @@
+/**
+ * This package defines basic trigonometric functions on real numbers.
+ */
+package TrigFunctions {
+	import ScalarValues::Real;
+	
+	feature pi : Real;
+	inv piPrecision { RealFunctions::round(pi * 1E20) == 314159265358979323846.0 }
+	
+	function deg(theta_rad : Real) {
+		theta_rad * 180 / pi
+	}
+	function rad(theta_deg : Real) {
+		theta_deg * pi / 180
+	}
+	
+	datatype UnitBoundedReal :> Real {
+		private x :>> self;
+		inv unitBound { -1.0 <= x & x <= 1.0 }
+	}
+	
+	function sin(theta : Real) : UnitBoundedReal;
+	function cos(theta : Real) : UnitBoundedReal;
+	function tan(theta : Real) : Real {
+		sin(theta) / cos(theta)
+	}
+	function cot(theta : Real) : Real {
+		cos(theta) / sin(theta)
+	}
+	
+	function arcsin(x : UnitBoundedReal) : Real;
+	function arccos(x : UnitBoundedReal) : Real;
+	function arctan(x : Real) : Real;
+}

--- a/org.omg.kerml.xpect.tests/library/VectorFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/VectorFunctions.kerml
@@ -1,0 +1,192 @@
+/**
+ * This package defines abstract functions on VectorValues corresponding to the algebraic operations
+ * provided by a vector space with inner product. It also includes concrete implementations of these
+ * functions specifically for CartesianVectorValues.
+ */
+package VectorFunctions {
+	private import ScalarValues::NumericalValue;
+	private import ScalarValues::Positive;
+	private import ScalarValues::Real;
+	private import ScalarValues::Boolean;
+	private import NumericalFunctions::*;
+	private import RealFunctions::sqrt;
+	private import TrigFunctions::arccos;
+	private import SequenceFunctions::size;
+	private import ControlFunctions::*;
+	
+	import VectorValues::*;
+	
+	/* Generic arithmetic functions for all VectorValues. */
+	
+	/**
+	 * Return whether a VectorValue is a zero vector.
+	 */
+	abstract function isZeroVector(v: VectorValue[1]): Boolean[1];
+	
+	/**
+	 * With two arguments, returns the sum of two VectorValues. With one argument, returns that VectorValue.
+	 */
+	abstract function '+' specializes DataFunctions::'+' (v: VectorValue[1], w: VectorValue[0..1]) u: VectorValue[1] {
+		inv zeroAddition { w == null or isZeroVector(w) implies u == w }
+		inv commutivity { w != null implies u == w + v }
+	}
+	
+	/**
+	 * With two arguments, returns the difference of two VectorValues. With one arguments, returns the inverse
+	 * of the given VectorValue, that is, the VectorValue that, when added to the original VectorValue, results in
+	 * the zeroVector.
+	 */
+	abstract function '-' specializes DataFunctions::'-' (v: VectorValue[1], w: VectorValue[0..1]) u: VectorValue[1] {
+		inv negation { w == null implies isZeroVector(v + u) }
+		inv difference { w != null implies v + u == w }
+	}
+	
+	/**
+	 * Return the sum of a collection of VectorValues. If the collection is empty, return a given zero vector.
+	 */
+	abstract function sum0 (coll: VectorValue[*] nonunique, zero: VectorValue[1]) s: VectorValue[1] {
+		inv precondition { isZeroVector(zero) }
+		coll->reduce '+' ?? zero
+	}
+
+	/* Functions specific to NumericalVectorValues. */
+	
+	/**
+	 * Construct a NumericalVectorValue whose elements are a non-empty list of component NumericalValues.
+	 * The dimension of the NumericalVectorValue is equal to the number of components.
+	 */
+	function VectorOf(components: NumericalValue[1..*] ordered nonunique): NumericalVectorValue {
+		NumericalVectorValue (
+			dimension = size(components),
+			elements = components
+		)
+	}
+	
+	/**
+	 * Scalar product of a NumericalValue and a NumericalVectorValue.
+	 */
+	abstract function scalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w: NumericalVectorValue[1] {
+		inv scaling { norm(w) == x * norm(v) }
+		inv zeroLength { isZeroVector(w) implies isZero(norm(w))}
+	}
+	alias '*' for scalarVectorMult;
+	
+	/**
+	 * Scalar product of a NumericalVectorValue and a NumericalValue, which has the same value as the scalar product of the
+	 * NumericalValue and the NumericalVectorValue.
+	 */
+	abstract function vectorScalarMult specializes DataFunctions::'*' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		scalarVectorMult(x, v)
+	}
+	
+	/**
+	 * Scalar quotient of a NumericalVectorValue and a NumericalValue, defined as the scalar product of the inverse of the 
+	 * NumericalValue and the NumericalVectorValue.
+	 */
+	abstract function vectorScalarDiv specializes DataFunctions::'/' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		scalarVectorMult(1.0 / x, v)
+	}
+
+	/**
+	 * Inner product of two NumericalVectorValues.
+	 */
+	abstract function inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) x: NumericalValue[1] {
+		inv commmutivity { x == inner(w, v) }
+		inv zeroInner { isZeroVector(v) or isZeroVector(w) implies isZero(x)}
+	}
+	
+	/**
+	 * The norm (magnitude) of a NumericalVectorValue, as a NumericalValue.
+	 */
+	abstract function norm(v: NumericalVectorValue[1]) l : NumericalValue[1] {
+		inv squareNorm { l * l == inner(v,v) }
+		inv lengthZero { isZero(l) == isZeroVector(v) }
+	}
+	
+	/**
+	 * The angle between two NumericalVectorValues, as a NumericalValue.
+	 */
+	abstract function angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta: NumericalValue[1] {
+		inv commutivity { theta == angle(w, v) }
+		inv lengthInsensitive { theta == angle(w / norm(w), v / norm(v)) }
+	}
+	
+	/* Specialized functions with concrete definitions for CartesianVectorValues. */
+	
+	/**
+	 * Construct a CartesianVectorValue whose elements are a non-empty list of Real components.
+	 * The dimension of the NumericalVectorValue is equal to the number of components.
+	 */
+	function CartesianVectorOf(components : Real[*]) : CartesianVectorValue {
+		CartesianVectorValue (
+			dimension = size(components),
+			elements = components
+		)
+	}
+	function CartesianThreeVectorOf specializes CartesianVectorOf(components: Real[*]): CartesianThreeVectorValue;
+	
+	/**
+	 * Cartesian zero vectors of 1, 2 and 3 dimensions.
+	 */
+	feature cartesianZeroVector: CartesianVectorValue[3] =
+		(
+			CartesianVectorOf(0.0),
+			CartesianVectorOf((0.0, 0.0)),
+			CartesianThreeVectorOf((0.0, 0.0, 0.0))
+		);
+	feature cartesian3DZeroVector: CartesianThreeVectorValue[1] =
+		cartesianZeroVector[3];
+	
+	/**
+	 * A CartesianVectorValue is a zero vector if all its elements are zero.
+	 */
+	function isCartesianZeroVector specializes isZeroVector (v: CartesianVectorValue): Boolean {
+		v.elements->forAll{in x; x == 0.0}
+	}
+	
+	function 'cartesian+' specializes '+' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+		inv precondition { w != null implies v.dimension == w.dimension }
+		if w == null? v
+		else CartesianVectorOf(
+			(1..w.dimension)->collect{in i : Positive; v[i] + w[i]}
+		)
+	}
+	
+	function 'cartesian-' specializes '-' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+		inv precondition { w != null implies v.dimension == w.dimension }
+		CartesianVectorOf(
+			if w == null? CartesianVectorOf(v.elements->collect{in x : Real; -x})
+			else CartesianVectorOf(
+				(1..v.dimension)->collect{in i : Positive; v[i] - w[i]}
+			)
+		)
+	}
+	
+	function cartesianScalarVectorMult specializes scalarVectorMult (x: Real[1], v: CartesianVectorValue[1]): CartesianVectorValue[1] {
+		CartesianVectorOf(
+			v.elements->collect{in y : Real; x * y}
+		)
+	}
+	function cartesianVectorScalarMult specializes vectorScalarMult (v: CartesianVectorValue[1], x: Real[1]): CartesianVectorValue[1] {
+		cartesianScalarVectorMult(x, v)
+	}
+	
+	function cartesianInner specializes inner(v: CartesianVectorValue[1], w : CartesianVectorValue[1]): Real[1]{
+		inv precondition { v.dimension == w.dimension }
+		(1..v.dimension)->collect{in i : Positive; v[i] * w[i]}->reduce RealFunctions::'+'
+	}
+	
+	function cartesianNorm specializes norm(v: CartesianVectorValue[1]) : NumericalValue[1] {
+		sqrt(cartesianInner(v, v))
+	}
+	
+	function cartesianAngle specializes angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]): Real[1] {
+		inv precondition { v.dimension == w.dimension }
+		arccos(cartesianInner(v, w) / (norm(v) * norm(w)))
+	}
+	
+	function sum(coll: CartesianThreeVectorValue): CartesianThreeVectorValue {
+		sum0(coll, cartesian3DZeroVector)
+	}
+	
+}

--- a/org.omg.kerml.xpect.tests/library/VectorValues.kerml
+++ b/org.omg.kerml.xpect.tests/library/VectorValues.kerml
@@ -1,0 +1,51 @@
+/**
+ * This package provides a basic model of abstract vectors as well as concrete vectors
+ * whose components are numerical values. The package VectorFunctions defines the 
+ * corresponding vector-space functions.
+ */
+package VectorValues {
+	private import ScalarValues::NumericalValue;
+	private import ScalarValues::Real;
+	private import Collections::Array;
+	
+	/**
+	 * A VectorValue is an abstract data type whose values may be operated on using
+	 * VectorFunctions.
+	 */
+	 abstract datatype VectorValue;
+	
+	/**
+	 * A NumericalVectorValue is a kind of VectorValue that is specifically represented
+	 * as a one-dimensional array of NumericalValues. The dimension is allowed to be empty,
+	 * permitting a NumericalVectorValue of rank 0, which is essentially isomorphic to a
+	 * scalar NumericalValue.
+	 */
+	datatype NumericalVectorValue :> VectorValue, Array {
+		feature dimension[0..1] :>> dimensions;
+		feature :>> elements : NumericalValue;
+	}
+	
+	/**
+	 * CartesianVectorValue is a specialization Numerical VectorValue for which there are 
+	 * specific implementations in VectorFunctions of the abstract vector-space functions.
+	 * 
+	 * Note: The restriction of the element type to Real is to facilitate
+	 * the complete definition of these functions.
+	 */
+	datatype CartesianVectorValue :> NumericalVectorValue {
+		feature :>> elements : Real;
+	}
+
+	/**
+	 * A ThreeVectorValue is a NumericalVectorValue that has dimension 3.
+	 */
+	datatype ThreeVectorValue :> NumericalVectorValue {
+		feature :>> dimension = 3;
+	}
+	
+	/**
+	 * A CartesianThreeVectorValue is a NumericalVectorValue that is both Cartesian and
+	 * has dimension 3.
+	 */	
+	datatype CartesianThreeVectorValue :> CartesianVectorValue, ThreeVectorValue;	
+}

--- a/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
@@ -61,6 +61,7 @@ package SysML {
 	abstract item def LoopActionUsage :> ActionUsage;
 	item def WhileLoopActionUsage :> LoopActionUsage;
 	item def ForLoopActionUsage :> LoopActionUsage;
+	item def TriggerInvocationExpression :> InvocationExpression;
 	
 	item def StateDefinition :> ActionDefinition;
 	item def StateUsage :> ActionUsage;

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
@@ -245,6 +245,7 @@ public class TypeImpl extends NamespaceImpl implements Type {
 		EList<Feature> features = new NonNotifyingEObjectEList<>(Feature.class, this, SysMLPackage.TYPE__FEATURE);
 		getFeatureMembership().stream().
 			map(FeatureMembership::getMemberFeature).
+			filter(f->f != null).
 			forEachOrdered(features::add);
 		return features;
 	}

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -9,6 +9,7 @@ package Quantities {
 	private import ScalarValues::Natural;
 	private import ScalarValues::Boolean;
 	private import ScalarValues::String;
+	private import VectorValues::NumericalVectorValue;
 	
 	/**
 	 * The value of a quantity is a tuple of one or more numbers (i.e. mathematical number values) and a reference to a measurement reference.
@@ -31,7 +32,7 @@ package Quantities {
         assert constraint boundMatch { (isBound == mRef.isBound) || (!isBound && mRef.isBound) }
 	}
 	
-	abstract attribute def VectorQuantityValue :> TensorQuantityValue {
+	abstract attribute def VectorQuantityValue :> TensorQuantityValue, NumericalVectorValue {
 		attribute :>> mRef: UnitsAndScales::VectorMeasurementReference;
 	}
 	

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -4,6 +4,13 @@ package QuantityCalculations {
     import UnitsAndScales::ScalarMeasurementReference;
     import UnitsAndScales::DimensionOneValue;
     
+    calc def isZero :> NumericalFunctions::isZero(x: ScalarQuantityValue): Boolean {
+    	NumericalFunctions::isZero(x.num)
+    }
+    calc def isUnit :> NumericalFunctions::isUnit(x: ScalarQuantityValue): Boolean {
+    	NumericalFunctions::isUnit(x.num)
+    }
+    
     calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): ScalarQuantityValue;
 
 	calc def Abs specializes NumericalFunctions::Abs (x: ScalarQuantityValue): ScalarQuantityValue;
@@ -37,12 +44,16 @@ package QuantityCalculations {
 	calc def ToReal(x: ScalarQuantityValue): Real;
 	calc def ToDimensionOneValue(x: Real): DimensionOneValue;
 	
-	calc def sum specializes ScalarFunctions::sum (collection: ScalarQuantityValue[0..*]): ScalarQuantityValue {
-		ScalarFunctions::sum0(collection, 0.0)
+	calc def sum specializes NumericalFunctions::sum (collection: ScalarQuantityValue[0..*]): ScalarQuantityValue {
+		private attribute zero : ScalarQuantityValue;
+		assert constraint { isZero(zero) }
+		NumericalFunctions::sum0(collection, zero)
 	}
 	
-	calc def product specializes ScalarFunctions::product (collection: ScalarQuantityValue[0..*]): ScalarQuantityValue {
-		ScalarFunctions::product1(collection, 1.0)
+	calc def product specializes NumericalFunctions::product (collection: ScalarQuantityValue[0..*]): ScalarQuantityValue {
+		private attribute one : ScalarQuantityValue;
+		assert constraint { isUnit(one) }
+		NumericalFunctions::product1(collection, one)
 	}
 
     calc def ConvertQuantity(x: ScalarQuantityValue, targetMRef: ScalarMeasurementReference): ScalarQuantityValue;

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -11,7 +11,7 @@ package QuantityCalculations {
     	NumericalFunctions::isUnit(x.num)
     }
     
-    calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): ScalarQuantityValue;
+    calc def '[' specializes BaseFunctions::'[' (x: Number, y: ScalarMeasurementReference): ScalarQuantityValue;
 
 	calc def abs specializes NumericalFunctions::abs (x: ScalarQuantityValue): ScalarQuantityValue;
 

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -4,16 +4,16 @@ package QuantityCalculations {
     import UnitsAndScales::ScalarMeasurementReference;
     import UnitsAndScales::DimensionOneValue;
     
-    calc def isZero :> NumericalFunctions::isZero(x: ScalarQuantityValue): Boolean {
+    calc def isZero specializes NumericalFunctions::isZero(x: ScalarQuantityValue): Boolean {
     	NumericalFunctions::isZero(x.num)
     }
-    calc def isUnit :> NumericalFunctions::isUnit(x: ScalarQuantityValue): Boolean {
+    calc def isUnit specializes NumericalFunctions::isUnit(x: ScalarQuantityValue): Boolean {
     	NumericalFunctions::isUnit(x.num)
     }
     
     calc def '[' specializes BaseFunctions::'[' (x: NumericalValue, y: ScalarMeasurementReference): ScalarQuantityValue;
 
-	calc def Abs specializes NumericalFunctions::Abs (x: ScalarQuantityValue): ScalarQuantityValue;
+	calc def abs specializes NumericalFunctions::abs (x: ScalarQuantityValue): ScalarQuantityValue;
 
 	calc def '+' specializes NumericalFunctions::'+' (x: ScalarQuantityValue, y: ScalarQuantityValue[0..1]): ScalarQuantityValue;
 	calc def '-' specializes NumericalFunctions::'-' (x: ScalarQuantityValue, y: ScalarQuantityValue[0..1]): ScalarQuantityValue;
@@ -27,16 +27,15 @@ package QuantityCalculations {
 	calc def '<=' specializes NumericalFunctions::'<=' (x: ScalarQuantityValue, y: ScalarQuantityValue): Boolean;
 	calc def '>=' specializes NumericalFunctions::'>=' (x: ScalarQuantityValue, y: ScalarQuantityValue): Boolean;
 
-	calc def Max specializes NumericalFunctions::Max (x: ScalarQuantityValue, y: ScalarQuantityValue): ScalarQuantityValue;
-	calc def Min specializes NumericalFunctions::Min (x: ScalarQuantityValue, y: ScalarQuantityValue): ScalarQuantityValue;
+	calc def max specializes NumericalFunctions::max (x: ScalarQuantityValue, y: ScalarQuantityValue): ScalarQuantityValue;
+	calc def min specializes NumericalFunctions::min (x: ScalarQuantityValue, y: ScalarQuantityValue): ScalarQuantityValue;
 
-	calc def '==' specializes BaseFunctions::'==' (x: ScalarQuantityValue, y: ScalarQuantityValue): Boolean;
-	calc def '!=' specializes BaseFunctions::'!=' (x: ScalarQuantityValue, y: ScalarQuantityValue): Boolean;
+	calc def '==' specializes DataFunctions::'==' (x: ScalarQuantityValue, y: ScalarQuantityValue): Boolean;
 		
-	calc def Sqrt(x: ScalarQuantityValue): ScalarQuantityValue;
+	calc def sqrt(x: ScalarQuantityValue): ScalarQuantityValue;
 
-	calc def Floor(x: ScalarQuantityValue): ScalarQuantityValue;
-	calc def Round(x: ScalarQuantityValue): ScalarQuantityValue;
+	calc def floor (x: ScalarQuantityValue): ScalarQuantityValue;
+	calc def round (x: ScalarQuantityValue): ScalarQuantityValue;
 	
 	calc def ToString specializes BaseFunctions::ToString (x: ScalarQuantityValue): String;
 	calc def ToInteger(x: ScalarQuantityValue): Integer;

--- a/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
@@ -1,14 +1,23 @@
 package VectorCalculations {
-	import ScalarValues::*;
-    import Quantities::VectorQuantityValue;
+	private import ScalarValues::Boolean;
+	private import ScalarValues::Number;
+    private import Quantities::VectorQuantityValue;
+    
+    calc def isZeroVectorQuantity :> VectorFunctions::isZeroVector(: VectorQuantityValue[1]): Boolean;
 
-    /* Vector addition and subtraction */
-	calc def '+' specializes NumericalFunctions::'+' (x: VectorQuantityValue, y: VectorQuantityValue): VectorQuantityValue;
-	calc def '-' specializes NumericalFunctions::'-' (x: VectorQuantityValue, y: VectorQuantityValue): VectorQuantityValue;
+    /* Addition and subtraction */
+	calc def '+' :> VectorFunctions::'+' (: VectorQuantityValue[1], : VectorQuantityValue[1]): VectorQuantityValue[1];
+	calc def '-' :> VectorFunctions::'-' (: VectorQuantityValue[1], : VectorQuantityValue[1]): VectorQuantityValue[1];
 
-    /* Scalar-vector multiplication */
-	calc def scalarVectorMult specializes NumericalFunctions::'*' (x: Real, y: VectorQuantityValue): VectorQuantityValue;
-	calc def vectorScalarMult specializes NumericalFunctions::'*' (x: VectorQuantityValue, y: Real): VectorQuantityValue;
-
+    /* Multiplication and division */
+	calc def scalarVectorMult :> VectorFunctions::scalarVectorMult (: Number[1], : VectorQuantityValue[1]): VectorQuantityValue[1];
+	calc def vectorScalarMult :> VectorFunctions::vectorScalarMult (: VectorQuantityValue[1], : Number[1]): VectorQuantityValue[1];
+	calc def vectorScalarDiv :> VectorFunctions::vectorScalarDiv (: Number[1], : VectorQuantityValue[1]): Number[1];
+	calc def inner :> VectorFunctions::inner (: VectorQuantityValue, : VectorQuantityValue[1]): Number[1];
+	
     alias '*' for scalarVectorMult;
+    
+    /* Norm and angle */
+	calc def norm :> VectorFunctions::norm (: VectorQuantityValue[1]): Number[1];
+	calc def angle :> VectorFunctions::angle (: VectorQuantityValue[1], : VectorQuantityValue[1]): Number[1];
 }

--- a/sysml.library/Kernel Library/ComplexFunctions.kerml
+++ b/sysml.library/Kernel Library/ComplexFunctions.kerml
@@ -5,23 +5,23 @@
 package ComplexFunctions {
 	import ScalarValues::*;
 		
-	feature i: Complex[1] = Rect(0.0, 1.0);
+	feature i: Complex[1] = rect(0.0, 1.0);
 	
-	function Rect(re: Real[1], im: Real[1]): Complex[1];
-	function Polar(abs: Real[1], arg: Real[1]): Complex[1];
+	function rect(re: Real[1], im: Real[1]): Complex[1];
+	function polar(abs: Real[1], arg: Real[1]): Complex[1];
 	
-	function Re(x: Complex[1]): Real[1];
-	function Im(x: Complex[1]): Real[1];
+	function re(x: Complex[1]): Real[1];
+	function im(x: Complex[1]): Real[1];
 	
-	function isZero(x : Complex) {
-		Re(x) == 0.0 and Im(x) == 0.0
+	function isZero specializes NumericalFunctions::isZero (x : Complex) {
+		re(x) == 0.0 and im(x) == 0.0
 	}
-	function isUnit(x : Complex) {
-		Re(x) == 1.0 and Im(x) == 0.0
+	function isUnit specializes NumericalFunctions::isUnit (x : Complex) {
+		re(x) == 1.0 and im(x) == 0.0
 	}
 	
-	function Abs specializes NumericalFunctions::Abs (x: Complex[1]): Real[1];
-	function Arg(x: Complex[1]): Real[1];
+	function abs specializes NumericalFunctions::abs (x: Complex[1]): Real[1];
+	function arg(x: Complex[1]): Real[1];
 	
 	function '+' specializes NumericalFunctions::'+' (x: Complex[1], y: Complex[0..1]): Complex[1];
 	function '-' specializes NumericalFunctions::'-' (x: Complex[1], y: Complex[0..1]): Complex[1];
@@ -36,10 +36,10 @@ package ComplexFunctions {
 	function ToComplex(x: String[1]): Complex[1];
 	
 	function sum specializes NumericalFunctions::sum (collection: Complex[0..*]): Complex[1] {
-		NumericalFunctions::sum0(collection, Rect(0.0, 0.0))
+		NumericalFunctions::sum0(collection, rect(0.0, 0.0))
 	}
 	
 	function product specializes NumericalFunctions::product (collection: Complex[0..*]): Complex[1] {
-		NumericalFunctions::product1(collection, Rect(1.0, 0.0))
+		NumericalFunctions::product1(collection, rect(1.0, 0.0))
 	}	
 }

--- a/sysml.library/Kernel Library/ComplexFunctions.kerml
+++ b/sysml.library/Kernel Library/ComplexFunctions.kerml
@@ -13,6 +13,13 @@ package ComplexFunctions {
 	function Re(x: Complex[1]): Real[1];
 	function Im(x: Complex[1]): Real[1];
 	
+	function isZero(x : Complex) {
+		Re(x) == 0.0 and Im(x) == 0.0
+	}
+	function isUnit(x : Complex) {
+		Re(x) == 1.0 and Im(x) == 0.0
+	}
+	
 	function Abs specializes NumericalFunctions::Abs (x: Complex[1]): Real[1];
 	function Arg(x: Complex[1]): Real[1];
 	
@@ -28,11 +35,11 @@ package ComplexFunctions {
 	function ToString specializes BaseFunctions::ToString (x: Complex[1]): String[1];
 	function ToComplex(x: String[1]): Complex[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Complex[0..*]): Complex[1] {
-		ScalarFunctions::sum0(collection, Rect(0.0, 0.0))
+	function sum specializes NumericalFunctions::sum (collection: Complex[0..*]): Complex[1] {
+		NumericalFunctions::sum0(collection, Rect(0.0, 0.0))
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Complex[0..*]): Complex[1] {
-		ScalarFunctions::product1(collection, Rect(1.0, 0.0))
+	function product specializes NumericalFunctions::product (collection: Complex[0..*]): Complex[1] {
+		NumericalFunctions::product1(collection, Rect(1.0, 0.0))
 	}	
 }

--- a/sysml.library/Kernel Library/ControlFunctions.kerml
+++ b/sysml.library/Kernel Library/ControlFunctions.kerml
@@ -6,8 +6,8 @@ package ControlFunctions {
 	private import Base::Anything;
 	private import ScalarValues::ScalarValue;
 	private import ScalarValues::Boolean;
-	private import ScalarFunctions::Min;
-	private import ScalarFunctions::Max;
+	private import ScalarFunctions::min;
+	private import ScalarFunctions::max;
 	
 	abstract function '.' {
 		in feature source : Anything[0..*] nonunique {
@@ -92,12 +92,12 @@ package ControlFunctions {
 	
 	function minimize(collection: ScalarValue[1..*]): ScalarValue[1] {
 		abstract composite expr fn[0..*] (argument: ScalarValue[1]): ScalarValue[1];
-		collection->collect {in x; fn(x)}->reduce Min
+		collection->collect {in x; fn(x)}->reduce min
 	}
 	
 	function maximize(collection: ScalarValue[1..*]): ScalarValue {
 		abstract composite expr fn[0..*] (argument: ScalarValue[1]): ScalarValue[1];
-		collection->collect {in x; fn(x)}->reduce Max
+		collection->collect {in x; fn(x)}->reduce max
 	}
 	
 }

--- a/sysml.library/Kernel Library/DataFunctions.kerml
+++ b/sysml.library/Kernel Library/DataFunctions.kerml
@@ -34,16 +34,5 @@ package DataFunctions {
 	
 	abstract function '==' specializes BaseFunctions::'=='(x: DataValue[0..1], y: DataValue[0..1]): Boolean[1];
 	
-	abstract function '..'(lower: DataValue[1], upper: DataValue[1]): DataValue[0..*] ordered;
-	
-	abstract function sum(collection: DataValue[0..*] ordered): DataValue[1];
-	abstract function product(collection: DataValue[0..*] ordered): DataValue[1];
-	
-	function sum0(collection: DataValue[0..*] ordered, zero: DataValue[1]): DataValue[1] {
-		collection->reduce '+' ?? zero
-	}
-	
-	function product1(collection: DataValue[0..*] ordered, one: DataValue[1]): DataValue[1] {
-		collection->reduce '*' ?? one
-	}
+	abstract function '..'(lower: DataValue[1], upper: DataValue[1]): DataValue[0..*] ordered;	
 }

--- a/sysml.library/Kernel Library/IntegerFunctions.kerml
+++ b/sysml.library/Kernel Library/IntegerFunctions.kerml
@@ -5,37 +5,37 @@
 package IntegerFunctions {
 	import ScalarValues::*;
 	
-	function Abs specializes NumericalFunctions::Abs (x: Integer[1]): Natural[1];
+	function abs specializes RationalFunctions::abs (x: Integer[1]): Natural[1];
 	
-	function '+' specializes NumericalFunctions::'+' (x: Integer[1], y: Integer[0..1]): Integer[1];
-	function '-' specializes NumericalFunctions::'-' (x: Integer[1], y: Integer[0..1]): Integer[1];
-	function '*' specializes NumericalFunctions::'*' (x: Integer[1], y: Integer[1]): Integer[1];
-	function '/' specializes NumericalFunctions::'/' (x: Integer[1], y: Integer[1]): Rational;
-	function '**' specializes NumericalFunctions::'**' (x: Integer[1], y: Natural): Integer[1];
-	function '^' specializes NumericalFunctions::'^' (x: Integer[1], y: Natural): Integer[1];
+	function '+' specializes RationalFunctions::'+' (x: Integer[1], y: Integer[0..1]): Integer[1];
+	function '-' specializes RationalFunctions::'-' (x: Integer[1], y: Integer[0..1]): Integer[1];
+	function '*' specializes RationalFunctions::'*' (x: Integer[1], y: Integer[1]): Integer[1];
+	function '/' specializes RationalFunctions::'/' (x: Integer[1], y: Integer[1]): Rational;
+	function '**' specializes RationalFunctions::'**' (x: Integer[1], y: Natural): Integer[1];
+	function '^' specializes RationalFunctions::'^' (x: Integer[1], y: Natural): Integer[1];
 	function '%' specializes NumericalFunctions::'%' (x: Integer[1], y: Integer[1]): Integer[1];
 	
-	function '<' specializes NumericalFunctions::'<' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '>' specializes NumericalFunctions::'>' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '<=' specializes NumericalFunctions::'<=' (x: Integer[1], y: Integer[1]): Boolean[1];
-	function '>=' specializes NumericalFunctions::'>=' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '<' specializes RationalFunctions::'<' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '>' specializes RationalFunctions::'>' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '<=' specializes RationalFunctions::'<=' (x: Integer[1], y: Integer[1]): Boolean[1];
+	function '>=' specializes RationalFunctions::'>=' (x: Integer[1], y: Integer[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Integer[1], y: Integer[1]): Integer[1];
-	function Min specializes NumericalFunctions::Min (x: Integer[1], y: Integer[1]): Integer[1];
+	function max specializes RationalFunctions::max (x: Integer[1], y: Integer[1]): Integer[1];
+	function min specializes RationalFunctions::min (x: Integer[1], y: Integer[1]): Integer[1];
 
 	function '==' specializes DataFunctions::'==' (x: Integer[0..1], y: Integer[0..1]): Boolean[1];
 	
 	function '..' specializes ScalarFunctions::'..' (lower: Integer[1], upper: Integer[1]): Integer[0..*];	
 	
-	function ToString specializes BaseFunctions::ToString (x: Integer[1]): String[1];
+	function ToString specializes RationalFunctions::ToString (x: Integer[1]): String[1];
 	function ToNatural(x: Integer[1]): Natural[1];
 	function ToInteger(x: String[1]): Integer[1];
 	
-	function sum specializes NumericalFunctions::sum(collection: Integer[0..*]): Integer[1] {
+	function sum specializes RationalFunctions::sum(collection: Integer[0..*]): Integer[1] {
 		NumericalFunctions::sum0(collection, 0)
 	}
 	
-	function product specializes NumericalFunctions::product(collection: Integer[0..*]): Integer[1] {
+	function product specializes RationalFunctions::product(collection: Integer[0..*]): Integer[1] {
 		NumericalFunctions::product1(collection, 1)
 	}
 }	

--- a/sysml.library/Kernel Library/IntegerFunctions.kerml
+++ b/sysml.library/Kernel Library/IntegerFunctions.kerml
@@ -31,11 +31,11 @@ package IntegerFunctions {
 	function ToNatural(x: Integer[1]): Natural[1];
 	function ToInteger(x: String[1]): Integer[1];
 	
-	function sum specializes ScalarFunctions::sum(collection: Integer[0..*]): Integer[1] {
-		ScalarFunctions::sum0(collection, 0)
+	function sum specializes NumericalFunctions::sum(collection: Integer[0..*]): Integer[1] {
+		NumericalFunctions::sum0(collection, 0)
 	}
 	
-	function product specializes ScalarFunctions::product(collection: Integer[0..*]): Integer[1] {
-		ScalarFunctions::product1(collection, 1)
+	function product specializes NumericalFunctions::product(collection: Integer[0..*]): Integer[1] {
+		NumericalFunctions::product1(collection, 1)
 	}
 }	

--- a/sysml.library/Kernel Library/NaturalFunctions.kerml
+++ b/sysml.library/Kernel Library/NaturalFunctions.kerml
@@ -15,7 +15,8 @@ package NaturalFunctions {
 	function '<=' specializes IntegerFunctions::'<=' (x: Natural[1], y: Natural[1]): Boolean[1];
 	function '>=' specializes IntegerFunctions::'>=' (x: Natural[1], y: Natural[1]): Boolean[1];	
 
-	function Max specializes IntegerFunctions::Max (x: Natural[1], y: Natural[1]): Natural[1];
+	function max specializes IntegerFunctions::max (x: Natural[1], y: Natural[1]): Natural[1];
+	function min specializes IntegerFunctions::min (x: Natural[1], y: Natural[1]): Natural[1];
 
 	function '==' specializes IntegerFunctions::'==' (x: Natural[0..1], y: Natural[0..1]): Boolean[1];
 	

--- a/sysml.library/Kernel Library/NumericalFunctions.kerml
+++ b/sysml.library/Kernel Library/NumericalFunctions.kerml
@@ -8,7 +8,7 @@ package NumericalFunctions {
 	abstract function isZero(x: NumericalValue[1]): Boolean;
 	abstract function isUnit(x : NumericalValue[1]): Boolean;
 	
-	abstract function Abs(x: NumericalValue[1]): NumericalValue[1];
+	abstract function abs(x: NumericalValue[1]): NumericalValue[1];
 		
 	abstract function '+' specializes ScalarFunctions::'+' (x: NumericalValue[1], y: NumericalValue[0..1]): NumericalValue[1];
 	abstract function '-' specializes ScalarFunctions::'-' (x: NumericalValue[1], y: NumericalValue[0..1]): NumericalValue[1];
@@ -23,11 +23,10 @@ package NumericalFunctions {
 	abstract function '<=' specializes ScalarFunctions::'<=' (x: NumericalValue[1], y: NumericalValue[1]): Boolean[1];
 	abstract function '>=' specializes ScalarFunctions::'>=' (x: NumericalValue[1], y: NumericalValue[1]): Boolean[1];
 	
-	abstract function Max specializes ScalarFunctions::Max (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
-	abstract function Min specializes ScalarFunctions::Min (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	abstract function max specializes ScalarFunctions::max (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	abstract function min specializes ScalarFunctions::min (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
 	
-	abstract function sum (collection: ScalarValue[0..*]): ScalarValue[1];
-	
+	abstract function sum (collection: ScalarValue[0..*]): ScalarValue[1];	
 	abstract function product (collection: ScalarValue[0..*]): ScalarValue[1];
 	
 	function sum0 (collection: NumericalValue[0..*], zero: ScalarValue[1]): ScalarValue {

--- a/sysml.library/Kernel Library/NumericalFunctions.kerml
+++ b/sysml.library/Kernel Library/NumericalFunctions.kerml
@@ -3,6 +3,10 @@
  */
 package NumericalFunctions {
 	import ScalarValues::*;
+	private import ControlFunctions::reduce;
+	
+	abstract function isZero(x: NumericalValue[1]): Boolean;
+	abstract function isUnit(x : NumericalValue[1]): Boolean;
 	
 	abstract function Abs(x: NumericalValue[1]): NumericalValue[1];
 		
@@ -21,4 +25,18 @@ package NumericalFunctions {
 	
 	abstract function Max specializes ScalarFunctions::Max (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
 	abstract function Min specializes ScalarFunctions::Min (x: NumericalValue[1], y: NumericalValue[1]): NumericalValue[1];
+	
+	abstract function sum (collection: ScalarValue[0..*]): ScalarValue[1];
+	
+	abstract function product (collection: ScalarValue[0..*]): ScalarValue[1];
+	
+	function sum0 (collection: NumericalValue[0..*], zero: ScalarValue[1]): ScalarValue {
+		inv { isZero(zero) }
+		collection->reduce '+' ?? zero
+	}
+	
+	function product1 (collection: ScalarValue[0..*], one: ScalarValue[1]): ScalarValue {
+		inv { isUnit(one) }
+		collection->reduce '*' ?? one
+	}
 }

--- a/sysml.library/Kernel Library/RationalFunctions.kerml
+++ b/sysml.library/Kernel Library/RationalFunctions.kerml
@@ -5,43 +5,43 @@
 package RationalFunctions {
 	import ScalarValues::*;
 	
-	function Rat(numer: Integer[1], denum: Integer[1]): Rational[1];
-	function Numer(rat: Rational[1]): Integer[1];
-	function Denom(rat: Rational[1]): Integer[1];
+	function rat(numer: Integer[1], denum: Integer[1]): Rational[1];
+	function numer(rat: Rational[1]): Integer[1];
+	function denom(rat: Rational[1]): Integer[1];
 	
-	function Abs specializes NumericalFunctions::Abs (x: Rational[1]): Rational[1];
+	function abs specializes RealFunctions::abs (x: Rational[1]): Rational[1];
 
-	function '+' specializes NumericalFunctions::'+' (x: Rational[1], y: Rational[0..1]): Rational[1];
-	function '-' specializes NumericalFunctions::'-' (x: Rational[1], y: Rational[0..1]): Rational[1];
-	function '*' specializes NumericalFunctions::'*' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '/' specializes NumericalFunctions::'/' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '**' specializes NumericalFunctions::'**' (x: Rational[1], y: Rational[1]): Rational[1];
-	function '^' specializes NumericalFunctions::'^' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '+' specializes RealFunctions::'+' (x: Rational[1], y: Rational[0..1]): Rational[1];
+	function '-' specializes RealFunctions::'-' (x: Rational[1], y: Rational[0..1]): Rational[1];
+	function '*' specializes RealFunctions::'*' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '/' specializes RealFunctions::'/' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '**' specializes RealFunctions::'**' (x: Rational[1], y: Rational[1]): Rational[1];
+	function '^' specializes RealFunctions::'^' (x: Rational[1], y: Rational[1]): Rational[1];
 	
-	function '<' specializes NumericalFunctions::'<' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '>' specializes NumericalFunctions::'>' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '<=' specializes NumericalFunctions::'<=' (x: Rational[1], y: Rational[1]): Boolean[1];
-	function '>=' specializes NumericalFunctions::'>=' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '<' specializes RealFunctions::'<' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '>' specializes RealFunctions::'>' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '<=' specializes RealFunctions::'<=' (x: Rational[1], y: Rational[1]): Boolean[1];
+	function '>=' specializes RealFunctions::'>=' (x: Rational[1], y: Rational[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Rational[1], y: Rational[1]): Rational[1];
-	function Min specializes NumericalFunctions::Min (x: Rational[1], y: Rational[1]): Rational[1];
+	function max specializes RealFunctions::max (x: Rational[1], y: Rational[1]): Rational[1];
+	function min specializes RealFunctions::min (x: Rational[1], y: Rational[1]): Rational[1];
 
-	function '==' specializes DataFunctions::'==' (x: Rational[0..1], y: Rational[0..1]): Boolean[1];
+	function '==' specializes RealFunctions::'==' (x: Rational[0..1], y: Rational[0..1]): Boolean[1];
 	
-	function GCD(x: Rational[1], y: Rational[1]): Integer[1];
+	function gcd(x: Rational[1], y: Rational[1]): Integer[1];
 		
-	function Floor(x: Rational[1]): Integer[1];
-	function Round(x: Rational[1]): Integer[1];
+	function floor specializes RealFunctions::floor (x: Rational[1]): Integer[1];
+	function round specializes RealFunctions::round (x: Rational[1]): Integer[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: Rational[1]): String[1];
+	function ToString specializes RealFunctions::ToString (x: Rational[1]): String[1];
 	function ToInteger(x: Rational[1]): Integer[1];
 	function ToRational(x: String[1]): Rational[1];
 	
-	function sum specializes NumericalFunctions::sum (collection: Rational[0..*]): Rational[1] {
-		NumericalFunctions::sum0(collection, Rat(0, 1))
+	function sum specializes RealFunctions::sum (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::sum0(collection, rat(0, 1))
 	}
 	
-	function product specializes NumericalFunctions::product (collection: Rational[0..*]): Rational[1] {
-		NumericalFunctions::product1(collection, Rat(1, 1))
+	function product specializes RealFunctions::product (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::product1(collection, rat(1, 1))
 	}	
 }

--- a/sysml.library/Kernel Library/RationalFunctions.kerml
+++ b/sysml.library/Kernel Library/RationalFunctions.kerml
@@ -37,11 +37,11 @@ package RationalFunctions {
 	function ToInteger(x: Rational[1]): Integer[1];
 	function ToRational(x: String[1]): Rational[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Rational[0..*]): Rational[1] {
-		ScalarFunctions::sum0(collection, Rat(0, 1))
+	function sum specializes NumericalFunctions::sum (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::sum0(collection, Rat(0, 1))
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Rational[0..*]): Rational[1] {
-		ScalarFunctions::product1(collection, Rat(1, 1))
+	function product specializes NumericalFunctions::product (collection: Rational[0..*]): Rational[1] {
+		NumericalFunctions::product1(collection, Rat(1, 1))
 	}	
 }

--- a/sysml.library/Kernel Library/RealFunctions.kerml
+++ b/sysml.library/Kernel Library/RealFunctions.kerml
@@ -5,47 +5,50 @@
 package RealFunctions {
 	import ScalarValues::*;
 	
-	function Re :> ComplexFunctions::Re(x: Real[1]): Real[1] {
+	function re :> ComplexFunctions::re(x: Real[1]): Real[1] {
 		x
 	}
-	function Im :> ComplexFunctions::Im(x: Real[1]): Real[1] {
+	function im :> ComplexFunctions::im(x: Real[1]): Real[1] {
 		0.0
 	}
 	
-	function Abs specializes NumericalFunctions::Abs (x: Real[1]): Real[1];
+	function abs specializes ComplexFunctions::abs (x: Real[1]): Real[1];
+	function arg specializes ComplexFunctions::arg (x: Real[1]): Real[1] {
+		0.0
+	}
 
-	function '+' specializes NumericalFunctions::'+' (x: Real[1], y: Real[0..1]): Real[1];
-	function '-' specializes NumericalFunctions::'-' (x: Real[1], y: Real[0..1]): Real[1];
-	function '*' specializes NumericalFunctions::'*' (x: Real[1], y: Real[1]): Real[1];
-	function '/' specializes NumericalFunctions::'/' (x: Real[1], y: Real[1]): Real[1];
-	function '**' specializes NumericalFunctions::'**' (x: Real[1], y: Real[1]): Real[1];
-	function '^' specializes NumericalFunctions::'^' (x: Real[1], y: Real[1]): Real[1];
+	function '+' specializes ComplexFunctions::'+' (x: Real[1], y: Real[0..1]): Real[1];
+	function '-' specializes ComplexFunctions::'-' (x: Real[1], y: Real[0..1]): Real[1];
+	function '*' specializes ComplexFunctions::'*' (x: Real[1], y: Real[1]): Real[1];
+	function '/' specializes ComplexFunctions::'/' (x: Real[1], y: Real[1]): Real[1];
+	function '**' specializes ComplexFunctions::'**' (x: Real[1], y: Real[1]): Real[1];
+	function '^' specializes ComplexFunctions::'^' (x: Real[1], y: Real[1]): Real[1];
 	
 	function '<' specializes NumericalFunctions::'<' (x: Real[1], y: Real[1]): Boolean[1];
 	function '>' specializes NumericalFunctions::'>' (x: Real[1], y: Real[1]): Boolean[1];
 	function '<=' specializes NumericalFunctions::'<=' (x: Real[1], y: Real[1]): Boolean[1];
 	function '>=' specializes NumericalFunctions::'>=' (x: Real[1], y: Real[1]): Boolean[1];
 
-	function Max specializes NumericalFunctions::Max (x: Real[1], y: Real[1]): Real[1];
-	function Min specializes NumericalFunctions::Min (x: Real[1], y: Real[1]): Real[1];
+	function max specializes NumericalFunctions::max (x: Real[1], y: Real[1]): Real[1];
+	function min specializes NumericalFunctions::min (x: Real[1], y: Real[1]): Real[1];
 
-	function '==' specializes DataFunctions::'==' (x: Real[0..1], y: Real[0..1]): Boolean[1];
+	function '==' specializes ComplexFunctions::'==' (x: Real[0..1], y: Real[0..1]): Boolean[1];
 			
-	function Sqrt(x: Real[1]): Real[1];
+	function sqrt(x: Real[1]): Real[1];
 
-	function Floor(x: Real[1]): Integer[1];
-	function Round(x: Real[1]): Integer[1];
+	function floor(x: Real[1]): Integer[1];
+	function round(x: Real[1]): Integer[1];
 	
-	function ToString specializes BaseFunctions::ToString (x: Real[1]): String[1];
+	function ToString specializes ComplexFunctions::ToString (x: Real[1]): String[1];
 	function ToInteger(x: Real[1]): Integer[1];
 	function ToRational(x: Real[1]): Rational[1];
 	function ToReal(x: String[1]): Real[1];
 	
-	function sum specializes NumericalFunctions::sum (collection: Real[0..*]): Real {
+	function sum specializes ComplexFunctions::sum (collection: Real[0..*]): Real {
 		NumericalFunctions::sum0(collection, 0.0)
 	}
 	
-	function product specializes NumericalFunctions::product (collection: Real[0..*]): Real {
+	function product specializes ComplexFunctions::product (collection: Real[0..*]): Real {
 		NumericalFunctions::product1(collection, 1.0)
 	}	
 }

--- a/sysml.library/Kernel Library/RealFunctions.kerml
+++ b/sysml.library/Kernel Library/RealFunctions.kerml
@@ -5,6 +5,13 @@
 package RealFunctions {
 	import ScalarValues::*;
 	
+	function Re :> ComplexFunctions::Re(x: Real[1]): Real[1] {
+		x
+	}
+	function Im :> ComplexFunctions::Im(x: Real[1]): Real[1] {
+		0.0
+	}
+	
 	function Abs specializes NumericalFunctions::Abs (x: Real[1]): Real[1];
 
 	function '+' specializes NumericalFunctions::'+' (x: Real[1], y: Real[0..1]): Real[1];
@@ -34,11 +41,11 @@ package RealFunctions {
 	function ToRational(x: Real[1]): Rational[1];
 	function ToReal(x: String[1]): Real[1];
 	
-	function sum specializes ScalarFunctions::sum (collection: Real[0..*]): Real {
-		ScalarFunctions::sum0(collection, 0.0)
+	function sum specializes NumericalFunctions::sum (collection: Real[0..*]): Real {
+		NumericalFunctions::sum0(collection, 0.0)
 	}
 	
-	function product specializes ScalarFunctions::product (collection: Real[0..*]): Real {
-		ScalarFunctions::product1(collection, 1.0)
+	function product specializes NumericalFunctions::product (collection: Real[0..*]): Real {
+		NumericalFunctions::product1(collection, 1.0)
 	}	
 }

--- a/sysml.library/Kernel Library/ScalarFunctions.kerml
+++ b/sysml.library/Kernel Library/ScalarFunctions.kerml
@@ -3,7 +3,6 @@
  */
 package ScalarFunctions {
 	import ScalarValues::*;
-	private import ControlFunctions::reduce;
 	
 	abstract function '+' specializes DataFunctions::'+' (x: ScalarValue[1], y: ScalarValue[0..1]): ScalarValue[1];
 	abstract function '-' specializes DataFunctions::'-' (x: ScalarValue[1], y: ScalarValue[0..1]): ScalarValue[1];
@@ -31,15 +30,4 @@ package ScalarFunctions {
 	abstract function Min specializes DataFunctions::Min (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
 	
 	abstract function '..' specializes DataFunctions::'..' (lower: ScalarValue[1], upper: ScalarValue[1]): ScalarValue[0..*];
-	
-	abstract function sum specializes DataFunctions::sum (collection: ScalarValue[0..*]): ScalarValue[1];
-	abstract function product specializes DataFunctions::product (collection: ScalarValue[0..*]): ScalarValue[1];
-	
-	function sum0 specializes DataFunctions::sum0 (collection: ScalarValue[0..*], zero: ScalarValue[1]): ScalarValue {
-		collection->reduce '+' ?? zero
-	}
-	
-	function product1 specializes DataFunctions::product1 (collection: ScalarValue[0..*], one: ScalarValue[1]): ScalarValue {
-		collection->reduce '*' ?? one
-	}
 }

--- a/sysml.library/Kernel Library/ScalarFunctions.kerml
+++ b/sysml.library/Kernel Library/ScalarFunctions.kerml
@@ -26,8 +26,8 @@ package ScalarFunctions {
 	abstract function '<=' specializes DataFunctions::'<=' (x: ScalarValue[1], y: ScalarValue[1]): Boolean[1];
 	abstract function '>=' specializes DataFunctions::'>=' (x: ScalarValue[1], y: ScalarValue[1]): Boolean[1];
 	
-	abstract function Max specializes DataFunctions::Max (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
-	abstract function Min specializes DataFunctions::Min (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
+	abstract function max specializes DataFunctions::Max (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
+	abstract function min specializes DataFunctions::Min (x: ScalarValue[1], y: ScalarValue[1]): ScalarValue[1];
 	
 	abstract function '..' specializes DataFunctions::'..' (lower: ScalarValue[1], upper: ScalarValue[1]): ScalarValue[0..*];
 }

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -20,7 +20,7 @@ package SpatialFrames {
 	
 	/**
 	 * A SpatialFrame is a three-dimensional Body that provides a spatial extent that 
-	 * acts as a frame of reference for defining the phyiscal position and displacement 
+	 * acts as a frame of reference for defining the physical position and displacement 
 	 * vectors of Points over time.
 	 */
 	abstract struct SpatialFrame specializes Body;
@@ -45,12 +45,11 @@ package SpatialFrames {
 		}
 		
 		/**
-		 * If the given point occurs within the extent of a Point that is a spaceShot of the given frame,
-		 * then the result positionVector is equal to the PositionOf the enclosing frame Point at
-		 * the given time.
+		 * The result positionVector is equal to the PositionOf the Point spaceShot of the
+		 * frame that encloses the given point, at the current time.
 		 */
 		inv spacePositionConstraint {
-			(frame.spaceSlices as Point)->forAll{in p : Point;
+			(frame.spaceShots as Point)->forAll{in p : Point;
 				p.spaceTimeEnclosedOccurrences->includes(point) implies
 					positionVector == PositionOf(p, time, frame)
 			}

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -6,9 +6,8 @@ package SpatialFrames {
 	private import VectorValues::ThreeVectorValue;
 	private import VectorValues::CartesianThreeVectorValue;
 	private import VectorFunctions::isZeroVector;
-	
-	// TODO: Replace with import after ST6RI-505 is done. 
-	struct Point;
+	private import Objects::Body;
+	private import Objects::Point;
 	
 	/**
 	 * A fixed SpatialFrame used as a universal default.
@@ -16,11 +15,11 @@ package SpatialFrames {
 	feature defaultFrame : SpatialFrame[1];
 	
 	/**
-	 * A SpatialFrame is a Structure that provides a spatial extent over all time, 
+	 * A SpatialFrame is a three-dimensional Body that provides a spatial extent over all time, 
 	 * that acts as a frame of reference for defining phyiscal position and displacement 
 	 * vectors.
 	 */
-	abstract struct SpatialFrame {
+	abstract struct SpatialFrame specializes Body {
 		// TODO: Add topological invariants after ST6RI-505 is done.
 	}
 	

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -45,12 +45,12 @@ package SpatialFrames {
 		}
 		
 		/**
-		 * If the given point occurs within a Point in the space interior of the given frame,
+		 * If the given point occurs within the extent of a Point that is a spaceShot of the given frame,
 		 * then the result positionVector is equal to the PositionOf the enclosing frame Point at
 		 * the given time.
 		 */
 		inv spacePositionConstraint {
-			(frame.spaceInterior as Point)->forAll{in p : Point;
+			(frame.spaceSlices as Point)->forAll{in p : Point;
 				p.spaceTimeEnclosedOccurrences->includes(point) implies
 					positionVector == PositionOf(p, time, frame)
 			}

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -1,0 +1,79 @@
+/**
+ * This package models SpatialFrames that provide a frame of reference for
+ * quantifying the position of points in a three-dimensional space. 
+ */
+package SpatialFrames {
+	private import VectorValues::ThreeVectorValue;
+	private import VectorValues::CartesianThreeVectorValue;
+	private import VectorFunctions::isZeroVector;
+	
+	// TODO: Replace with import after ST6RI-505 is done. 
+	struct Point;
+	
+	/**
+	 * A fixed SpatialFrame used as a universal default.
+	 */
+	feature defaultFrame : SpatialFrame[1];
+	
+	/**
+	 * A SpatialFrame is a Structure that provides a spatial extent over all time, 
+	 * that acts as a frame of reference for defining phyiscal position and displacement 
+	 * vectors.
+	 */
+	abstract struct SpatialFrame {
+		// TODO: Add topological invariants after ST6RI-505 is done.
+	}
+	
+	/**
+	 * The PositionOf a Point relative to a SpatialFrame as a positionVector that is a
+	 * ThreeVectorValue.
+	 */
+	abstract function PositionOf {
+		in point : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		return positionVector : ThreeVectorValue[1];
+	}
+	
+	/**
+	 * The DisplacementOf two Points relative to a SpatialFrame is the displacementVector
+	 * computed as the difference between the PositionOf the first point and PositionOf the
+	 * second point, relative to that SpatialFrame.
+	 */
+	function DisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		return displacementVector : ThreeVectorValue[1] =
+			PositionOf(point2, frame) - PositionOf(point1, frame);
+		
+		inv zeroDisplacementConstraint { 
+			(point1 == point2) == isZeroVector(displacementVector)
+		}
+	}
+	
+	/**
+	 * A CartesianSpatialFrame is a SpatialFrame relative to which all position and displacement
+	 * vectors can be represented as CartesianThreeVectorValues.
+	 */
+	struct CartesianSpatialFrame :> SpatialFrame;
+	
+	/**
+	 * The PositionOf a point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	function CartesianPositionOf :> PositionOf {
+		in point : Point[1];
+		in frame : CartesianSpatialFrame[1];
+		return positionVector : CartesianThreeVectorValue;
+	}
+	
+	/**
+	 * The DisplacementOf two points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	function Cartesian3DDisplacementOf :> DisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : CartesianSpatialFrame;
+		return displacementVector : CartesianThreeVectorValue[1];
+	}
+		
+}

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -51,7 +51,7 @@ package SpatialFrames {
 		 */
 		inv spacePositionConstraint {
 			(frame.spaceInterior as Point)->forAll{in p : Point;
-				p.subSpaceTimeOccurrences->includes(point) implies
+				p.spaceTimeEnclosedOccurrences->includes(point) implies
 					positionVector == PositionOf(p, time, frame)
 			}
 		}
@@ -88,8 +88,8 @@ package SpatialFrames {
 		 * the zero vector.
 		 */
 		inv zeroDisplacementConstraint {
-			(point1.subSpaceTimeOccurrences->includes(point2) or
-			point2.subSpaceTimeOccurrences->includes(point1)) implies
+			(point1.spaceTimeEnclosedOccurrences->includes(point2) or
+			point2.spaceTimeEnclosedOccurrences->includes(point1)) implies
 				isZeroVector(displacementVector)
 		}
 	}

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -1,6 +1,6 @@
 /**
- * This package models SpatialFrames that provide a frame of reference for
- * quantifying the position of points in a three-dimensional space. 
+ * This package models spatial frames of reference for quantifying the position of points 
+ * in a three-dimensional space. 
  */
 package SpatialFrames {
 	private import Clocks::*;

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -63,13 +63,13 @@ package SpatialFrames {
 	function CartesianPositionOf :> PositionOf {
 		in point : Point[1];
 		in frame : CartesianSpatialFrame[1];
-		return positionVector : CartesianThreeVectorValue;
+		return positionVector : CartesianThreeVectorValue[1];
 	}
 	
 	/**
 	 * The DisplacementOf two points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
 	 */
-	function Cartesian3DDisplacementOf :> DisplacementOf {
+	function CartesianDisplacementOf :> DisplacementOf {
 		in point1 : Point[1];
 		in point2 : Point[1];
 		in frame : CartesianSpatialFrame;

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -3,65 +3,134 @@
  * quantifying the position of points in a three-dimensional space. 
  */
 package SpatialFrames {
+	private import Clocks::*;
+	private import ScalarValues::NumericalValue;
 	private import VectorValues::ThreeVectorValue;
 	private import VectorValues::CartesianThreeVectorValue;
 	private import VectorFunctions::isZeroVector;
 	private import Objects::Body;
 	private import Objects::Point;
+	private import ControlFunctions::forAll;
+	private import SequenceFunctions::includes;
 	
 	/**
-	 * A fixed SpatialFrame used as a universal default.
+	 * defaultFrame is a fixed SpatialFrame used as a universal default.
 	 */
-	feature defaultFrame : SpatialFrame[1];
+	readonly feature defaultFrame : SpatialFrame[1];
 	
 	/**
-	 * A SpatialFrame is a three-dimensional Body that provides a spatial extent over all time, 
-	 * that acts as a frame of reference for defining phyiscal position and displacement 
-	 * vectors.
+	 * A SpatialFrame is a three-dimensional Body that provides a spatial extent that 
+	 * acts as a frame of reference for defining the phyiscal position and displacement 
+	 * vectors of Points over time.
 	 */
-	abstract struct SpatialFrame specializes Body {
-		// TODO: Add topological invariants after ST6RI-505 is done.
-	}
+	abstract struct SpatialFrame specializes Body;
 	
 	/**
-	 * The PositionOf a Point relative to a SpatialFrame as a positionVector that is a
-	 * ThreeVectorValue.
+	 * The PositionOf a Point relative to a SpatialFrame, at a specific time relative to a given
+	 * clock, as a positionVector that is a ThreeVectorValue.
 	 */
 	abstract function PositionOf {
 		in point : Point[1];
+		in time : NumericalValue[1];
 		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
 		return positionVector : ThreeVectorValue[1];
+		
+		/**
+		 * The given point must exist at the given time.
+		 */
+		inv positionTimePrecondition {
+			TimeOf(point.startShot) <= time and
+			time <= TimeOf(point.endShot)
+		}
+		
+		/**
+		 * If the given point occurs within a Point in the space interior of the given frame,
+		 * then the result positionVector is equal to the PositionOf the enclosing frame Point at
+		 * the given time.
+		 */
+		inv spacePositionConstraint {
+			(frame.spaceInterior as Point)->forAll{in p : Point;
+				p.subSpaceTimeOccurrences->includes(point) implies
+					positionVector == PositionOf(p, time, frame)
+			}
+		}
 	}
 	
 	/**
-	 * The DisplacementOf two Points relative to a SpatialFrame is the displacementVector
-	 * computed as the difference between the PositionOf the first point and PositionOf the
-	 * second point, relative to that SpatialFrame.
+	 * The CurrentPositionOf a Point relative to a SpatialFrame and a Clock is the PositionOf
+	 * the Point relative to the SpatialFrame at the currentTime of the Clock.
+	 */
+	abstract function CurrentPositionOf {
+		in point : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return positionVector : ThreeVectorValue[1] =
+			PositionOf(point, clock.currentTime, frame, clock);
+	}
+		
+	/**
+	 * The DisplacementOf two Points relative to a SpatialFrame, at a specific time relative to a
+	 * given clock, is the displacementVector computed as the difference between the PositionOf the 
+	 * first point and PositionOf the second point, relative to that SpatialFrame, at that time.
 	 */
 	function DisplacementOf {
 		in point1 : Point[1];
 		in point2 : Point[1];
+		in time : NumericalValue;
 		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
 		return displacementVector : ThreeVectorValue[1] =
-			PositionOf(point2, frame) - PositionOf(point1, frame);
-		
-		inv zeroDisplacementConstraint { 
-			(point1 == point2) == isZeroVector(displacementVector)
+			PositionOf(point2, time, frame, clock) - PositionOf(point1, time, frame, clock);
+			
+		/**
+		 * If either point1 or point2 occurs within the other, then the displacementVector is
+		 * the zero vector.
+		 */
+		inv zeroDisplacementConstraint {
+			(point1.subSpaceTimeOccurrences->includes(point2) or
+			point2.subSpaceTimeOccurrences->includes(point1)) implies
+				isZeroVector(displacementVector)
 		}
+	}
+	
+	/**
+	 * The CurrentDisplacementOf two points relative to a SpatialFrame and Clock is the DisplacementOf
+	 * the Points realtive to the SpacialFrame at the currentTime of the Clock.
+	 */
+	function CurrentDisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : SpatialFrame[1] default defaultFrame;
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : ThreeVectorValue[1] =
+			DisplacementOf(point1, point2, clock.currentTime, frame, clock);
 	}
 	
 	/**
 	 * A CartesianSpatialFrame is a SpatialFrame relative to which all position and displacement
 	 * vectors can be represented as CartesianThreeVectorValues.
 	 */
-	struct CartesianSpatialFrame :> SpatialFrame;
+	abstract struct CartesianSpatialFrame :> SpatialFrame;
 	
 	/**
-	 * The PositionOf a point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 * The PositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
 	 */
-	function CartesianPositionOf :> PositionOf {
+	abstract function CartesianPositionOf :> PositionOf {
+		in point : Point[1];
+		in time : NumericalValue[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return positionVector : CartesianThreeVectorValue[1];
+	}
+	
+	/**
+	 * The CurrentPositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	abstract function CartesianCurrentPositionOf :> CurrentPositionOf {
 		in point : Point[1];
 		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
 		return positionVector : CartesianThreeVectorValue[1];
 	}
 	
@@ -71,7 +140,20 @@ package SpatialFrames {
 	function CartesianDisplacementOf :> DisplacementOf {
 		in point1 : Point[1];
 		in point2 : Point[1];
-		in frame : CartesianSpatialFrame;
+		in time : NumericalValue[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
+		return displacementVector : CartesianThreeVectorValue[1];
+	}
+		
+	/**
+	 * The CurrentDisplacementOf two points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+	 */
+	function CartesianCurrentDisplacementOf :> CurrentDisplacementOf {
+		in point1 : Point[1];
+		in point2 : Point[1];
+		in frame : CartesianSpatialFrame[1];
+		in clock : Clock[1] default defaultClock;
 		return displacementVector : CartesianThreeVectorValue[1];
 	}
 		

--- a/sysml.library/Kernel Library/TrigFunctions.kerml
+++ b/sysml.library/Kernel Library/TrigFunctions.kerml
@@ -1,0 +1,30 @@
+package TrigFunctions {
+	import ScalarValues::Real;
+	
+	feature pi : Real;
+	
+	function deg(theta_rad : Real) {
+		theta_rad * 180 / pi
+	}
+	function rad(theta_deg : Real) {
+		theta_deg * pi / 180
+	}
+	
+	datatype UnitBoundedReal :> Real {
+		private x :>> self;
+		inv unitBound { -1.0 <= x & x <= 1.0 }
+	}
+	
+	function sin(theta : Real) : UnitBoundedReal;
+	function cos(theta : Real) : UnitBoundedReal;
+	function tan(theta : Real) : Real {
+		sin(theta) / cos(theta)
+	}
+	function Cot(theta : Real) : Real {
+		cos(theta) / sin(theta)
+	}
+	
+	function arcsin(x : UnitBoundedReal) : Real;
+	function arccos(x : UnitBoundedReal) : Real;
+	function arctan(x : Real) : Real;
+}

--- a/sysml.library/Kernel Library/TrigFunctions.kerml
+++ b/sysml.library/Kernel Library/TrigFunctions.kerml
@@ -2,6 +2,7 @@ package TrigFunctions {
 	import ScalarValues::Real;
 	
 	feature pi : Real;
+	inv piPrecision { RealFunctions::round(pi * 1E20) == 314159265358979323846.0 }
 	
 	function deg(theta_rad : Real) {
 		theta_rad * 180 / pi
@@ -20,7 +21,7 @@ package TrigFunctions {
 	function tan(theta : Real) : Real {
 		sin(theta) / cos(theta)
 	}
-	function Cot(theta : Real) : Real {
+	function cot(theta : Real) : Real {
 		cos(theta) / sin(theta)
 	}
 	

--- a/sysml.library/Kernel Library/TrigFunctions.kerml
+++ b/sysml.library/Kernel Library/TrigFunctions.kerml
@@ -1,3 +1,6 @@
+/**
+ * This package defines basic trigonometric functions on real numbers.
+ */
 package TrigFunctions {
 	import ScalarValues::Real;
 	

--- a/sysml.library/Kernel Library/VectorFunctions.kerml
+++ b/sysml.library/Kernel Library/VectorFunctions.kerml
@@ -1,0 +1,180 @@
+/**
+ * This package defines abstraft functions on VectorValues corresponding to the algebraic operations
+ * provided by a vector space with inner product. It also includes concrete implementations of these
+ * functions specifically for CartesianVectorValues.
+ */
+package VectorFunctions {
+	private import ScalarValues::NumericalValue;
+	private import ScalarValues::Positive;
+	private import ScalarValues::Real;
+	private import ScalarValues::Boolean;
+	private import NumericalFunctions::*;
+	private import RealFunctions::Sqrt;
+	private import TrigFunctions::arccos;
+	private import SequenceFunctions::size;
+	private import ControlFunctions::*;
+	
+	import VectorValues::*;
+	
+	/* Generic arithmetic functions for all VectorValues. */
+	
+	/**
+	 * Return whether a VectorValue is a zero vector.
+	 */
+	abstract function isZeroVector(v : VectorValue[1]): Boolean[1];
+	
+	/**
+	 * With two arguments, returns the sum of two VectorValues. With one argument, returns that VectorValue.
+	 */
+	abstract function '+' specializes DataFunctions::'+' (v: VectorValue[1], w: VectorValue[0..1]) u : VectorValue[1] {
+		inv zeroAddition { w == null or isZeroVector(w) implies u == w }
+		inv commutivity { w != null implies u == w + v }
+	}
+	
+	/**
+	 * With two arguments, returns the difference of two VectorValues. With one arguments, returns the inverse
+	 * of the given VectorValue, that is, the VectorValue that, when added to the original VectorValue, results in
+	 * the zeroVector.
+	 */
+	abstract function '-' specializes DataFunctions::'-' (v: VectorValue[1], w: VectorValue[0..1]) u: VectorValue[1] {
+		inv negation { w == null implies isZeroVector(v + u) }
+		inv difference { w != null implies v + u == w }
+	}
+
+	/* Functions specific to NumericalVectorValues. */
+	
+	/**
+	 * Construct a NumericalVectorValue whose elements are a non-empty list of component NumericalValues.
+	 * The dimension of the NumericalVectorValue is equal to the number of components.
+	 */
+	function VectorOf(components : NumericalValue[1..*] ordered nonunique) : NumericalVectorValue {
+		NumericalVectorValue (
+			dimension = size(components),
+			elements = components
+		)
+	}
+	
+	/**
+	 * Scalar product of a NumericalValue and a NumericalVectorValue.
+	 */
+	abstract function ScalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w : NumericalVectorValue[1] {
+		inv scaling { Length(w) == x * Length(v) }
+		inv zeroLength { isZeroVector(w) implies isZero(Length(w))}
+	}
+	alias '*' for ScalarVectorMult;
+	
+	/**
+	 * Scalar product of a NumericalVectorValue and a NumericalValue, which has the same value as the scalar product of the
+	 * NumericalValue and the NumericalVectorValue.
+	 */
+	abstract function VectorScalarMult specializes DataFunctions::'*' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		ScalarVectorMult(x, v)
+	}
+	
+	/**
+	 * Scalar quotient of a NumericalVectorValue and a NumericalValue, defined as the scalar product of the inverse of the 
+	 * NumericalValue and the NumericalVectorValue.
+	 */
+	abstract function VectorScalarDiv specializes DataFunctions::'/' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		ScalarVectorMult(1.0 / x, v)
+	}
+
+	/**
+	 * Inner product of two NumericalVectorValues.
+	 */
+	abstract function Inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w : NumericalVectorValue[1]) x : NumericalValue[1] {
+		inv commmutivity { x == Inner(w, v) }
+		inv zeroInner { isZeroVector(v) or isZeroVector(w) implies isZero(x)}
+	}
+	
+	/**
+	 * The length of a NumericalVectoralue, as a NumericalValue.
+	 */
+	abstract function Length(v: NumericalVectorValue[1]) l : NumericalValue[1] {
+		inv squareLength { l * l == Inner(v,v) }
+		inv lengthZero { isZero(l) == isZeroVector(v) }
+	}
+	
+	/**
+	 * The angle between two NumericalVectorValues, as a NumericalValue.
+	 */
+	abstract function Angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta : NumericalValue[1] {
+		inv commutivity { theta == Angle(w, v) }
+		inv lengthInsensitive { theta == Angle(w / Length(w), v / Length(v)) }
+	}
+	
+	/* Specialized functions with concrete definitions for CartesianVectorValues. */
+	
+	/**
+	 * Construct a CartesianVectorValue whose elements are a non-empty list of Real components.
+	 * The dimension of the NumericalVectorValue is equal to the number of components.
+	 */
+	function CartesianVectorOf(components : Real[*]) : CartesianVectorValue {
+		CartesianVectorValue (
+			dimension = size(components),
+			elements = components
+		)
+	}
+	function CartesianThreeVectorOf :> CartesianVectorOf(components : Real[*]): CartesianThreeVectorValue;
+	
+	/**
+	 * Cartesian zero vectors of 1, 2 and 3 dimensions.
+	 */
+	feature cartesianZeroVector : CartesianVectorValue[3] =
+		(
+			CartesianVectorOf(0.0),
+			CartesianVectorOf((0.0, 0.0)),
+			CartesianThreeVectorOf((0.0, 0.0, 0.0))
+		);
+	feature cartesian3DZeroVector : CartesianThreeVectorValue[1] =
+		cartesianZeroVector[3];
+	
+	/**
+	 * A CartesianVectorValue is a zero vector if all its elements are zero.
+	 */
+	function isCartesianZeroVector :> isZeroVector (v : CartesianVectorValue): Boolean {
+		v.elements->forAll{in x; x == 0.0}
+	}
+	
+	function 'Cartesian+' specializes '+' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+		inv precondition { w != null implies v.dimension == w.dimension }
+		if w == null? v
+		else CartesianVectorOf(
+			(1..w.dimension)->collect{in i : Positive; v[i] + w[i]}
+		)
+	}
+	
+	function 'Cartesian-' specializes '-' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+		inv precondition { w != null implies v.dimension == w.dimension }
+		CartesianVectorOf(
+			if w == null? CartesianVectorOf(v.elements->collect{in x : Real; -x})
+			else CartesianVectorOf(
+				(1..v.dimension)->collect{in i : Positive; v[i] - w[i]}
+			)
+		)
+	}
+	
+	function CartesianScalarVectorMult specializes ScalarVectorMult (x: Real[1], v: CartesianVectorValue[1]): CartesianVectorValue[1] {
+		CartesianVectorOf(
+			v.elements->collect{in y : Real; x * y}
+		)
+	}
+	function CartesianVectorScalarMult specializes VectorScalarMult (v: CartesianVectorValue[1], x: Real[1]): CartesianVectorValue[1] {
+		CartesianScalarVectorMult(x, v)
+	}
+	
+	function CartesianInner specializes Inner(v: CartesianVectorValue[1], w : CartesianVectorValue[1]): Real[1]{
+		inv precondition { v.dimension == w.dimension }
+		(1..v.dimension)->collect{in i : Positive; v[i] * w[i]}->reduce RealFunctions::'+'
+	}
+	
+	function CartesianLength specializes Length(v: CartesianVectorValue[1]) : NumericalValue[1] {
+		Sqrt(CartesianInner(v, v))
+	}
+	
+	function CartesianAngle specializes Angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]) : Real[1] {
+		inv precondition { v.dimension == w.dimension }
+		arccos(CartesianInner(v, w) / (Length(v) * Length(w)))
+	}
+	
+}

--- a/sysml.library/Kernel Library/VectorFunctions.kerml
+++ b/sysml.library/Kernel Library/VectorFunctions.kerml
@@ -9,7 +9,7 @@ package VectorFunctions {
 	private import ScalarValues::Real;
 	private import ScalarValues::Boolean;
 	private import NumericalFunctions::*;
-	private import RealFunctions::Sqrt;
+	private import RealFunctions::sqrt;
 	private import TrigFunctions::arccos;
 	private import SequenceFunctions::size;
 	private import ControlFunctions::*;
@@ -65,50 +65,50 @@ package VectorFunctions {
 	/**
 	 * Scalar product of a NumericalValue and a NumericalVectorValue.
 	 */
-	abstract function ScalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w: NumericalVectorValue[1] {
-		inv scaling { Length(w) == x * Length(v) }
-		inv zeroLength { isZeroVector(w) implies isZero(Length(w))}
+	abstract function scalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w: NumericalVectorValue[1] {
+		inv scaling { length(w) == x * length(v) }
+		inv zeroLength { isZeroVector(w) implies isZero(length(w))}
 	}
-	alias '*' for ScalarVectorMult;
+	alias '*' for scalarVectorMult;
 	
 	/**
 	 * Scalar product of a NumericalVectorValue and a NumericalValue, which has the same value as the scalar product of the
 	 * NumericalValue and the NumericalVectorValue.
 	 */
-	abstract function VectorScalarMult specializes DataFunctions::'*' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
-		ScalarVectorMult(x, v)
+	abstract function vectorScalarMult specializes DataFunctions::'*' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		scalarVectorMult(x, v)
 	}
 	
 	/**
 	 * Scalar quotient of a NumericalVectorValue and a NumericalValue, defined as the scalar product of the inverse of the 
 	 * NumericalValue and the NumericalVectorValue.
 	 */
-	abstract function VectorScalarDiv specializes DataFunctions::'/' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
-		ScalarVectorMult(1.0 / x, v)
+	abstract function vectorScalarDiv specializes DataFunctions::'/' (v: NumericalVectorValue[1], x: NumericalValue[1]): NumericalVectorValue[1] {
+		scalarVectorMult(1.0 / x, v)
 	}
 
 	/**
 	 * Inner product of two NumericalVectorValues.
 	 */
-	abstract function Inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) x: NumericalValue[1] {
-		inv commmutivity { x == Inner(w, v) }
+	abstract function inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) x: NumericalValue[1] {
+		inv commmutivity { x == inner(w, v) }
 		inv zeroInner { isZeroVector(v) or isZeroVector(w) implies isZero(x)}
 	}
 	
 	/**
 	 * The length of a NumericalVectorValue, as a NumericalValue.
 	 */
-	abstract function Length(v: NumericalVectorValue[1]) l : NumericalValue[1] {
-		inv squareLength { l * l == Inner(v,v) }
+	abstract function length(v: NumericalVectorValue[1]) l : NumericalValue[1] {
+		inv squareNorm { l * l == inner(v,v) }
 		inv lengthZero { isZero(l) == isZeroVector(v) }
 	}
 	
 	/**
 	 * The angle between two NumericalVectorValues, as a NumericalValue.
 	 */
-	abstract function Angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta: NumericalValue[1] {
-		inv commutivity { theta == Angle(w, v) }
-		inv lengthInsensitive { theta == Angle(w / Length(w), v / Length(v)) }
+	abstract function angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta: NumericalValue[1] {
+		inv commutivity { theta == angle(w, v) }
+		inv lengthInsensitive { theta == angle(w / length(w), v / length(v)) }
 	}
 	
 	/* Specialized functions with concrete definitions for CartesianVectorValues. */
@@ -144,7 +144,7 @@ package VectorFunctions {
 		v.elements->forAll{in x; x == 0.0}
 	}
 	
-	function 'Cartesian+' specializes '+' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+	function 'cartesian+' specializes '+' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
 		inv precondition { w != null implies v.dimension == w.dimension }
 		if w == null? v
 		else CartesianVectorOf(
@@ -152,7 +152,7 @@ package VectorFunctions {
 		)
 	}
 	
-	function 'Cartesian-' specializes '-' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
+	function 'cartesian-' specializes '-' (v: CartesianVectorValue[1], w: CartesianVectorValue[0..1]): CartesianVectorValue[1] {
 		inv precondition { w != null implies v.dimension == w.dimension }
 		CartesianVectorOf(
 			if w == null? CartesianVectorOf(v.elements->collect{in x : Real; -x})
@@ -162,27 +162,27 @@ package VectorFunctions {
 		)
 	}
 	
-	function CartesianScalarVectorMult specializes ScalarVectorMult (x: Real[1], v: CartesianVectorValue[1]): CartesianVectorValue[1] {
+	function cartesianScalarVectorMult specializes scalarVectorMult (x: Real[1], v: CartesianVectorValue[1]): CartesianVectorValue[1] {
 		CartesianVectorOf(
 			v.elements->collect{in y : Real; x * y}
 		)
 	}
-	function CartesianVectorScalarMult specializes VectorScalarMult (v: CartesianVectorValue[1], x: Real[1]): CartesianVectorValue[1] {
-		CartesianScalarVectorMult(x, v)
+	function cartesianVectorScalarMult specializes vectorScalarMult (v: CartesianVectorValue[1], x: Real[1]): CartesianVectorValue[1] {
+		cartesianScalarVectorMult(x, v)
 	}
 	
-	function CartesianInner specializes Inner(v: CartesianVectorValue[1], w : CartesianVectorValue[1]): Real[1]{
+	function cartesianInner specializes inner(v: CartesianVectorValue[1], w : CartesianVectorValue[1]): Real[1]{
 		inv precondition { v.dimension == w.dimension }
 		(1..v.dimension)->collect{in i : Positive; v[i] * w[i]}->reduce RealFunctions::'+'
 	}
 	
-	function CartesianLength specializes Length(v: CartesianVectorValue[1]) : NumericalValue[1] {
-		Sqrt(CartesianInner(v, v))
+	function cartesianLength specializes length(v: CartesianVectorValue[1]) : NumericalValue[1] {
+		sqrt(cartesianInner(v, v))
 	}
 	
-	function CartesianAngle specializes Angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]): Real[1] {
+	function cartesianAngle specializes angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]): Real[1] {
 		inv precondition { v.dimension == w.dimension }
-		arccos(CartesianInner(v, w) / (Length(v) * Length(w)))
+		arccos(cartesianInner(v, w) / (length(v) * length(w)))
 	}
 	
 	function sum(coll: CartesianThreeVectorValue): CartesianThreeVectorValue {

--- a/sysml.library/Kernel Library/VectorFunctions.kerml
+++ b/sysml.library/Kernel Library/VectorFunctions.kerml
@@ -21,12 +21,12 @@ package VectorFunctions {
 	/**
 	 * Return whether a VectorValue is a zero vector.
 	 */
-	abstract function isZeroVector(v : VectorValue[1]): Boolean[1];
+	abstract function isZeroVector(v: VectorValue[1]): Boolean[1];
 	
 	/**
 	 * With two arguments, returns the sum of two VectorValues. With one argument, returns that VectorValue.
 	 */
-	abstract function '+' specializes DataFunctions::'+' (v: VectorValue[1], w: VectorValue[0..1]) u : VectorValue[1] {
+	abstract function '+' specializes DataFunctions::'+' (v: VectorValue[1], w: VectorValue[0..1]) u: VectorValue[1] {
 		inv zeroAddition { w == null or isZeroVector(w) implies u == w }
 		inv commutivity { w != null implies u == w + v }
 	}
@@ -40,6 +40,14 @@ package VectorFunctions {
 		inv negation { w == null implies isZeroVector(v + u) }
 		inv difference { w != null implies v + u == w }
 	}
+	
+	/**
+	 * Return the sum of a collection of VectorValues. If the collection is empty, return a given zero vector.
+	 */
+	abstract function sum0 (coll: VectorValue[*] nonunique, zero: VectorValue[1]) s: VectorValue[1] {
+		inv precondition { isZeroVector(zero) }
+		coll->reduce '+' ?? zero
+	}
 
 	/* Functions specific to NumericalVectorValues. */
 	
@@ -47,7 +55,7 @@ package VectorFunctions {
 	 * Construct a NumericalVectorValue whose elements are a non-empty list of component NumericalValues.
 	 * The dimension of the NumericalVectorValue is equal to the number of components.
 	 */
-	function VectorOf(components : NumericalValue[1..*] ordered nonunique) : NumericalVectorValue {
+	function VectorOf(components: NumericalValue[1..*] ordered nonunique): NumericalVectorValue {
 		NumericalVectorValue (
 			dimension = size(components),
 			elements = components
@@ -57,7 +65,7 @@ package VectorFunctions {
 	/**
 	 * Scalar product of a NumericalValue and a NumericalVectorValue.
 	 */
-	abstract function ScalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w : NumericalVectorValue[1] {
+	abstract function ScalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w: NumericalVectorValue[1] {
 		inv scaling { Length(w) == x * Length(v) }
 		inv zeroLength { isZeroVector(w) implies isZero(Length(w))}
 	}
@@ -82,13 +90,13 @@ package VectorFunctions {
 	/**
 	 * Inner product of two NumericalVectorValues.
 	 */
-	abstract function Inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w : NumericalVectorValue[1]) x : NumericalValue[1] {
+	abstract function Inner specializes DataFunctions::'*'(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) x: NumericalValue[1] {
 		inv commmutivity { x == Inner(w, v) }
 		inv zeroInner { isZeroVector(v) or isZeroVector(w) implies isZero(x)}
 	}
 	
 	/**
-	 * The length of a NumericalVectoralue, as a NumericalValue.
+	 * The length of a NumericalVectorValue, as a NumericalValue.
 	 */
 	abstract function Length(v: NumericalVectorValue[1]) l : NumericalValue[1] {
 		inv squareLength { l * l == Inner(v,v) }
@@ -98,7 +106,7 @@ package VectorFunctions {
 	/**
 	 * The angle between two NumericalVectorValues, as a NumericalValue.
 	 */
-	abstract function Angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta : NumericalValue[1] {
+	abstract function Angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta: NumericalValue[1] {
 		inv commutivity { theta == Angle(w, v) }
 		inv lengthInsensitive { theta == Angle(w / Length(w), v / Length(v)) }
 	}
@@ -115,24 +123,24 @@ package VectorFunctions {
 			elements = components
 		)
 	}
-	function CartesianThreeVectorOf :> CartesianVectorOf(components : Real[*]): CartesianThreeVectorValue;
+	function CartesianThreeVectorOf specializes CartesianVectorOf(components: Real[*]): CartesianThreeVectorValue;
 	
 	/**
 	 * Cartesian zero vectors of 1, 2 and 3 dimensions.
 	 */
-	feature cartesianZeroVector : CartesianVectorValue[3] =
+	feature cartesianZeroVector: CartesianVectorValue[3] =
 		(
 			CartesianVectorOf(0.0),
 			CartesianVectorOf((0.0, 0.0)),
 			CartesianThreeVectorOf((0.0, 0.0, 0.0))
 		);
-	feature cartesian3DZeroVector : CartesianThreeVectorValue[1] =
+	feature cartesian3DZeroVector: CartesianThreeVectorValue[1] =
 		cartesianZeroVector[3];
 	
 	/**
 	 * A CartesianVectorValue is a zero vector if all its elements are zero.
 	 */
-	function isCartesianZeroVector :> isZeroVector (v : CartesianVectorValue): Boolean {
+	function isCartesianZeroVector specializes isZeroVector (v: CartesianVectorValue): Boolean {
 		v.elements->forAll{in x; x == 0.0}
 	}
 	
@@ -172,9 +180,13 @@ package VectorFunctions {
 		Sqrt(CartesianInner(v, v))
 	}
 	
-	function CartesianAngle specializes Angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]) : Real[1] {
+	function CartesianAngle specializes Angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]): Real[1] {
 		inv precondition { v.dimension == w.dimension }
 		arccos(CartesianInner(v, w) / (Length(v) * Length(w)))
+	}
+	
+	function sum(coll: CartesianThreeVectorValue): CartesianThreeVectorValue {
+		sum0(coll, cartesian3DZeroVector)
 	}
 	
 }

--- a/sysml.library/Kernel Library/VectorFunctions.kerml
+++ b/sysml.library/Kernel Library/VectorFunctions.kerml
@@ -1,5 +1,5 @@
 /**
- * This package defines abstraft functions on VectorValues corresponding to the algebraic operations
+ * This package defines abstract functions on VectorValues corresponding to the algebraic operations
  * provided by a vector space with inner product. It also includes concrete implementations of these
  * functions specifically for CartesianVectorValues.
  */
@@ -66,8 +66,8 @@ package VectorFunctions {
 	 * Scalar product of a NumericalValue and a NumericalVectorValue.
 	 */
 	abstract function scalarVectorMult specializes DataFunctions::'*' (x: NumericalValue[1], v: NumericalVectorValue[1]) w: NumericalVectorValue[1] {
-		inv scaling { length(w) == x * length(v) }
-		inv zeroLength { isZeroVector(w) implies isZero(length(w))}
+		inv scaling { norm(w) == x * norm(v) }
+		inv zeroLength { isZeroVector(w) implies isZero(norm(w))}
 	}
 	alias '*' for scalarVectorMult;
 	
@@ -96,9 +96,9 @@ package VectorFunctions {
 	}
 	
 	/**
-	 * The length of a NumericalVectorValue, as a NumericalValue.
+	 * The norm (magnitude) of a NumericalVectorValue, as a NumericalValue.
 	 */
-	abstract function length(v: NumericalVectorValue[1]) l : NumericalValue[1] {
+	abstract function norm(v: NumericalVectorValue[1]) l : NumericalValue[1] {
 		inv squareNorm { l * l == inner(v,v) }
 		inv lengthZero { isZero(l) == isZeroVector(v) }
 	}
@@ -108,7 +108,7 @@ package VectorFunctions {
 	 */
 	abstract function angle(v: NumericalVectorValue[1], w: NumericalVectorValue[1]) theta: NumericalValue[1] {
 		inv commutivity { theta == angle(w, v) }
-		inv lengthInsensitive { theta == angle(w / length(w), v / length(v)) }
+		inv lengthInsensitive { theta == angle(w / norm(w), v / norm(v)) }
 	}
 	
 	/* Specialized functions with concrete definitions for CartesianVectorValues. */
@@ -176,13 +176,13 @@ package VectorFunctions {
 		(1..v.dimension)->collect{in i : Positive; v[i] * w[i]}->reduce RealFunctions::'+'
 	}
 	
-	function cartesianLength specializes length(v: CartesianVectorValue[1]) : NumericalValue[1] {
+	function cartesianNorm specializes norm(v: CartesianVectorValue[1]) : NumericalValue[1] {
 		sqrt(cartesianInner(v, v))
 	}
 	
 	function cartesianAngle specializes angle(v: CartesianVectorValue[1], w: CartesianVectorValue[1]): Real[1] {
 		inv precondition { v.dimension == w.dimension }
-		arccos(cartesianInner(v, w) / (length(v) * length(w)))
+		arccos(cartesianInner(v, w) / (norm(v) * norm(w)))
 	}
 	
 	function sum(coll: CartesianThreeVectorValue): CartesianThreeVectorValue {

--- a/sysml.library/Kernel Library/VectorValues.kerml
+++ b/sysml.library/Kernel Library/VectorValues.kerml
@@ -1,0 +1,50 @@
+/**
+ * This package provides a basic model of abstract vectors as well as concrete vectors
+ * whose components are numerical values. The package VectorFunctions defines the 
+ * corresponding vector-space functions.
+ */
+package VectorValues {
+	private import ScalarValues::NumericalValue;
+	private import ScalarValues::Real;
+	private import Collections::Array;
+	
+	/**
+	 * A VectorValue is an abstract data type whose values may be operated on using
+	 * VectorFunctions.
+	 */
+	 abstract datatype VectorValue;
+	
+	/**
+	 * A NumericalVectorValue is a kind of VectorValue that is specifically represented
+	 * as a one-dimensional array of NumericalValues.
+	 */
+	datatype NumericalVectorValue :> VectorValue, Array {
+		// TODO: Change dimension multiplicity to 0..1 after ST6RI-513 is done.
+		feature dimension[1] :>> dimensions;
+		feature :>> elements : NumericalValue;
+	}
+	
+	/**
+	 * CartesianVectorValue is a specialization Numerical VectorValue for which there are 
+	 * specific implementations in VectorFunctions of the abstract vector-space functions.
+	 * 
+	 * Note: The restriction of the element type to Real is to facilitate
+	 * complete of thes functions.
+	 */
+	datatype CartesianVectorValue :> NumericalVectorValue {
+		feature :>> elements : Real;
+	}
+
+	/**
+	 * A ThreeVectorValue is a NumericalVectorValue that has dimension 3.
+	 */
+	datatype ThreeVectorValue :> NumericalVectorValue {
+		feature :>> dimension = 3;
+	}
+	
+	/**
+	 * A CartesianThreeVectorValue is a NumericalVectorValue that is both Cartesian and
+	 * has dimension 3.
+	 */	
+	datatype CartesianThreeVectorValue :> CartesianVectorValue, ThreeVectorValue;	
+}

--- a/sysml.library/Kernel Library/VectorValues.kerml
+++ b/sysml.library/Kernel Library/VectorValues.kerml
@@ -16,11 +16,12 @@ package VectorValues {
 	
 	/**
 	 * A NumericalVectorValue is a kind of VectorValue that is specifically represented
-	 * as a one-dimensional array of NumericalValues.
+	 * as a one-dimensional array of NumericalValues. The dimension is allowed to be empty,
+	 * permitting a NumericalVectorValue of rank 0, which is essentially isomorphic to a
+	 * scalar NumericalValue.
 	 */
 	datatype NumericalVectorValue :> VectorValue, Array {
-		// TODO: Change dimension multiplicity to 0..1 after ST6RI-513 is done.
-		feature dimension[1] :>> dimensions;
+		feature dimension[0..1] :>> dimensions;
 		feature :>> elements : NumericalValue;
 	}
 	

--- a/sysml.library/Kernel Library/VectorValues.kerml
+++ b/sysml.library/Kernel Library/VectorValues.kerml
@@ -29,7 +29,7 @@ package VectorValues {
 	 * specific implementations in VectorFunctions of the abstract vector-space functions.
 	 * 
 	 * Note: The restriction of the element type to Real is to facilitate
-	 * complete of thes functions.
+	 * the complete definition of these functions.
 	 */
 	datatype CartesianVectorValue :> NumericalVectorValue {
 		feature :>> elements : Real;

--- a/sysml/src/examples/Mass Roll-up Example/MassConstraintExample.sysml
+++ b/sysml/src/examples/Mass Roll-up Example/MassConstraintExample.sysml
@@ -1,7 +1,7 @@
 package MassConstraintExample {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def Engine {
 		attribute m :> mass;

--- a/sysml/src/examples/Mass Roll-up Example/MassRollup.sysml
+++ b/sysml/src/examples/Mass Roll-up Example/MassRollup.sysml
@@ -1,5 +1,5 @@
 package MassRollup {
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def MassedThing {
 		attribute mass :> ISQ::mass; 

--- a/sysml/src/examples/Simple Tests/CalculationTest.sysml
+++ b/sysml/src/examples/Simple Tests/CalculationTest.sysml
@@ -1,6 +1,6 @@
 package CalculationExample {
 	import ISQ::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def VehiclePart {
 		attribute m : MassValue;

--- a/sysml/src/examples/Simple Tests/ConstraintTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConstraintTest.sysml
@@ -1,7 +1,7 @@
 package ConstraintTest {
 	import ISQ::MassValue;
 	import SI::kg;
-	import ScalarFunctions::sum;
+	import NumericalFunctions::sum;
 	
 	constraint def MassAnalysis {
 		attribute totalMass: MassValue;

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
@@ -416,7 +416,7 @@ package sfriedenthal_VehicleModel_1_simplified{
         package AttributeDefinitions{
             import ScalarValues::*;
             // Scalar Functions provides Sum expression
-            import ScalarFunctions::*;
+            import NumericalFunctions::*;
             import ISQ::*;
             import SI::*;
             import USCustomaryUnits::*;
@@ -446,7 +446,7 @@ package sfriedenthal_VehicleModel_1_simplified{
             
             // kpl is approx .425 * mpg
             kpl : DerivedUnit = km / L;
-            rpm : DerivedUnit = 1 / min;
+            rpm : DerivedUnit = 1 / SI::min;
             kW : DerivedUnit = kilo * W;
             //
         }

--- a/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
+++ b/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
@@ -436,7 +436,7 @@ package VehicleModel_1_simplified{
         package AttributeDefinitions{
             import ScalarValues::*;
             // Scalar Functions provides Sum expression
-            import ScalarFunctions::*;
+            import NumericalFunctions::*;
             import ISQ::*;
             import SI::*;
             import USCustomaryUnits::*;
@@ -466,7 +466,7 @@ package VehicleModel_1_simplified{
             
             // kpl is approx .425 * mpg
             kpl : DerivedUnit = km / L;
-            rpm : DerivedUnit = 1 / min;
+            rpm : DerivedUnit = 1 / SI::min;
             kW : DerivedUnit = kilo * W;
             //
         }

--- a/sysml/src/training/28. Expressions/MassRollup1.sysml
+++ b/sysml/src/training/28. Expressions/MassRollup1.sysml
@@ -1,5 +1,5 @@
 package MassRollup1 {
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def MassedThing {
 		attribute simpleMass :> ISQ::mass; 

--- a/sysml/src/training/28. Expressions/MassRollup2.sysml
+++ b/sysml/src/training/28. Expressions/MassRollup2.sysml
@@ -1,5 +1,5 @@
 package MassRollup2 {
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def MassedThing {
 		attribute simpleMass :> ISQ::mass; 

--- a/sysml/src/training/29. Calculations/Calculation Definitions.sysml
+++ b/sysml/src/training/29. Calculations/Calculation Definitions.sysml
@@ -1,6 +1,5 @@
 package 'Calculation Definitions' {
 	import ScalarValues::Real;
-	import RealFunctions::Sqrt;
 	import ISQ::*;
 	
 	calc def Power (whlpwr : PowerValue, Cd : Real, Cf : Real, tm : MassValue, v : SpeedValue ) : PowerValue {

--- a/sysml/src/training/30. Constraints/Constraint Assertions-1.sysml
+++ b/sysml/src/training/30. Constraints/Constraint Assertions-1.sysml
@@ -1,7 +1,7 @@
 package 'Constraint Assertions-1' {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def Engine;
 	part def Transmission;

--- a/sysml/src/training/30. Constraints/Constraint Assertions-2.sysml
+++ b/sysml/src/training/30. Constraints/Constraint Assertions-2.sysml
@@ -1,7 +1,7 @@
 package 'Constraint Assertions-2' {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def Engine;
 	part def Transmission;

--- a/sysml/src/training/30. Constraints/Constraints Example-1.sysml
+++ b/sysml/src/training/30. Constraints/Constraints Example-1.sysml
@@ -1,7 +1,7 @@
 package 'Constraints Example-1' {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def Engine;
 	part def Transmission;

--- a/sysml/src/training/30. Constraints/Constraints Example-2.sysml
+++ b/sysml/src/training/30. Constraints/Constraints Example-2.sysml
@@ -1,7 +1,7 @@
 package 'Constraints Example-2' {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	part def Engine;
 	part def Transmission;

--- a/sysml/src/validation/10-Analysis and Trades/10a-Analysis.sysml
+++ b/sysml/src/validation/10-Analysis and Trades/10a-Analysis.sysml
@@ -1,7 +1,7 @@
 package '10a-Analysis' {
 	import ISQ::*;
 	import SI::*;
-	import ScalarFunctions::*;
+	import NumericalFunctions::*;
 	
 	package VehicleDesignModel {
 		part def Vehicle {

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
@@ -21,10 +21,10 @@ package '15_01-Constants' {
      */
     package 'Mathematical Constants' {
         attribute e: Real {
-        	assert constraint { Round(e * 1E20) == 271828182845904523536.0 }
+        	assert constraint { round(e * 1E20) == 271828182845904523536.0 }
         }
         attribute pi: Real {
-        	assert constraint { Round(pi * 1E20) == 314159265358979323846.0 }
+        	assert constraint { round(pi * 1E20) == 314159265358979323846.0 }
         }
     }
 


### PR DESCRIPTION
This pull request adds the following Kernel Library packages:

1. `VectorValues` – Provides a basic model of abstract vectors as well as concrete vectors whose components are numerical values.
2. `VectorFunctions` – Defines abstract functions on `VectorValue` corresponding to the algebraic operations provided by a vector space with inner product. It also includes concrete implementations of these functions specifically for `CartesianVectorValue`.
3. `TrigFunctions` – Defines basic trigonometric functions on real numbers and provides a constant feature for `pi`. (Included in this PR to provide the `arccos` function needed in the implementation of `VectorFunctions::CartesianAngle.`)
4. `SpatialFrame` – Models spatial frames of reference for quantifying the position vector of a point in a three-dimensional space.

It also makes the following updates to existing packages:

_Kernel Library_

1. `DataFunctions` and `ScalarFunctions`
    - The `sum` and `product` functions have been removed from `DataFunctions` and `ScalarFunctions`.
2. `NumericalFunctions`
    - The `sum` and `product` functions are now in `NumericalFunctions`.
    - The functions `isZero` and `isUnit` have been added to the package, to allow zero and unit values of a `NumericalValue` type to be abstractly identified without having to construct them concretely.
3. `ComplexFunctions`, `RealFunctions`, `RationalFunctions`, `IntegerFunctions` and `QuantityCalculations`
    - Updated as necessary due to the above changes.

_Quantities and Units Library_

4. `Quantities` – Makes `VectorQuantityValue` a kind of `NumericalVectorValue`.
5. `VectorCalculations` – Revised to provide calculation definitions for `VectorQuantityValue` that specialize the corresponding functions from `VectorFunctions`.

Finally, it makes updates across the mathematical function packages with a more consistent convention of starting the names of non-operator mathematical functions with a lower case letter.

**Note:** This PR does _not_ include a SysML-level version of`SpatialFrame` with functions specialized to take `TimeInstantValue` and return `VectorQuantityValue`. This may instead be included in the Geometry Domain Library update in PR #340, depending on the resolution of the discussion there.