### PR TITLE
ST6RI-556 Metadata for parameters of interest

### DIFF
--- a/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
@@ -1,0 +1,39 @@
+package ParametersOfInterestMetadata {
+	doc
+	/*
+	 * This package contains definitions of metadata identify key parameters of interest,
+	 * including measures of effectiveness (MOE) and other key measures of performance (MOP).
+	 */
+	 
+	 import Metaobjects::SemanticMetadata;
+	 
+	 attribute measuresOfEffectiveness[*] nonunique {
+	 	doc /* Base feature for attributes that are measures of effectiveness. */
+	 }
+	 
+	 attribute measuresOfPerformance[*] nonunique {
+	 	doc /* Base feature for attributes that are measures of performance. */
+	 }
+	 
+	 metadata def <moe> MeasureOfEffectiveness :> SemanticMetadata {
+	 	doc 
+	 	/*
+	 	 * MeasureOfEffectiveness is semantic metadata for identifying an attribute as a
+	 	 * measure of effectiveness.
+	 	 */
+	 	
+	 	:>> annotatedElement : SysML::Usage;
+	 	:>> baseType = measuresOfEffectiveness as SysML::Usage;
+	 }
+	 
+	 metadata def <mop> MeasureOfPerformance :> SemanticMetadata {
+	 	doc 
+	 	/*
+	 	 * MeasureOfPerformance is semantic metadata for identifying an attribute as a
+	 	 * measure of performance.
+	 	 */
+	 	
+	 	:>> annotatedElement : SysML::Usage;
+	 	:>> baseType = measuresOfPerformance as SysML::Usage;
+	 }
+}

--- a/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
@@ -1,7 +1,7 @@
 package ParametersOfInterestMetadata {
 	doc
 	/*
-	 * This package contains definitions of metadata identify key parameters of interest,
+	 * This package contains definitions of metadata to identify key parameters of interest,
 	 * including measures of effectiveness (MOE) and other key measures of performance (MOP).
 	 */
 	 


### PR DESCRIPTION
This pull request adds a Metadata Domain Library model to address the following SysML v2 RFP requirement:

>ANL 1.03: Parameters of Interest
>
>Proposals for SysML v2 shall include the capability to identify the key parameters of interest including measures-of-effectiveness (MoE) and other key measures of performance (MoP).