### PR TITLE
ST6RI-558 Cause-effect relationship

### DIFF
--- a/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
+++ b/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
@@ -1,0 +1,72 @@
+package CausationConnections {	
+	doc 
+	/* 
+	 * This package provides a library model modeling causes, effects, and causation connections 
+	 * between them.
+	 */
+
+	abstract occurrence causes[*] {
+		doc /* Occurrences that are causes. */
+	}
+	
+	abstract occurrence effects[*]  {
+		doc /* Occurrences that are effects. */
+	}
+	
+	abstract connection def Multicausation {
+		doc
+		/*
+		 * A Multicausation connection models the situation in which one set of
+		 * occurrences causes another.
+		 * 
+		 * To create a Multicausation connection, specialize this connection definition
+		 * adding specific end features of the relavent types. Ends representing causes
+		 * should subset 'causes', while ends representing effects should subset 'effects'.
+		 * There must be at least one cause and at least one effect.
+		 */
+		 
+		private import SequenceFunctions::*;
+		 
+		occurrence causes[1..*] :>> causes :> participant {
+			doc /* The causing occurrences. */
+		}
+		occurrence effects[1..*] :>> effects :> participant {
+			doc /* The effect occurrences caused by the causing occurrences. */
+		}
+		
+		private assert constraint disjointCauseEffect {
+			doc /* causes must be disjoint from effects. */
+			isEmpty(intersection(causes, effects))
+		}
+		
+		private succession causalOrdering first causes.startShot[nCauses] then effects[nEffects] {
+			doc /* All causes must exist before all effects. */
+			attribute nCauses = size(causes);
+			attribute nEffects = size(effects);
+		}
+	}
+	
+	abstract connection multicausations : Multicausation[*] {
+		doc /* multicausations is the base feature for Multicausation ConnectionUsages. */
+	}
+	
+	connection def Causation :> Multicausation {
+		doc
+		/*
+		 * A Causation is a binary Multicausation in which a single cause occurrence
+		 * causes a single effect occurrence.
+		 */
+		 
+		end occurrence theCause :>> causes :> source {
+			doc /* The single causing occurrence. */
+		}
+		
+		end occurrence theEffect :>> effects :> target {
+			doc /* The single effect occurrence resulting from the cause. */
+		}
+	}
+	
+	abstract connection causations : Causation[*] {
+		doc /* causations is the base feature for Causation ConnectionUsages. */
+	}
+}

--- a/sysml.library/Domain Libraries/Cause and Effect/CauseAndEffect.sysml
+++ b/sysml.library/Domain Libraries/Cause and Effect/CauseAndEffect.sysml
@@ -1,0 +1,81 @@
+package CauseAndEffect {
+	doc /* This package provides language-extension metadata for cause-effect modeling. */
+	
+	import CausationConnections::*;
+	private import ScalarValues::*;
+	private import Metaobjects::SemanticMetadata;
+
+	metadata def <cause> CauseMetadata :> SemanticMetadata {
+		doc
+		/*
+		 * CauseMetadata identifies a usage as being a cause occurrence.
+		 * It is intended to be used to tag the cause ends of a Multicausation.
+		 */
+		 
+		ref :>> annotatedElement : SysML::Usage;
+		ref :>> baseType = causes as SysML::Usage;
+	}
+	
+	metadata def <effect> EffectMetadata :> SemanticMetadata {
+		doc
+		/*
+		 * EffectMetadata identifies a usage as being an effect occurrence.
+		 * It is intended to be used to tag the effect ends of a Multicausation.
+		 */
+		 
+		ref :>> annotatedElement : SysML::Usage;
+		ref :>> baseType = effects as SysML::Usage;
+	}
+	
+	metadata def CausationMetadata {
+		doc
+		/*
+		 * CauseEffectMetadata allows for the specification of additional metadata about
+		 * a cause-effect connection or usage.
+		 */
+		 
+		ref :> annotatedElement : SysML::ConnectionDefinition;
+		ref :> annotatedElement : SysML::ConnectionUsage;
+		
+		attribute isNecessary : Boolean default false {
+			doc 
+			/* 
+			 * Whether all the causes are necessary for all the effects to occur.
+			 * If this is false (the default), then some or all of the effects may 
+			 * still have occurred even if some of the causes did not.
+			 */
+		}
+		
+		attribute isSufficient : Boolean default false {
+			doc
+			/*
+			 * Whether the causes were sufficient for all the effects to occur.
+			 * If this is false (the default), then it may be the case that some
+			 * other occurrences were also necessary for some or all of the effects
+			 * to have occurred.
+			 */
+		}
+		
+		attribute probability : Real[0..1] {
+			doc /* The probability that the causes will actually result in effects occurring. */
+		}	
+	}
+	
+	metadata def <multicausation> MulticausationSemanticMetadata :> CausationMetadata, SemanticMetadata {
+		doc
+		/*
+		 * MulticausationMetadata is SemanticMetadata for a Multicausation connection.
+		 */
+		 
+		ref :>> baseType = multicausations as SysML::Usage;
+	}
+	
+	metadata def <causation> CausationSemanticMetadadata :> CausationMetadata, SemanticMetadata {
+		doc
+		/*
+		 * CausationMetadata is SemanticMetadata for a Causation connection.
+		 */
+		 
+		ref :>> baseType = causations as SysML::Usage;
+	}
+}

--- a/sysml.library/Domain Libraries/Cause and Effect/CauseAndEffect.sysml
+++ b/sysml.library/Domain Libraries/Cause and Effect/CauseAndEffect.sysml
@@ -30,7 +30,7 @@ package CauseAndEffect {
 	metadata def CausationMetadata {
 		doc
 		/*
-		 * CauseEffectMetadata allows for the specification of additional metadata about
+		 * CausationMetadata allows for the specification of additional metadata about
 		 * a cause-effect connection or usage.
 		 */
 		 

--- a/sysml/src/examples/Cause and Effect Examples/CauseAndEffectExample.sysml
+++ b/sysml/src/examples/Cause and Effect Examples/CauseAndEffectExample.sysml
@@ -1,0 +1,55 @@
+package CauseAndEffectExample {
+	import CauseAndEffect::*;
+	
+	part def Causer1;
+	part def Causer2;
+	part def Effected1;
+	part def Effected2;
+	
+	#multicausation connection def MultiCauseEffect {
+		end #cause cause1 : Causer1;
+		end #cause cause2 : Causer2;
+		end #effect effect1 : Effected1;
+		end #effect effect2 : Effected2;
+	}
+	
+	part causer1 : Causer1;
+	part causer2 : Causer2;
+	part effected1 : Effected1;
+	part effected2 : Effected2;
+	
+	#multicausation connection : MultiCauseEffect connect
+		( cause1 :> causer1, cause2 :> causer2,
+		  effect1 :> effected1, effect2 :> effected2 );
+		  
+	#multicausation connect
+		( cause1 :> causer1, cause2 :> causer2,
+		  effect1 :> effected1, effect2 :> effected2 );
+
+    occurrence a;
+    item b;
+    part c;
+    action d;
+    
+	#multicausation connection {
+		end #cause :> a;
+		end #cause :> b;
+		end #effect :> c;
+		end #effect :> d;
+	}
+	
+	#cause causeA :> a;
+	#cause causeB :> b;
+	#effect effectC :> c;
+	#effect effectD :> d;
+	
+	#multicausation connect ( causeA, causeB, effectC, effectD );
+	
+	#causation connect a to c;
+	#causation connect b to d {
+		@CausationMetadata {
+			isNecessary = true;
+			probability = 0.1;
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds a Cause and Effect Domain Library model and metadata to address the following SysML v2 RFP requirement:

> CRC 1.3.04: Cause-Effect Relationship
>
> Proposals for SysML v2 shall include a capability to represent a Cause-Effect Relationship where one side of the relationship refers to the cause and the other side of the relationship refers to the effect.

The new library includes two packages.

**`CausationConnections` Package**

1. `Multicausation` is an abstract connection definition with no ends, but having two non-end features that collect cause occurrences and effect occurrences. This connection definition also asserts constraints that the the intersection of causes and effects is empty and that all causes exist (i.e, have at least started) before all effects.
2. `Causation` as a binary connection definition that specializes Multicausation for the simple case of a binary relationship between one cause and one effect.

**`CauseAndEffect` Package**

1. `CausationMetadata` is a metadata definition that can be used to annotate whether a causation `isNecessary` and/or `isSufficient`, and what its `probability` is.
2. `MulticausationSemanticMetadata` and `CausationSemanticMetadata` (short names `multicausation` and `causation`) are semantic metadata for declaring (respectively)`Multicausation` and `Causation` connection definitions and usages.
3. `CauseMetadata` and `EffectMetadata` (short names `cause` and `effect` are semantic metadata for marking usages as representing causes or effects in causations (particularly on the end features of multicausation connections).

**Modeling Approach**

A connection usage typed by `Multicausation` can add end features to relate the desired causes and effects. Each such end feature should subset one of the desired causes or effects and subset either the `causes` (for a cause) or `effects` (for an effect) feature of `Mulitcausation`. A binary causation can be modeled by a connection usage typed by `Causation`, in which case the first related element is the cause and the second one is the effect.

This modeling approach is simplified by use of the semantic metadata from the `CauseAndEffect` package (which also publicly reexports the content of the `CausationConnections` `package).

```
// Causes and effects can be any kinds of occurrences.
occurrence a;
item b;
part c;
action d;

// The #multicausation keyword identifies this as a Multicausation connection.
// The ends tagged #cause are the causes, and the ends tagged #effect are the effects.
#multicausation connection {
	end #cause :> a;
	end #cause :> b;
	end #effect :> c;
	end #effect :> d;
}
```

Instead of tagging the ends of the connection, the connected usages can instead be identified as causes and effects, allowing for a more compact connector syntax. Note that each such usage can be a cause or an effect, but not both.

```
#cause causeA :> a;
#cause causeB :> b;
#effect effectC :> c;
#effect effectD :> d;

#multicausation connect ( causeA, causeB, effectC, effectD );
```

For a binary causation, it is not necessary to use the **`#cause`** and **`#effect`** keywords, because the first related element is always the cause and the second related element is always the effect.

```
#causation connect a to c;
```

The `isNecessary`, `isSufficient` and `probability` attributes have been provided as additional metadata, rather than as features of the causation connections, because they really apply to the connection itself, not to the individual links instantiated for the connection. No further semantic model has been provided for these attributes at this time.

```
#causation connect b to d {
	@CausationMetadata {
		isNecessary = true;
		probability = 0.1;
	}
}
```

