### PR TITLE
ST6RI-547: Render members of State Space Representation (SSR) in Action

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
@@ -46,6 +46,11 @@ public class VActionMembers extends VBehavior {
     }
 
     public String caseFeature(Feature f) {
+        if (VSSRMembers.isStateSpaceMember(f)) {
+            if (!addRecLine(f, true)) return null;
+            VSSRMembers vs = new VSSRMembers(this);
+            return vs.start(f);
+        }
         FeatureDirectionKind fdk = f.getDirection();
         if (fdk == null) return null;
         switch (fdk) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -84,6 +84,7 @@ public class VCompartment extends VStructure {
     }
 
     protected boolean rec(Namespace n, Membership m, Element e, boolean force) {
+        if (parent == null) return false;
         VTree subtree = parent.subtree(n, m, e, force);
         if (subtree == null) return false;
         subtrees.add(subtree);
@@ -626,7 +627,7 @@ public class VCompartment extends VStructure {
         }
     }
 
-    private void startType(Type typ) {
+    public void startType(Type typ) {
         traverse(typ);
         addFeatures(featureEntries, 0);
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
@@ -1,0 +1,64 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation, PlantUML Visualization
+ * Copyright (c) 2022 Mgnite Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Hisashi Miyashita, Mgnite Inc.
+ * 
+ *****************************************************************************/
+
+package org.omg.sysml.plantuml;
+
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.Type;
+
+public class VSSRMembers extends VStructure {
+    private static boolean isRedefining(Feature f, String prefix) {
+        for (Redefinition rd: f.getOwnedRedefinition()) {
+            Feature rf = rd.getRedefinedFeature();
+            String qName = rf.getQualifiedName();
+            if (qName != null) {
+                if (qName.startsWith(prefix)) return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isStateSpaceMember(Feature f) {
+        return isRedefining(f, "StateSpaceRepresentation::StateSpaceDynamics::");
+    }
+
+    public String caseFeature(Feature f) {
+        addType(f, "comp usage ");
+        VCompartment vc = new VCompartment(this);
+        vc.startType(f);
+        vc.closeBlock();
+        return "";
+    }
+
+    public String start(Type typ) {
+        traverse(typ);
+        closeBlock();
+        return "";
+    }
+
+    VSSRMembers(Visitor v) {
+        super(v);
+    }
+}

--- a/sysml/src/examples/State Space Representation Examples/CartSample.sysml
+++ b/sysml/src/examples/State Space Representation Examples/CartSample.sysml
@@ -1,0 +1,61 @@
+// State Space Representation cart example
+
+package CartSample {
+    import StateSpaceRepresentation::*;
+    part def Cart {
+        attribute mass :> ISQ::mass;
+
+        attribute def CartInput :> Input {
+            attribute force :> ISQ::force;
+        }
+
+        attribute def CartOutput :> Output {
+            attribute velocity :> ISQ::speed;
+        }
+
+        attribute def CartState :> StateSpace {
+            attribute velocity :> ISQ::speed;
+        }
+
+        attribute def CartStateDerivative :> StateDerivative {
+            ref :>> stateSpace : CartState;
+            attribute accel :> ISQ::acceleration;
+        }
+    }
+
+    part def Pusher {
+        attribute def PusherOutput :> Output {
+            attribute force :> ISQ::force;
+        }
+    }
+
+    part context {
+        part cart : Cart {
+            action cartBehavior : ContinuousStateSpaceDynamics {
+                :>> input : CartInput;
+                :>> output : CartOutput;
+                :>> stateSpace : CartState;
+
+                calc :>> getDerivative(input: CartInput, stateSpace: CartState) {
+                    CartStateDerivative(input.force / mass)
+                }
+                calc :>> getOutput {
+                	in :>> stateSpace : CartState;
+                    CartOutput(stateSpace.velocity)
+                }
+            }
+        }
+        part pusher : Pusher {
+            attribute pusherForce :> ISQ::force;
+
+            action pusherBehavior : ContinuousStateSpaceDynamics {
+                :>> output : PusherOutput;
+                calc :>> getOutput {
+                    PusherOutput(pusherForce)
+                }
+            }
+        }
+
+        flow pusher.pusherBehavior.output.force to cart.cartBehavior.input.force;
+    }
+}

--- a/sysml/src/examples/State Space Representation Examples/EVSample.sysml
+++ b/sysml/src/examples/State Space Representation Examples/EVSample.sysml
@@ -1,0 +1,311 @@
+// State Space Representation EV example
+package EVSample {
+    import SI::*;
+    import StateSpaceRepresentation::*;
+
+    part def Vehicle {
+        attribute mass :> ISQ::mass;
+
+        attribute def VehicleInput :> Input {
+            attribute force :> ISQ::force;
+        }
+
+        attribute def VehicleOutput :> Output {
+            attribute accel :> ISQ::acceleration;
+            attribute velocity :> ISQ::speed;
+            attribute distance :> ISQ::distance;
+        }
+
+        attribute def VehicleState :> StateSpace {
+            attribute velocity :> ISQ::speed;
+            attribute distance :> ISQ::distance;
+        }
+    }
+
+    part def Battery {
+        attribute baseVoltage :> ISQ::electricPotential;
+        attribute socInit: ScalarValues::Real;
+        attribute capacity :> ISQ::electricCharge;
+        attribute internalResistance :> ISQ::resistance;
+
+        attribute def BatteryInput :> Input {
+            attribute current :> ISQ::electricCurrent;
+        }
+
+        attribute def BatteryOutput :> Output {
+            attribute voltage :> ISQ::electricPotential;
+        }
+
+        attribute def BatteryState :> StateSpace {
+            attribute soc: ScalarValues::Real;
+        }
+
+    }
+
+    part def Motor {
+        torquePerCurrent :> Quantities::scalarQuantities = ISQ::torque / ISQ::electricCurrent;
+
+        attribute motR :> ISQ::resistance;
+        attribute motL :> ISQ::inductance;
+
+        attribute def MotorInput :> Input {
+            attribute voltage :> ISQ::electricPotential;
+            attribute friction :> ISQ::torque;
+        }
+
+        attribute def MotorOutput :> Output {
+            attribute current :> ISQ::electricCurrent;
+            attribute torque :> ISQ::torque;
+        }
+
+        attribute def MotorState :> StateSpace {
+            attribute current :> ISQ::electricCurrent;
+        }
+    }
+
+    part def Tire {
+        attribute radius :> ISQ::length;
+        attribute moment :> ISQ::momentOfInertia;
+
+        attribute def TireInput :> Input {
+            attribute torque :> ISQ::torque;
+            attribute accel :> ISQ::acceleration;
+        }
+
+        attribute def TireOutput :> Output {
+            attribute force :> ISQ::force;
+            attribute outTorque :> ISQ::torque;
+        }
+    }
+
+    requirement def VehicleRequirement {
+        in vehicle : Vehicle;
+    }
+
+    analysis def VehicleAnalysis {
+        subject vehicle : Vehicle;
+        requirement vehicleRequirement : VehicleRequirement;
+    }
+
+
+    requirement def RangeRequirement :> VehicleRequirement {
+        doc /* The range of EV must be longer than the required spec under the flat road. */
+        attribute actualRange : LengthValue;
+        attribute requiredRange : LengthValue;
+
+        require constraint { actualRange >= requiredRange }
+    }
+
+    analysis def RangeAnalysis :> VehicleAnalysis () simulatedRange : LengthValue {
+        requirement rangeRequirement :>> vehicleRequirement : RangeRequirement;
+
+        objective rangeAnalysisObjective {
+            doc /* This analysis is to estimate the range of
+                 * the EV by simulating the vehicle driving under the compact vehicle regulation.
+                 */
+            require rangeRequirement {
+                :>> actualRange = simulatedRange;
+            }
+        }
+    }
+
+    requirement def EfficiencyRequirement :> VehicleRequirement {
+        doc /* The efficiency of EV must be better than the required spec. */
+        attribute actualEfficiency;
+        attribute requiredEfficiency;
+
+        require constraint { actualEfficiency >= requiredEfficiency }
+    }
+
+    analysis def EfficiencyAnalysis :> VehicleAnalysis () simulatedEfficiency {
+        requirement efficiencyRequirement :>> vehicleRequirement : EfficiencyRequirement;
+
+        objective efficiencyAnalysisObjective {
+            require efficiencyRequirement {
+                attribute :>> actualEfficiency = simulatedEfficiency;
+            }
+        }
+    }
+
+    requirement def MaxSpeedRequirement :> VehicleRequirement {
+        doc /* The maximum speed of EV must be larger than the required spec. */
+        attribute actualMaxSpeed :> ISQ::speed;
+        attribute requiredMaxSpeed :> ISQ::speed;
+    }
+
+    analysis def MaxSpeedAnalysis :> VehicleAnalysis () simulatedMaxSpeed {
+        requirement maxSpeedRequirement :>> vehicleRequirement : MaxSpeedRequirement;
+
+        objective maxSpeedAnalysisObjective {
+            require maxSpeedRequirement {
+                attribute :>> actualMaxSpeed = simulatedMaxSpeed;
+            }
+        }
+    }
+
+
+    part vehicle : Vehicle {
+        attribute :>> mass = 1000[kg];
+
+        /* airFrictionCoefficient [kg / m] = 1/2 * rho[kg/m^3] * Cd * S[m^2],
+         * where rho is air density, S is front projected area. */
+        attribute airFrictionCoefficient = 0.2;
+
+        attribute efficiency;
+
+        action vehicleBehavior : ContinuousStateSpaceDynamics {
+            :>> input : VehicleInput;
+            :>> output : VehicleOutput;
+            :>> stateSpace : VehicleState;
+        }
+        
+        part battery: Battery {
+            :>> baseVoltage = 300[V];
+            :>> capacity = 50['A⋅h'];
+            :>> socInit = 0.8;
+            :>> internalResistance = 1.8['Ω'];
+            action batteryBehavior : ContinuousStateSpaceDynamics {
+                :>> input : BatteryInput;
+                :>> output : BatteryOutput;
+                :>> stateSpace : BatteryState;
+            }
+        }
+
+        flow battery.batteryBehavior.output.voltage to motor.motorBehavior.input.voltage;
+        flow motor.motorBehavior.output.current to battery.batteryBehavior.input.current;
+
+        part motor: Motor {
+            :>> motR = 4['Ω'];
+            :>> motL = 0.2[H];
+
+            action motorBehavior : ContinuousStateSpaceDynamics {
+                :>> input : MotorInput;
+                :>> output : MotorOutput;
+                :>> stateSpace : MotorState;
+            }
+        }
+
+        flow motor.motorBehavior.output.torque to tire.tireBehavior.input.torque;
+        flow vehicleBehavior.output.accel to tire.tireBehavior.input.accel;
+
+        part tire: Tire {
+            :>> moment = 300['kg⋅m²'];
+            :>> radius = 0.7[m];
+            action tireBehavior : ContinuousStateSpaceDynamics {
+                :>> input : TireInput;
+                :>> output : TireOutput;
+            }
+        }
+
+        flow tire.tireBehavior.output.outTorque to motor.motorBehavior.input.friction;
+        flow tire.tireBehavior.output.force to vehicleBehavior.input.force;
+    }
+
+    part vehicle_compact :> vehicle {
+        attribute :>> mass = 800[kg];
+        part :>> tire {
+            :>> moment = 200['kg⋅m²'];
+            :>> radius = 0.5[m];
+        }
+    }
+
+    part smallEVRangeContext {
+        requirement smallEVRequirement : VehicleRequirement {
+            doc /* The small EVs must be ligher than 900[kg] */
+            in :>> vehicle = vehicle_compact;
+            /*  To comform with the regulation and the battery mass will impact it. */
+            assume constraint { vehicle.mass < 900[kg] }
+        }
+
+        analysis smallEVAnalysis : VehicleAnalysis {
+            subject :>> vehicle :> vehicle_compact;
+            requirement :>> vehicleRequirement = smallEVRequirement;
+        }
+
+        requirement <C1> rangeRequirementSmall :> smallEVRequirement : RangeRequirement {
+            doc /* The small EVs must run longer than 130km */
+            attribute :>> requiredRange = 130[km];
+        }
+
+        analysis rangeAnalysisSmall :> smallEVAnalysis : RangeAnalysis {
+            requirement :>> rangeRequirement = rangeRequirementSmall;
+            return simulatedRange = vehicle.vehicleBehavior.output.distance;
+        }
+
+        requirement <C2> efficiencyRequirementSmall :> smallEVRequirement : EfficiencyRequirement {
+            doc /* The target efficiency of small EVs is 0.9. */
+            attribute :>> requiredEfficiency = 0.9;
+        }
+
+        analysis efficiencyAnalysisSmall :> smallEVAnalysis : EfficiencyAnalysis {
+            requirement :>> efficiencyRequirement = efficiencyRequirementSmall;
+
+            return simulatedEfficiency = vehicle.efficiency;
+        }
+
+        requirement <C3> maxSpeedRequirementSmall :> smallEVRequirement : MaxSpeedRequirement {
+            doc /* The target maximum speed of small EVs is 130 [km/h]. */
+            attribute :>> requiredMaxSpeed = 130 [km/h];
+        }
+
+        analysis maxSpeedAnalysisSmall :> smallEVAnalysis : MaxSpeedAnalysis {
+            requirement :>> maxSpeedRequirement = maxSpeedRequirementSmall;
+            out voltage :> ISQ::electricPotential = vehicle.battery.batteryBehavior.output.voltage;
+            return simulatedMaxSpeed = vehicle.vehicleBehavior.output.velocity;
+        }
+    }
+
+    part vehicle_large :> vehicle {
+        attribute :>> mass = 1100[kg];
+        part :>> tire {
+            :>> moment = 300['kg⋅m²'];
+            :>> radius = 0.7[m];
+        }
+    }
+
+    part largeEVRangeContext {
+        requirement largeEVRequirement : VehicleRequirement {
+            doc /* The large EVs must be ligher than 900[kg] */
+            in :>> vehicle = vehicle_large;
+            /*  To comform with the regulation and the battery mass will impact it. */
+            assume constraint { vehicle.mass < 1200[kg] }
+        }
+
+        analysis largeEVAnalysis : VehicleAnalysis {
+            subject :>> vehicle :> vehicle_large;
+            requirement :>> vehicleRequirement = largeEVRequirement;
+        }
+
+        requirement <L1> rangeRequirementLarge :> largeEVRequirement : RangeRequirement {
+            doc /* The large EVs must run longer than 200km */
+            attribute :>> requiredRange = 200[km];
+        }
+
+        analysis rangeAnalysisLarge :> largeEVAnalysis : RangeAnalysis {
+            requirement :>> rangeRequirement = rangeRequirementLarge;
+            return simulatedRange = vehicle.vehicleBehavior.output.distance;
+        }
+
+        requirement <L2> efficiencyRequirementLarge :> largeEVRequirement : EfficiencyRequirement {
+            doc /* The target efficiency of large EVs is 0.8. */
+            attribute :>> requiredEfficiency = 0.8;
+        }
+
+        analysis efficiencyAnalysisLarge :> largeEVAnalysis : EfficiencyAnalysis {
+            requirement :>> efficiencyRequirement = efficiencyRequirementLarge;
+
+            return simulatedEfficiency = vehicle.efficiency;
+        }
+
+        requirement <L3> maxSpeedRequirementLarge :> largeEVRequirement : MaxSpeedRequirement {
+            doc /* The target maximum speed of large EVs is 140 [km/h]. */
+            attribute :>> requiredMaxSpeed = 140 [km/h];
+        }
+
+        analysis maxSpeedAnalysisLarge :> largeEVAnalysis : MaxSpeedAnalysis {
+            requirement :>> maxSpeedRequirement = maxSpeedRequirementLarge;
+            out voltage = vehicle.battery.batteryBehavior.output.voltage;
+            return simulatedMaxSpeed = vehicle.vehicleBehavior.output.velocity;
+        }
+    }
+}

--- a/sysml/src/examples/State Space Representation Examples/EVSample.sysml
+++ b/sysml/src/examples/State Space Representation Examples/EVSample.sysml
@@ -3,6 +3,8 @@ package EVSample {
     import SI::*;
     import StateSpaceRepresentation::*;
 
+    attribute <'A⋅h'> 'ampere hour'  : ElectricChargeUnit = A*h;
+
     part def Vehicle {
         attribute mass :> ISQ::mass;
 


### PR DESCRIPTION
Actions of SSR have `input`, `output`, and `stateSpace` but they were not rendered properly.  `input` and `output` are features having FeatureDirectionKind so that the visualizer could render these features but it did not render their vector components.  `stateSpace` does not have FeatureDirectionKind and it was not rendered at all.

I also added two SSR examples, CartSample and EVSample, in `sysml/src/examples/State Space Representation Examples` directory.
