### PR TITLE
ST6RI-552 Variants of a variation usage are not getting proper implicit subsettings

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/visibility/VisibilityTests_PublicImportAsFeatureAlias_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/visibility/VisibilityTests_PublicImportAsFeatureAlias_Rdef.kerml.xt
@@ -21,9 +21,11 @@ END_SETUP
 package Classes {
 	alias aliass for VisibilityPackage::c_Public::c_public;
 	alias Aliass for VisibilityPackage::c_Public;
-	feature Try{
+	feature Try : Aliass {
 		//scope are the same for at aliass and at Aliass
 		//* XPECT scope at aliass ---
+		   c_public, c_public.self, Try.c_public, Try.c_public.self, 
+		   Classes.Try.c_public, Classes.Try.c_public.self, 
 		   aliass, feature4, featurepublic,
 		   featurepublic.c_public, Try.featurepublic.c_public, Classes.Try.featurepublic.c_public,
 		   Aliass, Aliass.c_public, 
@@ -43,6 +45,8 @@ package Classes {
 		feature feature4 subsets aliass;
 		//XPECT linkedName at Aliass --> VisibilityPackage.c_Public
 		//* XPECT scope at Aliass ---
+		   c_public, c_public.self, Try.c_public, Try.c_public.self, 
+		   Classes.Try.c_public, Classes.Try.c_public.self, 
 		   aliass, feature4, featurepublic,
 		   featurepublic.c_public, Try.featurepublic.c_public, Classes.Try.featurepublic.c_public,
 		   Aliass, Aliass.c_public, 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -158,10 +158,17 @@ public class UsageAdapter extends FeatureAdapter {
 	
 	protected void addVariationTyping() {
 		Usage usage = getTarget();
-		Definition variationDefinition = UsageUtil.getOwningVariationDefinitionFor(usage);
-		if (variationDefinition != null && UsageUtil.isVariant(getTarget())) {
-			addImplicitGeneralType(SysMLPackage.eINSTANCE.getFeatureTyping(), variationDefinition);
-		}		
+		if (UsageUtil.isVariant(usage)) {
+			Definition variationDefinition = UsageUtil.getOwningVariationDefinitionFor(usage);
+			if (variationDefinition != null) {
+				addImplicitGeneralType(SysMLPackage.eINSTANCE.getFeatureTyping(), variationDefinition);
+			} else {
+				Usage variationUsage = UsageUtil.getOwningVariationUsageFor(usage);
+				if (variationUsage != null) {
+					addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), variationUsage);
+				}
+			}
+		}
 	}
 	
 	@Override

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
@@ -820,8 +820,7 @@ public class FeatureImpl extends TypeImpl implements Feature {
 	 */
 	public boolean isFeaturedWithin(Type type) {
 		List<Type> featuringTypes = getFeaturingType();
-		return featuringTypes.isEmpty() ||
-			   featuringTypes.stream().anyMatch(featuringType->
+		return featuringTypes.stream().anyMatch(featuringType->
 			   		type != null && TypeUtil.conforms(featuringType, type) ||
 					featuringType instanceof Feature &&
 					((Feature)featuringType).isFeaturedWithin(type));

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
@@ -578,7 +578,7 @@ public class TypeImpl extends NamespaceImpl implements Type {
 				inheritedMemberships.addAll(((TypeImpl)originalType).getMembership(excludedNamespaces, excludedTypes, includeProtected));
 			}
 		}
-		for (Type general: TypeUtil.getSupertypesOf(this)) {
+		for (Type general: TypeUtil.getGeneralTypesOf(this)) {
 			if (general != null && !excludedTypes.contains(general)) {
 				inheritedMemberships.addAll(((TypeImpl)general).getNonPrivateMembership(excludedNamespaces, excludedTypes, includeProtected));
 			}

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
@@ -606,7 +606,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                         attribute mass :> ISQ::mass=875[kg];
                         attribute driveTrainEfficiency:Real = 0.6;
                         port shaftPort_d:ShaftPort_d;
-                        perform ActionTree::providePower::distributeTorque;
+                        perform ActionTree::providePower.distributeTorque;
                         part rearWheel1:Wheel{
                             attribute redefines diameter;
                             port wheelToAxlePort:WheelToAxlePort;
@@ -641,7 +641,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                     }
                     part starterMotor:StarterMotor;
                     part engine:Engine{
-                        perform ActionTree::providePower::generateTorque redefines generateTorque;            
+                        perform ActionTree::providePower.generateTorque redefines generateTorque;            
                         part cylinders:Cylinder[4..6];
                         part alternator{
                             action generateElectricity;
@@ -661,13 +661,13 @@ package sfriedenthal_VehicleModel_1_simplified{
                         //conjugate notation ~
                         //port clutchPort:~DrivePwrPort;
                         port shaftPort_a:ShaftPort_a;
-                        perform ActionTree::providePower::amplifyTorque;
+                        perform ActionTree::providePower.amplifyTorque;
                     }
                     part driveshaft:Driveshaft{
                         attribute mass :> ISQ::mass=100[kg];
                         port shaftPort_b:ShaftPort_b;
                         port shaftPort_c:ShaftPort_c;
-                        perform ActionTree::providePower::transferTorque;
+                        perform ActionTree::providePower.transferTorque;
                     }
                     part vehicleSoftware:VehicleSoftware{
                         part vehicleController: VehicleController {
@@ -1109,7 +1109,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                 objective fuelEconomyAnalysisObjective {
                     /* the objective of this analysis is to determine whether the vehicle design configuration can 
                     satisfy the fuel economy requirements */
-                    require vehicleSpecification::vehicleFuelEconomyRequirements;
+                    require vehicleSpecification.vehicleFuelEconomyRequirements;
                 }
                 
                 action fuelConsumption {
@@ -1197,7 +1197,7 @@ package sfriedenthal_VehicleModel_1_simplified{
                 objective fuelEconomyAnalysisObjective {
                     doc /*the objective of this analysis is to determine whether the vehicle design configuration can 
                     satisfy the fuel economy requirements*/
-                    require vehicleSpecification::vehicleFuelEconomyRequirements;
+                    require vehicleSpecification.vehicleFuelEconomyRequirements;
                 }
                 /* this is the longhand for a calc
                 calc calc1:TraveledDistance(in=scenario) result;

--- a/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
+++ b/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
@@ -629,7 +629,7 @@ package VehicleModel_1_simplified{
                         attribute mass :> ISQ::mass=875[kg];
                         attribute driveTrainEfficiency:Real = 0.6;
                         port shaftPort_d:ShaftPort_d;
-                        perform ActionTree::providePower::distributeTorque;
+                        perform ActionTree::providePower.distributeTorque;
                         part rearWheel1:Wheel{
                             attribute redefines diameter;
                             port wheelToAxlePort:WheelToAxlePort;
@@ -664,7 +664,7 @@ package VehicleModel_1_simplified{
                     }
                     part starterMotor:StarterMotor;
                     part engine:Engine{
-                        perform ActionTree::providePower::generateTorque redefines generateTorque;            
+                        perform ActionTree::providePower.generateTorque redefines generateTorque;            
                         part cylinders:Cylinder[4..6];
                         part alternator{
                             action generateElectricity;
@@ -684,13 +684,13 @@ package VehicleModel_1_simplified{
                         //conjugate notation ~
                         //port clutchPort:~DrivePwrPort;
                         port shaftPort_a:ShaftPort_a;
-                        perform ActionTree::providePower::amplifyTorque;
+                        perform ActionTree::providePower.amplifyTorque;
                     }
                     part driveshaft:Driveshaft{
                         attribute mass :> ISQ::mass=100[kg];
                         port shaftPort_b:ShaftPort_b;
                         port shaftPort_c:ShaftPort_c;
-                        perform ActionTree::providePower::transferTorque;
+                        perform ActionTree::providePower.transferTorque;
                     }
                     part vehicleSoftware:VehicleSoftware{
                         part vehicleController: VehicleController {
@@ -1138,7 +1138,7 @@ package VehicleModel_1_simplified{
                 objective fuelEconomyAnalysisObjective {
                     /* the objective of this analysis is to determine whether the vehicle design configuration can 
                     satisfy the fuel economy requirements */
-                    require vehicleSpecification::vehicleFuelEconomyRequirements;
+                    require vehicleSpecification.vehicleFuelEconomyRequirements;
                 }
                 
                 action fuelConsumption {
@@ -1226,7 +1226,7 @@ package VehicleModel_1_simplified{
                 objective fuelEconomyAnalysisObjective {
                     doc /*the objective of this analysis is to determine whether the vehicle design configuration can 
                     satisfy the fuel economy requirements*/
-                    require vehicleSpecification::vehicleFuelEconomyRequirements;
+                    require vehicleSpecification.vehicleFuelEconomyRequirements;
                 }
                 /* this is the longhand for a calc
                 calc calc1:TraveledDistance(in=scenario) result;

--- a/sysml/src/training/33. Verification/Verification Case Usage Example.sysml
+++ b/sysml/src/training/33. Verification/Verification Case Usage Example.sysml
@@ -16,7 +16,7 @@ package 'Verification Case Usage Example' {
 		perform vehicleMassTest;
 		
 		part scale : Scale {
-			perform vehicleMassTest::collectData {
+			perform vehicleMassTest.collectData {
 				in part :>> testVehicle;
 				
 				// In reality, this would be some more involved process.

--- a/sysml/src/training/37. Allocation/Allocation Definition Example.sysml
+++ b/sysml/src/training/37. Allocation/Allocation Definition Example.sysml
@@ -11,7 +11,7 @@ package 'Allocation Definition Example' {
 		}
 		
 		part torqueGenerator : TorqueGenerator {
-			perform providePower::generateTorque;
+			perform providePower.generateTorque;
 		}
 		
 	}
@@ -24,7 +24,7 @@ package 'Allocation Definition Example' {
 		
 		part powerTrain : PowerTrain {
 			part engine {
-				perform providePower::generateTorque;
+				perform providePower.generateTorque;
 			}
 		}
 	

--- a/sysml/src/training/37. Allocation/Allocation Usage Example.sysml
+++ b/sysml/src/training/37. Allocation/Allocation Usage Example.sysml
@@ -10,7 +10,7 @@ package 'Allocation Usage Example' {
 		}
 		
 		part torqueGenerator : TorqueGenerator {
-			perform providePower::generateTorque;
+			perform providePower.generateTorque;
 		}
 	}
 	
@@ -22,7 +22,7 @@ package 'Allocation Usage Example' {
 		
 		part powerTrain : PowerTrain {
 			part engine : Engine {
-				perform providePower::generateTorque;
+				perform providePower.generateTorque;
 			}
 		}
 		

--- a/sysml/src/validation/06-Individual and Snapshots/6-Individual and Snapshots.sysml
+++ b/sysml/src/validation/06-Individual and Snapshots/6-Individual and Snapshots.sysml
@@ -112,7 +112,7 @@ package '6-Individual and Snapshots' {
 					 * state, which means that the vehicle must me in the state 
 					 * at the time of the snapshot.
 					 */
-					exhibit vehicleStates::on;
+					exhibit vehicleStates.on;
 				}
 				
 				snapshot road_ID1_t0 : Road_ID1 {
@@ -130,7 +130,7 @@ package '6-Individual and Snapshots' {
 					:>> velocity = v1;
 					:>> acceleration = a1;
 					
-					exhibit vehicleStates::on;
+					exhibit vehicleStates.on;
 				}
 				
 				snapshot road_ID1_t1 : Road_ID1 {
@@ -150,7 +150,7 @@ package '6-Individual and Snapshots' {
 					:>> velocity = vn;
 					:>> acceleration = an;
 					
-					exhibit vehicleStates::off;
+					exhibit vehicleStates.off;
 				}
 				
 				snapshot road_ID1_tn : Road_ID1 {

--- a/sysml/src/validation/08-Requirements/8-Requirements.sysml
+++ b/sysml/src/validation/08-Requirements/8-Requirements.sysml
@@ -46,7 +46,7 @@ package '8-Requirements' {
 				
 			part engine_v1: Engine {
 				port :>> drivePwrPort;
-				perform 'provide power'::'generate torque' :>> Engine::'generate torque';
+				perform 'provide power'.'generate torque' :>> 'generate torque';
 			}
 			
 			part transmission: Transmission {

--- a/sysml/src/validation/09-Verification/9-Verification-simplified.sysml
+++ b/sysml/src/validation/09-Verification/9-Verification-simplified.sysml
@@ -85,7 +85,7 @@ package '9-Verification-simplified' {
 			part testOperator : TestOperator;
 			
 			part scale : Scale {
-				perform vehicleMassTest::collectData {
+				perform vehicleMassTest.collectData {
 					in part :>> testVehicle;
 					
 					// In reality, this would be some more involved process.

--- a/sysml/src/validation/12-Dependency Relationships/12b-Allocation-1.sysml
+++ b/sysml/src/validation/12-Dependency Relationships/12b-Allocation-1.sysml
@@ -26,7 +26,7 @@ package '12b-Allocation-1' {
 		}
 		
 		part torqueGenerator : TorqueGenerator {
-			perform providePower::generateTorque :>> generateTorque;
+			perform providePower.generateTorque :>> generateTorque;
 		}
 		
 		satisfy torqueGeneration by torqueGenerator;			
@@ -38,7 +38,7 @@ package '12b-Allocation-1' {
 		
 		part powerTrain : PowerTrain {
 			part engine {
-				perform providePower::generateTorque;
+				perform providePower.generateTorque;
 			}
 		}
 	}

--- a/sysml/src/validation/12-Dependency Relationships/12b-Allocation.sysml
+++ b/sysml/src/validation/12-Dependency Relationships/12b-Allocation.sysml
@@ -8,14 +8,14 @@ package '12b-Allocation' {
 		}
 		
 		part torqueGenerator {
-			perform providePower::generateTorque;
+			perform providePower.generateTorque;
 		}
 	}
 	
 	package PhysicalModel {
 		part powerTrain {
 			part engine {
-				perform providePower::generateTorque;
+				perform providePower.generateTorque;
 			}
 		}
 	}


### PR DESCRIPTION
Fixed the transformation for variation typing in `UsageAdapter`.

This also allow the implementation of `FeatureImpl::isFeaturedWithin` so that features are not considered "within" package-level features. This results in a better validation for the featuring types of the target of subsetting relationships.