### PR TITLE
ST6RI-532 Minor fixes to space modeling & shape library

### DIFF
--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -14,10 +14,10 @@ package ShapeItems {
 	private import ControlFunctions::'?';
 
 	/**
-	 * A PlanarCurve is a flat Surface with a given area.
+	 * A PlanarCurve is a Curve with a given length embeddable in a plane.
 	 */
 	item def PlanarCurve :> Curve {
-		attribute :>> area [1] ;
+		attribute :>> length [1] ;
 
 		constraint { notEmpty(outerSpaceDimension) &  outerSpaceDimension <= 2 }
 	}

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -9,21 +9,35 @@ package ShapeItems {
 	private import Objects::*;
 	private import Items::Item;
 	private import SequenceFunctions::isEmpty;
-	
+	private import SequenceFunctions::notEmpty;
+	private import SequenceFunctions::size;	
+	private import ControlFunctions::'?';
+
 	/**
-	 * A Line is a Curve that is a straight line of a given length.
+	 * A PlanarCurve is a flat Surface with a given area.
 	 */
-	item def Line :> Curve {
-		attribute :>> length;
-		attribute :>> outerSpaceDimension = 1;
+	item def PlanarCurve :> Curve {
+		attribute :>> area [1] ;
+
+		constraint { notEmpty(outerSpaceDimension) &  outerSpaceDimension <= 2 }
 	}
 
 	/**
 	 * A PlanarSurface is a flat Surface with a given area.
 	 */
 	item def PlanarSurface :> Surface {
-		attribute :>> area;
+		attribute :>> area [1];
 		attribute :>> outerSpaceDimension = 2;
+
+		item :>> shape : PlanarCurve;
+	}
+
+	/**
+	 * A Line is a Curve that is a straight line of a given length.
+	 */
+	item def Line :> PlanarCurve {
+		attribute :>> length [1];
+		attribute :>> outerSpaceDimension = 1;
 	}
 
 	/**
@@ -39,12 +53,12 @@ package ShapeItems {
 	/**
 	 * A Circle is a Path in the shape of a circle of a given radius.
 	 */
-	item def Circle :> Path {
-		attribute radius :>> radius;
+	item def Circle :> Path, PlanarCurve {
+		attribute :>> radius;
 
 		item :>> faces [0];
 		item :>> edges [1] {
-			attribute circumference :>> length = Circle::radius * TrigFunctions::pi;
+			attribute circumference :>> length = Circle::radius * TrigFunctions::pi * 2;
 			item :>> shape : Item [0];
 			item :>> vertices [0];
 		}
@@ -54,15 +68,15 @@ package ShapeItems {
 	/**
 	 * A Disc is a Shell bounded by a Circle.
 	 */
-	item def Disc :> Shell {
-		attribute radius :>> radius;
+	item def Disc :> Shell, PlanarSurface {
+		attribute :>> radius;
 
 		item :>> shape : Circle [1] {
 			attribute :>> radius = Disc::radius;
 		}
 
 		item :>> faces : PlanarSurface [1] {
-			item :>> edges [1]; 
+			item :>> edges [1];
 		}
 		item :>> edges : Circle [1] = shape;
 		item :>> vertices [0];
@@ -76,9 +90,11 @@ package ShapeItems {
 	item def Sphere :> Shell {
 		attribute :>> radius;
 
-		item faces : Surface [1] :>> faces;
+		item :>> faces [1];
 		item :>> edges [0];
 		item :>> vertices [0];
+
+		attribute :>> genus = 0;
 	}
 
 	/**
@@ -86,28 +102,30 @@ package ShapeItems {
 	 * baseRadius, apexRadius and height.
 	 */
 	item def Cone :> Shell {
-		attribute baseRadius :> radius;
-		attribute apexRadius :> radius default 0 [m];
-		attribute :>> height;
+		attribute baseRadius [1] = radius;
+		attribute apexRadius [1] default 0 [m];
+		attribute :>> height [1];
+
+		attribute :>> radius [1];
 		attribute isTruncated : Boolean [1] = (apexRadius > 0);
 
-		item faces : Surface [2..3] :>> faces;
+		item :>> faces [2..3];
 		item bf : Disc [1] :> faces;
 		item af : Disc [0..1] :> faces;
 		item cf : Surface [1] :> faces;
 		constraint { (apexRadius == 0) == isEmpty(af) }
 
-		item edges : Circle [1..2] :>> edges;
-		item be [1] :> edges { 
+		item :>> edges : Circle [2..4];
+		item be [2] :> edges { 
 			attribute :>> radius = baseRadius;
 		}
-		item ae [0..1] :> edges { 
+		item ae [0..2] :> edges { 
 			attribute :>> radius = apexRadius;
 		}
-		constraint { isEmpty(af) == isEmpty(ae) }
+		constraint { isEmpty(af) ? isEmpty(ae) : size(ae) == 2 }
 
-		item vertices : Point [0..1] :>> vertices;
-		constraint { isEmpty(ae) == isEmpty(vertices) }
+		item :>> vertices [0..1];
+		constraint { isEmpty(ae) == notEmpty(vertices) }
 
 		/* Faces to edges */
 		connection :WithinBoth connect bf.edges [1] to be [0..*];
@@ -122,6 +140,7 @@ package ShapeItems {
 		connection :WithinBoth connect be [2] to be [2];
 		connection :WithinBoth connect ae [2] to ae [2];
 
+		attribute :>> genus = 0;
 	}
 
 	/**
@@ -129,9 +148,7 @@ package ShapeItems {
 	 * a right circular cylinder.
 	 */
 	item def Cylinder :> Cone {
-		attribute :>> radius = baseRadius;
-
-		attribute :>> baseRadius = apexRadius;
+		attribute :>> apexRadius = baseRadius;
 	}
 
 	/**
@@ -139,21 +156,21 @@ package ShapeItems {
 	 * given length, width and height.
 	 */
 	item def Cuboid :> Shell {
-		attribute :>> length;
-		attribute :>> width;
-		attribute :>> height;
+		attribute :>> length [1];
+		attribute :>> width [1];
+		attribute :>> height [1];
 
 		item faces : PlanarSurface [6] :>> faces {
 			item :>> edges [4]; 
 		}
-		item tf :> faces [1];
-		item bf :> faces [1];
-		item ff :> faces [1];
-		item rf :> faces [1];
-		item slf :> faces [1];
-		item srf :> faces [1];
+		item tf [1] :> faces;
+		item bf [1] :> faces;
+		item ff [1] :> faces;
+		item rf [1] :> faces;
+		item slf [1] :> faces;
+		item srf [1] :> faces;
 
-		item edges : Line [12] :>> edges {
+		item :>> edges : Line [24] {
 			item :>> vertices [2]; 
 		}
 		item tfe [2]  :> edges { attribute :>> length = Cuboid::length; }
@@ -169,7 +186,7 @@ package ShapeItems {
 		item urle [2] :> edges { attribute :>> length = Cuboid::height; }
 		item urre [2] :> edges { attribute :>> length = Cuboid::height; }
 
-		item vertices : Point [8] :>> vertices;
+		item :>> vertices [24];
 		item tflv [3] :> vertices;
 		item tfrv [3] :> vertices;
 		item trlv [3] :> vertices;
@@ -261,6 +278,8 @@ package ShapeItems {
 		connection :WithinBoth connect bfrv [3] to bfrv [3];
 		connection :WithinBoth connect brlv [3] to brlv [3];
 		connection :WithinBoth connect brrv [3] to brrv [3];
+
+		attribute :>> genus = 0;
 	}
 	alias Box for Cuboid;
 }

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -16,7 +16,8 @@ package Objects {
 	private import SequenceFunctions::notEmpty;
 	private import SequenceFunctions::union;
 	private import CollectionFunctions::contains;
-	private import ScalarValues::Integer;	     
+	private import ScalarValues::Integer;
+	private import ScalarValues::Natural;
 	
 	/**
 	 * Object is the most general class of structural occurrences that may change over time.
@@ -81,9 +82,9 @@ package Objects {
 	struct all Surface specializes Object {
 		feature redefines innerSpaceDimension = 2;
 		  /* The number of  "holes" in this Surface, assuming it isClosed. */
-		feature genus : Integer[0..1] default 0;
+		feature genus : Natural[0..1] default 0;
 
-		inv { notEmpty(genus) implies (isClosed & genus >= 0) }
+		inv { notEmpty(genus) implies isClosed }
 	}
 
 	/*

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -37,7 +37,7 @@ package Occurrences {
 		feature predecessors: Occurrence[0..*] subsets occurrences;
 		
 		/**
-		 * Occurrences that start after this occcurrence ends.
+		 * Occurrences that start after this occurrence ends.
 		 */
 		feature successors: Occurrence[0..*] subsets occurrences;
 		
@@ -84,7 +84,8 @@ package Occurrences {
 		 * to 3, without regard to higher dimensional spaces it might be emedded in.
 		 */
 		feature innerSpaceDimension : Natural [1];
-		inv { innerSpaceDimension >= 0 & innerSpaceDimension <= 3 }
+
+		inv { innerSpaceDimension <= 3 }
 
 		/**
 		 * For occurrences of innerSpaceDimension 1 or 2, the number of variables need to
@@ -188,7 +189,7 @@ package Occurrences {
 		/**
 		 * Occurrences of which this occurrence is a space shot.
 		 */
-		feature spaceShotOf: Occurrence[1..*] subsets spaceSliceOf;
+		feature spaceShotOf: Occurrence[0..*] subsets spaceSliceOf;
 
 		/**
 		 * Sets of occurrences, where the time and space taken by all the occurrences in each
@@ -270,12 +271,12 @@ package Occurrences {
 		 * An Occurrence of which this one is the space interior.
 		 */
 		feature spaceInteriorOf: Occurrence[0..1] subsets spaceSliceOf;
+
 		inv { notEmpty(spaceInterior) implies spaceInterior.innerSpaceDimension == innerSpaceDimension }
-		inv { innerSpaceDimension == 0 implies isEmpty(spaceInterior) }
 
 		/**
-		 * A space shot of this Occurrence that is not among those of its space interior, of
-		 * which it must be outside. It must have no spaceBoundary.
+		 * A space shot of this Occurrence that is not among those of its space interior, 
+		 * which must be outside it. It must not have a spaceBoundary.
 		 */
 		portion feature spaceBoundary: Occurrence[0..1] subsets spaceShots { 
 			feature redefines isClosed = true;
@@ -286,7 +287,8 @@ package Occurrences {
 		 */
 		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
 
-		inv { isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+		inv { !isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+		inv { innerSpaceDimension == 0 implies isEmpty(spaceBoundary) }
 
 		connector :OutsideOf 
 			from separateSpaceToo :> spaceInterior [0..1]
@@ -476,8 +478,8 @@ package Occurrences {
 	 * SnapshotsOf asserts one occurrence is a snapshot of another.
 	 */
 	assoc SnapshotOf specializes TimeSliceOf {
-		end feature snapshotOcccurrence: Occurrence[1..*] redefines timeSliceOccurrence subsets snapshottedOccurrence.snapshots;
-		end feature snapshottedOccurrence: Occurrence[0..*] redefines timeSlicedOccurrence subsets snapshotOcccurrence.snapshotOf;
+		end feature snapshotOccurrence: Occurrence[1..*] redefines timeSliceOccurrence subsets snapshottedOccurrence.snapshots;
+		end feature snapshottedOccurrence: Occurrence[0..*] redefines timeSlicedOccurrence subsets snapshotOccurrence.snapshotOf;
 	}
 
 	/**
@@ -498,8 +500,10 @@ package Occurrences {
 	 * it spaceShottedOccurrence.
 	 */
 	assoc SpaceShotOf specializes SpaceSliceOf {
-		end feature spaceShotOcccurrence: Occurrence[1..*] redefines spaceSliceOccurrence subsets spaceShottedOccurrence.spaceShots;
-		end feature spaceShottedOccurrence: Occurrence[1..*] redefines spaceSlicedOccurrence subsets spaceShotOcccurrence.spaceShotOf;
+		end feature spaceShotOccurrence: Occurrence[1..*] redefines spaceSliceOccurrence subsets spaceShottedOccurrence.spaceShots;
+		end feature spaceShottedOccurrence: Occurrence[1..*] redefines spaceSlicedOccurrence subsets spaceShotOccurrence.spaceShotOf;
+
+		inv { spaceShotOccurrence.innerSpaceDimension < spaceShottedOccurrence.innerSpaceDimension }
 	}
 
 	/**

--- a/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
+++ b/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
@@ -6,30 +6,34 @@ package CarWithShapeAndCSG {
 
 	item def Car :> CompoundSpatialItem {
 		item :>> shape : Cuboid [1] {
-			/* Quantify faces, etc, by redefining nested features. */
+			/* Quantify height, etc, by redefining nested features. */
 		}
 		part powerSource : Engine [1] :> componentItems;
 	}
 
 	part def Engine :> SpatialItem {
-  		item :>> shape [1];
-  		
+		item :>> shape [1];
+		
 		/* Specify relative positions of c1 and c2 here.  */
 		private attribute c1Position : VectorQuantityValue;
 		private attribute c2Position : VectorQuantityValue;
 		
- 		private item c1 : Cylinder, SpatialItem [1] {
- 			/* Quantify faces, etc, by redefining nested features. */
- 			attribute :>> coordinateFrame {
- 				attribute origin = c1Position;
- 			}
- 		}
- 		
-		private item c2 : Cylinder, SpatialItem [1] {
-			/* Quantify faces, etc, by redefining nested features. */
- 			attribute :>> coordinateFrame {
- 				attribute origin = c2Position;
- 			}
+		private item c1 : SpatialItem [1] {
+			item :>> shape : Cylinder [1] {
+				 /* Quantify radius, etc, by redefining nested features. */
+			}
+			attribute :>> coordinateFrame {
+				attribute origin = c1Position;
+			}
+		}
+		
+		private item c2 : SpatialItem [1] {
+			item :>> shape : Cylinder [1] {
+				 /* Quantify radius, etc, by redefining nested features. */
+			}
+			attribute :>> coordinateFrame {
+				attribute origin = c2Position;
+			}
 		}
 		
 		/* CSG intersection of c1 and c2. */


### PR DESCRIPTION
**Occurrences.kerml**

- `spaceShotOf` multiplicity: [1..] to [0..*].  Some occurrences aren't snapshots.

- invariants:
-- `innerSpaceDimension`: removed redundancy with feature type.
-- `spaceBoundaryOf`: isClosed to !isClosed
-- `spaceBoundary`: moved to after spaceBoundaryOf.
-- `SpaceShotOf`: Added that innerSpaceDimenion must be strictly lower (compare to SpaceSliceOf), not sure how it got left out.

- `spaceBoundary` description: reworded to avoid "of which".

- Typo in multiple places ("occcurrence" -> "occurrence").

**Objects.kerml**

`genus`: changed type Integer to Natural, simplified invariant.

**ShapeItems.sysml**

- Added `PlanarCurve`, to match PlanarSurface and used it below.

- Added multiplicities to quantification attributes (length, etc).

- `PlanarSurface::shape` typed by PlanarCurve.

- `Line` and `Circle` specialize PlanarCurve (moved Line after PlanarCurve/Surface).

- `Disc` specializes PlanarSurface.

- `Circle::edges::circumference`: Added "* 2".

- `Cone`: Restored radius (was being redefined), bound baseRadius to it.

- Corrected some cell multiplicities in Cone and Cuboid (along with invariant on Cone:ae).

- Added `genus = 0` to Sphere, Cone, and Cuboid.

- Removed redundant feature names when redefining as the same name.

- Moved multiplicities to just after subsetting feature names.

**CarWithShapeAndCSG.sysml**

Changed `Engine::c1` and `c2` to be cylindrically shaped, rather than specialize Cylinder, so they are bodies for intersection to each engine occurrence. The shape (space boundary) of engines is calculated by CAD tools.