### PR TITLE
ST6RI-540 Space modeling additions

### DIFF
--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -8,7 +8,6 @@ package ShapeItems {
 	private import SI::m;
 	private import Occurrences::WithinBoth;
 	private import Objects::*;
-	private import Links::SelfLink;	
 	private import Items::Item;
 	private import SequenceFunctions::isEmpty;
 	private import SequenceFunctions::notEmpty;
@@ -135,8 +134,8 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Triangle is three-sided Polygon  with given length (base), width (perpindicular distance
-	 * from base to apex), and offset of this perpindicular at the base from the center of the base.
+	 * A Triangle is three-sided Polygon  with given length (base), width (perpendicular distance
+	 * from base to apex), and offset of this perpendicular at the base from the center of the base.
 	 */
 	 item def Triangle :> Polygon {
 
@@ -276,7 +275,7 @@ package ShapeItems {
 	}
 
 	/**
-	 * A Hyperboloid is a ConicSurface with only hypebolic cross-sections.
+	 * A Hyperboloid is a ConicSurface with only hyperbolic cross-sections.
 	 */
 	item def Hyperboloid :> ConicSurface {
 		attribute transverseAxis : LengthValue [1] :> scalarQuantities;
@@ -317,8 +316,8 @@ package ShapeItems {
 	 */
 	item def RectangularToroid :> Toroid {
 
-		attribute rectangleLength [1] :>> length;
-		attribute rectangleWidth [1] :>> width;
+		attribute rectangleLength : LengthValue [1] :> scalarQuantities;
+		attribute rectangleWidth  : LengthValue [1] :> scalarQuantities;
 
 		item :>> revolvedCurve: Rectangle [1] {
 			attribute :>> length = rectangleLength;
@@ -682,19 +681,25 @@ package ShapeItems {
 		attribute :>> width [1];
 		attribute :>> height [1];
 	
-		item :>> tf  : Rectangle;
-		item :>> bf  : Rectangle;
-		item :>> ff  : Rectangle;
-		item :>> rf  : Rectangle;
-		item :>> slf : Rectangle;
-		item :>> srf : Rectangle;
+		item :>> tf  : Rectangle { attribute :>> length = RectangularCuboid::length;
+								   attribute :>> width	= RectangularCuboid::height; }
+		item :>> bf  : Rectangle { attribute :>> length = RectangularCuboid::length;
+								   attribute :>> width	= RectangularCuboid::height; }
+		item :>> ff  : Rectangle { attribute :>> length = RectangularCuboid::length;
+								   attribute :>> width	= RectangularCuboid::width; }
+		item :>> rf  : Rectangle { attribute :>> length = RectangularCuboid::length;
+								   attribute :>> width	= RectangularCuboid::width; }
+		item :>> slf : Rectangle { attribute :>> length = RectangularCuboid::height;
+								   attribute :>> width	= RectangularCuboid::width; }
+		item :>> srf : Rectangle { attribute :>> length = RectangularCuboid::height;
+								   attribute :>> width	= RectangularCuboid::width; }
 	}
 	alias Box for RectangularCuboid;
 
 	/**
 	 * A Pyramid is a Polyhedron with the sides of a polygon (base) forming the bases of triangles
-	 * that join at an apex point.  Its height is the perpindicular distance from the base to the apex,
-	 * and its offsets are between this perpindicular at the base and the center of the base.
+	 * that join at an apex point.	Its height is the perpendicular distance from the base to the apex,
+	 * and its offsets are between this perpendicular at the base and the center of the base.
 	 */
 	item def Pyramid :> Polyhedron { 
 

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -6,7 +6,7 @@ package ShapeItems {
 	private import ScalarValues::Positive;
 	private import ISQ::*;
 	private import SI::m;
-	private import Occurrences::WithinBoth;
+	private import Occurrences::MatesWith;
 	private import Objects::*;
 	private import Items::Item;
 	private import SequenceFunctions::isEmpty;
@@ -58,7 +58,7 @@ package ShapeItems {
 
 		assert constraint { isClosed == vertices->forAll{in p1 : Point;
 					vertices->exists{p2 : Point; p1 != p2 and
-							 includes(p1.spaceTimeCoincidentOccurrences, p2) } } }
+							 includes(p1.matingOccurrences, p2) } } }
 	}
 
 	attribute semiMajorAxis : LengthValue [0..*] :> scalarQuantities;
@@ -129,7 +129,7 @@ package ShapeItems {
 
 		assert constraint { (1..size(edges))->forAll {in i;
 					(edges[i] as StructuredSpaceObject).vertices == (vertices[(2*i)-1], vertices[2*i]) and  
-					includes(((edges[i] as StructuredSpaceObject).vertices[2] as Item).spaceTimeCoincidentOccurrences,
+					includes(((edges[i] as StructuredSpaceObject).vertices[2] as Item).matingOccurrences,
 						 (edges[i==size(edges) ? 1 : i+1]as StructuredSpaceObject).vertices[1]) } }
 	}
 
@@ -362,8 +362,8 @@ package ShapeItems {
 		binding [1] bind base.edges [0..*] = be [0..*];
 		binding [1] bind cf.edges [0..*] = be [0..*];
 
-		/* Coincident edges */
-		connection :WithinBoth connect be [2] to be [2];
+		/* Meeting edges */
+		connection :MatesWith connect be [1] to be [1];
 
 		attribute :>> genus = 0;
 	}
@@ -416,8 +416,8 @@ package ShapeItems {
 
 		binding [1] bind cf.edges [0..*] = ae [0..*];
 
-		/* Coincident edges */
-		connection :WithinBoth connect ae [2] to ae [2];
+		/* Meeting edges */
+		connection :MatesWith connect ae [1] to ae [1];
 	}
 
 	/**
@@ -513,7 +513,6 @@ package ShapeItems {
 
 		/* Bind face edges to specific edges */
 		binding [1] bind tf.edges [0..1] = tfe [0..1];
-		binding [1] bind tf.edges [0..1] = tfe [0..1];
 		binding [1] bind tf.edges [0..1] = tre [0..1];
 		binding [1] bind tf.edges [0..1] = tsle [0..1];
 		binding [1] bind bf.edges [0..1] = bfe [0..1];
@@ -549,25 +548,25 @@ package ShapeItems {
 		binding [1] bind urle.vertices [0..1] = trlv [0..1];
 		binding [1] bind urle.vertices [0..1] = brlv [0..1];
 
-		/* Edge coincidence */
-		connection :WithinBoth connect tfe [2] to tfe [2];
-		connection :WithinBoth connect tre [2] to tre [2];
-		connection :WithinBoth connect tsle [2] to tsle [2];
-		connection :WithinBoth connect bfe [2] to bfe [2];
-		connection :WithinBoth connect bre [2] to bre [2];
-		connection :WithinBoth connect bsle [2] to bsle [2];
-		connection :WithinBoth connect bsre [2] to bsre [2];
-		connection :WithinBoth connect ufle [2] to ufle [2];
-		connection :WithinBoth connect urle [2] to urle [2];
-		connection :WithinBoth connect bsre [2] to bsre [2];
+		/* Meeting edges */
+		connection :MatesWith connect tfe [1] to tfe [1];
+		connection :MatesWith connect tre [1] to tre [1];
+		connection :MatesWith connect tsle [1] to tsle [1];
+		connection :MatesWith connect bfe [1] to bfe [1];
+		connection :MatesWith connect bre [1] to bre [1];
+		connection :MatesWith connect bsle [1] to bsle [1];
+		connection :MatesWith connect bsre [1] to bsre [1];
+		connection :MatesWith connect ufle [1] to ufle [1];
+		connection :MatesWith connect urle [1] to urle [1];
+		connection :MatesWith connect bsre [1] to bsre [1];
 
-		/* Vertex coincidence  */
-		connection :WithinBoth connect tflv [3] to tflv [3];
-		connection :WithinBoth connect trlv [3] to trlv [3];
-		connection :WithinBoth connect bflv [3] to bflv [3];
-		connection :WithinBoth connect bfrv [3] to bfrv [3];
-		connection :WithinBoth connect brlv [3] to brlv [3];
-		connection :WithinBoth connect brrv [3] to brrv [3];
+		/* Meeting vertices  */
+		connection :MatesWith connect tflv [2] to tflv [2];
+		connection :MatesWith connect trlv [2] to trlv [2];
+		connection :MatesWith connect bflv [2] to bflv [2];
+		connection :MatesWith connect bfrv [2] to bfrv [2];
+		connection :MatesWith connect brlv [2] to brlv [2];
+		connection :MatesWith connect brrv [2] to brrv [2];
 	}
 
 	/**
@@ -660,17 +659,15 @@ package ShapeItems {
 		binding [1] bind urre.vertices [0..1] = trrv [0..1];
 		binding [1] bind urre.vertices [0..1] = brrv [0..1];
 
-		/* Edge coincidence */
+		/* Meeting edges */
+		connection :MatesWith connect tsre [1] to tsre [1];
+		connection :MatesWith connect ufre [1] to ufre [1];
+		connection :MatesWith connect urre [1] to urre [1];
+		connection :MatesWith connect bsre [1] to bsre [1];
 
-		connection :WithinBoth connect tsre [2] to tsre [2];
-		connection :WithinBoth connect ufre [2] to ufre [2];
-		connection :WithinBoth connect urre [2] to urre [2];
-		connection :WithinBoth connect bsre [2] to bsre [2];
-
-		/* Vertex coincidence  */
-
-		connection :WithinBoth connect tfrv [3] to tfrv [3];
-		connection :WithinBoth connect trrv [3] to trrv [3];
+		/* Meeting vertices  */
+		connection :MatesWith connect tfrv [2] to tfrv [2];
+		connection :MatesWith connect trrv [2] to trrv [2];
 	}
 
 	/**
@@ -724,15 +721,15 @@ package ShapeItems {
 
 		assert constraint { size(apex) == wallNumber }
 
-		/* Base to wall and wall to wall edge coincidence. */
+		/* Base to wall and wall to wall edge mating. */
 		assert constraint { (1..wallNumber)->forAll {in i;
-					includes((wall[i] as Triangle).base.spaceTimeCoincidentOccurrences,
+					includes((wall[i] as Triangle).base.matingOccurrences,
 							 Pyramid::base.edges[i]) and
-					includes(((wall[i] as Triangle).edges[3] as Item).spaceTimeCoincidentOccurrences,
+					includes(((wall[i] as Triangle).edges[3] as Item).matingOccurrences,
 							 (wall[i==wallNumber ? 1 : i+1] as Triangle).edges[2]) } }
 
-		/* Apex coincidence */
-		connection :WithinBoth connect apex [wallNumber] to apex [wallNumber];
+		/* Meeting apices. */
+		connection :MatesWith connect apex [wallNumber] to apex [wallNumber];
 	}
 
 	/**

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -86,7 +86,12 @@ package Occurrences {
 		 * Occurrences that this one completely includes in both space and time,
 		 * and vice-versa, including this one.
 		 */
-		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences;		
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences;
+
+		/**
+		 * Occurrences that have no space between them and this one.
+		 */
+		feature matingOccurrences: Occurrence[1..*] subsets occurrences;
 
 		/**
 		 * The number of variables needed to identify space points in this occurrence, from 0
@@ -622,9 +627,13 @@ package Occurrences {
 	 * MatesWith is an OutsideOf asserting that two occurrences have no space between them.
 	 */
 	assoc MatesWith specializes JustOutsideOf {
+		end feature matingSpaceToo: Occurrence[0..*] redefines separateSpaceToo
+		  subsets matingSpace.matingOccurrences;
+		end feature matingSpace: Occurrence[0..*] redefines separateSpace
+		  subsets matingSpaceToo.matingOccurrences;
 		feature inBetweenOccurrence: Occurrence [1] {
 			portion feature redefines spaceBoundary [1];
-			inv { contains(unionsOf, union(separateSpaceToo, separateSpace)) }
+			inv { contains(unionsOf, union(matingSpaceToo, matingSpace)) }
 			portion feature redefines spaceInterior [0];
 		}
 	}

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -11,8 +11,11 @@ package Occurrences {
 	private import Links::*;
 	private import Collections::Set;
 	private import Collections::OrderedSet;
-	private import SequenceFunctions::includes;
+	private import CollectionFunctions::isEmpty;
+	private import CollectionFunctions::notEmpty;
 	private import CollectionFunctions::contains;
+	private import SequenceFunctions::includes;
+	private import SequenceFunctions::union;
 
 	/**
 	 * Occurrence is the most general classifier of entities that have identity and
@@ -282,23 +285,54 @@ package Occurrences {
 
 		/**
 		 * A space shot of this Occurrence that is not among those of its space interior,
-		 * which must be outside it. It must not have a spaceBoundary.
+		 * which must be outside it. It must not have a spaceBoundary.	It can be divided
+		 * into space slices that also have no spaceBoundary, where the outer one surrounds
+		 * the inner ones.
 		 */
 		portion feature spaceBoundary: Occurrence[0..1] subsets spaceShots {
+
 			feature redefines isClosed = true;
+
+			feature spaceBounder: Occurrence redefines self;
+
+			outer: Occurrence [0..1] subsets spaceSlices {
+				feature redefines isClosed = true;
+				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
+			}
+
+			inner: Occurrence [0..*] subsets spaceSlices {
+				feature redefines isClosed = true;
+				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
+			}
+
+			inv { notEmpty(inner) implies notEmpty(outer) }
+			inv { notEmpty(outer) implies
+				contains(unionsOf, union(outer, inner)) }
 		}
 
 		/**
 		 * An Occurrence of which this one is the space boundary.
 		 */
-		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf;
+		feature spaceBoundaryOf: Occurrence[0..*] subsets spaceShotOf {
+			feature spaceBounderOf: Occurrence redefines self;
+			inv { spaceBounderOf.spaceBoundary == Occurrence::self }
+		}
 
 		inv { !isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
 		inv { innerSpaceDimension == 0 implies isEmpty(spaceBoundary) }
 
-		connector :OutsideOf
-			from separateSpaceToo :> spaceInterior [0..1]
-			to separateSpace :> spaceBoundary [1];
+		connector :SurroundedBy
+			from surroundingSpace :> spaceBoundary.outer [1]
+			to surroundedSpace :> spaceInterior [0..*];
+
+		connector :SurroundedBy
+			from surroundingSpace :> spaceInterior [1]
+			to surroundedSpace :> spaceBoundary.inner [0..*];
+
+		/**
+		 * Occurrences that completely occupy the space surrounded by an inner space boundary of this Occurrence.
+		 */
+		feature innerSpaceOccurrences: Occurrence [0..*];
 
 		/**
 		 * Tells whether an occurrence has a spaceBoundary, true if it does, false otherwise.
@@ -439,8 +473,8 @@ package Occurrences {
 	/**
 	 * Within asserts that its largerOccurrence completely overlaps its smallerOccurrence in
 	 * time and space. That is, all four dimensional points of the smallerOccurrence happen
-	 * during and are inside of the largerOccurrence. This means every occurrence is Within
-	 * itself and Within is transitive.
+	 * during and are included in the space of the largerOccurrence. This means every occurrence
+	 * is Within itself and Within is transitive.
 	 */
 	assoc all Within specializes HappensDuring, InsideOf {
 		end feature smallerOccurrence: Occurrence[1..*] redefines shorterOccurrence, smallerSpace
@@ -571,5 +605,59 @@ package Occurrences {
 	assoc OutsideOf specializes Without {
 		end feature separateSpaceToo: Occurrence[0..*] redefines separateOccurrenceToo;
 		end feature separateSpace: Occurrence[0..*] redefines separateOccurrence;
+	}
+
+	/**
+	 * JustOutsideOf is an OutsideOf asserting that two occurrences have some space slices with
+	 * no space between them.
+	 */
+	assoc JustOutsideOf specializes OutsideOf {
+
+		connector :MatesWith [1..*]
+			from separateSpace :> separateSpace.spaceSlices [0..*]
+			to separateSpaceToo :> separateSpaceToo.spaceSlices [0..*];
+	}
+
+	/**
+	 * MatesWith is an OutsideOf asserting that two occurrences have no space between them.
+	 */
+	assoc MatesWith specializes JustOutsideOf {
+		feature inBetweenOccurrence: Occurrence [1] {
+			portion feature redefines spaceBoundary [1];
+			inv { contains(unionsOf, union(separateSpaceToo, separateSpace)) }
+			portion feature redefines spaceInterior [0];
+		}
+	}
+
+	/**
+	 * InnerSpaceOf is an OutsideOf asserting that one occurrence (innerSpace) is the interior
+	 * of an occurrence (hOccurrence) formed from an inner space boundary of another occurrence (outerSpace). 
+	 */
+	assoc InnerSpaceOf specializes OutsideOf {
+		end feature outerSpace: Occurrence[0..*] redefines separateSpaceToo;
+		end feature innerSpace: Occurrence[0..*] redefines separateSpace subsets outerSpace.innerSpaceOccurrences {
+			feature redefines innerSpaceOccurrences [0]; }
+
+		feature hOccurrence: Occurrence [1];
+			
+		connector hbi: WithinBoth [0..1] from hOccurrence.spaceBoundary [0..1] to outerSpace.spaceBoundary.inner [0..1];
+		connector hbo: WithinBoth [0..1] from hOccurrence.spaceBoundary [0..1] to outerSpace [0..1];
+		connector :WithinBoth from hOccurrence.spaceInterior [1] to innerSpace [1];
+
+		inv { (isEmpty(hbi) == notEmpty(hbo)) &
+		      (notEmpty(hbo) == outerSpace.isClosed) }
+	}
+
+	/**
+	 * SurroundedBy is an OutsideOf asserting that one occurrence (surrounded) is included
+	 * in space by an inner space occurrence of the other (surrounding).
+	 */
+	assoc SurroundedBy specializes OutsideOf {
+		end feature surroundingSpace: Occurrence[0..*] redefines separateSpaceToo;
+		end feature surroundedSpace: Occurrence[0..*] redefines separateSpace;
+
+		connector :InsideOf
+			from smallerOccurrence :> surroundedSpace [0..1]
+			to largerOccurrence :> surroundingSpace.innerSpaceOccurrences [1..*];
 	}
 }

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -630,7 +630,7 @@ package Occurrences {
 	}
 
 	/**
-	 * InnerSpaceOf is an OutsideOf asserting that one occurrence (innerSpace) is the interior
+	 * InnerSpaceOf is an OutsideOf asserting that one occurrence (innerSpace) is the space interior
 	 * of an occurrence (hOccurrence) formed from an inner space boundary of another occurrence (outerSpace). 
 	 */
 	assoc InnerSpaceOf specializes OutsideOf {
@@ -649,8 +649,8 @@ package Occurrences {
 	}
 
 	/**
-	 * SurroundedBy is an OutsideOf asserting that one occurrence (surrounded) is included
-	 * in space by an inner space occurrence of the other (surrounding).
+	 * SurroundedBy is an OutsideOf asserting that one occurrence (surrounded space) is included
+	 * in space by an inner space occurrence of another (surrounding space).
 	 */
 	assoc SurroundedBy specializes OutsideOf {
 		end feature surroundingSpace: Occurrence[0..*] redefines separateSpaceToo;

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -7,10 +7,16 @@ package Items {
 	private import Objects::objects;
 	private import Parts::Part;
 	private import Parts::parts;
+	private import Occurrences::HappensWhile;
+	private import Occurrences::JustOutsideOf;
+	private import Objects::StructuredSpaceObject;
 	private import Constraints::ConstraintCheck;
 	private import Constraints::constraintChecks;
+	private import CollectionFunctions::contains;
+	private import SequenceFunctions::isEmpty;
 	private import SequenceFunctions::notEmpty;
 	private import SequenceFunctions::includes;
+	private import SequenceFunctions::union;
 	private import ControlFunctions::forAll;
 	
 	/**
@@ -29,29 +35,54 @@ package Items {
 		item shape : Item :>> spaceBoundary;
 		
 		/**
-		 * Other shapes that spatially envelop this Item.
+		 * Each enveloping shape is the shape of an Item that includes this Item in space and time.
 		 */
-		item envelopingShapes : Item[0..*] {
-			attribute :>> innerSpaceDimension = shape.innerSpaceDimension;
+		item envelopingShapes : Item[0..*] {  /* envelopingBoundaries?	Occurrence::enclosed => included, envelopingBoundaries -> enclose ?*/
+
+			  /* Enables 2 dim items to be enveloped by 2 or 3 dim shapes. */
+			attribute :>> innerSpaceDimension = (Item::innerSpaceDimension == 3  | Item::outerSpaceDimension == 3
+							     ? 2 : Item::outerSpaceDimension-1);   /* Curves bounding flat surfaces SHOULD BE COPLANAR ? */
+			assert constraint { Item::innerSpaceDimension < 3 implies notEmpty(outerSpaceDimension) }
+
+			item envelopingShape: Item :>> self;
+
+			  /* Could use existential to avoid introducing features to enveloping shapes. */
+			item envelopingItem [1]; /* Shape constraint below, to avoid envelopingShape being a portion. */
+
+			assert constraint { envelopingItem.shape.spaceTimeCoincidentOccurrences->includes(envelopingShape) &
+					    envelopingItem.spaceTimeEnclosedOccurrences->includes(Item::self) }
 		}
 		
 		/**
-		 * An Item is enveloped by all its envelopingShapes. That is, for each envelopingShape, there
-		 * is an Item with that shape that encloses this Item in space for its entire lifetime.
+		 * Bounding shapes are enveloping shapes that are structured space objects with every face or every edge
+		 * intersecting this Item.
 		 */
-		assert constraint envelopingShapeConstraint { 
-			envelopingShapes->forAll { in envelopingShape : Item;
-				item envelopingItem {
-					item :>> shape = envelopingShape; 
-				}
-				envelopingItem.spaceTimeEnclosedOccurrences->includes(Item::self)
+		item boundingShapes : StructuredSpaceObject [0..*] :> envelopingShapes {
+
+			item boundingShape: Item :>> self;
+
+			item :>> faces {
+				item face :>> self;
+				item inter [1];
+				assert constraint { contains(inter.intersectionsOf, union(face, boundingShape)) }
+			}
+			item :>> edges {
+				item edge :>> self;
+				item inter [1];
+				assert constraint { isEmpty(faces) implies
+							contains(inter.intersectionsOf, union(edge, boundingShape)) }
 			}
 		}
-		
+
 		/**
-		 * An Item is solid if it is three-dimensional and has a non-empty shape (boundary).
+		 * Voids  are inner space occurrences that have "nothing (material) in them" (TBD). *sufficient, need assertion*
 		 */
-		attribute isSolid = innerSpaceDimension == 3 and notEmpty(shape);
+		item voids :> innerSpaceOccurrences [0..*];
+
+		/**
+		 * An Item is solid if it has no voids.
+		 */
+		attribute isSolid = isEmpty(voids);
 		
 		/**
 		 * The Items that are composite subitems of this Item.
@@ -67,9 +98,16 @@ package Items {
 		 * Constraints that have been checked by this item.
 		 */
 		abstract ref constraint checkedConstraints: ConstraintCheck[0..*] :> constraintChecks, enactedPerformances;
-
 	}
 	
+	/**
+	 * Touching occurrences are just outside each other and happen at the same time.
+	 */
+	connection def Touches :> JustOutsideOf, HappensWhile {
+		end touchedOccurrence [0..*] :>> separateSpaceToo, thisOccurrence;
+		end touchedOccurrenceToo [0..*] :>> separateSpaceToo, thatOccurrence;
+	}
+
 	/**
 	 * items is the base feature of all ItemUsages.
 	 */

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -37,7 +37,7 @@ package Items {
 		/**
 		 * Each enveloping shape is the shape of an Item that includes this Item in space and time.
 		 */
-		item envelopingShapes : Item[0..*] {  /* envelopingBoundaries?	Occurrence::enclosed => included, envelopingBoundaries -> enclose ?*/
+		item envelopingShapes : Item[0..*] {
 
 			  /* Enables 2 dim items to be enveloped by 2 or 3 dim shapes. */
 			attribute :>> innerSpaceDimension = (Item::innerSpaceDimension == 3  | Item::outerSpaceDimension == 3
@@ -100,7 +100,7 @@ package Items {
 	}
 	
 	/**
-	 * Touching occurrences are just outside each other and happen at the same time.
+	 * Touching items are just outside each other and happen at the same time.
 	 */
 	connection def Touches :> JustOutsideOf, HappensWhile {
 		end item touchedItemToo [0..*] :>> separateSpaceToo, thisOccurrence;

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -46,7 +46,6 @@ package Items {
 
 			item envelopingShape: Item :>> self;
 
-			  /* Could use existential to avoid introducing features to enveloping shapes. */
 			item envelopingItem [1]; /* Shape constraint below, to avoid envelopingShape being a portion. */
 
 			assert constraint { envelopingItem.shape.spaceTimeCoincidentOccurrences->includes(envelopingShape) &
@@ -75,9 +74,9 @@ package Items {
 		}
 
 		/**
-		 * Voids  are inner space occurrences that have "nothing (material) in them" (TBD). *sufficient, need assertion*
+		 * Voids are inner space occurrences of this Item.
 		 */
-		item voids :> innerSpaceOccurrences [0..*];
+		item voids :>> innerSpaceOccurrences [0..*];
 
 		/**
 		 * An Item is solid if it has no voids.
@@ -104,8 +103,8 @@ package Items {
 	 * Touching occurrences are just outside each other and happen at the same time.
 	 */
 	connection def Touches :> JustOutsideOf, HappensWhile {
-		end touchedOccurrence [0..*] :>> separateSpaceToo, thisOccurrence;
-		end touchedOccurrenceToo [0..*] :>> separateSpaceToo, thatOccurrence;
+		end item touchedItemToo [0..*] :>> separateSpaceToo, thisOccurrence;
+		end item touchedItem [0..*] :>> separateSpace, thatOccurrence;
 	}
 
 	/**

--- a/sysml/src/examples/Geometry Examples/CarWithEnvelopingShape.sysml
+++ b/sysml/src/examples/Geometry Examples/CarWithEnvelopingShape.sysml
@@ -1,31 +1,16 @@
 package CarWithEnvelopingShape {
 	import ShapeItems::Box;
-	import SpatialItems::*;
 	import SI::mm;
 
 	/**
 	 * Example car with simple enveloping shape that is a solid box
 	 */
-	part def Car :> CompoundSpatialItem {
+	part def Car {
 
 		item boundingBox : Box [1] :> boundingShapes {
 			:>> length = 4800 [mm];
 			:>> width  = 1840 [mm];
 			:>> height = 1350 [mm];
-
-			  /* Need to ORIENT BOX TO COORD SYSTEM.
-			     HP: Could define Box by displacement vector from origin.
-			     AP242 ?
-			  */
-
-			  /* Bounding box origin usually at a vertez, but car origin typically in center. */
-
-			attribute :>> nestedCoordinateFrame {  /* OR coordinateFrame? */
-				attribute :>> transformation : TranslationRotationSequence {
-					attribute :>> source = Car::nestedCoordinateFrame;  /* OR coordinateFrame? */
-					attribute :>> elements = Translation((-length/2, -width/2, 0)[Car::coordinateFrame]);
-				}
-			}
 		}
 	}
 }

--- a/sysml/src/examples/Geometry Examples/CarWithEnvelopingShape.sysml
+++ b/sysml/src/examples/Geometry Examples/CarWithEnvelopingShape.sysml
@@ -1,17 +1,31 @@
 package CarWithEnvelopingShape {
-    import ShapeItems::Box;
+	import ShapeItems::Box;
+	import SpatialItems::*;
 	import SI::mm;
 
 	/**
 	 * Example car with simple enveloping shape that is a solid box
 	 */
-	part def Car {
-		
-		private item :> envelopingShapes : Box[1] {
+	part def Car :> CompoundSpatialItem {
+
+		item boundingBox : Box [1] :> boundingShapes {
 			:>> length = 4800 [mm];
-			:>> width = 1840 [mm];
+			:>> width  = 1840 [mm];
 			:>> height = 1350 [mm];
+
+			  /* Need to ORIENT BOX TO COORD SYSTEM.
+			     HP: Could define Box by displacement vector from origin.
+			     AP242 ?
+			  */
+
+			  /* Bounding box origin usually at a vertez, but car origin typically in center. */
+
+			attribute :>> nestedCoordinateFrame {  /* OR coordinateFrame? */
+				attribute :>> transformation : TranslationRotationSequence {
+					attribute :>> source = Car::nestedCoordinateFrame;  /* OR coordinateFrame? */
+					attribute :>> elements = Translation((-length/2, -width/2, 0)[Car::coordinateFrame]);
+				}
+			}
 		}
-		
 	}
 }


### PR DESCRIPTION
These are the remaining space modeling capabilities (except bounding box orientation, taking as a separate issue for later).  Slides at [ST4MD-392](https://openmbee.atlassian.net/browse/ST4MD-392?focusedCommentId=13514) (May 16, 2022).

**Occurrences.kerml**

Added inner and outer occurrence references nested under Occurrence::spaceBoundary.  These are space slices that also have no spaceBoundary, where the outer one surrounds the inner ones (see SurroundedBy below).  Also added inverse constraint to spaceBoundaryOf.

Added associations from Occurrence to itself (indirectly) specializing OutsideOf:

- JustOutsideOf linking occurrences that have space slices with no space between them (MatesWith).

- MatesWith specializing JustOutsideOf linking occurrences that have no space between them.

- InnerSpaceOf linking an occurrence to another that completely occupies the space surrounded by an inner space boundary of the first occurrence.  Added Occurrence::innerSpaceOccurrences as cross-navigation feature for this.

- SurroundedBy linking an occurrence that is included in space by an innerSpaceOccurrence of the other.  Types additional connectors in Occurrence that encure spaceBoundary surrounds spaceInterior, and spaceInterior surrounds inner space boundaries.

<br/>

**Items.sysml**

Generalized Item::envelopingShapes to cover curves and surfaces enveloping 2 dimensional shapes.  Nested original constraint.

Added Item::boundingShapes specializing envelopingShapes as StructuredSpaceObjects in which every face/edge intersects the Item.

Added Item::voids as SysML name for innerSpaceOccurrences.  Defined isSolid as having no voids.

<br/>

**CarWithEnvelopingShape.sysml**

Replaced envelopingShapes with boundingShapes.

<br/>

**ShapeItems.sysml**

Minor updates.
