### PR TITLE
ST6RI-546 Inherited membership computation does not handle feature chains properly

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
@@ -578,7 +578,7 @@ public class TypeImpl extends NamespaceImpl implements Type {
 				inheritedMemberships.addAll(((TypeImpl)originalType).getMembership(excludedNamespaces, excludedTypes, includeProtected));
 			}
 		}
-		for (Type general: TypeUtil.getSupertypesOf(this)) {
+		for (Type general: TypeUtil.getGeneralTypesOf(this)) {
 			if (general != null && !excludedTypes.contains(general)) {
 				inheritedMemberships.addAll(((TypeImpl)general).getNonPrivateMembership(excludedNamespaces, excludedTypes, includeProtected));
 			}


### PR DESCRIPTION
Changed `TypeImpl::addInheritedMemberships` to use `TypeUtil::getGeneralTypesOf`.