### PR TITLE
ST6RI-513 Order constraint of VectorQuantityValue incorrect

### DIFF
--- a/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/UnitsAndScales.sysml
@@ -55,7 +55,7 @@ package UnitsAndScales {
 	 * a VectorMeasurementReference) w.r.t. another (independent or reference) coordinate system.
 	 */
 	attribute def VectorMeasurementReference :> TensorMeasurementReference {
-		attribute :>> dimensions: Positive[1];
+		attribute :>> dimensions: Positive[0..1];
 		attribute isOrthogonal: Boolean[1] default true;
 		attribute placement: CoordinateTransformation[0..1];
 	}
@@ -71,8 +71,7 @@ package UnitsAndScales {
 	 * and for consistency with tensor and vector measurement references.
 	 */
 	abstract attribute def ScalarMeasurementReference :> VectorMeasurementReference {
-		attribute :>> dimensions = 1;
-		attribute :>> order = 0;
+		attribute :>> dimensions = ();
 		attribute :>> isOrthogonal = true;
 		attribute :>> mRefs = self;
 		attribute quantityDimension: QuantityDimension[1];

--- a/sysml.library/Kernel Library/Collections.kerml
+++ b/sysml.library/Kernel Library/Collections.kerml
@@ -42,18 +42,28 @@ package Collections {
      * An Array is a fixed size, multi-dimensional Collection of which the elements are nonunique and ordered. 
      * Its dimensions specify how many dimensions the array has, and how many elements there are in each dimension. 
      * The rank is equal to the number of dimensions. The flattenedSize is equal to the total number of elements 
-     * in the array. The elements of an Array can be assessed by a tuple of indices. The number of indices in such tuple is equal to rank. 
-	 * The packing of the elements, i.e. the flattened representation, follows the C programming language convention, 
-	 * namely the last index varies fastest.
+     * in the array.
+     * 
+     * Feature elements is a flattened sequence of all elements of an Array and can be accessed by a tuple of indices. 
+     * The number of indices is equal to rank. The elements are packed according to row-major convention, as in the C programming language.
+     * 
+     * The elements of an Array can be assessed by a tuple of indices. The number of indices in such tuple is equal to rank. 
+	 * The packing of the elements, i.e. the flattened representation, follows the row-major convention, 
+	 * as in the C programming language.
 	 * 
-	 * Note: Array can represent the generalized mathematical concept of an infinite matrix of any rank, i.e. not limited to rank two.
+	 * Note 1. Feature dimensions may be empty, which denotes a zero dimensional array, allowing an Array to collapse to a single element. 
+	 * This is useful to allow for specialization of an Array into a type restricted to represent a scalar. 
+	 * The flattenedSize of a zero dimensional array is 1.
+	 * 
+	 * 
+	 * Note 2: An Array can represent the generalized mathematical concept of an infinite matrix of any rank, i.e. not limited to rank two.
      */
     datatype Array :> OrderedCollection {
         // Feature `dimensions` defines the N-dimensional shape of the Array
         // The alternative name `shape` (as used in many programming languages) is not used as it would interfere with a geometric shape feature.
-        feature dimensions: Positive[1..*] ordered nonunique;
+        feature dimensions: Positive[0..*] ordered nonunique;
         feature rank: Natural[1] = size(dimensions);
-        feature flattenedSize: Natural[1] = dimensions->reduce '*';
+        feature flattenedSize: Positive[1] = dimensions->reduce '*' ?? 1;
         inv { flattenedSize == size(elements) }
     }
     


### PR DESCRIPTION
Fixed as discussed in [ST4MD-386](https://openmbee.atlassian.net/browse/ST4MD-386) and updated documentation, i.e.:

- Revised multiplicity of Array::dimensions: `feature dimensions: Positive[0..*] ordered nonunique;`
- Revised derivation of Array::flattenedSize: `feature flattenedSize : Positive[1] = dimensions->reduce '*' ?? 1;`
- Revised multiplicity of VectorMeasurementReference::dimensions: `attribute :>> dimensions : Positive[0..1];`
- Removed binding of `order `in ScalarMeasurementReference
- Redefined `attribute dimensions = ()` in ScalarMeasurementReference 