### PR TITLE
ST6RI-531: Non-ASCII characters may not be parsed properly in Jupyter

### DIFF
--- a/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/ISysML.java
+++ b/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/ISysML.java
@@ -35,10 +35,17 @@ public class ISysML {
 
     private static volatile SysMLKernel kernel;
 
+    public static void initialize() {
+        System.setProperty("file.encoding", "UTF-8");
+        kernel = new SysMLKernel();
+    }
+
     public static void main(String[] args) throws Exception {
         if (args.length < 1) {
             throw new IllegalArgumentException("Missing connection file argument");
         }
+
+        initialize();
 
         Path connectionFile = Paths.get(args[0]);
 
@@ -52,8 +59,6 @@ public class ISysML {
         KernelConnectionProperties connProps = KernelConnectionProperties.parse(contents);
         JupyterConnection connection = new JupyterConnection(connProps);
 
-
-        kernel = new SysMLKernel();
         kernel.becomeHandlerForConnection(connection);
 
         connection.connect();

--- a/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/ISysML.java
+++ b/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/ISysML.java
@@ -36,7 +36,6 @@ public class ISysML {
     private static volatile SysMLKernel kernel;
 
     public static void initialize() {
-        System.setProperty("file.encoding", "UTF-8");
         kernel = new SysMLKernel();
     }
 

--- a/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/SysMLKernel.java
+++ b/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/SysMLKernel.java
@@ -45,6 +45,10 @@ public class SysMLKernel extends BaseKernel {
     private final Magics magics;
     private final MyMagicParser magicParser;
 
+    public Magics getMagics() {
+        return magics;
+    }
+
     public SysMLKernel() {
         this.interactive = SysMLInteractive.getInstance();
         Optional<String> libraryPath = Optional.ofNullable(System.getenv(ISysML.LIBRARY_PATH_KEY));

--- a/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2019, 2020 Model Driven Solutions, Inc.
+ * Copyright (c) 2019-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -38,6 +38,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.resource.IResourceDescription.Manager;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 
@@ -68,6 +69,7 @@ public abstract class SysMLUtil {
 	protected SysMLUtil(ResourceDescriptionsData resourceDescriptionData) {
 		SysMLPackage.eINSTANCE.getName();
 		this.resourceSet = new ResourceSetImpl();
+		this.resourceSet.getLoadOptions().put(XtextResource.OPTION_ENCODING, "UTF-8");
 		this.index = resourceDescriptionData;
 		ResourceDescriptionsData.ResourceSetAdapter.installResourceDescriptionsData(this.resourceSet, this.index);
 	}
@@ -214,7 +216,7 @@ public abstract class SysMLUtil {
 	}
 	
 	/**
-	 * If the given path identifies an file with an allowable extension, then read it. 
+	 * If the given path identifies a file with an allowable extension, then read it. 
 	 * If the given path is for a directory, then recursively read all the allowable files in it, 
 	 * directly or indirectly.
 	 * 


### PR DESCRIPTION
This PR intends to fix the bug that the SysML kernel may wrongly load model library files in UTF-8 encoding.

We have two approaches to fix this bug: one is that explicitly specifying UTF-8 encoding to load SysML files by using something like `XtextResource.setEncoding`; the other is that system's default file encodings with System property.

However, the first approach  would require to modify more codes related to Xtext so that the fix and test should be more complicated.  So I decided to take the second approach in this PR because we confirmed this problem did not occur under the environment where the default encoding is UTF-8.

In this fix, I propose to extract SysML kernel initialization part to the separate method `initialize()` because the most part of `main()` comes from IJava implementation (see https://github.com/SpencerPark/IJava/blob/master/src/main/java/io/github/spencerpark/ijava/IJava.java for details).  I also made it public to allow other modules to do `initialize()` part with different Jupyter connections.

I also made the getter method as `SysMLKernel.getMagics()` for the similar purpose to test and extend the kernel while it is optional in this PR.  

