### PR TITLE
ST6RI-527 Shape library additions

### DIFF
--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -7,11 +7,16 @@ package ShapeItems {
 	private import SI::m;
 	private import Occurrences::WithinBoth;
 	private import Objects::*;
+	private import Links::SelfLink;	
 	private import Items::Item;
 	private import SequenceFunctions::isEmpty;
 	private import SequenceFunctions::notEmpty;
-	private import SequenceFunctions::size;	
+	private import SequenceFunctions::size;
+	private import SequenceFunctions::includes;
 	private import ControlFunctions::'?';
+	private import ControlFunctions::forAll;
+	private import ControlFunctions::exists;
+	private import Quantities::scalarQuantities;
 
 	/**
 	 * A PlanarCurve is a Curve with a given length embeddable in a plane.
@@ -41,56 +46,196 @@ package ShapeItems {
 	}
 
 	/**
-	 * Shell is the most general Surface shape.
+	 * Path is the most general structured Curve.
 	 */
-	abstract item def Shell :> Item, StructuredSpaceObject, Surface;
-
-	/**
-	 * Path is the most general Curve shape.
-	 */
-	abstract item def Path :> Item, StructuredSpaceObject, Curve;
-
-	/**
-	 * A Circle is a Path in the shape of a circle of a given radius.
-	 */
-	item def Circle :> Path, PlanarCurve {
-		attribute :>> radius;
-
+	abstract item def Path :> StructuredSpaceObject, Curve {
 		item :>> faces [0];
-		item :>> edges [1] {
-			attribute circumference :>> length = Circle::radius * TrigFunctions::pi * 2;
-			item :>> shape : Item [0];
-			item :>> vertices [0];
+		item :>> edges [1..*] {
+			item :>> vertices [0..2];
 		}
+		item :>> vertices = edges.vertices;
+
+		assert constraint { isClosed == vertices->forAll{in p1 : Point;
+					vertices->exists{p2 : Point; p1 != p2 and
+							 includes(p1.spaceTimeCoincidentOccurrences, p2) } } }
+	}
+
+	attribute semiMajorAxis : LengthValue [0..*] :> scalarQuantities;
+	attribute semiMinorAxis : LengthValue [0..*] :> scalarQuantities;
+	attribute xoffset : LengthValue [0..*] :> scalarQuantities default 0 [m];
+	attribute yoffset : LengthValue [0..*] :> scalarQuantities default 0 [m];
+	attribute baseLength : LengthValue [0..*] :> scalarQuantities;
+	attribute baseWidth : LengthValue [0..*] :> scalarQuantities;
+
+	/**
+	 * An ConicSection is a closed PlanarCurve, possibly disconnected, see Hyperbola.
+	 */
+	item def ConicSection :> Path, PlanarCurve {
+
+		item :>> edges [1..2];
+
 		item :>> vertices [0];
 	}
 
 	/**
-	 * A Disc is a Shell bounded by a Circle.
+	 * An Ellipse is a ConicSection in the shape of an ellipse of a given semiaxes.
+	 */
+	item def Ellipse :> ConicSection {
+		attribute :>> semiMajorAxis [1];
+		attribute :>> semiMinorAxis [1];
+
+		item :>> edges [1];
+	}
+
+	/**
+	 * A Circle is an Ellipse with equal radii.
+	 */
+	item def Circle :> Ellipse {
+		attribute :>> radius [1] = semiMajorAxis;
+
+		assert constraint { semiMajorAxis == semiMinorAxis }
+
+		item :>> edges {
+			attribute length [1] = Circle::radius * TrigFunctions::pi * 2;
+		}
+	}
+
+	/**
+	 * A Parabola is a planar Path in the shape of a parabola of a given focal length.
+	 */
+	item def Parabola :> ConicSection {
+		attribute focalDistance : LengthValue [1] :> scalarQuantities;
+
+		item :>> edges [1];
+	}
+
+	/**
+	 * A Hyperbola is a planar Path in the shape of a hyperbola with given axes.
+	 */
+	item def Hyperbola :> ConicSection {
+		attribute tranverseAxis : LengthValue [1] :> scalarQuantities;
+		attribute conjugateAxis : LengthValue [1] :> scalarQuantities;
+	}
+
+	/**
+	 * A Polygon is a closed planar Path with straight edges.
+	 */
+	item def Polygon :> Path, PlanarCurve {
+
+		item :>> edges : Line { item :>> vertices [2]; }
+
+		attribute :>> isClosed = true;
+
+		assert constraint { (1..size(edges))->forAll {in i;
+					(edges[i] as StructuredSpaceObject).vertices == (vertices[(2*i)-1], vertices[2*i]) and  
+					includes(((edges[i] as StructuredSpaceObject).vertices[2] as Item).spaceTimeCoincidentOccurrences,
+						 (edges[i==size(edges) ? 1 : i+1]as StructuredSpaceObject).vertices[1]) } }
+	}
+
+	/**
+	 * A Triangle is three-sided Polygon  with given length (base), width (perpindicular distance
+	 * from base to apex), and offset of this perpindicular at the base from the center of the base.
+	 */
+	 item def Triangle :> Polygon {
+
+		attribute :>> length [1];
+		attribute :>> width [1];
+		attribute :>> xoffset [1];
+
+		item :>> edges [3] = (base, e2, e3);
+		item base [1] { length = Triangle::length; }
+		item e2 [1];
+		item e3 [1];
+
+		item :>> vertices [6];
+		item v12  [2] ordered = (vertices[2], vertices[3]);
+		item apex [2] ordered = (vertices[4], vertices[5]);
+		item v31  [2] ordered = (vertices[6], vertices[1]);
+	}
+
+	/**
+	 * A RightTriangle is a Triangle with base and third edge at right angles.
+	 */
+	item def RightTriangle :> Triangle {
+
+		attribute :>> xoffset = length / 2;
+
+		item :>> e2 { attribute :>> length = Triangle::width; }
+
+		item hypotenuse :>> e3 {
+			attribute :>> length = ( Triangle::length^2 + Triangle::width^2 );
+		}
+	}
+
+	/**
+	 * A Quadrilateral is a four-sided Polygon.
+	 */
+	item def Quadrilateral :> Polygon {
+
+		item :>> edges [4] = (e1, e2, e3, e4);
+		item e1 [1];
+		item e2 [1];
+		item e3 [1];
+		item e4 [1];
+
+		item :>> vertices;
+		item v12 [2] ordered = (vertices[2], vertices[3]);
+		item v23 [2] ordered = (vertices[4], vertices[5]);
+		item v34 [2] ordered = (vertices[6], vertices[7]);
+		item v41 [2] ordered = (vertices[7], vertices[1]);
+	}
+
+	/**
+	 * A Rectangle is a Quadrilateral two four right angles and given length and width.
+	 */
+	item def Rectangle :> Quadrilateral {
+		attribute :>> length [1];
+		attribute :>> width [1];
+
+		item :>> e1 { attribute :>> length = Rectangle::length; }
+		item :>> e2 { attribute :>> length = Rectangle::width; }
+		item :>> e3 { attribute :>> length = e1.length; }
+		item :>> e4 { attribute :>> length = e2.length; }
+	}
+
+	/**
+	 * Shell is the most general structured Surface.
+	 */
+	abstract item def Shell :> StructuredSpaceObject, Surface;
+
+	/**
+	 * A Disc is a Shell bound by an Ellipse.
 	 */
 	item def Disc :> Shell, PlanarSurface {
-		attribute :>> radius;
+		attribute :>> semiMajorAxis [1];
+		attribute :>> semiMinorAxis [1];
 
-		item :>> shape : Circle [1] {
-			attribute :>> radius = Disc::radius;
+		item :>> shape : Ellipse [1] {
+			attribute :>> semiMajorAxis = Disc::semiMajorAxis;
+			attribute :>> semiMinorAxis = Disc::semiMinorAxis;
 		}
 
 		item :>> faces : PlanarSurface [1] {
 			item :>> edges [1];
 		}
-		item :>> edges : Circle [1] = shape;
+		item :>> edges : Ellipse [1] = shape;
 		item :>> vertices [0];
-
-		connection :WithinBoth connect faces.edges [1] to edges [0..*];
 	}
 
 	/**
-	 * A Sphere is a Shell in the shape of a sphere of a given radius.
+	 * A CircularDisc is a Shell bound by a Circle.
 	 */
-	item def Sphere :> Shell {
-		attribute :>> radius;
+	item def CircularDisc :> Disc {
+		attribute :>> radius [1] = semiMajorAxis;
+		item :>> shape : Circle;
+		item :>> edges : Circle;
+	}
 
-		item :>> faces [1];
+	/**
+	 * An ConicSurface is a surface that has ConicSection cross-sections.
+	 */
+	item def ConicSurface :> Shell {
+		item :>> faces [1..2];
 		item :>> edges [0];
 		item :>> vertices [0];
 
@@ -98,188 +243,514 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Cone is a Shell in the shape of a right circular code, possibly truncated, with given
-	 * baseRadius, apexRadius and height.
+	 * An Ellipsoid is a ConicSurface with only elliptical cross-sections.
 	 */
-	item def Cone :> Shell {
-		attribute baseRadius [1] :> length = radius;
-		attribute apexRadius [1] :> length default 0 [m];
+	item def Ellipsoid :> ConicSurface {
+		attribute semiAxis1 : LengthValue [1] :> scalarQuantities; 
+		attribute semiAxis2 : LengthValue [1] :> scalarQuantities;
+		attribute semiAxis3 : LengthValue [1] :> scalarQuantities;
+
+		item :>> faces [1];
+	}
+
+	/**
+	 * A Sphere is an Ellipsoid with all the same semiaxes.
+	 */
+	item def Sphere :> Ellipsoid {
+
+		attribute :>> radius [1] = semiAxis1;
+
+		assert constraint { ( semiAxis1 == semiAxis2 ) &
+						( semiAxis2 ==  semiAxis3 ) }
+	}
+
+	/**
+	 * An Paraboloid is a ConicSurface with only parabolic cross-sections.
+	 */
+	item def Paraboloid :> ConicSurface {
+		attribute focalDistance : LengthValue [1] :> scalarQuantities;
+
+		item :>> faces [1];
+	}
+
+	/**
+	 * An Paraboloid is a ConicSurface with only hypebolic cross-sections.
+	 */
+	item def Hyperboloid :> ConicSurface {
+		attribute tranverseAxis : LengthValue [1] :> scalarQuantities;
+		attribute conjugateAxis : LengthValue [1] :> scalarQuantities;
+
+		item :>> faces [1..2];
+	}
+
+	/**
+	 * A Toroid is a surface generated from revolving a planar closed curve about an line coplanar
+	 * with the curve. It is single sided with one hole.
+	 */
+	item def Toroid :> Shell {
+
+		attribute revolutionRadius : LengthValue [1] :> scalarQuantities;
+
+		item revolvedCurve : PlanarCurve [1] { attribute :>> isClosed = true; }
+
+		item :>> faces [1];
+		item :>> edges [0];
+		item :>> vertices [0];
+
+		attribute :>> genus = 1;
+	}
+
+	/**
+	 * A Torus is Toroid is a revolution of a Circle.
+	 */
+	item def Torus :> Toroid {
+
+		attribute majorRadius :>> revolutionRadius;
+		attribute minorRadius : LengthValue [1] :> scalarQuantities;
+
+		item :>> revolvedCurve: Circle [1] { attribute :>> radius = minorRadius; }
+	}
+
+
+	/**
+	 * A RectangularToroid is a revolution of a Rectangle.
+	 */
+	item def RectangularToroid :> Toroid {
+
+		attribute rectangleLength [1] :>> length;
+		attribute rectangleWidth [1] :>> width;
+
+		item :>> revolvedCurve: Rectangle [1] {
+			attribute :>> length = rectangleLength;
+			attribute :>> width  = rectangleWidth;
+		}
+	}
+
+
+	/**
+	 * A ConeOrCylinder is a Cone or a Cylinder with a given elliptical base, height, width
+	 * (perpindicular distance from the base to the center of the top side or vertex),
+	 * and offsets of this perpindicular at the base from the center of the base.
+	 */
+	item def ConeOrCylinder :> Shell {
+		attribute :>> semiMajorAxis [1];
+		attribute :>> semiMinorAxis [1];
 		attribute :>> height [1];
 
-		attribute :>> radius [1];
-		attribute isTruncated : Boolean [1] = apexRadius > 0;
+		attribute :>> xoffset [1];
+		attribute :>> yoffset [1];
 
 		item :>> faces [2..3];
-		item bf : Disc [1] :> faces;
+		item base : Disc [1] :> faces;
 		item af : Disc [0..1] :> faces;
 		item cf : Surface [1] :> faces;
-		assert constraint { (apexRadius == 0) == isEmpty(af) }
 
-		item :>> edges : Circle [2..4];
+		item :>> edges [2..4];
 		item be [2] :> edges { 
-			attribute :>> radius = baseRadius;
+			attribute :>> semiMajorAxis = ConeOrCylinder::semiMajorAxis;
+			attribute :>> semiMinorAxis = ConeOrCylinder::semiMinorAxis;
 		}
-		item ae [0..2] :> edges { 
-			attribute :>> radius = apexRadius;
+		item ae [0..2] :> edges {
+			attribute :>> semiMajorAxis = be.semiMajorAxis;
+			attribute :>> semiMinorAxis = be.semiMinorAxis;
 		}
-		assert constraint { isEmpty(af) ? isEmpty(ae) : size(ae) == 2 }
+		assert constraint { size(ae) == ( isEmpty(af) ? 0 : 2 ) &
+				    size(edges) == (isEmpty(af) ? 2 : 4 )  }
 
 		item :>> vertices [0..1];
-		assert constraint { isEmpty(ae) == notEmpty(vertices) }
+		assert constraint { isEmpty(af) == notEmpty(vertices) }
 
-		/* Faces to edges */
-		connection :WithinBoth connect bf.edges [1] to be [0..*];
-		connection :WithinBoth connect af.edges [1] to ae [0..*];
-		connection :WithinBoth connect cf.edges [1] to be [0..*];
-		connection :WithinBoth connect cf.edges [1] to ae [0..*];
-
-		/* Faces to vertices */
-		connection :WithinBoth connect cf.vertices [1] to vertices [0..*];
+		/* Bind face edges to specific edges */
+		connection : SelfLink [1] connect base.edges [0..*] to be [0..*];
+		connection : SelfLink [1] connect cf.edges [0..*] to be [0..*];
 
 		/* Coincident edges */
 		connection :WithinBoth connect be [2] to be [2];
-		connection :WithinBoth connect ae [2] to ae [2];
 
 		attribute :>> genus = 0;
 	}
 
 	/**
-	 * A Cylinder is a Cone whose baseRadius and apexRadius are the same, representing
-	 * a right circular cylinder.
+	 * A Cone has two faces and one vertex.
 	 */
-	item def Cylinder :> Cone {
-		attribute :>> apexRadius = baseRadius;
+	item def Cone :> ConeOrCylinder {
+
+		item :>> faces [2];
+
+		item apex :>> vertices;
+
+		/* Bind face vertices to vertices */
+		connection : SelfLink [1] connect cf.vertices [0..*] to apex [0..*];
 	}
 
 	/**
-	 * A Cuboid is a Shell in the shape of a six-sided polyhedron with rectangular sides, with
-	 * given length, width and height.
+	 * An EccentricCone is a Cone with least one positive offset.
 	 */
-	item def Cuboid :> Shell {
-		attribute :>> length [1];
-		attribute :>> width [1];
-		attribute :>> height [1];
+	item def EccentricCone :> Cone {
+		assert constraint { xoffset > 0 or yoffset > 0 }
+	}
 
-		item faces : PlanarSurface [6] :>> faces {
-			item :>> edges [4]; 
-		}
-		item tf [1] :> faces;
-		item bf [1] :> faces;
-		item ff [1] :> faces;
-		item rf [1] :> faces;
-		item slf [1] :> faces;
-		item srf [1] :> faces;
+	/**
+	 * A CircularCone is a Cone with a circular base.
+	 */
+	item def CircularCone :> Cone {
 
-		item :>> edges : Line [24] {
-			item :>> vertices [2]; 
-		}
-		item tfe [2]  :> edges { attribute :>> length = Cuboid::length; }
-		item tre [2]  :> edges { attribute :>> length = Cuboid::length; }
-		item tsle [2] :> edges { attribute :>> length = Cuboid::width; }
-		item tsre [2] :> edges { attribute :>> length = Cuboid::width; }
-		item bfe [2]  :> edges { attribute :>> length = Cuboid::length; }
-		item bre [2]  :> edges { attribute :>> length = Cuboid::length; }
-		item bsle [2] :> edges { attribute :>> length = Cuboid::width; }
-		item bsre [2] :> edges { attribute :>> length = Cuboid::width; }
-		item ufle [2] :> edges { attribute :>> length = Cuboid::height; }
-		item ufre [2] :> edges { attribute :>> length = Cuboid::height; }
-		item urle [2] :> edges { attribute :>> length = Cuboid::height; }
-		item urre [2] :> edges { attribute :>> length = Cuboid::height; }
+		attribute :>> radius [1] = semiMajorAxis;
 
-		item :>> vertices [24];
-		item tflv [3] :> vertices;
-		item tfrv [3] :> vertices;
-		item trlv [3] :> vertices;
-		item trrv [3] :> vertices;
-		item bflv [3] :> vertices;
-		item bfrv [3] :> vertices;
-		item brlv [3] :> vertices;
-		item brrv [3] :> vertices;
-		
-		/* Faces to edges */
-		connection :WithinBoth connect tf.edges [1] to tfe [0..*];
-		connection :WithinBoth connect tf.edges [1] to tre [0..*];
-		connection :WithinBoth connect tf.edges [1] to tsle [0..*];
-		connection :WithinBoth connect tf.edges [1] to tsre [0..*];
+		assert constraint { semiMajorAxis == semiMinorAxis }
 
-		connection :WithinBoth connect bf.edges [1] to bfe [0..*];
-		connection :WithinBoth connect bf.edges [1] to bre [0..*];
-		connection :WithinBoth connect bf.edges [1] to bsle [0..*];
-		connection :WithinBoth connect bf.edges [1] to bsre [0..*];
+		item :>> base : CircularDisc;
+	}
 
-		connection :WithinBoth connect ff.edges [1] to tfe [0..*];
-		connection :WithinBoth connect ff.edges [1] to bfe [0..*];
-		connection :WithinBoth connect ff.edges [1] to ufle [0..*];
-		connection :WithinBoth connect ff.edges [1] to ufre [0..*];
+	/**
+	 * A RightCircularCone is a CircularCone with zero offsets.
+	 */
+	item def RightCircularCone :> CircularCone {
+		attribute :>> xoffset = 0;
+		attribute :>> yoffset = 0;
+	}
 
-		connection :WithinBoth connect rf.edges [1] to tre [0..*];
-		connection :WithinBoth connect rf.edges [1] to bre [0..*];
-		connection :WithinBoth connect rf.edges [1] to urle [0..*];
-		connection :WithinBoth connect rf.edges [1] to urre [0..*];
+	/**
+	 * A Cylinder has two elliptical sides joined by a curved side.
+	 */
+	item def Cylinder :> ConeOrCylinder {
+		item :>> af [1];
 
-		connection :WithinBoth connect slf.edges [1] to tsle [0..*];
-		connection :WithinBoth connect slf.edges [1] to bsle [0..*];
-		connection :WithinBoth connect slf.edges [1] to ufle [0..*];
-		connection :WithinBoth connect slf.edges [1] to urle [0..*];
-
-		connection :WithinBoth connect srf.edges [1] to tsre [0..*];
-		connection :WithinBoth connect srf.edges [1] to bsre [0..*];
-		connection :WithinBoth connect srf.edges [1] to ufre [0..*];
-		connection :WithinBoth connect srf.edges [1] to urre [0..*];
-		
-		/* Edges to vertices */
-		connection :WithinBoth connect tfe.vertices [1] to tflv [0..*];
-		connection :WithinBoth connect tfe.vertices [1] to tfrv [0..*];
-		connection :WithinBoth connect tre.vertices [1] to trlv [0..*];
-		connection :WithinBoth connect tre.vertices [1] to trrv [0..*];
-		connection :WithinBoth connect tsle.vertices [1] to tflv [0..*];
-		connection :WithinBoth connect tsle.vertices [1] to trlv [0..*];
-		connection :WithinBoth connect tsre.vertices [1] to tfrv [0..*];
-		connection :WithinBoth connect tsre.vertices [1] to trrv [0..*];
-
-		connection :WithinBoth connect bfe.vertices [1] to bflv [0..*];
-		connection :WithinBoth connect bfe.vertices [1] to bfrv [0..*];
-		connection :WithinBoth connect bre.vertices [1] to brlv [0..*];
-		connection :WithinBoth connect bre.vertices [1] to brrv [0..*];
-		connection :WithinBoth connect bsle.vertices [1] to bflv [0..*];
-		connection :WithinBoth connect bsle.vertices [1] to brlv [0..*];
-		connection :WithinBoth connect bsre.vertices [1] to bfrv [0..*];
-		connection :WithinBoth connect bsre.vertices [1] to brrv [0..*];
-
-		connection :WithinBoth connect ufle.vertices [1] to tflv [0..*];
-		connection :WithinBoth connect ufle.vertices [1] to bflv [0..*];
-		connection :WithinBoth connect ufre.vertices [1] to tfrv [0..*];
-		connection :WithinBoth connect ufre.vertices [1] to bfrv [0..*];
-		connection :WithinBoth connect urle.vertices [1] to trlv [0..*];
-		connection :WithinBoth connect urle.vertices [1] to brlv [0..*];
-		connection :WithinBoth connect urre.vertices [1] to trrv [0..*];
-		connection :WithinBoth connect urre.vertices [1] to brrv [0..*];
+		connection : SelfLink [1] connect cf.edges [0..*] to ae [0..*];
 
 		/* Coincident edges */
+		connection :WithinBoth connect ae [2] to ae [2];
+	}
+
+	/**
+	 * An EccentricCylinder is a Cylinder with least one positive offset.
+	 */
+	item def EccentricCylinder :> Cylinder {
+		assert constraint { xoffset > 0 or yoffset > 0 }
+	}
+
+	/**
+	 * A CircularCylinder is a Cylinder with two circular sides.
+	 */
+	 item def CircularCylinder :> Cylinder {
+		attribute :>> radius [1] = semiMajorAxis;
+
+		item :>> base : CircularDisc;
+		item :>> af : CircularDisc;
+	}
+
+	/**
+	 * A RightCircularCylinder is a CircularCylinder with zero offsets.
+	 */
+	item def RightCircularCylinder :> CircularCylinder {
+		attribute :>> xoffset = 0;
+		attribute :>> yoffset = 0;
+	}
+
+	/**
+	 * A Polyhedron is a closed Shell with polygonal sides.
+	 */
+	item def Polyhedron :> Shell {
+
+		attribute :>> isClosed = true;
+
+		item :>> faces : Polygon;
+
+		attribute :>> genus = 0;
+	}
+
+	/**
+	 * A CuboidOrTriangularPrism is either a Cuboid or TriangularPrism.
+	 */
+
+	item def CuboidOrTriangularPrism :> Polyhedron {
+
+		item :>> faces [5..6];
+		item tf	 : Quadrilateral [1] :> faces;
+		item bf	 : Quadrilateral [1] :> faces;
+		item ff	 : Polygon :> faces { item :>> edges [3..4]; }
+		item rf	 : Polygon :> faces { item :>> edges [3..4]; }
+		item slf : Quadrilateral [1] :> faces;
+		item srf : Quadrilateral [0..1] :> faces;
+
+		item :>> edges;
+		assert constraint { size(edges) == 18 or size(edges) == 24 }
+		
+		item tfe  [2]	 :> edges;
+		item tre  [2]	 :> edges;
+		item tsle [2]	 :> edges;
+		item tsre [0..2] :> edges;
+		item bfe  [2]	 :> edges;
+		item bre  [2]	 :> edges;
+		item bsle [2]	 :> edges;
+		item bsre [2]	 :> edges;
+		item ufle [2]	 :> edges;
+		item ufre [0..2] :> edges;
+		item urle [2]	 :> edges;
+		item urre [0..2] :> edges;
+
+		assert constraint { ( isEmpty(srf) implies isEmpty(tsre) ) and
+				    ( isEmpty(tsre) == isEmpty(ufre) ) and
+				    ( isEmpty(ufre) == isEmpty(urre) ) }
+
+		item :>> vertices;
+		assert constraint { size(vertices) == size(edges) }
+
+		item tflv [3]	 :> vertices;
+		item tfrv [0..3] :> vertices;
+		item trlv [3]	 :> vertices;
+		item trrv [0..3] :> vertices;
+		item bflv [3]	 :> vertices;
+		item bfrv [3]	 :> vertices;
+		item brlv [3]	 :> vertices;
+		item brrv [3]	 :> vertices;
+		
+		assert constraint { ( isEmpty(tfrv) == isEmpty(trrv) ) }
+
+		/* Bind face edges to specific edges */
+		connection : SelfLink [1] connect tf.edges [0..1] to tfe [0..1];
+		connection : SelfLink [1] connect tf.edges [0..1] to tre [0..1];
+		connection : SelfLink [1] connect tf.edges [0..1] to tsle [0..1];
+		connection : SelfLink [1] connect bf.edges [0..1] to bfe [0..1];
+		connection : SelfLink [1] connect bf.edges [0..1] to bre [0..1];
+		connection : SelfLink [1] connect bf.edges [0..1] to bsle [0..1];
+		connection : SelfLink [1] connect bf.edges [0..1] to bsre [0..1];
+
+		connection : SelfLink [1] connect ff.edges [0..1] to tfe [0..1];
+		connection : SelfLink [1] connect ff.edges [0..1] to bfe [0..1];
+		connection : SelfLink [1] connect ff.edges [0..1] to ufle [0..1];
+
+		connection : SelfLink [1] connect rf.edges [0..1] to tre [0..1];
+		connection : SelfLink [1] connect rf.edges [0..1] to bre [0..1];
+		connection : SelfLink [1] connect rf.edges [0..1] to urle [0..1];
+
+		/* connection : SelfLink edge connect vertices to specific vertices */
+
+		connection : SelfLink [1] connect tfe.vertices [0..1] to tflv [0..1];
+		connection : SelfLink [1] connect tre.vertices [0..1] to trlv [0..1];
+		connection : SelfLink [1] connect tsle.vertices [0..1] to tflv [0..1];
+		connection : SelfLink [1] connect tsle.vertices [0..1] to trlv [0..1];
+
+		connection : SelfLink [1] connect bfe.vertices [0..1] to bflv [0..1];
+		connection : SelfLink [1] connect bfe.vertices [0..1] to bfrv [0..1];
+		connection : SelfLink [1] connect bre.vertices [0..1] to brlv [0..1];
+		connection : SelfLink [1] connect bre.vertices [0..1] to brrv [0..1];
+		connection : SelfLink [1] connect bsle.vertices [0..1] to bflv [0..1];
+		connection : SelfLink [1] connect bsle.vertices [0..1] to brlv [0..1];
+		connection : SelfLink [1] connect bsre.vertices [0..1] to bfrv [0..1];
+		connection : SelfLink [1] connect bsre.vertices [0..1] to brrv [0..1];
+
+		connection : SelfLink [1] connect ufle.vertices [0..1] to tflv [0..1];
+		connection : SelfLink [1] connect ufle.vertices [0..1] to bflv [0..1];
+		connection : SelfLink [1] connect urle.vertices [0..1] to trlv [0..1];
+		connection : SelfLink [1] connect urle.vertices [0..1] to brlv [0..1];
+
+		/* Edge coincidence */
 		connection :WithinBoth connect tfe [2] to tfe [2];
 		connection :WithinBoth connect tre [2] to tre [2];
 		connection :WithinBoth connect tsle [2] to tsle [2];
-		connection :WithinBoth connect tsre [2] to tsre [2];
 		connection :WithinBoth connect bfe [2] to bfe [2];
 		connection :WithinBoth connect bre [2] to bre [2];
 		connection :WithinBoth connect bsle [2] to bsle [2];
 		connection :WithinBoth connect bsre [2] to bsre [2];
 		connection :WithinBoth connect ufle [2] to ufle [2];
-		connection :WithinBoth connect ufre [2] to ufre [2];
 		connection :WithinBoth connect urle [2] to urle [2];
-		connection :WithinBoth connect urre [2] to urre [2];
+		connection :WithinBoth connect bsre [2] to bsre [2];
 
-		/* Coincident vertices */
+		/* Vertex coincidence  */
 		connection :WithinBoth connect tflv [3] to tflv [3];
-		connection :WithinBoth connect tfrv [3] to tfrv [3];
 		connection :WithinBoth connect trlv [3] to trlv [3];
-		connection :WithinBoth connect trrv [3] to trrv [3];
 		connection :WithinBoth connect bflv [3] to bflv [3];
 		connection :WithinBoth connect bfrv [3] to bfrv [3];
 		connection :WithinBoth connect brlv [3] to brlv [3];
 		connection :WithinBoth connect brrv [3] to brrv [3];
-
-		attribute :>> genus = 0;
 	}
-	alias Box for Cuboid;
+
+	/**
+	 * A TriangularPrism is a Polyhedron with five sides, two triangular and
+	 * the others quadrilateral.
+	 */
+	item def TriangularPrism :> CuboidOrTriangularPrism {
+
+		item :>> faces [5];
+		item :>> ff : Triangle;
+		item :>> rf : Triangle;
+
+		item :>> edges [18];
+
+		item :>> vertices;
+
+		/* Bind face edges to specific edges */
+		connection : SelfLink [1] connect tf.edges [0..1] to bsre [0..1];
+
+		/* Bind edge vertices to vertices */
+		connection : SelfLink [1] connect tfe.vertices  [0..1] to bfrv [0..1];
+		connection : SelfLink [1] connect tre.vertices  [0..1] to bfrv [0..1];
+	}
+
+	/**
+	 * A RightTriangularPrism  a TriangularPrism with two right triangluar sides,
+	 * with given length, width, and height.
+	 */
+	item def RightTriangularPrism :> TriangularPrism { 
+		attribute :>> length [1];
+		attribute :>> width [1];
+		attribute :>> height [1];
+
+		item :>> tf  : Rectangle;
+		item :>> bf  : Rectangle;
+		item :>> ff : RightTriangle {
+			attribute :>> length = RightTriangularPrism::length;
+			attribute :>> width = RightTriangularPrism::width;
+		}
+		item :>> rf : RightTriangle {
+			attribute :>> length = ff.length;
+			attribute :>> width = rf.width;
+		}
+		item :>> slf : Rectangle;
+		item :>> srf : Rectangle;
+
+		item :>> tfe  { attribute :>> length = ff.hypotenuse.length; }
+		item :>> tre  { attribute :>> length = tfe.length; }
+		item :>> tsle { attribute :>> length = height; }
+		item :>> bfe  { attribute :>> length = RightTriangularPrism::length; }
+		item :>> bre  { attribute :>> length = RightTriangularPrism::length; }
+		item :>> bsle { attribute :>> length = height; }
+		item :>> bsre { attribute :>> length = height; }
+		item :>> ufle { attribute :>> length = width;  } 
+		item :>> urle { attribute :>> length = width; }
+	}
+	alias Wedge for RightTriangularPrism;
+
+	/**
+	 * A Cuboid is a Polyhedron with six sides, all quadrilateral.
+	 */
+	item def Cuboid :> CuboidOrTriangularPrism {
+
+		item :>> faces [6];
+		item :>> ff : Quadrilateral;
+		item :>> rf : Quadrilateral;
+
+		item :>> edges [24];
+
+		item :>> vertices [24];
+
+		/* Bind face edges to specific edges */
+
+		connection : SelfLink [1] connect tf.edges [0..1] to tsre [0..1];
+		connection : SelfLink [1] connect ff.edges [0..1] to ufre [0..1];
+		connection : SelfLink [1] connect rf.edges [0..1] to urre [0..1];
+
+		connection : SelfLink [1] connect srf.edges [0..1] to tsre [0..1];
+		connection : SelfLink [1] connect srf.edges [0..1] to bsre [0..1];
+		connection : SelfLink [1] connect srf.edges [0..1] to ufre [0..1];
+		connection : SelfLink [1] connect srf.edges [0..1] to urre [0..1];
+
+		/* connection : SelfLink edge connect vertices to vertices */
+
+		connection : SelfLink [1] connect tfe.vertices  [0..1] to tfrv [0..1];
+		connection : SelfLink [1] connect tre.vertices  [0..1] to trrv [0..1];
+		connection : SelfLink [1] connect tsre.vertices [0..1] to tfrv [0..1];
+		connection : SelfLink [1] connect tsre.vertices [0..1] to trrv [0..1];
+
+		connection : SelfLink [1] connect ufre.vertices [0..1] to tfrv [0..1];
+		connection : SelfLink [1] connect ufre.vertices [0..1] to bfrv [0..1];
+		connection : SelfLink [1] connect urre.vertices [0..1] to trrv [0..1];
+		connection : SelfLink [1] connect urre.vertices [0..1] to brrv [0..1];
+
+		/* Edge coincidence */
+
+		connection :WithinBoth connect tsre [2] to tsre [2];
+		connection :WithinBoth connect ufre [2] to ufre [2];
+		connection :WithinBoth connect urre [2] to urre [2];
+		connection :WithinBoth connect bsre [2] to bsre [2];
+
+		/* Vertex coincidence  */
+
+		connection :WithinBoth connect tfrv [3] to tfrv [3];
+		connection :WithinBoth connect trrv [3] to trrv [3];
+	}
+
+	/**
+	 * A RectangularCuboid is a Cuboid with all Rectangular sides.
+	 */
+	item def RectangularCuboid :> Cuboid {
+
+		item :>> tf  : Rectangle;
+		item :>> bf  : Rectangle;
+		item :>> ff  : Rectangle;
+		item :>> rf  : Rectangle;
+		item :>> slf : Rectangle;
+		item :>> srf : Rectangle;
+	}
+	alias Box for RectangularCuboid;
+
+
+	/**
+	 * A Pyramid is a Polyhedron with the sides of a polygon (base) forming the bases of triangles
+	 * that coincide at an apex.  Its height is the perpindicular distance from the base to the apex,
+	 * and its offsets are between this perpindicular at the base and the center of the base.
+	 */
+	item def Pyramid :> Polyhedron { 
+
+		attribute :>> height [1];
+		attribute :>> xoffset;
+		attribute :>> yoffset;
+
+		item :>> faces;
+		item base [1] :> faces;
+		item wall : Triangle :> faces;
+		attribute wallNumber : Positive = size(wall);
+
+		assert constraint { size(faces) == wallNumber + 1 }
+		assert constraint { wallNumber == size(base.edges) }
+
+		item :>> edges;
+
+		assert constraint { size(edges) == wallNumber * 4 }
+
+		item :>> vertices;
+		item apex :> vertices = wall.apex;
+
+		assert constraint { size(vertices) == size(edges) }
+		assert constraint { size(apex) == wallNumber }
+
+		/* Base to wall and wall to wall edge coincidence. */
+		assert constraint { (1..wallNumber)->forAll {in i;
+					includes((wall[i] as Triangle).base.spaceTimeCoincidentOccurrences,
+							 Pyramid::base.edges[i]) and
+					includes(((wall[i] as Triangle).edges[3] as Item).spaceTimeCoincidentOccurrences,
+							 (wall[i==wallNumber ? 1 : i+1] as Triangle).edges[2]) } }
+
+		/* Apex coincidence */
+		connection :WithinBoth connect apex [wallNumber] to apex [wallNumber];
+	}
+
+	/**
+	 * A Tetrahedron is Pyramid with a triangular base.
+	 */
+	item def Tetrahedron :> Pyramid {
+
+		attribute :>> baseLength [1];
+		attribute :>> baseWidth [1];
+
+		item :>> base : Triangle {
+			attribute :>> length = Tetrahedron::baseLength;
+			attribute :>> width  = Tetrahedron::baseWidth;
+		}
+	}
+
+	/**
+	 * A RectangularPyramid is Pyramid with a rectangular base.
+	 */
+	item def RectangularPyramid :> Pyramid {
+
+		attribute :>> baseLength [1];
+		attribute :>> baseWidth [1];
+
+		item :>> base : Rectangle {
+			attribute :>> length = RectangularPyramid::baseLength;
+			attribute :>> width = RectangularPyramid::baseWidth;
+		}
+	}
 }

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -90,7 +90,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Circle is an Ellipse with equal axes.
+	 * A Circle is an Ellipse with semiaxes equal to its radius.
 	 */
 	item def Circle :> Ellipse {
 		attribute :>> radius [1] = semiMajorAxis;
@@ -326,7 +326,6 @@ package ShapeItems {
 		}
 	}
 
-
 	/**
 	 * A ConeOrCylinder is Shell that a Cone or a Cylinder with a given elliptical base,
 	 * height, width (perpendicular distance from the base to the center of the top side or vertex),
@@ -361,8 +360,8 @@ package ShapeItems {
 		assert constraint { isEmpty(af) == notEmpty(vertices) }
 
 		/* Bind face edges to specific edges */
-		connection : SelfLink [1] connect base.edges [0..*] to be [0..*];
-		connection : SelfLink [1] connect cf.edges [0..*] to be [0..*];
+		binding [1] bind base.edges [0..*] = be [0..*];
+		binding [1] bind cf.edges [0..*] = be [0..*];
 
 		/* Coincident edges */
 		connection :WithinBoth connect be [2] to be [2];
@@ -379,8 +378,8 @@ package ShapeItems {
 
 		item apex :>> vertices;
 
-		/* Bind face vertices to vertices */
-		connection : SelfLink [1] connect cf.vertices [0..*] to apex [0..*];
+		/* Bind face vertices to specific vertices */
+		binding [1] bind cf.vertices [0..*] = apex [0..*];
 	}
 
 	/**
@@ -416,7 +415,7 @@ package ShapeItems {
 	item def Cylinder :> ConeOrCylinder {
 		item :>> af [1];
 
-		connection : SelfLink [1] connect cf.edges [0..*] to ae [0..*];
+		binding [1] bind cf.edges [0..*] = ae [0..*];
 
 		/* Coincident edges */
 		connection :WithinBoth connect ae [2] to ae [2];
@@ -514,42 +513,42 @@ package ShapeItems {
 		assert constraint { ( isEmpty(tfrv) == isEmpty(trrv) ) }
 
 		/* Bind face edges to specific edges */
-		connection : SelfLink [1] connect tf.edges [0..1] to tfe [0..1];
-		connection : SelfLink [1] connect tf.edges [0..1] to tre [0..1];
-		connection : SelfLink [1] connect tf.edges [0..1] to tsle [0..1];
-		connection : SelfLink [1] connect bf.edges [0..1] to bfe [0..1];
-		connection : SelfLink [1] connect bf.edges [0..1] to bre [0..1];
-		connection : SelfLink [1] connect bf.edges [0..1] to bsle [0..1];
-		connection : SelfLink [1] connect bf.edges [0..1] to bsre [0..1];
+		binding [1] bind tf.edges [0..1] = tfe [0..1];
+		binding [1] bind tf.edges [0..1] = tfe [0..1];
+		binding [1] bind tf.edges [0..1] = tre [0..1];
+		binding [1] bind tf.edges [0..1] = tsle [0..1];
+		binding [1] bind bf.edges [0..1] = bfe [0..1];
+		binding [1] bind bf.edges [0..1] = bre [0..1];
+		binding [1] bind bf.edges [0..1] = bsle [0..1];
+		binding [1] bind bf.edges [0..1] = bsre [0..1];
 
-		connection : SelfLink [1] connect ff.edges [0..1] to tfe [0..1];
-		connection : SelfLink [1] connect ff.edges [0..1] to bfe [0..1];
-		connection : SelfLink [1] connect ff.edges [0..1] to ufle [0..1];
+		binding [1] bind ff.edges [0..1] = tfe [0..1];
+		binding [1] bind ff.edges [0..1] = bfe [0..1];
+		binding [1] bind ff.edges [0..1] = ufle [0..1];
 
-		connection : SelfLink [1] connect rf.edges [0..1] to tre [0..1];
-		connection : SelfLink [1] connect rf.edges [0..1] to bre [0..1];
-		connection : SelfLink [1] connect rf.edges [0..1] to urle [0..1];
+		binding [1] bind rf.edges [0..1] = tre [0..1];
+		binding [1] bind rf.edges [0..1] = bre [0..1];
+		binding [1] bind rf.edges [0..1] = urle [0..1];
 
-		/* connection : SelfLink edge connect vertices to specific vertices */
+		/* Bind edge vertices to specific vertices */
+		binding [1] bind tfe.vertices [0..1] = tflv [0..1];
+		binding [1] bind tre.vertices [0..1] = trlv [0..1];
+		binding [1] bind tsle.vertices [0..1] = tflv [0..1];
+		binding [1] bind tsle.vertices [0..1] = trlv [0..1];
 
-		connection : SelfLink [1] connect tfe.vertices [0..1] to tflv [0..1];
-		connection : SelfLink [1] connect tre.vertices [0..1] to trlv [0..1];
-		connection : SelfLink [1] connect tsle.vertices [0..1] to tflv [0..1];
-		connection : SelfLink [1] connect tsle.vertices [0..1] to trlv [0..1];
+		binding [1] bind bfe.vertices [0..1] = bflv [0..1];
+		binding [1] bind bfe.vertices [0..1] = bfrv [0..1];
+		binding [1] bind bre.vertices [0..1] = brlv [0..1];
+		binding [1] bind bre.vertices [0..1] = brrv [0..1];
+		binding [1] bind bsle.vertices [0..1] = bflv [0..1];
+		binding [1] bind bsle.vertices [0..1] = brlv [0..1];
+		binding [1] bind bsre.vertices [0..1] = bfrv [0..1];
+		binding [1] bind bsre.vertices [0..1] = brrv [0..1];
 
-		connection : SelfLink [1] connect bfe.vertices [0..1] to bflv [0..1];
-		connection : SelfLink [1] connect bfe.vertices [0..1] to bfrv [0..1];
-		connection : SelfLink [1] connect bre.vertices [0..1] to brlv [0..1];
-		connection : SelfLink [1] connect bre.vertices [0..1] to brrv [0..1];
-		connection : SelfLink [1] connect bsle.vertices [0..1] to bflv [0..1];
-		connection : SelfLink [1] connect bsle.vertices [0..1] to brlv [0..1];
-		connection : SelfLink [1] connect bsre.vertices [0..1] to bfrv [0..1];
-		connection : SelfLink [1] connect bsre.vertices [0..1] to brrv [0..1];
-
-		connection : SelfLink [1] connect ufle.vertices [0..1] to tflv [0..1];
-		connection : SelfLink [1] connect ufle.vertices [0..1] to bflv [0..1];
-		connection : SelfLink [1] connect urle.vertices [0..1] to trlv [0..1];
-		connection : SelfLink [1] connect urle.vertices [0..1] to brlv [0..1];
+		binding [1] bind ufle.vertices [0..1] = tflv [0..1];
+		binding [1] bind ufle.vertices [0..1] = bflv [0..1];
+		binding [1] bind urle.vertices [0..1] = trlv [0..1];
+		binding [1] bind urle.vertices [0..1] = brlv [0..1];
 
 		/* Edge coincidence */
 		connection :WithinBoth connect tfe [2] to tfe [2];
@@ -587,11 +586,11 @@ package ShapeItems {
 		item :>> vertices;
 
 		/* Bind face edges to specific edges */
-		connection : SelfLink [1] connect tf.edges [0..1] to bsre [0..1];
+		binding [1] bind tf.edges [0..1] = bsre [0..1];
 
-		/* Bind edge vertices to vertices */
-		connection : SelfLink [1] connect tfe.vertices  [0..1] to bfrv [0..1];
-		connection : SelfLink [1] connect tre.vertices  [0..1] to bfrv [0..1];
+		/* Bind edge vertices to specific vertices */
+		binding [1] bind tfe.vertices  [0..1] = bfrv [0..1];
+		binding [1] bind tre.vertices  [0..1] = bfrv [0..1];
 	}
 
 	/**
@@ -642,27 +641,25 @@ package ShapeItems {
 		item :>> vertices;
 
 		/* Bind face edges to specific edges */
+		binding [1] bind tf.edges [0..1] = tsre [0..1];
+		binding [1] bind ff.edges [0..1] = ufre [0..1];
+		binding [1] bind rf.edges [0..1] = urre [0..1];
 
-		connection : SelfLink [1] connect tf.edges [0..1] to tsre [0..1];
-		connection : SelfLink [1] connect ff.edges [0..1] to ufre [0..1];
-		connection : SelfLink [1] connect rf.edges [0..1] to urre [0..1];
+		binding [1] bind srf.edges [0..1] = tsre [0..1];
+		binding [1] bind srf.edges [0..1] = bsre [0..1];
+		binding [1] bind srf.edges [0..1] = ufre [0..1];
+		binding [1] bind srf.edges [0..1] = urre [0..1];
 
-		connection : SelfLink [1] connect srf.edges [0..1] to tsre [0..1];
-		connection : SelfLink [1] connect srf.edges [0..1] to bsre [0..1];
-		connection : SelfLink [1] connect srf.edges [0..1] to ufre [0..1];
-		connection : SelfLink [1] connect srf.edges [0..1] to urre [0..1];
+		/* Bind edge vertices to specific vertices */
+		binding [1] bind tfe.vertices  [0..1] = tfrv [0..1];
+		binding [1] bind tre.vertices  [0..1] = trrv [0..1];
+		binding [1] bind tsre.vertices [0..1] = tfrv [0..1];
+		binding [1] bind tsre.vertices [0..1] = trrv [0..1];
 
-		/* connection : SelfLink edge connect vertices to vertices */
-
-		connection : SelfLink [1] connect tfe.vertices  [0..1] to tfrv [0..1];
-		connection : SelfLink [1] connect tre.vertices  [0..1] to trrv [0..1];
-		connection : SelfLink [1] connect tsre.vertices [0..1] to tfrv [0..1];
-		connection : SelfLink [1] connect tsre.vertices [0..1] to trrv [0..1];
-
-		connection : SelfLink [1] connect ufre.vertices [0..1] to tfrv [0..1];
-		connection : SelfLink [1] connect ufre.vertices [0..1] to bfrv [0..1];
-		connection : SelfLink [1] connect urre.vertices [0..1] to trrv [0..1];
-		connection : SelfLink [1] connect urre.vertices [0..1] to brrv [0..1];
+		binding [1] bind ufre.vertices [0..1] = tfrv [0..1];
+		binding [1] bind ufre.vertices [0..1] = bfrv [0..1];
+		binding [1] bind urre.vertices [0..1] = trrv [0..1];
+		binding [1] bind urre.vertices [0..1] = brrv [0..1];
 
 		/* Edge coincidence */
 

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -3,6 +3,7 @@
  */
 package ShapeItems {
 	private import ScalarValues::Boolean;
+	private import ScalarValues::Positive;
 	private import ISQ::*;
 	private import SI::m;
 	private import Occurrences::WithinBoth;
@@ -24,6 +25,7 @@ package ShapeItems {
 	item def PlanarCurve :> Curve {
 		attribute :>> length [1];
 
+		attribute :>> outerSpaceDimension;
 		assert constraint { notEmpty(outerSpaceDimension) &  outerSpaceDimension <= 2 }
 	}
 
@@ -68,7 +70,7 @@ package ShapeItems {
 	attribute baseWidth : LengthValue [0..*] :> scalarQuantities;
 
 	/**
-	 * An ConicSection is a closed PlanarCurve, possibly disconnected, see Hyperbola.
+	 * A ConicSection is a closed PlanarCurve, possibly disconnected, see Hyperbola.
 	 */
 	item def ConicSection :> Path, PlanarCurve {
 
@@ -88,7 +90,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Circle is an Ellipse with equal radii.
+	 * A Circle is an Ellipse with equal axes.
 	 */
 	item def Circle :> Ellipse {
 		attribute :>> radius [1] = semiMajorAxis;
@@ -101,7 +103,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Parabola is a planar Path in the shape of a parabola of a given focal length.
+	 * A Parabola is a ConicSection in the shape of a parabola of a given focal length.
 	 */
 	item def Parabola :> ConicSection {
 		attribute focalDistance : LengthValue [1] :> scalarQuantities;
@@ -110,7 +112,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Hyperbola is a planar Path in the shape of a hyperbola with given axes.
+	 * A Hyperbola is a ConicSection in the shape of a hyperbola with given axes.
 	 */
 	item def Hyperbola :> ConicSection {
 		attribute tranverseAxis : LengthValue [1] :> scalarQuantities;
@@ -154,7 +156,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A RightTriangle is a Triangle with base and third edge at right angles.
+	 * A RightTriangle is a Triangle with sides opposite the hypotenuse at right angles.
 	 */
 	item def RightTriangle :> Triangle {
 
@@ -178,7 +180,7 @@ package ShapeItems {
 		item e3 [1];
 		item e4 [1];
 
-		item :>> vertices;
+		item :>> vertices [8];
 		item v12 [2] ordered = (vertices[2], vertices[3]);
 		item v23 [2] ordered = (vertices[4], vertices[5]);
 		item v34 [2] ordered = (vertices[6], vertices[7]);
@@ -186,7 +188,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Rectangle is a Quadrilateral two four right angles and given length and width.
+	 * A Rectangle is a Quadrilateral four right angles and given length and width.
 	 */
 	item def Rectangle :> Quadrilateral {
 		attribute :>> length [1];
@@ -223,7 +225,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A CircularDisc is a Shell bound by a Circle.
+	 * A CircularDisc is a Disc bound by a Circle.
 	 */
 	item def CircularDisc :> Disc {
 		attribute :>> radius [1] = semiMajorAxis;
@@ -232,7 +234,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * An ConicSurface is a surface that has ConicSection cross-sections.
+	 * A ConicSurface is a Surface that has ConicSection cross-sections.
 	 */
 	item def ConicSurface :> Shell {
 		item :>> faces [1..2];
@@ -261,11 +263,11 @@ package ShapeItems {
 		attribute :>> radius [1] = semiAxis1;
 
 		assert constraint { ( semiAxis1 == semiAxis2 ) &
-						( semiAxis2 ==  semiAxis3 ) }
+						    ( semiAxis2 ==  semiAxis3 ) }
 	}
 
 	/**
-	 * An Paraboloid is a ConicSurface with only parabolic cross-sections.
+	 * A Paraboloid is a ConicSurface with only parabolic cross-sections.
 	 */
 	item def Paraboloid :> ConicSurface {
 		attribute focalDistance : LengthValue [1] :> scalarQuantities;
@@ -274,13 +276,11 @@ package ShapeItems {
 	}
 
 	/**
-	 * An Paraboloid is a ConicSurface with only hypebolic cross-sections.
+	 * A Hyperboloid is a ConicSurface with only hypebolic cross-sections.
 	 */
 	item def Hyperboloid :> ConicSurface {
-		attribute tranverseAxis : LengthValue [1] :> scalarQuantities;
+		attribute transverseAxis : LengthValue [1] :> scalarQuantities;
 		attribute conjugateAxis : LengthValue [1] :> scalarQuantities;
-
-		item :>> faces [1..2];
 	}
 
 	/**
@@ -301,7 +301,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Torus is Toroid is a revolution of a Circle.
+	 * A Torus is a revolution of a Circle.
 	 */
 	item def Torus :> Toroid {
 
@@ -328,9 +328,9 @@ package ShapeItems {
 
 
 	/**
-	 * A ConeOrCylinder is a Cone or a Cylinder with a given elliptical base, height, width
-	 * (perpindicular distance from the base to the center of the top side or vertex),
-	 * and offsets of this perpindicular at the base from the center of the base.
+	 * A ConeOrCylinder is Shell that a Cone or a Cylinder with a given elliptical base,
+	 * height, width (perpendicular distance from the base to the center of the top side or vertex),
+	 * and offsets of this perpendicular at the base from the center of the base.
 	 */
 	item def ConeOrCylinder :> Shell {
 		attribute :>> semiMajorAxis [1];
@@ -345,7 +345,7 @@ package ShapeItems {
 		item af : Disc [0..1] :> faces;
 		item cf : Surface [1] :> faces;
 
-		item :>> edges [2..4];
+		item :>> edges [2..4] = faces.edges;
 		item be [2] :> edges { 
 			attribute :>> semiMajorAxis = ConeOrCylinder::semiMajorAxis;
 			attribute :>> semiMinorAxis = ConeOrCylinder::semiMinorAxis;
@@ -355,9 +355,9 @@ package ShapeItems {
 			attribute :>> semiMinorAxis = be.semiMinorAxis;
 		}
 		assert constraint { size(ae) == ( isEmpty(af) ? 0 : 2 ) &
-				    size(edges) == (isEmpty(af) ? 2 : 4 )  }
+				            size(edges) == (isEmpty(af) ? 2 : 4 )  }
 
-		item :>> vertices [0..1];
+		item :>> vertices [0..1] = faces.vertices;
 		assert constraint { isEmpty(af) == notEmpty(vertices) }
 
 		/* Bind face edges to specific edges */
@@ -371,7 +371,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Cone has two faces and one vertex.
+	 * A Cone has one elliptical sides joined to a point by a curved side.
 	 */
 	item def Cone :> ConeOrCylinder {
 
@@ -406,8 +406,8 @@ package ShapeItems {
 	 * A RightCircularCone is a CircularCone with zero offsets.
 	 */
 	item def RightCircularCone :> CircularCone {
-		attribute :>> xoffset = 0;
-		attribute :>> yoffset = 0;
+		attribute :>> xoffset { attribute :>> num = 0; }
+		attribute :>> yoffset { attribute :>> num = 0; }
 	}
 
 	/**
@@ -435,6 +435,8 @@ package ShapeItems {
 	 item def CircularCylinder :> Cylinder {
 		attribute :>> radius [1] = semiMajorAxis;
 
+		assert constraint { semiMajorAxis == semiMinorAxis }
+
 		item :>> base : CircularDisc;
 		item :>> af : CircularDisc;
 	}
@@ -443,8 +445,8 @@ package ShapeItems {
 	 * A RightCircularCylinder is a CircularCylinder with zero offsets.
 	 */
 	item def RightCircularCylinder :> CircularCylinder {
-		attribute :>> xoffset = 0;
-		attribute :>> yoffset = 0;
+		attribute :>> xoffset { attribute :>> num = 0; }
+		attribute :>> yoffset { attribute :>> num = 0; }
 	}
 
 	/**
@@ -454,13 +456,17 @@ package ShapeItems {
 
 		attribute :>> isClosed = true;
 
-		item :>> faces : Polygon;
+		item :>> faces : Polygon [2..*];
+		
+		item :>> edges = faces.edges;
+		
+		attribute :>> outerSpaceDimension = (size(faces) > 2 ? 3 : 2);
 
 		attribute :>> genus = 0;
 	}
 
 	/**
-	 * A CuboidOrTriangularPrism is either a Cuboid or TriangularPrism.
+	 * A CuboidOrTriangularPrism is a Polyhedron that is either a Cuboid or TriangularPrism.
 	 */
 
 	item def CuboidOrTriangularPrism :> Polyhedron {
@@ -468,8 +474,8 @@ package ShapeItems {
 		item :>> faces [5..6];
 		item tf	 : Quadrilateral [1] :> faces;
 		item bf	 : Quadrilateral [1] :> faces;
-		item ff	 : Polygon :> faces { item :>> edges [3..4]; }
-		item rf	 : Polygon :> faces { item :>> edges [3..4]; }
+		item ff	 : Polygon [1] :> faces { item :>> edges [3..4]; }
+		item rf	 : Polygon [1] :> faces { item :>> edges [3..4]; }
 		item slf : Quadrilateral [1] :> faces;
 		item srf : Quadrilateral [0..1] :> faces;
 
@@ -633,7 +639,7 @@ package ShapeItems {
 
 		item :>> edges [24];
 
-		item :>> vertices [24];
+		item :>> vertices;
 
 		/* Bind face edges to specific edges */
 
@@ -675,7 +681,10 @@ package ShapeItems {
 	 * A RectangularCuboid is a Cuboid with all Rectangular sides.
 	 */
 	item def RectangularCuboid :> Cuboid {
-
+		attribute :>> length [1];
+		attribute :>> width [1];
+		attribute :>> height [1];
+	
 		item :>> tf  : Rectangle;
 		item :>> bf  : Rectangle;
 		item :>> ff  : Rectangle;
@@ -685,10 +694,9 @@ package ShapeItems {
 	}
 	alias Box for RectangularCuboid;
 
-
 	/**
 	 * A Pyramid is a Polyhedron with the sides of a polygon (base) forming the bases of triangles
-	 * that coincide at an apex.  Its height is the perpindicular distance from the base to the apex,
+	 * that join at an apex point.  Its height is the perpindicular distance from the base to the apex,
 	 * and its offsets are between this perpindicular at the base and the center of the base.
 	 */
 	item def Pyramid :> Polyhedron { 
@@ -703,7 +711,7 @@ package ShapeItems {
 		attribute wallNumber : Positive = size(wall);
 
 		assert constraint { size(faces) == wallNumber + 1 }
-		assert constraint { wallNumber == size(base.edges) }
+		assert constraint { size(wall) == size(base.edges) }
 
 		item :>> edges;
 
@@ -712,7 +720,6 @@ package ShapeItems {
 		item :>> vertices;
 		item apex :> vertices = wall.apex;
 
-		assert constraint { size(vertices) == size(edges) }
 		assert constraint { size(apex) == wallNumber }
 
 		/* Base to wall and wall to wall edge coincidence. */

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -117,12 +117,15 @@ package Objects {
 		  }
 
 		portion feature faces : Surface[0..*] ordered subsets structuredSpaceObjectCells {
+			feature redefines edges subsets StructuredSpaceObject::edges;
+			feature redefines vertices subsets StructuredSpaceObject::vertices;
 			derived feature redefines spaceBoundary; 
 			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
 		}
 
 		portion feature edges : Curve[0..*] ordered subsets structuredSpaceObjectCells {
+			feature redefines vertices subsets StructuredSpaceObject::vertices;
 			derived feature redefines spaceBoundary;
 			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
@@ -132,17 +135,5 @@ package Objects {
 		
 		derived feature redefines innerSpaceDimension = 
 			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
-
-		connector feE :WithinBoth
-			from thisOccurrence :> faces.edges [0..*]
-			to thatOccurrence :> edges [0..*];
-
-		connector evV :WithinBoth
-			from thisOccurrence :> edges.vertices [0..*]
-			to thatOccurrence :> vertices [0..*];
-
-		connector fvV :WithinBoth
-			from thisOccurrence :> faces.vertices [0..*]
-			to thatOccurrence :> vertices [0..*];
 	  }
 }

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -134,6 +134,6 @@ package Objects {
 		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
-			(if notEmpty(faces)? 2 else (if notEmpty(edges)? 1 else 0));
+			if notEmpty(faces) ? 2 else if notEmpty(edges) ? 1 else 0;
 	  }
 }

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -80,6 +80,12 @@ package Occurrences {
 		}
 
 		/**
+		 * Occurrences that this one completely includes in both space and time,
+		 * and vice-versa, including this one.
+		 */
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences;		
+
+		/**
 		 * The number of variables needed to identify space points in this occurrence, from 0
 		 * to 3, without regard to higher dimensional spaces it might be embedded in.
 		 */
@@ -448,8 +454,10 @@ package Occurrences {
 	 * itself and transitive.
 	 */
 	assoc WithinBoth specializes Within {
-		end feature thisOccurrence: Occurrence[1..*] redefines smallerOccurrence;
-		end feature thatOccurrence: Occurrence[1..*] redefines largerOccurrence;
+		end feature thisOccurrence: Occurrence[1..*] redefines smallerOccurrence
+		  subsets thatOccurrence.spaceTimeCoincidentOccurrences;
+		end feature thatOccurrence: Occurrence[1..*] redefines largerOccurrence
+		  subsets thisOccurrence.spaceTimeCoincidentOccurrences;
 
 		connector :Within
 			from smallerOccurrence :> thatOccurrence [1]


### PR DESCRIPTION
**ShapeItems.sysml**

- Added topo structure and constraints to Path.

- Added more LengthValue attributes with unrestricted domains when they were needed across unrelated item defs (semiMajorAxis, semiMinorAxis, xoffset, yoffset, baseLength,baseWidth).

- Replaced alot of WithinBoth connectors with bindings, as they should've been before (also in Objects::StructuredSpaceObject).

- Added shapes below (indentation for subclassing).  HP and I decided not to support truncation as in STEP because they can be specified by CSG (except the prism, which could be considered a truncated cuboid) and change the topology, violating the typical subclassing expectations (eg, a truncated cone is not a cone).  Added supporting shapes, like triangles, and generalizations, like polyhedra and toroids (some aren't quantified, but they have topo structure to inherit).
```
  ConicSection
    Ellipse
      Circle (from before)
    Parabola
    Hyperbola

  Polygon
    Triangle
      RightTriangle
    Quadrilateral
      Rectangle

  Disc::shape:Ellipse
    CircularDisc (was Disc)

  ConicSurface
    Ellipsoid
      Sphere (from before)
    Paraboloid
    Hyperboloid

  Toroid
    Torus
    RectangularToroid

  ConeOrCylinder (replaces previous truncatable cone)
    Cone
      EccentricCone
      CircularCone
        RightCircularCone
    Cylinder
      EccentricCylinder
      CircularCylinder
        RightCircularCylinder

  Polyhedron
    CuboidOrTriangularPrism
      TriangularPrism
        RightTriangularPrism (alias Wedge)
      Cuboid
        RectangularCuboid
    Pyramid      
      Tetrahedron
      RectangularPyramid
```
**Objects.kerml**

- In StructuredSpaceObject, replaced WithinBoth connectors with subsetting under faces and edges. They were supposed to be bindings with subsetting multiplicities.

**Occurrences.kerml**

- Added spaceTimeCoincidentOccurrences and subset participant ("end") features of WithinBoth from it.
