### PR TITLE
ST6RI-510: Improved Interconnection View

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -422,6 +422,7 @@ public class SysML2PlantUMLText {
     private int idCounter;
     private IDMap idMap;
 
+    // element 1<-* id 1<-* path(feature, featureChain, featureChainExpression, ItemFlowEnd)
     private class IDMap {    	
         private final Map<Element, Integer> idMap = new HashMap<Element, Integer>();
         private final IDMap prev;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
@@ -36,7 +36,7 @@ import org.omg.sysml.lang.sysml.Type;
 public class VActionMembers extends VBehavior {
 
     private void addNode(Feature f, String type) {
-        String name = getNameAnyway(f, true);
+        String name = getNameAnyway(f);
         append(type);
         append(' ');
         addNameWithId(f, name, true);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
@@ -139,7 +139,7 @@ public abstract class VBehavior extends VDefault {
         	}
         }
         if (text.length() == 0) {
-            String name = getNameAnyway(au, true);
+            String name = getNameAnyway(au);
             text.append(name);
         }
         addPUMLLine(au, send ? "send " : "accept ", text.toString());

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Succession;
@@ -60,12 +61,12 @@ public class VCase extends VTree {
     }
 
     @Override
-    protected VTree newVTree(Membership membership) {
-        return new VCase(this, membership);
+    protected VTree newVTree(Namespace namespace, Membership membership) {
+        return new VCase(this, namespace, membership);
     }
 
     private String addCase(Type typ) {
-        String name = getNameAnyway(typ, true);
+        String name = getNameAnyway(typ);
         addRecLine(name, typ, true);
         addSpecializations(typ);
 
@@ -104,8 +105,8 @@ public class VCase extends VTree {
         return addCase(ucd);
     }
 
-    VCase(Visitor vt, Membership membership) {
-        super(vt, membership);
+    VCase(Visitor vt, Namespace namespace, Membership membership) {
+        super(vt, namespace, membership);
     }
 
     VCase(VCaseMembers vt) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
@@ -61,7 +61,7 @@ public class VCaseMembers extends VBehavior {
     }
 
     private void recMembership(Membership ms, boolean inside) {
-        rec(new VCase(this, ms), ms, inside);
+        rec(new VCase(this, getCurrentNamespace(), ms), ms, inside);
     }
 
     private void recElement(Element e, boolean inside) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -50,6 +50,7 @@ import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.FlowConnectionUsage;
 import org.omg.sysml.lang.sysml.ItemFlow;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.OccurrenceUsage;
 import org.omg.sysml.lang.sysml.PartUsage;
@@ -81,11 +82,15 @@ public class VCompartment extends VStructure {
         return compartmentMost;
     }
 
-    protected boolean rec(Membership m, Element e, boolean force) {
-        VTree subtree = parent.subtree(m, e, force);
+    protected boolean rec(Namespace n, Membership m, Element e, boolean force) {
+        VTree subtree = parent.subtree(n, m, e, force);
         if (subtree == null) return false;
         subtrees.add(subtree);
         return true;
+    }
+
+    protected boolean rec(Membership m, Element e, boolean force) {
+        return rec(getCurrentNamespace(), m, e, force);
     }
 
     private boolean recCurrentMembership(Element e, boolean force) {
@@ -314,7 +319,7 @@ public class VCompartment extends VStructure {
                     CompTree ct = new CompTree(fe);
                     ct.process(f2);
                 } else {
-                    rec(m, e, true);
+                    rec(f, m, e, true);
                 }
             }
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -139,7 +139,7 @@ public class VDefault extends VTraverser {
     }
 
     protected boolean addRecLine(Type typ, boolean withStyle) {
-    	String name = getNameAnyway(typ, true);
+    	String name = getNameAnyway(typ);
         return addRecLine(name, typ, withStyle);
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -109,17 +109,18 @@ public class VDefault extends VTraverser {
         }
     }
 
-    protected void addPUMLLine(Type typ, String keyword, String name, String style) {
+    protected int addPUMLLine(Type typ, String keyword, String name, String style) {
         append(keyword);
-        addNameWithId(typ, name, true);
+        int id = addNameWithId(typ, name, true);
         if (style != null) {
             append(style);
         }
         addLink(typ);
+        return id;
     }
 
-    protected void addPUMLLine(Type typ, String keyword, String name) {
-        addPUMLLine(typ, keyword, name, styleString(typ));
+    protected int addPUMLLine(Type typ, String keyword, String name) {
+        return addPUMLLine(typ, keyword, name, styleString(typ));
     }
 
     protected boolean addRecLine(String name, Type typ, boolean withStyle) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
@@ -30,6 +30,7 @@ import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.StateDefinition;
 import org.omg.sysml.lang.sysml.StateUsage;
 import org.omg.sysml.lang.sysml.Type;
@@ -50,8 +51,8 @@ public class VMixed extends VTree {
     }
 
     @Override
-    protected VTree newVTree(Membership membership) {
-        return new VMixed(this, membership);
+    protected VTree newVTree(Namespace namespace, Membership membership) {
+        return new VMixed(this, namespace, membership);
     }
 
     private String process(Visitor v, Element e) {
@@ -115,8 +116,8 @@ public class VMixed extends VTree {
     }
 
 
-    private VMixed(VTree vt, Membership membership) {
-        super(vt, membership);
+    private VMixed(VTree vt, Namespace namespace, Membership membership) {
+        super(vt, namespace, membership);
     }
 
     public VMixed(Visitor vt) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -93,7 +93,7 @@ public class VPath extends VTraverser {
             if (!isMatching()) return;
             if (unmatched != 0) return;
             if (match(e)) {
-                pathIdMap.put(idTarget, id);
+                putPathIdMap(id, idTarget);
                 isSet = true;
             }
         }
@@ -386,6 +386,20 @@ public class VPath extends VTraverser {
     }
 
     private final Map<Element, Integer> pathIdMap = new HashMap<Element, Integer>();
+    private final Map<Integer, Set<Element>> pathIdRevMap = new HashMap<Integer, Set<Element>>();
+
+    private void putPathIdMap(Integer id, Element e) {
+        pathIdMap.put(e, id);
+        Set<Element> es = pathIdRevMap.get(id);
+        if (es == null) {
+            es = new HashSet<Element>(1);
+            es.add(e);
+            pathIdRevMap.put(id, es);
+        } else {
+            es.add(e);
+        }
+    }
+
     private List<RefPC> current = new ArrayList<RefPC>();
 
     private static Type typeOfInheriting(Type owningType, Feature f) {
@@ -496,6 +510,10 @@ public class VPath extends VTraverser {
 
     public Integer getId(Element e) {
         return pathIdMap.get(e);
+    }
+
+    public Set<Element> getPaths(Integer id) {
+    	return pathIdRevMap.get(id);
     }
 
     VPath() {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
@@ -184,7 +184,7 @@ public class VSequence extends VDefault {
 
     private void addParticipant(Type participant) {
         if (checkId(participant)) return;
-        addPUMLLine(participant, "participant ", getNameAnyway(participant, true));
+        addPUMLLine(participant, "participant ", getNameAnyway(participant));
         append('\n');
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
@@ -31,7 +31,7 @@ import org.omg.sysml.lang.sysml.Type;
 
 public class VStateMachine extends VDefault {
     private void addState(Type typ, boolean isParallel, boolean withStyle) {
-        String name = getNameAnyway(typ, true);
+        String name = getNameAnyway(typ);
         if (isParallel) {
             name = name + "\\n" + "<b>parallel</b>";
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
@@ -118,7 +118,7 @@ public class VStateMembers extends VBehavior {
     public String startStateUsage(Type typ) {
         traverse(typ);
         if (descriptions != null) {
-            String name = getNameAnyway(typ, true);
+            String name = getNameAnyway(typ);
             int size = descriptions.size();
             for (int i = 0; i < size; i++) {
                 append("desc ");

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -168,7 +168,7 @@ public abstract class VStructure extends VDefault {
     }
 
     protected String extractTitleName(Element e) {
-        String name = getNameAnyway(e, true);
+        String name = getNameAnyway(e);
         if (!(e instanceof Feature)) return name;
 
         Feature f = (Feature) e;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -62,7 +62,7 @@ public abstract class VStructure extends VDefault {
         }
     }
 
-    private static Pattern patEq = Pattern.compile("^\\s*=");
+    private static Pattern patEq = Pattern.compile("^\\s*:?=");
     private boolean addFeatureMembershipText(Feature f) {
         boolean flag = false;
         for (Membership m: f.getOwnedMembership()) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -42,6 +42,10 @@ import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
 public abstract class VTraverser extends Visitor {
     private Set<Namespace> visited;
 
+    private Namespace currentNamespace;
+    protected Namespace getCurrentNamespace() {
+        return currentNamespace;
+    }
     private Membership currentMembership;
     protected Membership getCurrentMembership() {
         return currentMembership;
@@ -127,6 +131,7 @@ public abstract class VTraverser extends Visitor {
     public String traverse(Namespace ns) {
         VPath vpath = getVPath();
         vpath.enter(ns);
+        this.currentNamespace = ns;
         if (showInherited() && (ns instanceof Type)) {
             traverseWithInherited((Type) ns);
         } else {
@@ -138,6 +143,7 @@ public abstract class VTraverser extends Visitor {
             }
             setInherited(false);
         }
+        this.currentNamespace = null;
         vpath.leave(ns);
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -33,6 +33,7 @@ import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;
+import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.ReferenceUsage;
 import org.omg.sysml.lang.sysml.RequirementConstraintMembership;
@@ -51,12 +52,19 @@ public class VTree extends VStructure {
         return style;
     }
 
+    private Namespace namespace;
     private Membership membership;
+
+    private Namespace getNamespace() {
+        if (namespace != null) return namespace;
+        if (membership != null) return membership.getMembershipOwningNamespace();
+        return null;
+    }
 
     protected void addRel(Element typ, Element rel, String text) {
         hasItems = true;
-        if (membership == null) return;
-        Element tgt = membership.getMembershipOwningNamespace();
+        Element tgt = getNamespace();
+        if (tgt == null) return;
         addPRelation(tgt, typ, rel, text);
     }
     
@@ -171,8 +179,8 @@ public class VTree extends VStructure {
     }
 
     /* VCompartment uses */
-    VTree subtree(Membership membership, Element e, boolean force) {
-        VTree vt = newVTree(membership);
+    VTree subtree(Namespace namespace, Membership membership, Element e, boolean force) {
+        VTree vt = newVTree(namespace, membership);
         vt.pushIdMap();
         vt.visit(e);
         if (!(force || vt.hasItems)) {
@@ -240,12 +248,13 @@ public class VTree extends VStructure {
         return "";
     }
 
-    protected VTree newVTree(Membership membership) {
-        return new VTree(this, membership);
+    protected VTree newVTree(Namespace namespace, Membership membership) {
+        return new VTree(this, namespace, membership);
     }
 
-    protected VTree(Visitor vt, Membership membership) {
+    protected VTree(Visitor vt, Namespace namespace, Membership membership) {
         super(vt);
+        this.namespace = namespace;
         this.membership = membership;
     }
     
@@ -255,6 +264,7 @@ public class VTree extends VStructure {
 
     public VTree() {
         super();
+        this.namespace = null;
         this.membership = null;
     }
 }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -352,7 +352,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
 
     private Element fullyQualifiedElement;
 
-    protected String getNameAnyway(Element e, boolean creole) {
+    protected String getNameAnyway(Element e, boolean creole, boolean isInherited) {
         String ret = null;
         if (e.equals(fullyQualifiedElement)) {
             ret = e.getQualifiedName();
@@ -373,7 +373,15 @@ public abstract class Visitor extends SysMLSwitch<String> {
                 ret = "<i>" + ret + "</i>";
             }
         }
-        return ret;
+        if (isInherited) {
+            return '^' + ret;
+        } else {
+            return ret;
+        }
+    }
+
+    protected String getNameAnyway(Element e) {
+        return getNameAnyway(e, true, isInherited());
     }
 
     protected static String getFeatureChainName(Feature f) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -65,6 +65,14 @@ public abstract class Visitor extends SysMLSwitch<String> {
 
     private StringBuilder sb;
 
+    protected int getCurrentLength() {
+        return sb.length();
+    }
+
+    protected void insert(int point, String str) {
+        sb.insert(point, str);
+    }
+
     protected void append(String str) {
         sb.append(str);
     }
@@ -214,11 +222,12 @@ public abstract class Visitor extends SysMLSwitch<String> {
         append('"');
     }
 
-    protected void addNameWithId(Element e, String name, boolean force) {
+    protected int addNameWithId(Element e, String name, boolean force) {
         quote(name);
         append(" as ");
-        addIdStr(e, force);
+        int id = addIdStr(e, force);
         append(' ');
+        return id;
     }
 
     private void close() {
@@ -257,21 +266,25 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return 'E' + ii.toString();
     }
 
-    private void appendId(StringBuilder ss, Element e, boolean force) {
+    private int appendId(StringBuilder ss, Element e, boolean force) {
         if (e == null) {
             ss.append("[*]");
+            return 0;
         } else {
             ss.append('E');
+            int id;
             if (force) {
-                ss.append(newId(e));
+                id = newId(e);
             } else {
-                ss.append(getId(e));
+                id = getId(e);
             }
+            ss.append(id);
+            return id;
         }
     }
 
-    protected void addIdStr(Element e, boolean force) {
-        appendId(sb, e, force);
+    protected int addIdStr(Element e, boolean force) {
+        return appendId(sb, e, force);
     }
 
     private final List<PRelation> pRelations;


### PR DESCRIPTION
By this PR, interconnection view makes use of the directions of connections and flow connections to give better rendering results.  For example:

```
package TestConnection0 {
    part a1 {
        port p1;
    }
    part a2 {
        port p2;
    }
    flow from a1.p1 to a2.p2;
}
```
gives
![Screen Shot 2022-03-29 at 2 22 31 PM](https://user-images.githubusercontent.com/10537/160679320-6bd77628-2db5-4d6c-8d23-5858a609ce9f.png)

This PR also renders specializations in interconnection views.
