### PR TITLE
ST6RI-539: SysMLLibraryUtil.isModelLibrary does not work in Jupyter on Windows

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/lang/sysml/util/SysMLLibraryUtil.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/lang/sysml/util/SysMLLibraryUtil.xtend
@@ -28,19 +28,31 @@ import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.emf.ecore.resource.Resource
 import org.omg.sysml.lang.sysml.Element
 import org.omg.sysml.lang.sysml.Type
+import org.eclipse.emf.common.util.URI
 
 class SysMLLibraryUtil {
 	
-	public static final String DEFAULT_MODEL_LIBRARY_DIRECTORY = "/resource/sysml.library";
+	public static final String DEFAULT_MODEL_LIBRARY_PATH = "/resource/sysml.library";
 	
-	static String modelLibraryDirectory = DEFAULT_MODEL_LIBRARY_DIRECTORY;
+	static String modelLibraryPath = DEFAULT_MODEL_LIBRARY_PATH;
 	
-	def static setModelLibraryDirectory(String path) {
-		modelLibraryDirectory = path
+	def static setModelLibraryDirectory(String dir) {
+		val uri = URI.createFileURI(dir);
+		modelLibraryPath = uri.devicePath ?: uri.path;
+	}
+
+	def static getModelLibraryPath() {
+		modelLibraryPath
 	}
 	
 	def static isModelLibrary(Resource resource) {
-		return resource !== null && resource.URI.path.contains(modelLibraryDirectory)
+		if (resource === null) {
+			return false;
+		} else {
+			val path = resource.URI.devicePath ?: resource.URI.path;
+			if (path === null) return false;
+			return path.contains(modelLibraryPath);
+		}
 	}
 	
 	def static IModelLibraryProvider getInstance(Resource resource) {


### PR DESCRIPTION
In Jupyter environment, SysML kernel indirectly calls setModelLibraryDirectory with the kernel directory string, which contains OS-specific path syntax such as backslash and drive letter and volume separator (`c:`).  This makes inconsistencies in isModelLibrary path matching.

In this fix, setModelLibrary normalize the directory string to EMF URI form and use drivePath() if it's not null; otherwise use path().  Also I changed the name of `modelLibraryDirectory` to `modelLibraryPath` because it's normalized to URI path syntax.

isModelLibray() also checks if path() is not null because some EMF Resource URI does not have path() part.

This fix also adds getModelLibraryPath() getter method for other modules to obtain the library path.
