### PR TITLE
ST6RI-561 Metadata for element icon images

### DIFF
--- a/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
@@ -62,7 +62,7 @@ package ImageMetadata {
 			doc
 			/*
 			 * A full-sized image that can be used to render the annotated element on a
-			 * a graphical view, potentially as an alternative to its standard rendering.
+			 * graphical view, potentially as an alternative to its standard rendering.
 			 */
 		}
 		

--- a/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
@@ -53,9 +53,9 @@ package ImageMetadata {
 		/*
 		 * Icon metadata can be used to annotate a model element with an image to be used
 		 * to show render the element on a diagram and/or a small image to be used as an
-		 * adornment on a graphical or textual redndering. Alternatively, other metadata
-		 * can be annotated with an Icon to indicate that any model element annotated
-		 * by the containing metadata can be rendered according to the Icon.
+		 * adornment on a graphical or textual rendering. Alternatively, another metadata
+		 * definition can be annotated with an Icon to indicate that any model element 
+		 * annotated by the containing metadata can be rendered according to the Icon.
 		 */
 		 
 		attribute fullImage : Image[0..1] {

--- a/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
@@ -1,0 +1,78 @@
+package ImageMetadata {
+	doc
+	/*
+	 * This package provides attributive data and metadata to allow a model element to be
+	 * annotated with an image to be used in its graphical rendering or as a marker to
+	 * adorn graphical or textual renderings.
+	 */
+	 
+	import ScalarValues::String;
+	
+	attribute def Image {
+		doc
+		/*
+		 * Image provides the data necessary for the physical definition of 
+		 * a graphical image.
+		 */
+		 
+		attribute content : String[0..1] {
+			doc
+			/*
+			 * Binary data for the image according to the given MIME type, 
+			 * encoded as given by the encoding.
+			 */
+		}
+		
+		attribute encoding : String[0..1] {
+			doc
+			/*
+			 * Describes how characters in the content are to be decoded into 
+			 * binary data. At least "base64", "hex", "identify", and "JSONescape"
+			 * shall be supported.
+			 */
+		}
+		
+		attribute type : String[0..1] {
+			doc
+			/*
+			 * The MIME type according to which the content should be interpreted.
+			 */
+		}
+		
+		attribute location : String[0..1] {
+			doc
+			/*
+			 * A URI for the location of a resource containing the image content,
+			 * as an alternative for embedding it in the content attribute.
+			 */
+		}
+	}
+	
+	metadata def Icon {
+		doc
+		/*
+		 * Icon metadata can be used to annotate a model element with an image to be used
+		 * to show render the element on a diagram and/or a small image to be used as an
+		 * adornment on a graphical or textual redndering. Alternatively, other metadata
+		 * can be annotated with an Icon to indicate that any model element annotated
+		 * by the containing metadata can be rendered according to the Icon.
+		 */
+		 
+		attribute fullImage : Image[0..1] {
+			doc
+			/*
+			 * A full-sized image that can be used to render the annotated element on a
+			 * a graphical view, potentially as an alternative to its standard rendering.
+			 */
+		}
+		
+		attribute smallImage : Image[0..1] {
+			doc
+			/*
+			 * A smaller image that can be used as an adornment on the graphical rendering
+			 * of the annotated element or as a marker in a textual rendering.
+			 */
+		}
+	}
+	
+}


### PR DESCRIPTION
This PR introduces the `ImageMetadata` library model, as part of the SysML Metadata Domain Library. This library model includes the following.

1. `Image` attribute definition, which captures the data necessary for the physical definition of a graphical image. This can be used directly within `Icon` annotations (see below), or it can be used to create library models of image usages that can be referenced from `Icon` annotations. Alternatively, the images themselves can be physically stored in separate resources from the SysML model and referenced by URI. 

2. `Icon` metadata definition, which can be used to annotate a model element with an image to be used to show render the element on a diagram and/or a small image to be used as an adornment on a graphical or textual rendering. Alternatively, another metadata definition can be annotated with an `Icon` to indicate that any model element annotated by the containing metadata can be rendered according to the `Icon`.

While this model of icon images is not inherently specific to SysML, the graphical rendering of models is currently only defined for SysML, not KerML. Therefore, the `ImageMetadata` library model is defined as a SysML model in the SysML-level Metadata Domain Library, and its relation to the rendering of standard model views will be discussed in the SysML Specification.