### PR TITLE
ST6RI-538 Rename UnitsAndScales library package to MeasurementReferences

### DIFF
--- a/kerml/src/examples/Vehicle Example/VehicleDefinitions.kerml
+++ b/kerml/src/examples/Vehicle Example/VehicleDefinitions.kerml
@@ -2,11 +2,6 @@
  * Example vehicle definitions model.
  **/
 package VehicleDefinitions {
-	import ScalarValues::*;
-	import Quantities::*;
-	import UnitsAndScales::*;
-	import ISQ::*;
-	import SI::*;
 	
 	/* BLOCKS */
 	

--- a/kerml/src/examples/Vehicle Example/VehicleUsages.kerml
+++ b/kerml/src/examples/Vehicle Example/VehicleUsages.kerml
@@ -5,7 +5,6 @@ package VehicleUsages {
 	import SI::N;
 	import SI::m;
 	import VehicleDefinitions::*;
-	import ScalarFunctions::*;
 
 	/* VALUES */	 
 	feature T1 = 10.0[N * m];

--- a/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
@@ -6,9 +6,7 @@ package SpatialItems {
 	private import Objects::Point;
 	private import SpatialFrames::SpatialFrame;
 	private import Quantities::VectorQuantityValue;
-	private import UnitsAndScales::VectorMeasurementReference;
-	private import UnitsAndScales::CoordinateFrame;
-	private import UnitsAndScales::CoordinateTransformation;
+	private import MeasurementReferences::CoordinateFrame;
 	private import Time::Clock;
 	private import Time::TimeInstantValue;
 	private import ISQ::Cartesian3dSpatialCoordinateFrame;
@@ -28,7 +26,7 @@ package SpatialItems {
 		ref item localClock : Clock[1] default Time::defaultClock;
 		
 		/**
-		 * The three-dimensional VectorMeasurementReference to be used as the measurement reference for position 
+		 * The three-dimensional CoordinateFrame to be used as the measurement reference for position 
 		 * and displacement vector values relative to this SpatialItem.
 		 */
 		attribute coordinateFrame : CoordinateFrame[1] default Cartesian3dSpatialCoordinateFrame() {

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQ.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQ.sysml
@@ -4,7 +4,7 @@
 package ISQ {
 	private import ScalarValues::Real;
 	private import Quantities::*;
-	private import UnitsAndScales::*;
+	private import MeasurementReferences::*;
 
 	import ISQBase::*;                  // ISO/IEC 80000 base quantities and general concepts
     import ISQSpaceTime::*;             // ISO 80000-3 "Space and Time"

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQAcoustics.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQAcoustics.sysml
@@ -12,7 +12,7 @@
 package ISQAcoustics {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQAtomicNuclear.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQAtomicNuclear.sysml
@@ -12,7 +12,7 @@
 package ISQAtomicNuclear {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQBase.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQBase.sysml
@@ -8,7 +8,7 @@
 package ISQBase {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
 
     /**
      * source: item 3-1.1 length

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQCharacteristicNumbers.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQCharacteristicNumbers.sysml
@@ -12,7 +12,7 @@
 package ISQCharacteristicNumbers {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     /**

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQChemistryMolecular.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQChemistryMolecular.sysml
@@ -12,7 +12,7 @@
 package ISQChemistryMolecular {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQCondensedMatter.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQCondensedMatter.sysml
@@ -12,7 +12,7 @@
 package ISQCondensedMatter {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQElectromagnetism.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQElectromagnetism.sysml
@@ -12,7 +12,7 @@
 package ISQElectromagnetism {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQInformation.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQInformation.sysml
@@ -12,7 +12,7 @@
 package ISQInformation {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQLight.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQLight.sysml
@@ -12,7 +12,7 @@
 package ISQLight {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQMechanics.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQMechanics.sysml
@@ -12,7 +12,7 @@
 package ISQMechanics {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQSpaceTime.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQSpaceTime.sysml
@@ -12,7 +12,7 @@
 package ISQSpaceTime {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     /**

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQThermodynamics.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQThermodynamics.sysml
@@ -12,7 +12,7 @@
 package ISQThermodynamics {
     private import ScalarValues::Real;
     private import Quantities::*;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     private import ISQBase::*;
 
     // Quantity definitions referenced from other ISQ packages

--- a/sysml.library/Domain Libraries/Quantities and Units/MeasurementReferences.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/MeasurementReferences.sysml
@@ -1,7 +1,7 @@
 /**
  * This package defines the representations for measurement references.
  */
-package UnitsAndScales {
+package MeasurementReferences {
 	private import Collections::Array;
 	private import Collections::List;
 	private import ScalarValues::*;

--- a/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Quantities.sysml
@@ -17,12 +17,12 @@ package Quantities {
 	 * scalar and vector quantities, that are tensor quantities of order 0 and 1 respectively.
 	 * The measurement reference used to express a quantity value must have a type, dimensions and order that match the quantity, i.e.,
 	 * a TensorQuantityValue must use a TensorMeasurementReference, a VectorQuantityValue a VectorMeasurementReference, 
-	 * and a ScalarQuantityValue a ScalarMeasurementReference. See package UnitsAndScales for details.
+	 * and a ScalarQuantityValue a ScalarMeasurementReference. See package MeasurementReferences for details.
 	 */
 	abstract attribute def TensorQuantityValue :> Array {
 		attribute isBound: Boolean;
 		attribute num: Number[1..*] ordered nonunique :>> elements;
-		attribute mRef: UnitsAndScales::TensorMeasurementReference;
+		attribute mRef: MeasurementReferences::TensorMeasurementReference;
         attribute :>> dimensions = mRef.dimensions;
 		attribute order :>> rank = mRef.order;
         attribute contravariantOrder: Natural;
@@ -33,11 +33,11 @@ package Quantities {
 	}
 	
 	abstract attribute def VectorQuantityValue :> TensorQuantityValue, NumericalVectorValue {
-		attribute :>> mRef: UnitsAndScales::VectorMeasurementReference;
+		attribute :>> mRef: MeasurementReferences::VectorMeasurementReference;
 	}
 	
 	abstract attribute def ScalarQuantityValue :> VectorQuantityValue, NumericalValue {
-		attribute :>> mRef: UnitsAndScales::ScalarMeasurementReference;
+		attribute :>> mRef: MeasurementReferences::ScalarMeasurementReference;
 	}
 	
 	/**

--- a/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/QuantityCalculations.sysml
@@ -1,8 +1,8 @@
 package QuantityCalculations {
 	import ScalarValues::*;
     import Quantities::ScalarQuantityValue;
-    import UnitsAndScales::ScalarMeasurementReference;
-    import UnitsAndScales::DimensionOneValue;
+    import MeasurementReferences::ScalarMeasurementReference;
+    import MeasurementReferences::DimensionOneValue;
     
     calc def isZero specializes NumericalFunctions::isZero(x: ScalarQuantityValue): Boolean {
     	NumericalFunctions::isZero(x.num)

--- a/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
@@ -5,7 +5,7 @@
  * Note 2: This is a representative but not yet complete list of measurement units.
  */
 package SI {
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     import ISQ::*;
     import SIPrefixes::*;
 

--- a/sysml.library/Domain Libraries/Quantities and Units/SIPrefixes.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SIPrefixes.sysml
@@ -2,7 +2,7 @@
  * Definition of SI unit prefixes as specified in ISO/IEC 80000-1
  */
 package SIPrefixes {
-	private import UnitsAndScales::*;
+	private import MeasurementReferences::*;
 
 	/*
 	 * ISO/IEC 80000-1 prefixes for decimal multiples and sub-multiples

--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -11,7 +11,7 @@ package Time {
 	private import ScalarValues::String;
 	private import Quantities::ScalarQuantityValue;
 	private import Quantities::scalarQuantities;
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     import ISQBase::DurationValue;
     import ISQBase::DurationUnit;
     import ISQBase::duration;

--- a/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
@@ -4,7 +4,7 @@
  * See https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
  */
 package <USCU> USCustomaryUnits {
-    private import UnitsAndScales::*;
+    private import MeasurementReferences::*;
     import ISQ::*;
     private import SI::*;
 

--- a/sysml/src/examples/Analysis Examples/Turbojet Stage Analysis.sysml
+++ b/sysml/src/examples/Analysis Examples/Turbojet Stage Analysis.sysml
@@ -1,6 +1,6 @@
 package 'Turbojet Stage Analysis' {
 	import Quantities::ScalarQuantityValue;
-	import UnitsAndScales::DimensionOneValue;
+	import MeasurementReferences::DimensionOneValue;
 	import ISQ::*;
 	
 	package 'Thermodynamic Functions' {

--- a/sysml/src/examples/Analysis Examples/Vehicle Analysis Demo.sysml
+++ b/sysml/src/examples/Analysis Examples/Vehicle Analysis Demo.sysml
@@ -2,7 +2,7 @@ package 'Vehicle Analysis Demo' {
 	package VehicleQuantities {
 	    import ScalarValues::*;
 	    import Quantities::*;
-	    import UnitsAndScales::*;
+	    import MeasurementReferences::*;
 	    import ISQ::*;
 	    import USCustomaryUnits::*;
 	    

--- a/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
+++ b/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
@@ -3,10 +3,10 @@ package CarWithShapeAndCSG {
     import ShapeItems::*;
     import Objects::Point;
 	import Quantities::VectorQuantityValue;
-	import UnitsAndScales::CoordinateFrame;
-	import UnitsAndScales::TranslationRotationSequence;
-	import UnitsAndScales::Translation;
-	import UnitsAndScales::Rotation;
+	import MeasurementReferences::CoordinateFrame;
+	import MeasurementReferences::TranslationRotationSequence;
+	import MeasurementReferences::Translation;
+	import MeasurementReferences::Rotation;
 	import SI::*;
 
 	/**

--- a/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
+++ b/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
@@ -7,10 +7,10 @@ package VehicleGeometryAndCoordinateFrames {
     import ShapeItems::*;
     import SpatialItems::*;
 
-    import UnitsAndScales::CoordinateFrame;
-    import UnitsAndScales::TranslationRotationSequence;
-    import UnitsAndScales::Translation;
-    import UnitsAndScales::Rotation;
+    import MeasurementReferences::CoordinateFrame;
+    import MeasurementReferences::TranslationRotationSequence;
+    import MeasurementReferences::Translation;
+    import MeasurementReferences::Rotation;
     
     private import Collections::Array;
     private import ScalarValues::Boolean;

--- a/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
+++ b/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
@@ -2,7 +2,7 @@ package AnalysisIndividualExample {
 	package VehicleQuantities {
 	    import ScalarValues::*;
 	    import Quantities::*;
-	    import UnitsAndScales::*;
+	    import MeasurementReferences::*;
 	    import ISQ::*;
 	    import USCustomaryUnits::*;
 	    

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex B VehicleModel.sysml
@@ -435,7 +435,7 @@ package sfriedenthal_VehicleModel_1_simplified{
 
             // (from Ed's model) the following defines new quantities and units used in fuel economy reqts and analysis
             import Quantities::*;
-            import UnitsAndScales::DerivedUnit;
+            import MeasurementReferences::DerivedUnit;
             import SIPrefixes::kilo;
             
             /* should we add quantity and unit as key words? */

--- a/sysml/src/examples/Vehicle Example/VehicleDefinitions.sysml
+++ b/sysml/src/examples/Vehicle Example/VehicleDefinitions.sysml
@@ -4,7 +4,7 @@
 package VehicleDefinitions {
 	import ScalarValues::*;
 	import Quantities::*;
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import ISQ::*;
 	import SI::*;
 	

--- a/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
+++ b/sysml/src/examples/Vehicle Example/VehicleModel_1_Simplified.sysml
@@ -457,7 +457,7 @@ package VehicleModel_1_simplified{
 
             // (from Ed's model) the following defines new quantities and units used in fuel economy reqts and analysis
             import Quantities::*;
-            import UnitsAndScales::DerivedUnit;
+            import MeasurementReferences::DerivedUnit;
             import SIPrefixes::kilo;
             
             /* should we add quantity and unit as key words? */

--- a/sysml/src/validation/10-Analysis and Trades/10c-Fuel Economy Analysis.sysml
+++ b/sysml/src/validation/10-Analysis and Trades/10c-Fuel Economy Analysis.sysml
@@ -1,7 +1,7 @@
 package '10c-Fuel Economy Analysis' {
 	import ScalarValues::*;
 	import Quantities::*;
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import ISQ::*;
 	import USCustomaryUnits::*;
 	

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
@@ -1,5 +1,5 @@
 package '15_01-Constants' {
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
     import SI::*;
     import RealFunctions::*;
 

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_08-Range Restriction.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_08-Range Restriction.sysml
@@ -1,5 +1,5 @@
 package '15_08-Range Restriction' {
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import SI::*;
 	import '15_01-Constants'::'Mathematical Constants'::pi;
 	

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_13-Discretely Sampled Function Value.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_13-Discretely Sampled Function Value.sysml
@@ -4,7 +4,7 @@ package '15_13-Discretely Sampled Function Value' {
 	import Collections::Array;
 	import ISQ::*;
 	import SI::*;
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import Time::*;
 
 	attribute def MissionElapsedTimeScale :> TimeScale {

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_19-Materials with Properties.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_19-Materials with Properties.sysml
@@ -1,7 +1,7 @@
 package '15_19-Materials with Properties' {
 	import ScalarValues::Real;
 	import Quantities::*;
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import SI::*;
 	
     attribute def AtomicMassValue :> MassValue;

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_19a-Materials with Properties.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_19a-Materials with Properties.sysml
@@ -1,7 +1,7 @@
 package '15_19a-Materials with Properties' {
 	import ScalarValues::*;
 	import Quantities::*;
-	import UnitsAndScales::*;
+	import MeasurementReferences::*;
 	import SI::*;
 	
     attribute def AtomicMassValue :> MassValue;


### PR DESCRIPTION
Changed the name of the Quantities and Units Library `UnitsAndScales` package to `MeasurementReferences`, which better reflects what it contains (units and scales are kinds of measurement references). Updated references in all other library and example models in the repository.