### PR TITLE
ST6RI-505 Spatial & topology Kernel Library model for occurrences

### DIFF
--- a/kerml/src/examples/Simple Tests/Associations.kerml
+++ b/kerml/src/examples/Simple Tests/Associations.kerml
@@ -1,0 +1,11 @@
+package Associations {	
+	assoc A {
+		end x;
+		end y[1..*];
+	}
+	
+	assoc B specializes A {
+		end x1;
+		end y1[0..*] redefines y;
+	}
+}

--- a/org.omg.kerml.xpect.tests/library/Clocks.kerml
+++ b/org.omg.kerml.xpect.tests/library/Clocks.kerml
@@ -3,11 +3,10 @@
  * usable for quantifying the time of an Occurrence.
  */
 package Clocks {
-	private import ScalarValues::ScalarValue;
+	private import ScalarValues::NumericalValue;
 	private import ScalarValues::Real;
 	private import Occurrences::Occurrence;
 	private import ControlFunctions::forAll;
-	private import ISQ::DurationValue;
 	
 	/**
 	 * defaultClock is a single Clock that can be used as a default.
@@ -15,7 +14,7 @@ package Clocks {
 	readonly feature defaultClock : Clock[1];
 	
 	/**
-	 * A Clock provides a scalar currentTime that advances montonically
+	 * A Clock provides a numerical currentTime that advances montonically
 	 * over its lifetime. Clock is an abstract base Structure that can be
 	 * specialized for different kinds of time quantification (e.g., discrete
 	 * time, continuous time, time with units, etc.).
@@ -23,9 +22,9 @@ package Clocks {
 	abstract struct Clock {
 		private thisClock : Clock :>> self;
 		/**
-		 * A numerical time reference that advances over the lifetime of the Clock. 
+		 * A scalar time reference that advances over the lifetime of the Clock. 
 		 */
-		readonly feature currentTime : ScalarValue[1];
+		readonly feature currentTime : NumericalValue[1];
 						
 		/**
 		 * The currentTime of a snapshot of a Clock is equal to
@@ -39,17 +38,21 @@ package Clocks {
 	}
 	
 	/**
-	 * TimeOf returns a scalar timeValue for a given Occurrence relative to
-	 * a given Clock. The timeValue is the time of the start of the Occurrence,
+	 * TimeOf returns a numerical timeInstant for a given Occurrence relative to
+	 * a given Clock. The timeInstant is the time of the start of the Occurrence,
 	 * which is considered to be synchronized with the snapshot of the Clock 
-	 * with a currentTime equal to the returned timeValue.
+	 * with a currentTime equal to the returned timeInstant.
 	 */
-	abstract function TimeOf(o : Occurrence[1], clock : Clock[1]) timeValue : ScalarValue[1] {
+	abstract function TimeOf {
+		in o : Occurrence[1];
+		in clock : Clock[1] default defaultClock;
+		return timeInstant : NumericalValue[1];
+		
 		/**
 		 * The TimeOf an Occurrence is equal to the time of its start snapshot.
 		 */
 		 inv startTimeConstraint { 
-		 	timeValue == TimeOf(o.startShot, clock)
+		 	timeInstant == TimeOf(o.startShot, clock)
 		 }	 
 
 		/**
@@ -59,7 +62,7 @@ package Clocks {
 		 */
 		inv timeOrderingConstraint {
 			o.predecessors->forAll{in p : Occurrence; 
-				TimeOf(p.endShot, clock) <= timeValue
+				TimeOf(p.endShot, clock) <= timeInstant
 			}
 		}
 				
@@ -70,7 +73,7 @@ package Clocks {
 		 */
 		inv timeContinuityConstraint {
 			o.immediatePredecessors->forAll{in p : Occurrence; 
-				TimeOf(p.endShot, clock) == timeValue
+				TimeOf(p.endShot, clock) == timeInstant
 			}
 		}				
 	}
@@ -80,8 +83,11 @@ package Clocks {
 	 * given Clock, which is equal to the TimeOf the end snapshot of the
 	 * Occurrence minus the TimeOf its start snapshot.
 	 */
-	function DurationOf(o : Occurrence[1], clock : Clock[1]) duration : ScalarValue {
-		TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock)
+	function DurationOf {
+		in o : Occurrence[1]; 
+		in clock : Clock[1] default defaultClock;
+		return duration : NumericalValue =
+			TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock);
 	}
 	
 	/**

--- a/org.omg.kerml.xpect.tests/library/CollectionFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/CollectionFunctions.kerml
@@ -6,6 +6,7 @@ package CollectionFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;
 	private import SequenceFunctions::equals;
+	private import SequenceFunctions::includes;
 	private import ControlFunctions::exists;
 	import Collections::*;
 	
@@ -25,8 +26,12 @@ package CollectionFunctions {
 		SequenceFunctions::notEmpty(col.elements)
 	}
 	
-	function contains(col: Collection[1], value: Anything[1]): Boolean[1] {
-		col.elements->exists {in x; x == value}
+	function contains(col: Collection[1], values: Anything[*]): Boolean[1] {
+		col.elements->includes(values)
+	}
+	
+	function containsAll(col1: Collection[1], col2: Collection[2]): Boolean[1] {
+		contains(col1, col2.elements)
 	}	
 	
 	function head(col: OrderedCollection[1]): Anything[0..1] {

--- a/org.omg.kerml.xpect.tests/library/Collections.kerml
+++ b/org.omg.kerml.xpect.tests/library/Collections.kerml
@@ -42,18 +42,28 @@ package Collections {
      * An Array is a fixed size, multi-dimensional Collection of which the elements are nonunique and ordered. 
      * Its dimensions specify how many dimensions the array has, and how many elements there are in each dimension. 
      * The rank is equal to the number of dimensions. The flattenedSize is equal to the total number of elements 
-     * in the array. The elements of an Array can be assessed by a tuple of indices. The number of indices in such tuple is equal to rank. 
-	 * The packing of the elements, i.e. the flattened representation, follows the C programming language convention, 
-	 * namely the last index varies fastest.
+     * in the array.
+     * 
+     * Feature elements is a flattened sequence of all elements of an Array and can be accessed by a tuple of indices. 
+     * The number of indices is equal to rank. The elements are packed according to row-major convention, as in the C programming language.
+     * 
+     * The elements of an Array can be assessed by a tuple of indices. The number of indices in such tuple is equal to rank. 
+	 * The packing of the elements, i.e. the flattened representation, follows the row-major convention, 
+	 * as in the C programming language.
 	 * 
-	 * Note: Array can represent the generalized mathematical concept of an infinite matrix of any rank, i.e. not limited to rank two.
+	 * Note 1. Feature dimensions may be empty, which denotes a zero dimensional array, allowing an Array to collapse to a single element. 
+	 * This is useful to allow for specialization of an Array into a type restricted to represent a scalar. 
+	 * The flattenedSize of a zero dimensional array is 1.
+	 * 
+	 * 
+	 * Note 2: An Array can represent the generalized mathematical concept of an infinite matrix of any rank, i.e. not limited to rank two.
      */
     datatype Array :> OrderedCollection {
         // Feature `dimensions` defines the N-dimensional shape of the Array
         // The alternative name `shape` (as used in many programming languages) is not used as it would interfere with a geometric shape feature.
-        feature dimensions: Positive[1..*] ordered nonunique;
+        feature dimensions: Positive[0..*] ordered nonunique;
         feature rank: Natural[1] = size(dimensions);
-        feature flattenedSize: Natural[1] = dimensions->reduce '*';
+        feature flattenedSize: Positive[1] = dimensions->reduce '*' ?? 1;
         inv { flattenedSize == size(elements) }
     }
     

--- a/org.omg.kerml.xpect.tests/library/Objects.kerml
+++ b/org.omg.kerml.xpect.tests/library/Objects.kerml
@@ -9,8 +9,14 @@ package Objects {
 	private import Occurrences::occurrences;
 	private import Occurrences::HappensLink;
 	private import Occurrences::SelfSameLifeLink;
+	private import Occurrences::WithinBoth;	       
 	private import Performances::Performance;
 	private import Performances::performances;
+	private import SequenceFunctions::isEmpty;
+	private import SequenceFunctions::notEmpty;
+	private import SequenceFunctions::union;
+	private import CollectionFunctions::contains;
+	private import ScalarValues::Integer;	     
 	
 	/**
 	 * Object is the most general class of structural occurrences that may change over time.
@@ -26,7 +32,12 @@ package Objects {
 		/**
 		 * Performances which are enacted by this object.
 		 */
-		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, suboccurrences;
+		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences;
+
+		/**
+		 * A space boundary that is a structured space object.
+		 */
+		portion structuredSpaceBoundary : StructuredSpaceObject[0..1] subsets spaceBoundary;
 	}
 	
 	/**
@@ -56,4 +67,81 @@ package Objects {
 	 */
 	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects;
 	
+
+	/**
+	 * A Body is an Object of inner space dimension 3.
+	 */
+	struct all Body specializes Object {
+		feature redefines innerSpaceDimension = 3;
+	}
+
+	/**
+	 * A Surface is an Object of inner space dimension 2.
+	 */
+	struct all Surface specializes Object {
+		feature redefines innerSpaceDimension = 2;
+		  /* The number of  "holes" in this Surface, assuming it isClosed. */
+		feature genus : Integer[0..1] default 0;
+
+		inv { notEmpty(genus) implies (isClosed & genus >= 0) }
+	}
+
+	/*
+	 * A Curve is an Object of inner space dimension 1.
+	 */
+	struct all Curve specializes Object {
+		feature redefines innerSpaceDimension = 1;
+	}
+
+	/*
+	 * A Point is an Object of inner space dimension 0.
+	 */
+	struct all Point specializes Object {
+		feature redefines innerSpaceDimension = 0;
+	}
+
+	/*
+	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
+	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
+	 * that are points, with edges and vertices on the boundary of faces, and vertices on the boundary of
+	 * edges. Cells overlap when a structured space object is closed, as required to be a space boundary of
+	 * an object (faces overlap at their edges and/or vertices, while edges overlap at their vertices). The
+	 * inner space dimension of structured space object is the highest of their cells.
+	 */
+	abstract struct StructuredSpaceObject specializes Object {
+
+		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
+		  { feature cellOrientation : Integer [0..1];
+		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
+		  }
+
+		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells {
+			derived feature redefines spaceBoundary; 
+			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
+		}
+
+		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells {
+			derived feature redefines spaceBoundary;
+			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
+		}
+
+		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
+		
+		derived feature redefines innerSpaceDimension = 
+			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
+
+		connector feE :WithinBoth
+			from thisOccurrence :> faces.edges [0..*]
+			to thatOccuurence :> edges [0..*];
+
+		connector evV :WithinBoth
+			from thisOccurrence :> edges.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
+
+		connector fvV :WithinBoth
+			from thisOccurrence :> faces.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
+	  }
 }

--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -1,29 +1,35 @@
 /**
- * This package defines the concept of occurrences and the associations between them 
- * that assert relationships modeling four-dimensional semantics. 
- * [Currently this is primarily time semantics.]
+ * This package defines modeling constructs for anything existing or occurring in time and space, with
+ * associations between them that assert temporal and spatial relationships.
  */
 package Occurrences {
 	private import Base::Anything;
 	private import Base::things;
 	private import Base::DataValue;
+	private import ScalarValues::Integer;
+	private import ScalarValues::Boolean;
 	private import Links::*;
+	private import Collections::Set;
+	private import Collections::OrderedSet;
+	private import SequenceFunctions::includes;
+	private import CollectionFunctions::contains;
 	
 	/**
 	 * Occurrence is the most general classifier of entities that have identity and 
-	 * may occur over time.
+	 * occur over time and space.
 	 * 
-	 * The features of Occurrence specify the semantics of portions, slices and
-	 * snapshots of an occurrence over time.
+	 * The features of Occurrence specify the semantics of associations between occurrences that
+	 * assert complete inclusion and exclusion in time or space, or both, which includes
+	 * portions of an occurrence (having the same identity).  Portions include slices and shots
+	 * over time and space.
 	 */
 	abstract class Occurrence specializes Anything {
 		private import SequenceFunctions::*;
-		private import ControlFunctions::forAll;
 		
-		feature portionOfLife : Life[1] subsets portionOf;
+		feature portionOfLife: Life[1] subsets portionOf;
 		
-		feature self : Occurrence[1] redefines Anything::self subsets timeSlices, sameLifeOccurrences;
-		feature sameLifeOccurrences : Occurrence[1..*] subsets things;
+		feature self: Occurrence[1] redefines Anything::self subsets timeSlices, spaceSlices, sameLifeOccurrences;
+		feature sameLifeOccurrences: Occurrence[1..*] subsets things;
 		
 		/**
 		 * Occurrences that end before this occurrence starts.
@@ -35,29 +41,67 @@ package Occurrences {
 		 */
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
-	  	/**
-	   	 * Occurrences that end just before this occurrence starts, with no
-	     * possibility of other occurrences happening in the time between them.
-	     */
+		/**
+		 * Occurrences that end just before this occurrence starts, with no
+		 * possibility of other occurrences happening in the time between them.
+		 */
 		feature immediatePredecessors: Occurrence[0..*] subsets predecessors;
 
-  		/**
-   		 * Occurrences that start just after this occurrence ends, with no
-   		 * possibility of other occurrences happening in the time between them.
-   		 */
+		/**
+		 * Occurrences that start just after this occurrence ends, with no
+		 * possibility of other occurrences happening in the time between them.
+		 */
 		feature immediateSuccessors: Occurrence[0..*] subsets successors;
 
 		/**
 		 * Occurrences that start no earlier than and end no later than
 		 * this occurrence, including at least this occurrence.
 		 */
-		feature suboccurrences: Occurrence[1..*] subsets occurrences;
-		
+		feature timeEnclosedOccurrences: Occurrence[1..*] subsets occurrences;
+
 		/**
-		 * Occurrences that are portions of this occurrence, including at
-		 * least this occurrence.
+		 * Occurrences that this one completely includes in space (not necessarily in time),
+		 * including this one.
 		 */
-		portion feature portions: Occurrence[1..*] subsets suboccurrences;
+		feature spaceEnclosedOccurrences: Occurrence[1..*] subsets occurrences;
+
+		/**
+		 * Occurrences that this one completely includes in both space and time,
+		 * including this one.
+		 */
+		feature spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences;
+
+		/**
+		 * All space time enclosed occurrences that take up zero time and space.
+		 */
+		feature all spaceTimeEnclosedPoints : Occurrence[1..*] subsets spaceTimeEnclosedOccurrences {
+			redefines innerSpaceDimension = 0;
+			binding startShot[1] = endShot[1];
+		}
+
+		/**
+		 * The number of variables need to identify space points in this occurrence, from 0
+		 * to 3, without regard to higher dimensional spaces it might be emedded in.
+		 */
+		feature innerSpaceDimension : Integer [1];
+		inv { innerSpaceDimension >= 0 & innerSpaceDimension <= 3 }
+
+		/**
+		 * For occurrences of innerSpaceDimension 1 or 2, the number of variables need to
+		 * identify their space points in higher dimensions they might be embedded in, from
+		 * the innerSpaceDimension to 3. An outerSpaceDimension equal to innerSpaceDimension
+		 * indicates the occurrence is spatially straight (innerSpaceDimension 1 embedded in
+		 * 2 or 3 dimensions) or flat (innerSpaceDimension 2 embedded in 3 dimensions).
+		 */
+		feature outerSpaceDimension : Integer [0..1];
+		inv { notEmpty(outerSpaceDimension) implies
+			 (outerSpaceDimension >= innerSpaceDimension & outerSpaceDimension <= 3) }
+
+		/**
+		 * All spaceTimeEnclosedOccurrences that have the same portionOfLife (considered the same
+		 * thing occurring), see PortionOf.
+		 */
+		portion feature all portions: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences;
 		
 		/**
 		 * Occurrences of which this occurrence is a portion, including at
@@ -66,14 +110,14 @@ package Occurrences {
 		feature portionOf : Occurrence[1..*];
 		
 		/**
-		 * Portions of an occurrence over some slice of time, including at
-		 * least this occurrence.
+		 * Portions of an occurrence taking up all of its space over some period of time,
+		 * including at least this occurrence.
 		 */
 		portion feature timeSlices: Occurrence[1..*] subsets portions;
 		
 		/**
-		 * Occurrences of which this occurrence is a time slice, including at
-		 * least this occurrence.
+		 * Occurrences of which this occurrence is a time slice, including at least this
+		 * occurrence.
 		 */
 		feature timeSliceOf : Occurrence[1..*] subsets portionOf;
 		
@@ -81,9 +125,10 @@ package Occurrences {
 		 * Time slices of an occurrence that happen at a single instant of time
 		 * (i.e., have no duration).
 		 */
-		portion feature all snapshots: Occurrence[1..*] subsets timeSlices;
-		inv { snapshots->forAll {in s:Occurrence; s.startShot == s.endShot} }
-		inv { snapshots == union(startShot, union(middleShots, endShot)) }
+		portion feature all snapshots: Occurrence[1..*] subsets timeSlices {
+			binding startShot[1] = endShot[1];
+		}
+		inv { snapshots == union(startShot, union(middleTimeSlice.snapshots, endShot)) }
 		
 		/**
 		 * Occurrences of which this occurrence is a snapshot.
@@ -96,27 +141,161 @@ package Occurrences {
 		portion feature startShot: Occurrence[1] subsets snapshots;
 		
 		/**
-		 * The snapshots in between the startShot and endShot. There are none
-		 * when the startShot and endShot are the same.
+		 * A time slice that takes all the time between the start shot and end shot. There
+		 * is none when the startShot and endShot are the same.
 		 */
-		portion feature all middleShots: Occurrence[0..*] subsets snapshots;
-		inv { isEmpty(middleShots) == (startShot == endShot) }
-		
+		portion feature middleTimeSlice: Occurrence[0..1] subsets timeSlices;
+		inv { isEmpty(middleTimeSlice) == (startShot == endShot) }
+
+		/**
+		 * The startShot happens immediately before the middle time slice.
+		 */
+		connector :HappensJustBefore 
+			from earlierOccurrence :> startShot [1] 
+			to laterOccurrence :> middleTimeSlice [0..1];
+
 		/** 
 		 * The snapshot at the end of the occurrence in time.
 		 */
 		portion feature endShot: Occurrence[1] subsets snapshots;
-		
+
 		/**
-		 * The startShot happens before all middleShots.
+		 * The endShot happens after the middle time slice.
 		 */
-		succession startShot[1] then middleShots[0..*];
-		
+		 connector :HappensJustBefore 
+			from earlierOccurrence :> middleTimeSlice [0..1]
+			to laterOccurrence :> endShot [1];
+
 		/**
-		 * The endShot happens after all middleShots.
+		 * Portions of this occurrence that extend for exactly the same time and some or all
+		 * the space, relative to spatial location of this occurrence, including at least
+		 * this occurrence.
+
 		 */
-		succession middleShots[0..*] then endShot[1];
-		
+		portion feature spaceSlices: Occurrence[1..*] subsets portions;
+
+		/**
+		 * Occurrences of which this occurrence is a space slice, including at least this
+		 * occurrence.
+		 */
+		feature spaceSliceOf: Occurrence[1..*] subsets portionOf;
+
+		/**
+		 * All spaceSlices of this occurrence that are of a lower inner space dimension than it.
+		 */
+		portion feature spaceShots: Occurrence[1..*] subsets spaceSlices;
+
+		/**
+		 * Occurrences of which this occurrence is a space shot.
+		 */
+		feature spaceShotOf: Occurrence[1..*] subsets spaceSliceOf;
+
+		/**
+		 * Sets of occurrences, where the time and space taken by all the occurrences in each
+		 * set together is the same as taken by this occurrence (all four dimensional points in
+		 * the occurrences of each set are at the same time and space as those of this
+		 * occurrence).
+		 */
+		feature unionsOf: Set[0..*] {
+			feature redefines elements: Occurrence[0..*];
+			feature union: Occurrence[0..1];
+
+			connector :Within
+				  from smallerOccurrence :> elements [0..*]
+				  to largerOccurrence :> union [1];
+			connector :Within 
+				  from smallerOccurrence :> union.spaceTimeEnclosedPoints [0..*]
+				  to largerOccurrence :> elements [1..*];
+		}
+		binding unionsOf.union[0..1] = self[1];
+
+		/**
+		 * Sets of occurrences, where the time and space taken in common between the occurrences
+		 * in each set is at the same as taken by this occurrence (all four dimensional points
+		 * common to the occurrences in each set are at the same time and space as those in this
+		 * occurrence).
+		 */
+		feature intersectionsOf: Set[0..*] {
+			feature redefines elements: Occurrence[0..*]
+			  { feature all notIntersection: Occurrence[0..*] subsets spaceTimeEnclosedPoints; }
+			feature intersection: Occurrence[0..1];
+			
+			connector :Within
+				  from smallerOccurrence :> intersection [1]
+				  to largerOccurrence :> elements [0..*];
+			connector :Without
+				  from separateOccurrenceToo :> elements.notIntersection [0..*]
+				  to separateOccurrence :> intersection [1];
+			connector :Without
+				  from separateOccurrenceToo :> elements.notIntersection [0..*]
+				  to separateOccurrence :> elements [1..*];
+		}
+		binding intersectionsOf.intersection[0..1] = self[1];
+
+		/**
+		 * Ordered sets of occurrences, where the time and space taken by first occurrence in
+		 * each set that is not in the time and space taken by the remaining occurrences is the
+		 * same as taken by this occurrence (all four dimensional points in the minuend that are
+		 * not in any subtrahend are at the same time and space as those in this occurrence).
+		 */
+		feature differencesOf: OrderedSet[0..*] {
+			feature redefines elements: Occurrence[0..*];
+			feature difference: Occurrence[0..1];
+			feature minuend: Occurrence [0..1] subsets elements, interdiff.elements = head(elements);
+			feature subtrahend: Occurrence[*] subsets elements = tail(elements);
+			feature interdiff: Set [0..1] {
+				feature redefines elements: Occurrence[1..*];
+				feature all notSubtrahend: Occurrence [0..*] subsets elements;
+			}
+			
+			connector :Without
+				  from separateOccurrenceToo :> interdiff.notSubtrahend [0..*]
+				  to separateOccurrence :> subtrahend [1..*];
+
+			inv { isEmpty(difference) == isEmpty(interdiff) }
+			inv { notEmpty(difference) implies (difference.intersectionsOf == interdiff) }
+		}
+		binding differencesOf.difference[0..1] = self[1];
+
+		/**
+		 * A space slice of this occurrence that includes all its space shots except the
+		 * space boundary, which must exist and be outsideOf it.  The space interior must be
+		 * of the same inner space dimension as this occurrence, except if it is zero,
+		 * whereupon there is no space interior.
+		 */
+		portion feature spaceInterior: Occurrence[0..1] subsets spaceSlices;
+
+		/**
+		 * An Occurrence of which this one is the space interior.
+		 */
+		feature spaceInteriorOf: Occurrence[0..1] subsets spaceSliceOf;
+		inv { notEmpty(spaceInterior) implies spaceInterior.innerSpaceDimension == innerSpaceDimension }
+		inv { innerSpaceDimension == 0 implies isEmpty(spaceInterior) }
+
+		/**
+		 * A space shot of this Occurrence that is not among those of its space interior, of
+		 * which it must be outside. It must have no spaceBoundary.
+		 */
+		portion feature spaceBoundary: Occurrence[0..1] subsets spaceShots
+		  { feature redefines isClosed = true; }
+
+		/**
+		 * An Occurrence of which this one is the space boundary.
+		 */
+		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
+
+		inv { isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+
+		connector :OutsideOf 
+			from separateSpaceToo :> spaceInterior [0..1]
+			to separateSpace :> spaceBoundary [1];
+
+		/**
+		 * Tells whether an occurrence has a spaceBoundary, true if it does, false otherwise.
+		 */
+		feature isClosed : Boolean [1];
+		inv { isClosed == isEmpty(spaceBoundary) }
+
 		/**
 		 * The incoming transfers received by this occurrence. 
 		 */
@@ -172,8 +351,8 @@ package Occurrences {
 		end feature myselfSameLife: Anything[1..*] redefines source;
 		end feature selfSameLife: Anything[1..*] redefines target;
 
-	 	feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
-	 	feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
+		feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
+		feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
 		binding oSelf of sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
 
 		feature all sourceDataValue : DataValue [0..1] subsets myselfSameLife;
@@ -184,15 +363,15 @@ package Occurrences {
 	subclassifier SelfLink specializes SelfSameLifeLink; 
 
 	/**
-	 * HappensLink is the base of the associations that assert temporal relationships 
-	 * between a sourceOccurrence and a targetOccurrence. Because HappensLinks assert 
-	 * temporal relationships, they cannot themselves be Occurrences that happen in time.
-	 * Therefore HappensLink is disjoint with LinkObject, that is, no HappensLink can 
-	 * also be a LinkObject.
+	 * HappensLink is the most general associations that assert temporal relationships between a
+	 * sourceOccurrence and a targetOccurrence. Because HappensLinks assert temporal
+	 * relationships, they cannot themselves be Occurrences that happen in time.  Therefore
+	 * HappensLink is disjoint with LinkObject, that is, no HappensLink can also be a
+	 * LinkObject.
 	 */
 	assoc HappensLink specializes BinaryLink {
-		end feature sourceOccurrence: Occurrence[0..*];
-		end feature targetOccurrence: Occurrence[0..*];
+		end feature sourceOccurrence: Occurrence[0..*] redefines BinaryLink::source;
+		end feature targetOccurrence: Occurrence[0..*] redefines BinaryLink::target;
 	}
 
 	/**
@@ -200,10 +379,10 @@ package Occurrences {
 	 * That is, the time interval of the shorterOccurrence is completely within that of the
 	 * longerOccurrence, or every snapshot of the shorterOccurrence happens while (at the
 	 * same time as) some snapshot of the longerOccurrence. Note that this means every 
-	 * occurrence happens during itself.
+	 * Occurrence HappensDuring itself and that HappensDuring is transitive.
 	 */
 	assoc HappensDuring specializes HappensLink {
-		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.suboccurrences;
+		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.timeEnclosedOccurrences;
 		end feature longerOccurrence: Occurrence[1..*] redefines targetOccurrence;
 		
 		/*
@@ -216,7 +395,7 @@ package Occurrences {
 		subset longerOccurrence.predecessors subsets shorterOccurrence.predecessors;
 		subset longerOccurrence.successors subsets shorterOccurrence.successors;
 		
-		subset shorterOccurrence.suboccurrences subsets longerOccurrence.suboccurrences;
+		subset shorterOccurrence.timeEnclosedOccurrences subsets longerOccurrence.timeEnclosedOccurrences;
 	}
 	
 	/**
@@ -228,68 +407,155 @@ package Occurrences {
 		end feature thatOccurrence: Occurrence[1..*] redefines longerOccurrence;
 		
 		connector :HappensDuring 
-			from shorterOccurrence :> thatOccurrence 
-			to longerOccurrence :> thisOccurrence;
+			from shorterOccurrence :> thatOccurrence [1]
+			to longerOccurrence :> thisOccurrence  [1];
 	}
-	
-	/**
-	 * HappensBefore asserts that the earlierOccurrence happens before the laterOccurrence.
-	 * That is, the time interval of the earlierOccurrence is completely before that of the 
-	 * laterOccurrence, or every snapshot of the earlierOccurrence happens before every 
-	 * snapshot of the laterOccurrence. Note that this means no occurrence happens before itself.
-	 */
-	assoc HappensBefore specializes HappensLink {
-		end feature earlierOccurrence: Occurrence[0..*] redefines BinaryLink::source subsets laterOccurrence.predecessors;
-		end feature laterOccurrence: Occurrence[0..*] redefines BinaryLink::target subsets earlierOccurrence.successors;
-		
-		subset laterOccurrence.successors subsets earlierOccurrence.successors;
-		
-		inv { earlierOccurrence != laterOccurrence }
-	}
-	
-	/**
-	 * HappensJustBefore is HappensBefore asserting that the earlierOccurrence happens just 
-	 * before the laterOccurrence, with with no possibility of other occurrences happening in the 
-	 * time between them.
-	 */
-	assoc HappensJustBefore specializes HappensBefore {
-  		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
-		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
 
-  		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	/**
+	 * InsideOf asserts that its largerSpace completely overlaps its smallerSpace in space (not
+	 * necessarily in time, see HappensDuring). That is, all four dimensional points of the
+	 * smallerSpace are in the spatial extent of the largerSpace. Note that this means every
+	 * Occurrence is InsideOf itself and that InsideOf is transitive.
+	 */
+	assoc InsideOf specializes BinaryLink {
+		end feature smallerSpace: Occurrence[1..*] redefines source, largerSpace.spaceEnclosedOccurrences;
+		end feature largerSpace: Occurrence[1..*] redefines target;
+
+		subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
+
+		inv { includes(largerSpace.timeEnclosedOccurrences, smallerSpace) implies (self istype Within) }
+	}
+
+	/**
+	 * Within asserts that its largerOccurrence completely overlaps its smallerOccurrence in
+	 * time and space. That is, all four dimensional points of the smallerOccurrence happen
+	 * during and are inside of the largerOccurrence. This means every occurrence is Within
+	 * itself and Within is transitive.
+	 */
+	assoc all Within specializes HappensDuring, InsideOf {
+		end feature smallerOccurrence: Occurrence[1..*] redefines shorterOccurrence, smallerSpace
+		  subsets largerOccurrence.spaceTimeEnclosedOccurrences;
+		end feature largerOccurrence: Occurrence[1..*] redefines longerOccurrence, largerSpace;
+	 }
+
+	/**
+	 * WithinBoth asserts that two occurrences are Within each other, that is, they occupy the
+	 * same four dimensional region.  Note that this means every Occurrence is WithinBoth with
+	 * itself and transitive.
+	 */
+	assoc WithinBoth specializes Within {
+		end feature thisOccurrence: Occurrence[1..*] redefines smallerOccurrence;
+		end feature thatOccurrence: Occurrence[1..*] redefines largerOccurrence;
+		
+		connector :Within
+			from smallerOccurrence :> thatOccurrence [1]
+			to largerOccurrence :> thisOccurrence [1];
 	}
 
 	/**
 	 * PortionOf asserts one occurrence is a portion of another, including at least itself. 
 	 */
-	assoc PortionOf specializes HappensDuring { 
-		end feature portionedOccurrence: Occurrence[1..*] redefines longerOccurrence subsets portionOccurrence.portionOf;
-		end feature portionOccurrence: Occurrence[1..*] redefines shorterOccurrence subsets portionedOccurrence.portions; 
+	assoc PortionOf specializes Within { 
+		end feature portionOccurrence: Occurrence[1..*] redefines smallerOccurrence subsets portionedOccurrence.portions; 
+		end feature portionedOccurrence: Occurrence[1..*] redefines largerOccurrence subsets portionOccurrence.portionOf;
+
+		binding portionOccurrence.portionOfLife[1] = portionedOccurrence.portionOfLife[1];
 	}
 	
 	/**
-	 * TimeSliceOf asserts once occurrence is a time slice of another, including at least itself.
+	 * TimeSliceOf asserts one occurrence is a time slice of another, including at least itself.
 	 */
 	assoc TimeSliceOf specializes PortionOf {
-		end feature timeSlicedOccurrence: Occurrence[1..*] redefines portionedOccurrence subsets timeSliceOccurrence.timeSliceOf;
 		end feature timeSliceOccurrence: Occurrence[1..*] redefines portionOccurrence subsets timeSlicedOccurrence.timeSlices;
+		end feature timeSlicedOccurrence: Occurrence[1..*] redefines portionedOccurrence subsets timeSliceOccurrence.timeSliceOf;
 	}
 	
 	/**
-	 * SnapshotsOf asserts once occurrence is a snapshot of another.
+	 * SnapshotsOf asserts one occurrence is a snapshot of another.
 	 */
 	assoc SnapshotOf specializes TimeSliceOf {
-		end feature snapshottedOccurrence: Occurrence[1..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
 		end feature snapshotOcccurrence: Occurrence[1..*] redefines timeSliceOccurrence subsets snapshottedOccurrence.snapshots;
+		end feature snapshottedOccurrence: Occurrence[0..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
+	}
+
+	/**
+	 * SpaceSliceOf asserts that it spaceSliceOccurrence extends for exactly the same time and
+	 * some or all the space of the spaceSlicedOccurrence and that the spaceSliceOccurrence is
+	 * of the same of lower innerSpaceDimension than the spaceSliceOccurrence.  Note that this
+	 * means every occurrence is a SpaceSliceOf itself and SpaceSliceOf is transitive.
+	 */
+	assoc SpaceSliceOf specializes PortionOf {
+		end feature spaceSliceOccurrence: Occurrence[1..*] redefines portionOccurrence subsets spaceSlicedOccurrence.spaceSlices;
+		end feature spaceSlicedOccurrence: Occurrence[1..*] redefines portionedOccurrence subsets spaceSliceOccurrence.spaceSliceOf;
+
+		inv { spaceSliceOccurrence.innerSpaceDimension <= spaceSlicedOccurrence.innerSpaceDimension }
 	}
 	
+	/**
+	 * SpaceShotOf asserts that its spaceShotOccurrence is of a lower inner space dimension than
+	 * it spaceShottedOccurrence.
+	 */
+	assoc SpaceShotOf specializes SpaceSliceOf {
+		end feature spaceShotOcccurrence: Occurrence[1..*] redefines spaceSliceOccurrence subsets spaceShottedOccurrence.spaceShots;
+		end feature spaceShottedOccurrence: Occurrence[1..*] redefines spaceSlicedOccurrence subsets spaceShotOcccurrence.spaceShotOf;
+	}
+
+	/**
+	 * Without is the most general association that asserts complete separation (no overlap) in
+	 * either space or time, or both, between two occurrences.  That is, no four dimensional
+	 * points are in both occurrences. Note that this means no Occurrence is Without itself.
+	 */
+	assoc Without specializes BinaryLink {
+		end feature separateOccurrenceToo: Occurrence[0..*] redefines BinaryLink::source;
+		end feature separateOccurrence: Occurrence[0..*] redefines BinaryLink::target;
+
+		inv { separateOccurrenceToo != separateOccurrence }
+	}
+
+	/**
+	 * HappensBefore asserts that the earlierOccurrence is completely separated in time (not
+	 * necessarily in space, see OutsideOf), with the earlierOccurrence happening completely
+	 * before the laterOccurrence.	That is, no snapshot of the earlierOccurrence happens at the
+	 * same time as any snapshot of the laterOccurrence, with all snapshots of earlierOccurrence
+	 * happening before those the laterOccurrence, including the endShot of the earlierOccurrence
+	 * and startShot of the laterOccurrence. Note that this means no Occurrence HappensBefore
+	 * itself.
+	 */
+	assoc HappensBefore specializes HappensLink, Without {
+		end feature earlierOccurrence: Occurrence[0..*] redefines sourceOccurrence, separateOccurrenceToo subsets laterOccurrence.predecessors;
+		end feature laterOccurrence: Occurrence[0..*] redefines targetOccurrence, separateOccurrence subsets earlierOccurrence.successors;
+
+		/* HappensBefore is transitive. */
+		subset laterOccurrence.successors subsets earlierOccurrence.successors;
+	}
+	
+	/**
+	 * HappensJustBefore is HappensBefore asserting that there is no possibility of another
+	 * occurrences happening in the time between the earlierOccurrence and laterOccurrence.
+	 */
+	assoc HappensJustBefore specializes HappensBefore {
+		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
+		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
+
+		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	}
+
 	/**
 	 * happensBeforeLinks is a specialization of binaryLinks restricted to type HappensBefore.
 	 * It is the default subsetting for succession connectors.
 	 */
 	 feature happensBeforeLinks: HappensBefore[0..*] nonunique subsets binaryLinks {
-	 	end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
-	 	end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
-	 }
-	 
+		end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
+		end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
+	 } 
+
+	/**
+	 * OutsideOf asserts that two occurrences do not overlap in space (not necessarily in time,
+	 * see HappensBefore).	That is, no four dimensional points of the occurrences are in the
+	 * spatial extent of both of them. This means no Occurrence is OutsideOf itself.
+	 */
+	assoc OutsideOf specializes Without {
+		end feature separateSpaceToo: Occurrence[0..*] redefines separateOccurrenceToo;
+		end feature separateSpace: Occurrence[0..*] redefines separateOccurrence;
+	}
 }

--- a/org.omg.kerml.xpect.tests/library/Performances.kerml
+++ b/org.omg.kerml.xpect.tests/library/Performances.kerml
@@ -31,7 +31,7 @@ package Performances {
 		/**
 		 * suboccurrences of this Performance that are also Performances.
 		 */
-		step subperformances: Performance[0..*] subsets performances, suboccurrences;
+		step subperformances: Performance[0..*] subsets performances, timeEnclosedOccurrences;
 		
 		/**
 		 * subperformances of this Performance that are Evaluations.

--- a/org.omg.kerml.xpect.tests/library/SequenceFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/SequenceFunctions.kerml
@@ -22,7 +22,7 @@ package SequenceFunctions {
 		!isEmpty(seq)
 	}
 	function includes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
-		seq2->forAll {in x; seq1->includes(x)}
+		seq2->forAll {in x; seq1->exists{in y; x == y}}
 	}
 	function includesOnly(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq1->includes(seq2) && seq2->includes(seq1)

--- a/org.omg.kerml.xpect.tests/library/Triggers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Triggers.kerml
@@ -5,7 +5,7 @@
  */
 package Triggers {
 	private import ScalarValues::Boolean;
-	private import ScalarValues::ScalarValue;
+	private import ScalarValues::NumericalValue;
 	private import Occurrences::Occurrence;
 	
 	import Clocks::*;
@@ -19,7 +19,7 @@ package Triggers {
 		/**
 		 * The time at which the TimeSignal should be sent.
 		 */
-		feature signalTime : ScalarValue[1];
+		feature signalTime : NumericalValue[1];
 		
 		/**
 		 * The Clock whose currentTime is being monitored.
@@ -60,20 +60,20 @@ package Triggers {
 		/**
 		 * The ChangeSignal for the condition, as monitored by the monitor.
 		 */
-		out feature signal : ChangeSignal[1] = ChangeSignal(condition, monitor);
+		return feature signal : ChangeSignal[1] = ChangeSignal(condition, monitor);
 		
 		step :> monitor.startObservation(receiver, signal);			
 	}
 	
 	/**
 	 * TriggerAt returns a monitored TimeSignal to be sent to a receiver when
-	 * the currentTime of a given Clock reaches a specific time. 
+	 * the currentTime of a given Clock reaches a specific timeInstant. 
 	 */
 	function TriggerAt {
 		/**
 		 * The time instant, relative to the clock, at which the TimeSignal should be sent. 
 		 */
-		in feature time : ScalarValue[1];
+		in feature timeInstant : NumericalValue[1];
 		
 		/**
 		 * The Occurrence to which the TimeSignal is to be sent.
@@ -81,7 +81,7 @@ package Triggers {
 		in feature receiver : Occurrence[1];
 		
 		/**
-		 * The Clock to be used as the reference for the time. The default is
+		 * The Clock to be used as the reference for the timeInstant. The default is
 		 * the Clocks::defaultClock. 
 		 */
 		in feature clock : Clock[1] default defaultClock;
@@ -93,9 +93,9 @@ package Triggers {
 		in feature monitor : ChangeMonitor[1] default defaultMonitor;
 		
 		/**
-		 * The TimeSignal for the given time, as monitored by the monitor.
+		 * The TimeSignal for the given timeInstant, as monitored by the monitor.
 		 */
-		out feature signal : TimeSignal[1] = TimeSignal(time, clock, monitor);
+		return feature signal : TimeSignal[1] = TimeSignal(timeInstant, clock, monitor);
 		
 		step :> monitor.startObservation(receiver, signal);
 	}
@@ -108,7 +108,7 @@ package Triggers {
 		/**
 		 * The time duration, relative to the clock, after which the TimeSignal is sent.
 		 */
-		in feature delay : ScalarValue[1];
+		in feature delay : NumericalValue[1];
 		
 		/**
 		 * The Occurrence to which the TimeSignal is to be sent.
@@ -131,7 +131,7 @@ package Triggers {
 		 * The TimeSignal for the currentTime of the clock when the function is invoked
 		 * plus the given time delay, as monitored by the monitor.
 		 */
-		out signal : TimeSignal[1] = 
+		return signal : TimeSignal[1] = 
 			TriggerAt(clock.currentTime + delay, receiver, clock, monitor);
 	}	
 	

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_EndRedefinitionGoodCase.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_EndRedefinitionGoodCase.kerml.xt
@@ -1,0 +1,37 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Objects.kerml"}
+		File {from ="/library/Performances.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Objects.kerml"}
+				File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+package test{
+	assoc A {
+		end x;
+		end y[1..*];
+	}
+	
+	assoc B specializes A {
+		end x1;
+		// Reducing multiplicity lower bound is OK for an end feature.
+		end y1[0..*] redefines y;
+	}
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2018 IncQuery Labs Ltd.
- * Copyright (c) 2018-2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2018-2022 Model Driven Solutions, Inc.
  * Copyright (c) 2020 California Institute of Technology/Jet Propulsion Laboratory
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -57,7 +57,6 @@ import org.omg.sysml.lang.sysml.util.ISysMLScope
 import org.eclipse.emf.ecore.EClass
 import org.omg.sysml.lang.sysml.FeatureChaining
 import org.omg.sysml.lang.sysml.Subsetting
-import org.omg.sysml.lang.sysml.MultiplicityRange
 import org.omg.sysml.lang.sysml.Redefinition
 import org.omg.sysml.lang.sysml.LiteralInfinity
 import org.omg.sysml.lang.sysml.LiteralInteger
@@ -375,15 +374,15 @@ class KerMLValidator extends AbstractKerMLValidator {
 				setted_m_l = setted_m_u
 			}
 			
-			var setting_m_l = (setting_m as MultiplicityRange).lowerBound
-			val setting_m_u = (setting_m as MultiplicityRange).upperBound
+			var setting_m_l = setting_m.lowerBound
+			val setting_m_u = setting_m.upperBound
 			
 			if (setting_m_l === null) {
 				setting_m_l = setting_m_u
 			}
 			
-			// Lower bound (only check if the Subsetting is a Redefinition): setting must be >= setted
-			if (sub instanceof Redefinition) {
+			// Lower bound (only check if the Subsetting is a Redefinition and Features are not ends): setting must be >= setted
+			if (sub instanceof Redefinition && !subsettingFeature.isEnd()) {
 				if (setting_m_l instanceof LiteralInteger && setted_m_l instanceof LiteralInteger && (setting_m_l as LiteralInteger).getValue < (setted_m_l as LiteralInteger).getValue ||
 					setting_m_l instanceof LiteralInfinity && setted_m_l instanceof LiteralInteger && 0 < (setted_m_l as LiteralInteger).getValue) {
 					warning("Redefining feature should not have smaller multiplicity lower bound", sub, 

--- a/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
@@ -16,7 +16,7 @@ package Ports {
 		/**
 		 * The Ports that are subports of this Port.
 		 */
-		port subports: Port :> suboccurrences;
+		port subports: Port :> timeEnclosedOccurrences;
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -12,7 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *  
- * You should have received a copy of theGNU Lesser General Public License
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
@@ -182,7 +182,7 @@ public class ImplicitGeneralizationMap {
 		
 		put(DecisionNodeImpl.class, "subaction", "Actions::Action::decisions");
 		
-		put(EventOccurrenceUsageImpl.class, "suboccurrence", "Occurrences::Occurrence::suboccurrences");
+		put(EventOccurrenceUsageImpl.class, "suboccurrence", "Occurrences::Occurrence::timeEnclosedOccurrences");
 
 		put(ExhibitStateUsageImpl.class, "enactedPerformance", "Parts::Part::exhibitedStates");
 		

--- a/sysml.library/Kernel Library/CollectionFunctions.kerml
+++ b/sysml.library/Kernel Library/CollectionFunctions.kerml
@@ -6,6 +6,7 @@ package CollectionFunctions {
 	private import Base::Anything;
 	private import ScalarValues::*;
 	private import SequenceFunctions::equals;
+	private import SequenceFunctions::includes;
 	private import ControlFunctions::exists;
 	import Collections::*;
 	
@@ -25,8 +26,12 @@ package CollectionFunctions {
 		SequenceFunctions::notEmpty(col.elements)
 	}
 	
-	function contains(col: Collection[1], value: Anything[1]): Boolean[1] {
-		col.elements->exists {in x; x == value}
+	function contains(col: Collection[1], values: Anything[*]): Boolean[1] {
+		col.elements->includes(values)
+	}
+	
+	function containsAll(col1: Collection[1], col2: Collection[2]): Boolean[1] {
+		contains(col1, col2.elements)
 	}	
 	
 	function head(col: OrderedCollection[1]): Anything[0..1] {

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -103,9 +103,9 @@ package Objects {
 	/*
 	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
 	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
-	 * that are points, with edges and verticies on the boundary of faces, and verticies on the boundary of
+	 * that are points, with edges and vertices on the boundary of faces, and vertices on the boundary of
 	 * edges. Cells overlap when a structured space object is closed, as required to be a space boundary of
-	 * an object (faces overlap at their edges and/or verticies, while edges overlap at their verticies). The
+	 * an object (faces overlap at their edges and/or vertices, while edges overlap at their vertices). The
 	 * inner space dimension of structured space object is the highest of their cells.
 	 */
 	abstract struct StructuredSpaceObject specializes Object {

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -12,7 +12,10 @@ package Objects {
 	private import Occurrences::WithinBoth;	       
 	private import Performances::Performance;
 	private import Performances::performances;
+	private import SequenceFunctions::isEmpty;
 	private import SequenceFunctions::notEmpty;
+	private import SequenceFunctions::union;
+	private import CollectionFunctions::contains;
 	private import ScalarValues::Integer;	     
 	
 	/**
@@ -100,10 +103,10 @@ package Objects {
 	/*
 	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
 	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
-	 * that are points, with the highest of their inner space dimensions being that of the structured space
-	 * object. Some structured space cells overlap when this structured space object is closed, as required to
-	 * be a space boundary of an object (faces overlap at their edges and/or verticies, while edges overlap at
-	 * their verticies).
+	 * that are points, with edges and verticies on the boundary of faces, and verticies on the boundary of
+	 * edges. Cells overlap when a structured space object is closed, as required to be a space boundary of
+	 * an object (faces overlap at their edges and/or verticies, while edges overlap at their verticies). The
+	 * inner space dimension of structured space object is the highest of their cells.
 	 */
 	abstract struct StructuredSpaceObject specializes Object {
 
@@ -112,9 +115,17 @@ package Objects {
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
 		  }
 
-		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells;
+		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells {
+			derived feature redefines spaceBoundary; 
+			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
+		}
 
-		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells;
+		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells {
+			derived feature redefines spaceBoundary;
+			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
+		}
 
 		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
 		

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -102,7 +102,7 @@ package Objects {
 
 	/*
 	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
-	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and verticies
+	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
 	 * that are points, with edges and verticies on the boundary of faces, and verticies on the boundary of
 	 * edges. Cells overlap when a structured space object is closed, as required to be a space boundary of
 	 * an object (faces overlap at their edges and/or verticies, while edges overlap at their verticies). The
@@ -117,17 +117,17 @@ package Objects {
 
 		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells {
 			derived feature redefines spaceBoundary; 
-			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, verticies)) }
-			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, verticies)) }
+			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
 		}
 
 		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells {
 			derived feature redefines spaceBoundary;
-			inv { isEmpty(spaceBoundary) == isEmpty(verticies) }
-			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, verticies) }
+			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
 		}
 
-		portion feature verticies : Point[0..*] subsets structuredSpaceObjectCells;
+		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
 			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
@@ -137,11 +137,11 @@ package Objects {
 			to thatOccuurence :> edges [0..*];
 
 		connector evV :WithinBoth
-			from thisOccurrence :> edges.verticies [0..*]
-			to thatOccuurence :> verticies [0..*];
+			from thisOccurrence :> edges.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
 
 		connector fvV :WithinBoth
-			from thisOccurrence :> faces.verticies [0..*]
-			to thatOccuurence :> verticies [0..*];
+			from thisOccurrence :> faces.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
 	  }
 }

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -108,7 +108,7 @@ package Objects {
 	 */
 	abstract struct StructuredSpaceObject specializes Object {
 
-		abstract portion feature structuredSpaceObjectCells : Object[1..*] subsets Occurrence::spaceShots
+		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceShots
 		  { feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
 		  }

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -32,7 +32,7 @@ package Objects {
 		/**
 		 * Performances which are enacted by this object.
 		 */
-		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, suboccurrences;
+		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences;
 
 		/**
 		 * A space boundary that is a structured space object.

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -9,8 +9,11 @@ package Objects {
 	private import Occurrences::occurrences;
 	private import Occurrences::HappensLink;
 	private import Occurrences::SelfSameLifeLink;
+	private import Occurrences::WithinBoth;	       
 	private import Performances::Performance;
 	private import Performances::performances;
+	private import SequenceFunctions::notEmpty;
+	private import ScalarValues::Integer;	     
 	
 	/**
 	 * Object is the most general class of structural occurrences that may change over time.
@@ -27,6 +30,11 @@ package Objects {
 		 * Performances which are enacted by this object.
 		 */
 		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, suboccurrences;
+
+		/**
+		 * A space boundary that is a structured space object.
+		 */
+		portion structuredSpaceBoundary : StructuredSpaceObject[0..1] subsets spaceBoundary;
 	}
 	
 	/**
@@ -56,4 +64,71 @@ package Objects {
 	 */
 	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects;
 	
+
+	/**
+	 * A Body is an Object of inner space dimension 3.
+	 */
+	struct Body specializes Object {   /* sufficient? */
+		feature redefines innerSpaceDimension = 3;
+	}
+
+	/**
+	 * A Surface is an Object of inner space dimension 2.
+	 */
+	struct Surface specializes Object {   /* sufficient? */
+		feature redefines innerSpaceDimension = 2;
+		  /* The number of  "holes" in this Surface, assuming it isClosed. */
+		feature genus : Integer[0..1] default 0;
+
+		inv { notEmpty(genus) implies (isClosed & genus >= 0) }
+	}
+
+	/*
+	 * A Curve is an Object of inner space dimension 1.
+	 */
+	struct Curve specializes Object {   /* sufficient? */
+		feature redefines innerSpaceDimension = 1;
+	}
+
+	/*
+	 * A Point is an Object of inner space dimension 0.
+	 */
+	struct Point specializes Object {   /* sufficient? */
+		feature redefines innerSpaceDimension = 0;
+	}
+
+	/*
+	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) 
+	 * of the same or lower inner space dimension: faces that are surfaces, edges that are curves, and 
+	 * vertices that are points, with the highest of their inner space dimensions being that of the structured 
+	 * space object. Structured space cells overlap (for faces and edges at their own structured space
+	 * cells) when this structured space object is closed, as required to be a structured space
+	 * boundary of an object (faces overlap at their edges and/or verticies, while edges overlap at
+	 * their verticies).
+	 */
+	abstract struct StructuredSpaceObject specializes Object {
+
+		abstract portion feature structuredSpaceObjectCells : Object[1..*] subsets Occurrence::spaceShots
+		  { feature cellOrientation : Integer [0..1];
+		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
+		  }
+
+		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells;
+
+		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells;
+
+		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
+		
+		connector feE :WithinBoth
+			from thisOccurrence :> faces.edges [0..*]
+			to thatOccuurence :> edges [0..*];
+
+		connector evV :WithinBoth
+			from thisOccurrence :> edges.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
+
+		connector fvV :WithinBoth
+			from thisOccurrence :> faces.vertices [0..*]
+			to thatOccuurence :> vertices [0..*];
+	  }
 }

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -68,14 +68,14 @@ package Objects {
 	/**
 	 * A Body is an Object of inner space dimension 3.
 	 */
-	struct Body specializes Object {   /* sufficient? */
+	struct all Body specializes Object {
 		feature redefines innerSpaceDimension = 3;
 	}
 
 	/**
 	 * A Surface is an Object of inner space dimension 2.
 	 */
-	struct Surface specializes Object {   /* sufficient? */
+	struct all Surface specializes Object {
 		feature redefines innerSpaceDimension = 2;
 		  /* The number of  "holes" in this Surface, assuming it isClosed. */
 		feature genus : Integer[0..1] default 0;
@@ -86,29 +86,28 @@ package Objects {
 	/*
 	 * A Curve is an Object of inner space dimension 1.
 	 */
-	struct Curve specializes Object {   /* sufficient? */
+	struct all Curve specializes Object {
 		feature redefines innerSpaceDimension = 1;
 	}
 
 	/*
 	 * A Point is an Object of inner space dimension 0.
 	 */
-	struct Point specializes Object {   /* sufficient? */
+	struct all Point specializes Object {
 		feature redefines innerSpaceDimension = 0;
 	}
 
 	/*
-	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) 
-	 * of the same or lower inner space dimension: faces that are surfaces, edges that are curves, and 
-	 * vertices that are points, with the highest of their inner space dimensions being that of the structured 
-	 * space object. Structured space cells overlap (for faces and edges at their own structured space
-	 * cells) when this structured space object is closed, as required to be a structured space
-	 * boundary of an object (faces overlap at their edges and/or verticies, while edges overlap at
+	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
+	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
+	 * that are points, with the highest of their inner space dimensions being that of the structured space
+	 * object. Some structured space cells overlap when this structured space object is closed, as required to
+	 * be a space boundary of an object (faces overlap at their edges and/or verticies, while edges overlap at
 	 * their verticies).
 	 */
 	abstract struct StructuredSpaceObject specializes Object {
 
-		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceShots
+		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
 		  { feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
 		  }
@@ -119,6 +118,9 @@ package Objects {
 
 		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
 		
+		derived feature redefines innerSpaceDimension = 
+			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
+
 		connector feE :WithinBoth
 			from thisOccurrence :> faces.edges [0..*]
 			to thatOccuurence :> edges [0..*];

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -102,7 +102,7 @@ package Objects {
 
 	/*
 	 * A StructuredSpaceObject is an Object that is broken up into smaller structured space objects (cells) of
-	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and vertices
+	 * the same or lower inner space dimension: faces that are surfaces, edges that are curves, and verticies
 	 * that are points, with edges and verticies on the boundary of faces, and verticies on the boundary of
 	 * edges. Cells overlap when a structured space object is closed, as required to be a space boundary of
 	 * an object (faces overlap at their edges and/or verticies, while edges overlap at their verticies). The
@@ -117,17 +117,17 @@ package Objects {
 
 		portion feature faces : Surface[0..*] subsets structuredSpaceObjectCells {
 			derived feature redefines spaceBoundary; 
-			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
-			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
+			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, verticies)) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, verticies)) }
 		}
 
 		portion feature edges : Curve[0..*] subsets structuredSpaceObjectCells {
 			derived feature redefines spaceBoundary;
-			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
-			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
+			inv { isEmpty(spaceBoundary) == isEmpty(verticies) }
+			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, verticies) }
 		}
 
-		portion feature vertices : Point[0..*] subsets structuredSpaceObjectCells;
+		portion feature verticies : Point[0..*] subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
 			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
@@ -137,11 +137,11 @@ package Objects {
 			to thatOccuurence :> edges [0..*];
 
 		connector evV :WithinBoth
-			from thisOccurrence :> edges.vertices [0..*]
-			to thatOccuurence :> vertices [0..*];
+			from thisOccurrence :> edges.verticies [0..*]
+			to thatOccuurence :> verticies [0..*];
 
 		connector fvV :WithinBoth
-			from thisOccurrence :> faces.vertices [0..*]
-			to thatOccuurence :> vertices [0..*];
+			from thisOccurrence :> faces.verticies [0..*]
+			to thatOccuurence :> verticies [0..*];
 	  }
 }

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -8,22 +8,33 @@ package Occurrences {
 	private import Base::things;
 	private import Base::DataValue;
 	private import Links::*;
+	private import Collections::Set;
+	private import Collections::OrderedSet;
+	private import SequenceFunctions::isEmpty;
+	private import SequenceFunctions::notEmpty;
+	private import ScalarValues::Boolean;
+	private import DataFunctions::'&';
+	private import ScalarValues::Integer;
+	private import DataFunctions::'<=';
+	private import DataFunctions::'>=';
 	
 	/**
 	 * Occurrence is the most general classifier of entities that have identity and 
-	 * may occur over time.
+	 * occur over time and space.
 	 * 
-	 * The features of Occurrence specify the semantics of portions, slices and
-	 * snapshots of an occurrence over time.
+	 * The features of Occurrence specify the semantics of associations between occurrences that
+	 * assert complete inclusion and exclusion in time or space, or both, which includes
+	 * portions of an occurrence (having the same identity).  Portions include slices and shots
+	 * over time and space.
 	 */
 	abstract class Occurrence specializes Anything {
 		private import SequenceFunctions::*;
 		private import ControlFunctions::forAll;
 		
-		feature portionOfLife : Life[1] subsets portionOf;
+		feature portionOfLife: Life[1] subsets portionOf;
 		
-		feature self : Occurrence[1] redefines Anything::self subsets timeSlices, sameLifeOccurrences;
-		feature sameLifeOccurrences : Occurrence[1..*] subsets things;
+		feature self: Occurrence[1] redefines Anything::self subsets timeSlices, spaceSlices, sameLifeOccurrences;
+		feature sameLifeOccurrences: Occurrence[1..*] subsets things;
 		
 		/**
 		 * Occurrences that end before this occurrence starts.
@@ -35,16 +46,16 @@ package Occurrences {
 		 */
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
-	  	/**
-	   	 * Occurrences that end just before this occurrence starts, with no
-	     * possibility of other occurrences happening in the time between them.
-	     */
+		/**
+		 * Occurrences that end just before this occurrence starts, with no
+		 * possibility of other occurrences happening in the time between them.
+		 */
 		feature immediatePredecessors: Occurrence[0..*] subsets predecessors;
 
-  		/**
-   		 * Occurrences that start just after this occurrence ends, with no
-   		 * possibility of other occurrences happening in the time between them.
-   		 */
+		/**
+		 * Occurrences that start just after this occurrence ends, with no
+		 * possibility of other occurrences happening in the time between them.
+		 */
 		feature immediateSuccessors: Occurrence[0..*] subsets successors;
 
 		/**
@@ -52,12 +63,49 @@ package Occurrences {
 		 * this occurrence, including at least this occurrence.
 		 */
 		feature suboccurrences: Occurrence[1..*] subsets occurrences;
-		
+
 		/**
-		 * Occurrences that are portions of this occurrence, including at
-		 * least this occurrence.
+		 * Occurrences that this one completely includes in space (not necessarily in time),
+		 * including this one.
 		 */
-		portion feature portions: Occurrence[1..*] subsets suboccurrences;
+		feature subSpaceOccurrences: Occurrence[1..*] subsets occurrences;
+
+		/**
+		 * Occurrences that this one completely includes in both space and time,
+		 * including this one.
+		 */
+		feature subSpaceTimeOccurrences: Occurrence[1..*] subsets suboccurrences, subSpaceOccurrences;
+
+		/**
+		 * All sub space time occurrences that take up no time or space.
+		 */
+		feature all spaceTimePoints : Occurrence[1..*] subsets subSpaceTimeOccurrences {
+		  redefines innerSpaceDimension = 0; }
+		inv { spaceTimePoints->forAll {in stp:Occurrence; stp.startShot == stp.endShot}}
+
+		/**
+		 * The number of variables need to identify space points in this occurrence, from 0
+		 * to 3, without regard to higher dimensional spaces it might be emedded in.
+		 */
+		feature innerSpaceDimension : Integer [1];
+		inv { innerSpaceDimension >= 0 & innerSpaceDimension <= 3 }
+
+		/**
+		 * For occurrences of innerSpaceDimension 1 or 2, the number of variables need to
+		 * identify their space points in higher dimensions they might be embedded in, from
+		 * the innerSpaceDimension to 3. An outerSpaceDimension equal to innerSpaceDimension
+		 * indicates the occurrence is spatially straight (innerSpaceDimension 1 embedded in
+		 * 2 or 3 dimensions) or flat (innerSpaceDimension 2 embedded in 3 dimensions).
+		 */
+		feature outerSpaceDimension : Integer [0..1];
+		inv { notEmpty(outerSpaceDimension) implies
+			 (outerSpaceDimension >= innerSpaceDimension & outerSpaceDimension <= 3) }
+
+		/**
+		 * All subSpaceTimeOccurrences that have the same portionOfLife (considered the same
+		 * thing occurring), see PortionOf.
+		 */
+		portion feature all portions: Occurrence[1..*] subsets subSpaceTimeOccurrences;
 		
 		/**
 		 * Occurrences of which this occurrence is a portion, including at
@@ -66,14 +114,14 @@ package Occurrences {
 		feature portionOf : Occurrence[1..*];
 		
 		/**
-		 * Portions of an occurrence over some slice of time, including at
-		 * least this occurrence.
+		 * Portions of an occurrence taking up all of its space over some period of time,
+		 * including at least this occurrence.
 		 */
 		portion feature timeSlices: Occurrence[1..*] subsets portions;
 		
 		/**
-		 * Occurrences of which this occurrence is a time slice, including at
-		 * least this occurrence.
+		 * Occurrences of which this occurrence is a time slice, including at least this
+		 * occurrence.
 		 */
 		feature timeSliceOf : Occurrence[1..*] subsets portionOf;
 		
@@ -83,7 +131,7 @@ package Occurrences {
 		 */
 		portion feature all snapshots: Occurrence[1..*] subsets timeSlices;
 		inv { snapshots->forAll {in s:Occurrence; s.startShot == s.endShot} }
-		inv { snapshots == union(startShot, union(middleShots, endShot)) }
+		inv { snapshots == union(startShot, union(middleTimeSlice.snapshots, endShot)) }
 		
 		/**
 		 * Occurrences of which this occurrence is a snapshot.
@@ -96,27 +144,151 @@ package Occurrences {
 		portion feature startShot: Occurrence[1] subsets snapshots;
 		
 		/**
-		 * The snapshots in between the startShot and endShot. There are none
-		 * when the startShot and endShot are the same.
+		 * A time slice that takes all the time between the start shot and end shot. There
+		 * is none when the startShot and endShot are the same.
 		 */
-		portion feature all middleShots: Occurrence[0..*] subsets snapshots;
-		inv { isEmpty(middleShots) == (startShot == endShot) }
-		
+		portion feature middleTimeSlice: Occurrence[0..1] subsets timeSlices;
+		inv { isEmpty(middleTimeSlice) == (startShot == endShot) }
+
+		/**
+		 * The startShot happens immediately before the middle time slice.
+		 */
+		connector :HappensJustBefore 
+			from earlierOccurrence :> startShot [1] 
+			to laterOccurrence :> middleTimeSlice [0..1];
+
 		/** 
 		 * The snapshot at the end of the occurrence in time.
 		 */
 		portion feature endShot: Occurrence[1] subsets snapshots;
-		
+
 		/**
-		 * The startShot happens before all middleShots.
+		 * The endShot happens after the middle time slice.
 		 */
-		succession startShot[1] then middleShots[0..*];
-		
+		 connector :HappensJustBefore 
+			from earlierOccurrence :> middleTimeSlice [0..1]
+			to laterOccurrence :> endShot [1];
+
 		/**
-		 * The endShot happens after all middleShots.
+		 * Portions of this occurrence that extend for exactly the same time and some or all
+		 * the space, relative to spatial location of this occurrence, including at least
+		 * this occurrence.
+
 		 */
-		succession middleShots[0..*] then endShot[1];
-		
+		portion feature spaceSlices: Occurrence[1..*] subsets portions;
+
+		/**
+		 * Occurrences of which this occurrence is a space slice, including at least this
+		 * occurrence.
+		 */
+		feature spaceSliceOf: Occurrence[1..*] subsets portionOf;
+
+		/**
+		 * All spaceSlices of this occurrence that are of a lower inner space dimension than it.
+		 */
+		portion feature spaceShots: Occurrence[1..*] subsets spaceSlices;
+
+		/**
+		 * Occurrences of which this occurrence is a space shot.
+		 */
+		feature spaceShotOf: Occurrence[1..*] subsets spaceSliceOf;
+
+		/**
+		 * Sets of Occurrences, where the Occurrences in each set taken together have the
+		 * same time and space extent as this occurrence.
+		 */
+		feature unionsOf: Set[0..*] {
+			feature redefines elements: Occurrence[0..*];
+			feature union: Occurrence[0..1];
+
+			connector :Within
+				  from smallerOccurrence :> elements [0..*]
+				  to largerOccurrence :> union [1];
+			connector :Within 
+				  from smallerOccurrence :> union.spaceTimePoints [0..*]
+				  to largerOccurrence :> elements [1..*];
+		}
+		binding unionsOf.union[0..1] = self[1];
+
+		/**
+		 * Sets of Occurrences, where the largest time and space extent common to the
+		 * Occurrences in each set is the same as this occurrence.
+		 */
+		feature intersectionsOf: Set[0..*] {
+			feature redefines elements: Occurrence[0..*]
+			  { feature all notIntersection: Occurrence[0..*] subsets portions; }
+			feature intersection: Occurrence[0..1];
+			
+			connector :Within
+				  from smallerOccurrence :> intersection [1]
+				  to largerOccurrence :> elements [0..*];
+			connector :Without
+				  from separateOccurrenceToo :> elements.notIntersection [0..*]
+				  to separateOccurrence :> intersection [1];
+			connector :Without
+				  from separateOccurrenceToo :> elements.notIntersection [0..*]
+				  to separateOccurrence :> elements [1..*];
+		}
+		binding intersectionsOf.intersection[0..1] = self[1];
+
+		/**
+		 * Ordered sets of Occurrences, where the time and space extent of first Occurrence
+		 * in each set (minuend) that is not in the time and space extent of the remaining
+		 * Occurrences (subtrahend) is the same as this occurrence.
+		 */
+		feature differencesOf: OrderedSet[0..*] {
+			feature redefines elements: Occurrence[0..*];
+			feature difference: Occurrence[0..1];
+			feature interdiff: Set [0..1] {
+				feature minuend: Occurrence [1]; /* ??FIRST in differencesOf.ELEMENTS SYNTAX? */
+				feature all notSubtrahend: Occurrence [0..*] subsets elements;
+			}
+			feature subtrahend: Occurrence[*] subsets elements; /* ??ELEMENTS AFTER FIRST SYNTAX? */
+
+			connector :Without
+				  from separateOccurrenceToo :> interdiff.notSubtrahend [0..*]
+				  to separateOccurrence :> subtrahend [1];
+
+		}
+		binding differencesOf.difference[0..1] = self[1];
+
+		/**
+		 * A space slice of this occurrence that includes all its space shots except the
+		 * space boundary, which must exist and be outsideOf it.  The space interior must be
+		 * of the same inner space dimension as this occurrence, except if it is zero,
+		 * whereupon there is no space interior.
+		 */
+		portion feature spaceInterior: Occurrence[0..1] subsets spaceSlices;
+
+		/**
+		 * An Occurrence of which this one is the space interior.
+		 */
+		feature spaceInteriorOf: Occurrence[0..1] subsets spaceSliceOf;
+		inv { notEmpty(spaceInterior) implies spaceInterior.innerSpaceDimension == innerSpaceDimension }
+		inv { innerSpaceDimension == 0 implies isEmpty(spaceInterior) }
+
+		/**
+		 * A space shot of this Occurrence that is not among those of its space interior, of
+		 * which it must be outside. It must have no spaceBoundary.
+		 */
+		portion feature spaceBoundary: Occurrence[0..1] subsets spaceShots
+		  { feature redefines isClosed = true; }
+
+		/**
+		 * An Occurrence of which this one is the space boundary.
+		 */
+		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
+
+		connector :OutsideOf 
+			from separateSpaceToo :> spaceInterior [0..1]
+			to separateSpace :> spaceBoundary [1];
+
+		/**
+		 * Tells whether an occurrence has a spaceBoundary, true if it does, false otherwise.
+		 */
+		feature isClosed : Boolean [1];
+		inv { isClosed == isEmpty(spaceBoundary) }
+
 		/**
 		 * The incoming transfers received by this occurrence. 
 		 */
@@ -172,8 +344,8 @@ package Occurrences {
 		end feature myselfSameLife: Anything[1..*] redefines source;
 		end feature selfSameLife: Anything[1..*] redefines target;
 
-	 	feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
-	 	feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
+		feature all sourceOccurrence : Occurrence [0..1] subsets myselfSameLife;
+		feature all targetOccurrence : Occurrence [0..1] subsets selfSameLife, sourceOccurrence.sameLifeOccurrences;
 		binding oSelf of sourceOccurrence.portionOfLife = targetOccurrence.portionOfLife;
 
 		feature all sourceDataValue : DataValue [0..1] subsets myselfSameLife;
@@ -184,15 +356,15 @@ package Occurrences {
 	subclassifier SelfLink specializes SelfSameLifeLink; 
 
 	/**
-	 * HappensLink is the base of the associations that assert temporal relationships 
-	 * between a sourceOccurrence and a targetOccurrence. Because HappensLinks assert 
-	 * temporal relationships, they cannot themselves be Occurrences that happen in time.
-	 * Therefore HappensLink is disjoint with LinkObject, that is, no HappensLink can 
-	 * also be a LinkObject.
+	 * HappensLink is the most general associations that assert temporal relationships between a
+	 * sourceOccurrence and a targetOccurrence. Because HappensLinks assert temporal
+	 * relationships, they cannot themselves be Occurrences that happen in time.  Therefore
+	 * HappensLink is disjoint with LinkObject, that is, no HappensLink can also be a
+	 * LinkObject.
 	 */
 	assoc HappensLink specializes BinaryLink {
-		end feature sourceOccurrence: Occurrence[0..*];
-		end feature targetOccurrence: Occurrence[0..*];
+		end feature sourceOccurrence: Occurrence[0..*] redefines BinaryLink::source;
+		end feature targetOccurrence: Occurrence[0..*] redefines BinaryLink::target;
 	}
 
 	/**
@@ -200,7 +372,7 @@ package Occurrences {
 	 * That is, the time interval of the shorterOccurrence is completely within that of the
 	 * longerOccurrence, or every snapshot of the shorterOccurrence happens while (at the
 	 * same time as) some snapshot of the longerOccurrence. Note that this means every 
-	 * occurrence happens during itself.
+	 * Occurrence HappensDuring itself and that HappensDuring is transitive.
 	 */
 	assoc HappensDuring specializes HappensLink {
 		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.suboccurrences;
@@ -228,44 +400,56 @@ package Occurrences {
 		end feature thatOccurrence: Occurrence[1..*] redefines longerOccurrence;
 		
 		connector :HappensDuring 
-			from shorterOccurrence :> thatOccurrence 
-			to longerOccurrence :> thisOccurrence;
+			from shorterOccurrence :> thatOccurrence [1]
+			to longerOccurrence :> thisOccurrence  [1];
 	}
-	
-	/**
-	 * HappensBefore asserts that the earlierOccurrence happens before the laterOccurrence.
-	 * That is, the time interval of the earlierOccurrence is completely before that of the 
-	 * laterOccurrence, or every snapshot of the earlierOccurrence happens before every 
-	 * snapshot of the laterOccurrence. Note that this means no occurrence happens before itself.
-	 */
-	assoc HappensBefore specializes HappensLink {
-		end feature earlierOccurrence: Occurrence[0..*] redefines BinaryLink::source subsets laterOccurrence.predecessors;
-		end feature laterOccurrence: Occurrence[0..*] redefines BinaryLink::target subsets earlierOccurrence.successors;
-		
-		subset laterOccurrence.successors subsets earlierOccurrence.successors;
-		
-		inv { earlierOccurrence != laterOccurrence }
-	}
-	
-	/**
-	 * HappensJustBefore is HappensBefore asserting that the earlierOccurrence happens just 
-	 * before the laterOccurrence, with with no possibility of other occurrences happening in the 
-	 * time between them.
-	 */
-	assoc HappensJustBefore specializes HappensBefore {
-  		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
-		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
 
-  		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	/**
+	 * InsideOf asserts that its largerSpace completely overlaps its smallerSpace in space (not
+	 * necessarily in time, see HappensDuring). That is, all four dimensional points of the
+	 * smallerSpace are in the spatial extent of the largerSpace. Note that this means every
+	 * Occurrence is InsideOf itself and that InsideOf is transitive.
+	 */
+	assoc InsideOf specializes BinaryLink {
+		end feature smallerSpace: Occurrence[1..*] redefines source, largerSpace.subSpaceOccurrences;
+		end feature largerSpace: Occurrence[1..*] redefines target;
+
+		subset smallerSpace.subSpaceOccurrences subsets largerSpace.subSpaceOccurrences;
+	}
+
+	/**
+	 * Within asserts that its largerOccurrence completely overlaps its smallerOccurrence in
+	 * time and space. That is, all four dimensional points of the smallerOccurrence happen
+	 * during and are inside of the largerOccurrence). This means every occurrence is Within
+	 * itself and Within is transitive.
+         */
+	assoc all Within specializes HappensDuring, InsideOf {
+		end feature smallerOccurrence: Occurrence[1..*] redefines shorterOccurrence, smallerSpace
+		  subsets largerOccurrence.subSpaceTimeOccurrences;
+		end feature largerOccurrence: Occurrence[1..*] redefines longerOccurrence, largerSpace;
+	 }
+
+	/**
+	 * WithinBoth asserts that two occurrences are Within each other, that is, they occupy the
+	 * same four dimensional region.  Note that this means every Occurrence is WithinBoth with
+	 * itself and transitive.
+	 */
+	assoc WithinBoth specializes Within {
+		end feature thisOccurrence: Occurrence[1..*] redefines smallerOccurrence;
+		end feature thatOccurrence: Occurrence[1..*] redefines largerOccurrence;
+		
+		connector :Within
+			from smallerOccurrence :> thatOccurrence [1]
+			to largerOccurrence :> thisOccurrence [1];
 	}
 
 	/**
 	 * PortionOf asserts one occurrence is a portion of another, including at least itself. 
 	 */
-	assoc PortionOf specializes HappensDuring { 
-		end feature portionOccurrence: Occurrence[1..*] redefines shorterOccurrence subsets portionedOccurrence.portions;
-		end feature portionedOccurrence: Occurrence[1..*] redefines longerOccurrence subsets portionOccurrence.portionOf;
-		
+	assoc PortionOf specializes Within { 
+		end feature portionOccurrence: Occurrence[1..*] redefines smallerOccurrence subsets portionedOccurrence.portions; 
+		end feature portionedOccurrence: Occurrence[1..*] redefines largerOccurrence subsets portionOccurrence.portionOf;
+
 		binding portionOccurrence.portionOfLife[1] = portionedOccurrence.portionOfLife[1];
 	}
 	
@@ -284,14 +468,85 @@ package Occurrences {
 		end feature snapshotOcccurrence: Occurrence[1..*] redefines timeSliceOccurrence subsets snapshottedOccurrence.snapshots;
 		end feature snapshottedOccurrence: Occurrence[1..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
 	}
+
+	/**
+	 * SpaceSliceOf asserts that it spaceSliceOccurrence extends for exactly the same time and
+	 * some or all the space of the spaceSlicedOccurrence and that the spaceSliceOccurrence is
+	 * of the same of lower innerSpaceDimension than the spaceSliceOccurrence.  Note that this
+	 * means every occurrence is a SpaceSliceOf itself and SpaceSliceOf is transitive.
+	 */
+	assoc SpaceSliceOf specializes PortionOf {
+		end feature spaceSliceOccurrence: Occurrence[1..*] redefines portionOccurrence subsets spaceSlicedOccurrence.spaceSlices;
+		end feature spaceSlicedOccurrence: Occurrence[1..*] redefines portionedOccurrence subsets spaceSliceOccurrence.spaceSliceOf;
+
+		inv { spaceSliceOccurrence.innerSpaceDimension <= spaceSlicedOccurrence.innerSpaceDimension }
+	}
 	
+	/**
+	 * SpaceShotOf asserts that its spaceShotOccurrence is of a lower inner space dimension than
+	 * it spaceShottedOccurrence.
+	 */
+	assoc SpaceShotOf specializes SpaceSliceOf {
+		end feature spaceShotOcccurrence: Occurrence[1..*] redefines spaceSliceOccurrence subsets spaceShottedOccurrence.spaceShots;
+		end feature spaceShottedOccurrence: Occurrence[1..*] redefines spaceSlicedOccurrence subsets spaceShotOcccurrence.spaceShotOf;
+	}
+
+	/**
+	 * Without is the most general association that asserts complete separation (no overlap) in
+	 * either space or time, or both, between two occurrences.  That is, no four dimensional
+	 * points are in both occurrences. Note that this means no Occurrence is Without itself.
+	 */
+	assoc Without specializes BinaryLink {
+		end feature separateOccurrenceToo: Occurrence[0..*] redefines BinaryLink::source;
+		end feature separateOccurrence: Occurrence[0..*] redefines BinaryLink::target;
+
+		inv { separateOccurrenceToo != separateOccurrence }
+	}
+
+	/**
+	 * HappensBefore asserts that the earlierOccurrence is completely separated in time (not
+	 * necessarily in space, see OutsideOf), with the earlierOccurrence happening completely
+	 * before the laterOccurrence.	That is, no snapshot of the earlierOccurrence happens at the
+	 * same time as any snapshot of the laterOccurrence, with all snapshots of earlierOccurrence
+	 * happening before those the laterOccurrence, including the endShot of the earlierOccurrence
+	 * and startShot of the laterOccurrence. Note that this means no Occurrence HappensBefore
+	 * itself.
+	 */
+	assoc HappensBefore specializes HappensLink, Without {
+		end feature earlierOccurrence: Occurrence[0..*] redefines sourceOccurrence, separateOccurrenceToo subsets laterOccurrence.predecessors;
+		end feature laterOccurrence: Occurrence[0..*] redefines targetOccurrence, separateOccurrence subsets earlierOccurrence.successors;
+
+		/* HappensBefore is transitive. */
+		subset laterOccurrence.successors subsets earlierOccurrence.successors;
+	}
+	
+	/**
+	 * HappensJustBefore is HappensBefore asserting that there is no possibility of another
+	 * occurrences happening in the time between the earlierOccurrence and laterOccurrence.
+	 */
+	assoc HappensJustBefore specializes HappensBefore {
+		end feature redefines earlierOccurrence: Occurrence[0..*] subsets laterOccurrence.immediatePredecessors;
+		end feature redefines laterOccurrence: Occurrence[0..*] subsets earlierOccurrence.immediateSuccessors;
+
+		disjoint earlierOccurrence.successors from laterOccurrence.predecessors;
+	}
+
 	/**
 	 * happensBeforeLinks is a specialization of binaryLinks restricted to type HappensBefore.
 	 * It is the default subsetting for succession connectors.
 	 */
 	 feature happensBeforeLinks: HappensBefore[0..*] nonunique subsets binaryLinks {
-	 	end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
-	 	end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
-	 }
-	 
+		end feature earlierOccurrence: Occurrence[0..*] redefines HappensBefore::earlierOccurrence, binaryLinks::source;
+		end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
+	 } 
+
+	/**
+	 * OutsideOf asserts that two occurrences do not overlap in space (not necessarily in time,
+	 * see HappensBefore).  That is, no four dimensional points of the occurrences are in the
+	 * spatial extent of both of them. This means no Occurrence is OutsideOf itself.
+	 */
+	assoc OutsideOf specializes Without {
+		end feature separateSpaceToo: Occurrence[0..*] redefines separateOccurrenceToo;
+		end feature separateSpace: Occurrence[0..*] redefines separateOccurrence;
+	}
 }

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -57,24 +57,24 @@ package Occurrences {
 		 * Occurrences that start no earlier than and end no later than
 		 * this occurrence, including at least this occurrence.
 		 */
-		feature suboccurrences: Occurrence[1..*] subsets occurrences;
+		feature timeEnclosedOccurrences: Occurrence[1..*] subsets occurrences;
 
 		/**
 		 * Occurrences that this one completely includes in space (not necessarily in time),
 		 * including this one.
 		 */
-		feature subSpaceOccurrences: Occurrence[1..*] subsets occurrences;
+		feature spaceEnclosedOccurrences: Occurrence[1..*] subsets occurrences;
 
 		/**
 		 * Occurrences that this one completely includes in both space and time,
 		 * including this one.
 		 */
-		feature subSpaceTimeOccurrences: Occurrence[1..*] subsets suboccurrences, subSpaceOccurrences;
+		feature spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences;
 
 		/**
 		 * All sub space time occurrences that take up zero time and space.
 		 */
-		feature all subSpaceTimePoints : Occurrence[1..*] subsets subSpaceTimeOccurrences {
+		feature all spaceTimeEnclosedPoints : Occurrence[1..*] subsets spaceTimeEnclosedOccurrences {
 			redefines innerSpaceDimension = 0;
 			binding startShot[1] = endShot[1];
 		}
@@ -98,10 +98,10 @@ package Occurrences {
 			 (outerSpaceDimension >= innerSpaceDimension & outerSpaceDimension <= 3) }
 
 		/**
-		 * All subSpaceTimeOccurrences that have the same portionOfLife (considered the same
+		 * All spaceTimeEnclosedOccurrences that have the same portionOfLife (considered the same
 		 * thing occurring), see PortionOf.
 		 */
-		portion feature all portions: Occurrence[1..*] subsets subSpaceTimeOccurrences;
+		portion feature all portions: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences;
 		
 		/**
 		 * Occurrences of which this occurrence is a portion, including at
@@ -204,7 +204,7 @@ package Occurrences {
 				  from smallerOccurrence :> elements [0..*]
 				  to largerOccurrence :> union [1];
 			connector :Within 
-				  from smallerOccurrence :> union.subSpaceTimePoints [0..*]
+				  from smallerOccurrence :> union.spaceTimeEnclosedPoints [0..*]
 				  to largerOccurrence :> elements [1..*];
 		}
 		binding unionsOf.union[0..1] = self[1];
@@ -217,7 +217,7 @@ package Occurrences {
 		 */
 		feature intersectionsOf: Set[0..*] {
 			feature redefines elements: Occurrence[0..*]
-			  { feature all notIntersection: Occurrence[0..*] subsets subSpaceTimePoints; }
+			  { feature all notIntersection: Occurrence[0..*] subsets spaceTimeEnclosedPoints; }
 			feature intersection: Occurrence[0..1];
 			
 			connector :Within
@@ -382,7 +382,7 @@ package Occurrences {
 	 * Occurrence HappensDuring itself and that HappensDuring is transitive.
 	 */
 	assoc HappensDuring specializes HappensLink {
-		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.suboccurrences;
+		end feature shorterOccurrence: Occurrence[1..*] redefines sourceOccurrence subsets longerOccurrence.timeEnclosedOccurrences;
 		end feature longerOccurrence: Occurrence[1..*] redefines targetOccurrence;
 		
 		/*
@@ -395,7 +395,7 @@ package Occurrences {
 		subset longerOccurrence.predecessors subsets shorterOccurrence.predecessors;
 		subset longerOccurrence.successors subsets shorterOccurrence.successors;
 		
-		subset shorterOccurrence.suboccurrences subsets longerOccurrence.suboccurrences;
+		subset shorterOccurrence.timeEnclosedOccurrences subsets longerOccurrence.timeEnclosedOccurrences;
 	}
 	
 	/**
@@ -418,12 +418,12 @@ package Occurrences {
 	 * Occurrence is InsideOf itself and that InsideOf is transitive.
 	 */
 	assoc InsideOf specializes BinaryLink {
-		end feature smallerSpace: Occurrence[1..*] redefines source, largerSpace.subSpaceOccurrences;
+		end feature smallerSpace: Occurrence[1..*] redefines source, largerSpace.spaceEnclosedOccurrences;
 		end feature largerSpace: Occurrence[1..*] redefines target;
 
-		subset smallerSpace.subSpaceOccurrences subsets largerSpace.subSpaceOccurrences;
+		subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
 
-		inv { includes(largerSpace.suboccurrences, smallerSpace) implies (self istype Within) }
+		inv { includes(largerSpace.timeEnclosedOccurrences, smallerSpace) implies (self istype Within) }
 	}
 
 	/**
@@ -434,7 +434,7 @@ package Occurrences {
 	 */
 	assoc all Within specializes HappensDuring, InsideOf {
 		end feature smallerOccurrence: Occurrence[1..*] redefines shorterOccurrence, smallerSpace
-		  subsets largerOccurrence.subSpaceTimeOccurrences;
+		  subsets largerOccurrence.spaceTimeEnclosedOccurrences;
 		end feature largerOccurrence: Occurrence[1..*] redefines longerOccurrence, largerSpace;
 	 }
 

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -240,11 +240,11 @@ package Occurrences {
 			feature redefines elements: Occurrence[0..*];
 			feature difference: Occurrence[0..1];
 			feature interdiff: Set [0..1] {
-				feature minuend: Occurrence [1]; /* ??FIRST in differencesOf.ELEMENTS SYNTAX? */
+				feature minuend: Occurrence [1] subsets elements = head(elements);
 				feature all notSubtrahend: Occurrence [0..*] subsets elements;
 			}
-			feature subtrahend: Occurrence[*] subsets elements; /* ??ELEMENTS AFTER FIRST SYNTAX? */
-
+			feature subtrahend: Occurrence[*] subsets elements = tail(elements);
+			
 			connector :Without
 				  from separateOccurrenceToo :> interdiff.notSubtrahend [0..*]
 				  to separateOccurrence :> subtrahend [1];

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -9,9 +9,10 @@ package Occurrences {
 	private import ScalarValues::Integer;
 	private import ScalarValues::Boolean;
 	private import Links::*;
-	private import SequenceFunctions::includes;
 	private import Collections::Set;
 	private import Collections::OrderedSet;
+	private import SequenceFunctions::includes;
+	private import CollectionFunctions::contains;
 	
 	/**
 	 * Occurrence is the most general classifier of entities that have identity and 
@@ -283,7 +284,7 @@ package Occurrences {
 		 */
 		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
 
-		inv { isClosed implies includes(self.unionsOf.elements, union(spaceBoundary, spaceInterior)) }
+		inv { isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
 
 		connector :OutsideOf 
 			from separateSpaceToo :> spaceInterior [0..1]

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -72,7 +72,7 @@ package Occurrences {
 		feature spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences;
 
 		/**
-		 * All sub space time occurrences that take up zero time and space.
+		 * All space time enclosed occurrences that take up zero time and space.
 		 */
 		feature all spaceTimeEnclosedPoints : Occurrence[1..*] subsets spaceTimeEnclosedOccurrences {
 			redefines innerSpaceDimension = 0;

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -6,7 +6,7 @@ package Occurrences {
 	private import Base::Anything;
 	private import Base::things;
 	private import Base::DataValue;
-	private import ScalarValues::Integer;
+	private import ScalarValues::Natural;
 	private import ScalarValues::Boolean;
 	private import Links::*;
 	private import Collections::Set;
@@ -83,7 +83,7 @@ package Occurrences {
 		 * The number of variables need to identify space points in this occurrence, from 0
 		 * to 3, without regard to higher dimensional spaces it might be emedded in.
 		 */
-		feature innerSpaceDimension : Integer [1];
+		feature innerSpaceDimension : Natural [1];
 		inv { innerSpaceDimension >= 0 & innerSpaceDimension <= 3 }
 
 		/**
@@ -93,7 +93,7 @@ package Occurrences {
 		 * indicates the occurrence is spatially straight (innerSpaceDimension 1 embedded in
 		 * 2 or 3 dimensions) or flat (innerSpaceDimension 2 embedded in 3 dimensions).
 		 */
-		feature outerSpaceDimension : Integer [0..1];
+		feature outerSpaceDimension : Natural [0..1];
 		inv { notEmpty(outerSpaceDimension) implies
 			 (outerSpaceDimension >= innerSpaceDimension & outerSpaceDimension <= 3) }
 

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -466,7 +466,7 @@ package Occurrences {
 	 */
 	assoc SnapshotOf specializes TimeSliceOf {
 		end feature snapshotOcccurrence: Occurrence[1..*] redefines timeSliceOccurrence subsets snapshottedOccurrence.snapshots;
-		end feature snapshottedOccurrence: Occurrence[1..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
+		end feature snapshottedOccurrence: Occurrence[0..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
 	}
 
 	/**

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -1,7 +1,6 @@
 /**
- * This package defines the concept of occurrences and the associations between them 
- * that assert relationships modeling four-dimensional semantics. 
- * [Currently this is primarily time semantics.]
+ * This package defines modeling constructs for anything existing or occurring in time and space, with
+ * associations between them that assert temporal and spatial relationships.
  */
 package Occurrences {
 	private import Base::Anything;
@@ -10,10 +9,10 @@ package Occurrences {
 	private import Links::*;
 	private import Collections::Set;
 	private import Collections::OrderedSet;
-	private import SequenceFunctions::isEmpty;
-	private import SequenceFunctions::notEmpty;
+	private import CollectionFunctions::contains;
 	private import ScalarValues::Boolean;
 	private import DataFunctions::'&';
+	private import DataFunctions::'|';	  
 	private import ScalarValues::Integer;
 	private import DataFunctions::'<=';
 	private import DataFunctions::'>=';
@@ -29,7 +28,6 @@ package Occurrences {
 	 */
 	abstract class Occurrence specializes Anything {
 		private import SequenceFunctions::*;
-		private import ControlFunctions::forAll;
 		
 		feature portionOfLife: Life[1] subsets portionOf;
 		
@@ -77,11 +75,12 @@ package Occurrences {
 		feature subSpaceTimeOccurrences: Occurrence[1..*] subsets suboccurrences, subSpaceOccurrences;
 
 		/**
-		 * All sub space time occurrences that take up no time or space.
+		 * All sub space time occurrences that take up zero time and space.
 		 */
-		feature all spaceTimePoints : Occurrence[1..*] subsets subSpaceTimeOccurrences {
-		  redefines innerSpaceDimension = 0; }
-		inv { spaceTimePoints->forAll {in stp:Occurrence; stp.startShot == stp.endShot}}
+		feature all subSpaceTimePoints : Occurrence[1..*] subsets subSpaceTimeOccurrences {
+			redefines innerSpaceDimension = 0;
+			binding startShot[1] = endShot[1];
+		}
 
 		/**
 		 * The number of variables need to identify space points in this occurrence, from 0
@@ -129,8 +128,9 @@ package Occurrences {
 		 * Time slices of an occurrence that happen at a single instant of time
 		 * (i.e., have no duration).
 		 */
-		portion feature all snapshots: Occurrence[1..*] subsets timeSlices;
-		inv { snapshots->forAll {in s:Occurrence; s.startShot == s.endShot} }
+		portion feature all snapshots: Occurrence[1..*] subsets timeSlices {
+			binding startShot[1] = endShot[1];
+		}
 		inv { snapshots == union(startShot, union(middleTimeSlice.snapshots, endShot)) }
 		
 		/**
@@ -194,8 +194,10 @@ package Occurrences {
 		feature spaceShotOf: Occurrence[1..*] subsets spaceSliceOf;
 
 		/**
-		 * Sets of Occurrences, where the Occurrences in each set taken together have the
-		 * same time and space extent as this occurrence.
+		 * Sets of occurrences, where the time and space taken by all the occurrences in each
+		 * set together is the same as taken by this occurrence (all four dimensional points in
+		 * the occurrences of each set are at the same time and space as those of this
+		 * occurrence).
 		 */
 		feature unionsOf: Set[0..*] {
 			feature redefines elements: Occurrence[0..*];
@@ -205,18 +207,20 @@ package Occurrences {
 				  from smallerOccurrence :> elements [0..*]
 				  to largerOccurrence :> union [1];
 			connector :Within 
-				  from smallerOccurrence :> union.spaceTimePoints [0..*]
+				  from smallerOccurrence :> union.subSpaceTimePoints [0..*]
 				  to largerOccurrence :> elements [1..*];
 		}
 		binding unionsOf.union[0..1] = self[1];
 
 		/**
-		 * Sets of Occurrences, where the largest time and space extent common to the
-		 * Occurrences in each set is the same as this occurrence.
+		 * Sets of occurrences, where the time and space taken in common between the occurrences
+		 * in each set is at the same as taken by this occurrence (all four dimensional points
+		 * common to the occurrences in each set are at the same time and space as those in this
+		 * occurrence).
 		 */
 		feature intersectionsOf: Set[0..*] {
 			feature redefines elements: Occurrence[0..*]
-			  { feature all notIntersection: Occurrence[0..*] subsets portions; }
+			  { feature all notIntersection: Occurrence[0..*] subsets subSpaceTimePoints; }
 			feature intersection: Occurrence[0..1];
 			
 			connector :Within
@@ -232,23 +236,27 @@ package Occurrences {
 		binding intersectionsOf.intersection[0..1] = self[1];
 
 		/**
-		 * Ordered sets of Occurrences, where the time and space extent of first Occurrence
-		 * in each set (minuend) that is not in the time and space extent of the remaining
-		 * Occurrences (subtrahend) is the same as this occurrence.
+		 * Ordered sets of occurrences, where the time and space taken by first occurrence in
+		 * each set that is not in the time and space taken by the remaining occurrences is the
+		 * same as taken by this occurrence (all four dimensional points in the minuend that are
+		 * not in any subtrahend are at the same time and space as those in this occurrence).
 		 */
 		feature differencesOf: OrderedSet[0..*] {
 			feature redefines elements: Occurrence[0..*];
 			feature difference: Occurrence[0..1];
+			feature minuend: Occurrence [0..1] subsets elements, interdiff.elements = head(elements);
+			feature subtrahend: Occurrence[*] subsets elements = tail(elements);
 			feature interdiff: Set [0..1] {
-				feature minuend: Occurrence [1] subsets elements = head(elements);
+				feature redefines elements: Occurrence[1..*];
 				feature all notSubtrahend: Occurrence [0..*] subsets elements;
 			}
-			feature subtrahend: Occurrence[*] subsets elements = tail(elements);
 			
 			connector :Without
 				  from separateOccurrenceToo :> interdiff.notSubtrahend [0..*]
-				  to separateOccurrence :> subtrahend [1];
+				  to separateOccurrence :> subtrahend [1..*];
 
+			inv { isEmpty(difference) == isEmpty(interdiff) }
+			inv { notEmpty(difference) implies (difference.intersectionsOf == interdiff) }
 		}
 		binding differencesOf.difference[0..1] = self[1];
 
@@ -278,6 +286,8 @@ package Occurrences {
 		 * An Occurrence of which this one is the space boundary.
 		 */
 		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
+
+		inv { isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
 
 		connector :OutsideOf 
 			from separateSpaceToo :> spaceInterior [0..1]
@@ -415,14 +425,16 @@ package Occurrences {
 		end feature largerSpace: Occurrence[1..*] redefines target;
 
 		subset smallerSpace.subSpaceOccurrences subsets largerSpace.subSpaceOccurrences;
+
+		inv { contains(largerSpace.suboccurrences, smallerSpace) implies (self istype Within) }
 	}
 
 	/**
 	 * Within asserts that its largerOccurrence completely overlaps its smallerOccurrence in
 	 * time and space. That is, all four dimensional points of the smallerOccurrence happen
-	 * during and are inside of the largerOccurrence). This means every occurrence is Within
+	 * during and are inside of the largerOccurrence. This means every occurrence is Within
 	 * itself and Within is transitive.
-         */
+	 */
 	assoc all Within specializes HappensDuring, InsideOf {
 		end feature smallerOccurrence: Occurrence[1..*] redefines shorterOccurrence, smallerSpace
 		  subsets largerOccurrence.subSpaceTimeOccurrences;
@@ -542,7 +554,7 @@ package Occurrences {
 
 	/**
 	 * OutsideOf asserts that two occurrences do not overlap in space (not necessarily in time,
-	 * see HappensBefore).  That is, no four dimensional points of the occurrences are in the
+	 * see HappensBefore).	That is, no four dimensional points of the occurrences are in the
 	 * spatial extent of both of them. This means no Occurrence is OutsideOf itself.
 	 */
 	assoc OutsideOf specializes Without {

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -6,16 +6,12 @@ package Occurrences {
 	private import Base::Anything;
 	private import Base::things;
 	private import Base::DataValue;
+	private import ScalarValues::Integer;
+	private import ScalarValues::Boolean;
 	private import Links::*;
+	private import SequenceFunctions::includes;
 	private import Collections::Set;
 	private import Collections::OrderedSet;
-	private import CollectionFunctions::contains;
-	private import ScalarValues::Boolean;
-	private import DataFunctions::'&';
-	private import DataFunctions::'|';	  
-	private import ScalarValues::Integer;
-	private import DataFunctions::'<=';
-	private import DataFunctions::'>=';
 	
 	/**
 	 * Occurrence is the most general classifier of entities that have identity and 
@@ -287,7 +283,7 @@ package Occurrences {
 		 */
 		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
 
-		inv { isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+		inv { isClosed implies includes(self.unionsOf.elements, union(spaceBoundary, spaceInterior)) }
 
 		connector :OutsideOf 
 			from separateSpaceToo :> spaceInterior [0..1]
@@ -426,7 +422,7 @@ package Occurrences {
 
 		subset smallerSpace.subSpaceOccurrences subsets largerSpace.subSpaceOccurrences;
 
-		inv { contains(largerSpace.suboccurrences, smallerSpace) implies (self istype Within) }
+		inv { includes(largerSpace.suboccurrences, smallerSpace) implies (self istype Within) }
 	}
 
 	/**

--- a/sysml.library/Kernel Library/Performances.kerml
+++ b/sysml.library/Kernel Library/Performances.kerml
@@ -31,7 +31,7 @@ package Performances {
 		/**
 		 * suboccurrences of this Performance that are also Performances.
 		 */
-		step subperformances: Performance[0..*] subsets performances, suboccurrences;
+		step subperformances: Performance[0..*] subsets performances, timeEnclosedOccurrences;
 		
 		/**
 		 * subperformances of this Performance that are Evaluations.

--- a/sysml.library/Kernel Library/SequenceFunctions.kerml
+++ b/sysml.library/Kernel Library/SequenceFunctions.kerml
@@ -22,7 +22,7 @@ package SequenceFunctions {
 		!isEmpty(seq)
 	}
 	function includes(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
-		seq2->forAll {in x; seq1->includes(x)}
+		seq2->forAll {in x; seq1->exists{in y; x == y}}
 	}
 	function includesOnly(seq1: Anything[0..*] nonunique, seq2: Anything[0..*] nonunique): Boolean[1] {
 		seq1->includes(seq2) && seq2->includes(seq1)

--- a/sysml.library/Systems Library/Ports.sysml
+++ b/sysml.library/Systems Library/Ports.sysml
@@ -16,7 +16,7 @@ package Ports {
 		/**
 		 * The Ports that are subports of this Port.
 		 */
-		port subports: Port :> suboccurrences;
+		port subports: Port :> timeEnclosedOccurrences;
 	}
 	
 	/**

--- a/sysml/src/examples/Interaction Sequencing Examples/ServerSequenceModel.sysml
+++ b/sysml/src/examples/Interaction Sequencing Examples/ServerSequenceModel.sysml
@@ -37,7 +37,7 @@ package ServerSequenceModel {
 		
 		part consumer {
 			event occurrence subscribe_source_event;
-			then event occurrence deliver_target_event :> suboccurrences;
+			then event occurrence deliver_target_event;
 		}
 	}
 }


### PR DESCRIPTION
(For @conradbock)

This pull request updates the `Occurrence` and `Object` Kernel Library models for spatial and topology semantics.

_Occurrences_
- Add modeling for spatial aspects of `Occurrences` and for constructive relations on Occurrences of union, intersection and difference.
- Add associations to represent spatial relationships `SpaceSliceOf`, `SpaceShotOf` and `OutsideOf`, and the spacetime relationship `WithOut`.

_Objects_
- Add specializations of `Object` for `Body`, `Surface`, `Curve` and `Point`, of inner space dimension 3, 2, 1 and 0, respectively.
- Add `StructuredSpaceObject` to represent an `Object` that is broken up into cells of the same or lower inner space dimension (faces, edges and vertices).

The pull request also fixes the following related bugs:

- ST6RI-518 The multiplicity of SnapshotOf::snapshottedOccurrence should be 0..*
- ST6RI-519 Multiplicity validation for end features is incorrect