### PR TITLE
ST6RI-559 Refinement relationship

### DIFF
--- a/sysml.library/Domain Libraries/Metadata/ModelingMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ModelingMetadata.sysml
@@ -81,4 +81,13 @@ package ModelingMetadata {
 		attribute text : String;
 	}
 	
+	/** 
+	 * Refinement is used to identify a dependency as modeling a refinement relationship.
+	 * In such a relationship, the source elements of the relationship provide a more precise and/or 
+	 * accurate representation than the target elements.
+	 */
+	metadata def <refinement> Refinement {
+		:>> annotatedElement : SysML::Dependency;
+	}
+	
 }


### PR DESCRIPTION
This pull request adds a `Refinement` metadata definition to the existing `ModelingMetadata` library model in the Metadata Domain Library, in order to address the following SysML v2 RFP requirement:

> CRC 1.3.07: Refine Relationship
>
>Proposals for SysML v2 shall include a capability to represent a Refine Relationship where the refined side of the relationships refers to the more precisely specified element.

The `Refinement` metadata (short name `refinement`) can be applied to a dependency declaration to model a refinement relationship in which the source elements refine the target elements. No formal semantics is provided for this relationship at this time. For example:

```
part def DesignModel;
package Specification;
requirement def SystemRequirements;

#refinement dependency DesignModel to Specification, SystemRequirements;
```