### PR TITLE
ST6RI-560 Derived requirement relationship

### DIFF
--- a/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
@@ -1,0 +1,48 @@
+package DerivationConnections {
+	doc
+	/*
+	 * This package provides a library model for derivation connections between requirements.
+	 */
+	
+	requirement originalRequirements[*] {
+		doc /* originalRequirements are the original requirements Derivation connections. */
+	}
+	requirement derivedRequirements[*] {
+		doc /* derivedRequiremetns are the derived requirments in Derivation connections. */
+	}
+	
+	abstract connection def Derivation {
+		doc
+		/*
+		 * A Derivation connection asserts that one or more derivedRequirements are derived from
+		 * a single originalRequirements. This means that any subject that satisfies the
+		 * originalRequirement should, in itself or though other things related to it, satisfy
+		 * each of the derivedRequirements.
+		 * 
+		 * A connection usage typed by Derivation must have requirement usages for all its ends.
+		 * The single end for the original requirement should subset originalRequirement, while
+		 * the rest of the ends should subset derivedRequirements.
+		 */
+		 
+		ref requirement :>> participant {
+			doc /* All the participants in a Derivation must be requirements. */
+		}
+		
+		ref requirement originalRequirement[1] :>> originalRequirements :> participant {
+			doc /* The single original requirement. */
+		}
+		ref requirement :>> derivedRequirements[1..*] :> participant {
+			doc /* The one or more requirements that are derived from the original requirement. */
+		}
+		
+		private assert constraint originalNotDerived {
+			doc /* The original requirement must not be a derived requirement. */
+			
+			derivedRequirements->SequenceFunctions::excludes(originalRequirement)
+		}		
+	}
+	
+	abstract connection derivations : Derivation[*] {
+		doc /* derivations is the base feature for Derivation connection usages. */
+	}
+}

--- a/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
@@ -39,7 +39,17 @@ package DerivationConnections {
 			doc /* The original requirement must not be a derived requirement. */
 			
 			derivedRequirements->SequenceFunctions::excludes(originalRequirement)
-		}		
+		}
+		
+		private assert constraint originalImpliesDerived {
+			doc 
+			/* 
+			 * Whenever the originalRequirement is satisfied, all of the derivedRequirements must also
+			 * be satisfied.
+			 */
+			 
+			originalRequirement.result implies ControlFunctions::allTrue(derivedRequirements.result)
+		}	
 	}
 	
 	abstract connection derivations : Derivation[*] {

--- a/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
@@ -1,0 +1,38 @@
+package RequirementDerivation {
+	doc /* This package provides language-extension metadata for modeling requirement derivation. */
+	
+	import DerivationConnections::*;
+	import Metaobjects::SemanticMetadata;
+	
+	metadata def <original> OriginalRequirementMetadata :> SemanticMetadata {
+		doc
+		/*
+		 * OriginalRequirementMetadata identifies a usage as an original requirement.
+		 * It is intended to be used to tag the original requirement end of a Derivation.
+		 */
+		 
+		:> annotatedElement : SysML::Usage;
+		:>> baseType = derivedRequirements as SysML::Usage;		
+	}
+	
+	metadata def <derive> DerivedRequirementMetadata :> SemanticMetadata {
+		doc
+		/*
+		 * DerivedRequirementMetadata identifies a usage as a derived requirement.
+		 * It is intended to be used to tag the derived requirement ends of a Derivation.
+		 */
+		 
+		:> annotatedElement : SysML::Usage;	
+		:>> baseType = originalRequirements as SysML::Usage;
+	}
+	
+	metadata def <derivation> DerivationMetadata :> SemanticMetadata {
+		doc
+		/*
+		 * DerivationMetadata is SemanticMetadata for a Derivation connection.
+		 */
+		 
+		:> annotatedElement : SysML::ConnectionDefinition;
+		:> annotatedElement : SysML::ConnectionUsage;
+	}	
+}

--- a/sysml/src/examples/Requirements Examples/RequirementDerivationExample.sysml
+++ b/sysml/src/examples/Requirements Examples/RequirementDerivationExample.sysml
@@ -1,0 +1,46 @@
+package RequirementDerivationExample {
+	import RequirementDerivation::*;
+	
+	requirement def Req1;
+	
+	requirement def Req1_1;
+	requirement def Req1_2;
+	
+	#derivation connection def Req1_Derivation {
+		end #original r1 : Req1;
+		end #derive r1_1 : Req1_1;
+		end #derive r1_2 : Req1_2;
+	}
+	
+	part def System;
+	part def Subsystem1;
+	part def Subsystem2;
+	
+	part system : System {
+		part sub1 : Subsystem1;
+		part sub2 : Subsystem2;
+	}
+	
+	part satisfactionContext {
+		ref :>> system;
+		
+		satisfy requirement req1 : Req1 by system;
+		satisfy requirement req1_1 : Req1_1 by system.sub1;
+		satisfy requirement req1_2 : Req1_2 by system.sub2;
+		
+		#derivation connection : Req1_Derivation {
+			end r1 :> req1;
+			end r1_1 :> req1_1;
+			end r1_2 :> req1_1;
+		}
+		
+	    // Alternative
+		#derivation connection : Req1_Derivation {
+			end #original satisfy requirement req1 : Req1 by system;
+			end #derive satisfy requirement req1_1 : Req1_1 by system.sub1;
+			end #derive satisfy requirement req1_2 : Req1_2 by system.sub2;
+		}
+	
+	}
+	
+}


### PR DESCRIPTION
This pull request adds a Requirement Derivation Domain Library model and metadata to address the following SysML v2 RFP requirement:

> RQT 1.3.4: Requirement Derivation
>
> Proposals for SysML v2 shall include a capability to represent a derive relationship that relates a derived requirement to a source requirement.

The new library includes two packages.

**`DerivationsConnections` Package**

1. `Derivation` is an abstract connection definition with no ends, but having two non-end requirement usages, one for an `originalRequirement` and one for all corresponding `derivedRequirements`. This connection definition also asserts that the `originalRequirement` value is not one of the `derivedRequirements` values and, if the check of the `originalRequirement` is true, then the checks for all the `derivedRequirements` are true.

**`RequirementDerivation` Package**

1. `DerivationMetadata` (short name `derivation`) is semantic metadata for declaring `Derivation` connections.
2. `OriginalRequirementMetadata` and `DerivedRequirementMetadata` (short names `original` and `derived` -- note that "derived" is already a reserved word) are semantic metadata for marking usages representing original and derived requirements, particularly on the end features of `Derivation` connections.

**Modeling Approach**

A connection definition or usage specializing `Derivation` can add one end feature for the desired original requirement, subsetting `originalRequirement`, and one or more end features for the derived requirements, subsetting `derivedRequirements`. This can be modeled succinctly using the metadata from the `RequirementDerivation` package (which also publicly reexports the content of the `DerivationsConnection` package).

For example:

```
requirement req1;
requirement req1_1;
requirement req1_2;

#derivation connection {
    end #original :> req1;
    end #derive :> req1_1;
    end #derive :> req1_2;
}
```