### PR TITLE
ST6RI-573 Added localClock to Occurrence, used as trigger clock default.

### DIFF
--- a/kerml/src/examples/Simple Tests/Classes.kerml
+++ b/kerml/src/examples/Simple Tests/Classes.kerml
@@ -8,13 +8,22 @@ package Classes {
 	}
 	
 	abstract class <'2'> B {
-		public abstract feature a: A;
+		public abstract feature a: A {
+			composite feature aa: A;
+		}
+		public composite feature a1: A;
+		feature x {
+			composite feature a: A;
+		}
 		package P { }
 	}
 	
-	private class C specializes Classes::'2' {
+	private struct C specializes Classes::'2' {
 		private y: A, '2'[0..*];
 		alias z for y;
+		composite feature c : C {
+			composite feature cc : C;
+		}
 	}
 	
 }

--- a/org.omg.sysml.xpect.tests/library.systems/Items.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Items.sysml
@@ -1,8 +1,10 @@
-/**
- * This package defines the base types for items and related structural elements in the
- * SysML language.
- */
 package Items {
+	doc
+	/*
+	 * This package defines the base types for items and related structural elements in the
+	 * SysML language.
+	 */
+
 	private import Objects::Object;
 	private import Objects::objects;
 	private import Parts::Part;
@@ -19,46 +21,62 @@ package Items {
 	private import SequenceFunctions::union;
 	private import ControlFunctions::forAll;
 	
-	/**
-	 * Item is the most general class of objects that are part of, exist in or flow through a system. 
-	 * Item is the base type of all ItemDefinitions.
-	 */
 	abstract item def Item :> Object {
+		doc
+		/*
+		 * Item is the most general class of objects that are part of, exist in or flow through a system. 
+		 * Item is the base type of all ItemDefinitions.
+		 */
+	
 		ref self: Item :>> Object::self;
 		
 		item start: Item :>> startShot;
 		item done: Item :>> endShot;
 		
-		/**
-		 * The shape of an Item is its spatial boundary.
-		 */
-		item shape : Item :>> spaceBoundary;
+		item shape : Item :>> spaceBoundary {
+		doc
+			/*
+			 * The shape of an Item is its spatial boundary.
+			 */
+		}
 		
-		/**
-		 * Each enveloping shape is the shape of an Item that spacially overlaps this Item for its
-		 * entire lifetime.
-		 */
 		item envelopingShapes : Item[0..*] {
+		doc
+			/*
+			 * Each enveloping shape is the shape of an Item that spacially overlaps this Item for its
+			 * entire lifetime.
+			 */		
 
-			 /** Enables two dimensional items to be enveloped by two or three dimensional shapes. */
+			 /* Enables two dimensional items to be enveloped by two or three dimensional shapes. */
 			attribute :>> innerSpaceDimension = 
 				if (that as Item).innerSpaceDimension == 3  | (that as Item).outerSpaceDimension == 3? 2 
-				else (that as Item).outerSpaceDimension - 1; 
+				else (that as Item).outerSpaceDimension - 1 {
+				doc
+			 	/* 
+			 	 * Enables two dimensional items to be enveloped by two or three dimensional shapes.
+			 	 */				
+			}
 			assert constraint { (that as Item).innerSpaceDimension < 3 implies notEmpty(outerSpaceDimension) }
 
-			item envelopingItem [1]; /* Shape constraint below, to avoid envelopingShape being a portion. */
+			item envelopingItem [1];
 
-			assert constraint { 
+			assert constraint {
+				doc
+				/* 
+				 * This constraint prevents an envelopingShape frombeing a portion.
+				 */
+				 
 				envelopingItem.shape.spaceTimeCoincidentOccurrences->includes(that) and
 				envelopingItem.spaceTimeEnclosedOccurrences->includes(that.that) 
 			}
 		}
 		
-		/**
-		 * envelopingShapes that are structured space objects with every face or every edge
-		 * intersecting this Item.
-		 */
 		item boundingShapes : StructuredSpaceObject [0..*] :> envelopingShapes {
+		doc
+			/*
+			 * envelopingShapes that are structured space objects with every face or every edge
+			 * intersecting this Item.
+			 */		
 
 			item boundingShape: Item :>> self;
 
@@ -75,43 +93,57 @@ package Items {
 			}
 		}
 
-		/**
-		 * Voids are inner space occurrences of this Item.
-		 */
-		item voids :>> innerSpaceOccurrences [0..*];
+		item voids :>> innerSpaceOccurrences [0..*] {
+			doc
+			/*
+			 * Voids are inner space occurrences of this Item.
+			 */
+		}
 
-		/**
-		 * An Item is solid if it has no voids.
-		 */
-		attribute isSolid = isEmpty(voids);
+		attribute isSolid = isEmpty(voids) {
+			doc
+			/*
+			 * An Item is solid if it has no voids.
+			 */
+		}
 		
-		/**
-		 * The Items that are composite subitems of this Item.
-		 */
-		abstract item subitems: Item[0..*] :> items;
+		abstract item subitems: Item[0..*] :> items, subobjects {
+			doc
+			/*
+			 * The Items that are composite subitems of this Item.
+			 */
+		}
 		
-		/**
-		 * The subitems of this Item that are Parts.
-		 */
-		abstract part subparts: Part[0..*] :> subitems, parts;
+		abstract part subparts: Part[0..*] :> subitems, parts {
+			doc
+			/*
+			 * The subitems of this Item that are Parts.
+			 */
+		}
 		
-		/**
-		 * Constraints that have been checked by this Item.
-		 */
-		abstract ref constraint checkedConstraints: ConstraintCheck[0..*] :> constraintChecks, enactedPerformances;
+		abstract constraint checkedConstraints: ConstraintCheck[0..*] :> constraintChecks, ownedPerformances {
+			doc
+			/*
+			 * Constraints that have been checked by this Item.
+			 */
+		}
 	}
 	
-	/**
-	 * Touching items are just outside each other and happen at the same time.
-	 */
 	connection def Touches :> JustOutsideOf, HappensWhile {
+		doc
+		/*
+		 * Touching items are just outside each other and happen at the same time.
+		 */
+	
 		end item touchedItemToo [0..*] :>> separateSpaceToo, thisOccurrence;
 		end item touchedItem [0..*] :>> separateSpace, thatOccurrence;
 	}
 
-	/**
-	 * items is the base feature of all ItemUsages.
-	 */
-	abstract item items : Item[0..*] nonunique :> objects;
+	abstract item items : Item[0..*] nonunique :> objects {
+		doc
+		/*
+		 * items is the base feature of all ItemUsages.
+		 */
+	}
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/OccurrenceTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/OccurrenceTest.sysml.xt
@@ -5,6 +5,9 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
 		File {from ="/library.kernel/Base.kerml"}
        	File {from ="/library.kernel/Occurrences.kerml"}
        	File {from ="/library.kernel/Objects.kerml"}
+       	File {from ="/library.systems/Attributes.sysml"}
+       	File {from ="/library.systems/Items.sysml"}
+       	File {from ="/library.systems/Parts.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -13,6 +16,9 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
 				File {from ="/library.kernel/Base.kerml"}
 		       	File {from ="/library.kernel/Occurrences.kerml"}
 		       	File {from ="/library.kernel/Objects.kerml"}
+		      	File {from ="/library.systems/Attributes.sysml"}
+		       	File {from ="/library.systems/Items.sysml"}
+		       	File {from ="/library.systems/Parts.sysml"}
 			}
 		}
 	}
@@ -20,12 +26,21 @@ END_SETUP
 */
 // XPECT noErrors ---> ""
 package OccurrenceTest {
-    occurrence def Occ {
-//*		ref occurrence occ1 : Occ;
+	occurrence def Occ {
+		attribute a;
+		ref occurrence occ1 : Occ;
 		occurrence occ2 : Occ;
+		item x;
+		part y;
 		
-		snapshot s;
+		individual snapshot s : Ind;
 		timeslice t;
+	}
+	
+	occurrence occ : Occ {
+		occurrence o1 : Occ;
+		ref occurrence o2 : Occ;
+		item z;
 	}
 
 	individual occurrence def Ind {
@@ -34,6 +49,8 @@ package OccurrenceTest {
 	}
 	individual occurrence ind : Ind, Occ {
 		snapshot s3;
-		timeslice t3;*/
+		individual timeslice t3;
 	}
+	
+	individual snapshot s4 : Ind;
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
@@ -5,6 +5,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
 		File {from ="/library.kernel/Base.kerml"}
        	File {from ="/library.kernel/Occurrences.kerml"}
        	File {from ="/library.kernel/Objects.kerml"}
+       	File {from ="/library.systems/Attributes.sysml"}
  		File {from ="/library.systems/Items.sysml"}
  		File {from ="/library.systems/Parts.sysml"}
  		File {from ="/library.systems/Ports.sysml"}
@@ -16,6 +17,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.simpletests.SysMLTests
 				File {from ="/library.kernel/Base.kerml"}
 		       	File {from ="/library.kernel/Occurrences.kerml"}
 		       	File {from ="/library.kernel/Objects.kerml"}
+		       	File {from ="/library.systems/Attributes.sysml"}
 				File {from ="/library.systems/Items.sysml"}
 				File {from ="/library.systems/Parts.sysml"}
  				File {from ="/library.systems/Ports.sysml"}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -72,6 +72,11 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 		return getDefaultSupertype("base");
 	}
 	
+	@Override
+	protected boolean isSuboccurrence() {
+		return super.isSuboccurrence() && !isSubaction();
+	}
+	
 	protected String getSubactionType() {
 		return isSubaction()? "subaction": 
 			   isOwnedAction()? "ownedAction":

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -23,6 +23,8 @@ package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
+import org.omg.sysml.lang.sysml.ItemDefinition;
+import org.omg.sysml.lang.sysml.ItemUsage;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
@@ -88,6 +90,9 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 			addRequirementSubsetting();
 		}
 		super.computeImplicitGeneralTypes();
+		if (isCheckedConstraint()) {
+			addDefaultGeneralType("checkedConstraint");
+		}
 		if (isOwnedPerformance()) {
 			addDefaultGeneralType("ownedPerformance");
 		} 
@@ -97,6 +102,19 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 		if (isEnclosedPerformance()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
+	}
+	
+	@Override
+	protected String getDefaultSupertype() {
+		return getDefaultSupertype("base");
+	}
+	
+	protected boolean isCheckedConstraint() {
+		ConstraintUsage target = getTarget();
+		Type owningType = target.getOwningType();
+		return target.isComposite() &&
+				(owningType instanceof ItemDefinition || owningType instanceof ItemUsage);
+				
 	}
 	
 	// Transformation

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -172,16 +172,36 @@ public class FeatureAdapter extends TypeAdapter {
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype(
-			hasStructureType()? "object":
-			hasClassType()? "occurrence":
+			hasStructureType()? isSubobject()? "subobject": "object":
+			hasClassType()? isSuboccurrence()? "suboccurrence": "occurrence":
 			hasDataType()? "dataValue":
 			"base");
 	}
 	
+	protected boolean isSuboccurrence() {
+		Feature target = getTarget();
+		Type owningType = target.getOwningType();
+		return target.isComposite() && 
+				(owningType instanceof org.omg.sysml.lang.sysml.Class ||
+				 owningType instanceof Feature && (hasClassType((Feature)owningType)));
+	}
+	
 	public boolean hasClassType() {
-		return getTarget().getOwnedTyping().stream().
+		return hasClassType(getTarget());
+	}
+	
+	public boolean hasClassType(Feature feature) {
+		return feature.getOwnedTyping().stream().
 				map(FeatureTyping::getType).anyMatch(org.omg.sysml.lang.sysml.Class.class::isInstance) ||
 				getImplicitGeneralTypes(SysMLPackage.Literals.FEATURE_TYPING).stream().anyMatch(org.omg.sysml.lang.sysml.Class.class::isInstance);
+	}
+	
+	protected boolean isSubobject() {
+		Feature target = getTarget();
+		Type owningType = target.getOwningType();
+		return target.isComposite() && 
+				(owningType instanceof org.omg.sysml.lang.sysml.Structure ||
+				 owningType instanceof Feature && (hasStructureType((Feature)owningType)));
 	}
 	
 	public boolean hasStructureType() {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ItemUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ItemUsageAdapter.java
@@ -44,6 +44,11 @@ public class ItemUsageAdapter extends OccurrenceUsageAdapter {
 					getDefaultSupertype("base");
 	}
 	
+	@Override
+	protected boolean isSuboccurrence() {
+		return super.isSuboccurrence() && !isSubitem();
+	}
+	
 	public boolean isSubitem() {
 		ItemUsage target = getTarget();
 		Type owningType = target.getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
@@ -37,6 +37,19 @@ public class OccurrenceUsageAdapter extends UsageAdapter {
 		return (OccurrenceUsage)super.getTarget();
 	}
 
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (isSuboccurrence()) {
+			addDefaultGeneralType("suboccurrence");
+		}
+	}
+	
+	@Override
+	protected String getDefaultSupertype() {
+		return getDefaultSupertype("base");
+	}
+	
 	protected void addOccurrenceTyping() {
 		OccurrenceUsage target = getTarget();
 		Type owningType = target.getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -85,7 +85,7 @@ public class UsageAdapter extends FeatureAdapter {
 	
 	@Override
 	protected String getDefaultSupertype() {
-		return getDefaultSupertype("base");
+		return super.getDefaultSupertype();
 	}
 	
 	// Computed Redefinitions

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -73,7 +73,9 @@ public class ImplicitGeneralizationMap {
 		put(FeatureImpl.class, "base", "Base::things");
 		put(FeatureImpl.class, "dataValue", "Base::dataValues");
 		put(FeatureImpl.class, "occurrence", "Occurrences::occurrences");
+		put(FeatureImpl.class, "suboccurrence", "Occurrences::Occurrence::suboccurrences");
 		put(FeatureImpl.class, "object", "Objects::objects");
+		put(FeatureImpl.class, "subobject", "Objects::Object::subobjects");
 		put(FeatureImpl.class, "participant", "Links::Link::participant");
 		put(FeatureImpl.class, "startingAt", "FeatureReferencingPerformances::FeatureAccessPerformance::onOccurrence::startingAt");
 		put(FeatureImpl.class, "accessedFeature", "FeatureReferencingPerformances::FeatureAccessPerformance::onOccurrence::startingAt::accessedFeature");
@@ -121,7 +123,6 @@ public class ImplicitGeneralizationMap {
 		put(StepImpl.class, "base", "Performances::performances");
 		put(StepImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(StepImpl.class, "subperformance", "Performances::Performance::subperformances");
-		put(StepImpl.class, "enactedPerformance", "Objects::Object::enactedPerformances");
 		put(StepImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		put(StepImpl.class, "incomingTransfer", "Occurrences::Occurrence::incomingTransfers");
 		put(StepImpl.class, "featureWrite", "FeatureReferencingPerformances::FeatureWritePerformance");
@@ -190,9 +191,9 @@ public class ImplicitGeneralizationMap {
 		
 		put(ConstraintDefinitionImpl.class, "base", "Constraints::ConstraintCheck");
 		put(ConstraintUsageImpl.class, "base", "Constraints::constraintChecks");
+		put(ConstraintUsageImpl.class, "checkedConstraint", "Items::Item::checkedConstraints");
 		put(ConstraintUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedEvaluations");
 		put(ConstraintUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
-		put(ConstraintUsageImpl.class, "enactedPerformance", "Items::Item::checkedConstraints");
 		put(ConstraintUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
 		put(DecisionNodeImpl.class, "subaction", "Actions::Action::decisions");

--- a/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
@@ -23,11 +23,11 @@ package SpatialItems {
 	
 		ref item :>> self : SpatialItem;
 
-		ref item localClock : Clock[1] default Time::defaultClock {
+		ref item :>> localClock : Clock[1] default Time::universalClock {
 			doc
 			/*
 			 * A local Clock to be used as the corresponding time reference within this SpatialItem. 
-			 * By default this is the global defaultClock.
+			 * By default this is the singleton universalClock.
 			 */
 			}
 		

--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -21,10 +21,10 @@ package Time {
     import ISQSpaceTime::TimeUnit;
     import ISQSpaceTime::time;
     
-    readonly part defaultClock : Clock[1] = Clocks::defaultClock {
-	    doc
+    readonly part universalClock : Clock[1] = Clocks::universalClock {
+   	 doc
 	    /*
-	     * defaultClock is a single Clock that can be used as a default.
+	     * universalClock is a single Clock that can be used as a default universal time reference.
 	     */
     }
 
@@ -46,7 +46,7 @@ package Time {
 		 */
 	
 		in o : Occurrence[1]; 
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default localClock;
 		return timeInstant : TimeInstantValue[1];
 	}
 
@@ -58,7 +58,7 @@ package Time {
 		 */
 	
 		in o : Occurrence[1]; 
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default localClock;
 		return duration : DurationValue;
 	}
 	
@@ -168,36 +168,36 @@ package Time {
 	 */
 
 	attribute def Iso8601DateTimeEncoding :> String {
-    doc
-    /*
-     * Extended string encoding of an ISO 8601-1 date and time
-     *
-     * The format of the string must comply with the following EBNF production:
-     * ['+' | '-'] YYYY '-' MM '-' DD 'T' hh ':' mm ':' ss ['.' fff [fff]] ('Z' | timezoneOffset )
-     * where:
-     *   YYYY is 4-or-more-digit year number, which can be negative for years before 0000;
-     *   MM is 2-digit month in year number, in which 01 is January, 02 is February, ..., 12 is December;
-     *   DD is 2-digit day in month number in range 01 to 28, 29, 30, 31 depending on month and leap year;
-     *   hh is 2-digit hour in day number in range 00 to 23;
-     *   mm is 2-digit minute in hour in range 00 to 59;
-     *   ss is 2-digit second in minute in range 00 to 60, in  in case of leap second;
-     *   ['.' fff [fff]] is an optional 3-digit millisecond or 6-digit microsecond fraction;
-     *   timezoneOffset is ('+' | '-') hhOffset ':' mmOffset, denoting the local timezone hour and minute offset w.r.t. UTC,
-     *   in which '+' specifies an offset ahead of UTC and '-' specifies an offset behind UTC;
-     *
-     * Note 1: All components are expressed with leading zeros.
-     * Note 2: 'Z' instead of timezoneOffset denotes a UTC time, i.e. zero time offset.
-     * Note 3: The ss value may only be 60 when a leap second is inserted.
-     *
-     * Examples of such a date and time value are:
-     * 2021-08-30T12:30:24Z (UTC date and time with second precision)
-     * 2018-01-23T23:14:44.304827Z (UTC date and time with microsecond precision)
-     * 1969-07-20T20:17:00Z (UTC date and time with second precision)
-     * 1969-07-20T15:17:00-05:00 (local date and time with second precision for a timezone 5 hour behind UTC)
-     * 1969-07-20T22:17:00+02:00 (local date and time with second precision for a timezone 2 hour ahead of UTC)
-     *
-     * TODO: Add constraint to verify ISO 8691 extended string encoding.
-     */
+	    doc
+	    /*
+	     * Extended string encoding of an ISO 8601-1 date and time
+	     *
+	     * The format of the string must comply with the following EBNF production:
+	     * ['+' | '-'] YYYY '-' MM '-' DD 'T' hh ':' mm ':' ss ['.' fff [fff]] ('Z' | timezoneOffset )
+	     * where:
+	     *   YYYY is 4-or-more-digit year number, which can be negative for years before 0000;
+	     *   MM is 2-digit month in year number, in which 01 is January, 02 is February, ..., 12 is December;
+	     *   DD is 2-digit day in month number in range 01 to 28, 29, 30, 31 depending on month and leap year;
+	     *   hh is 2-digit hour in day number in range 00 to 23;
+	     *   mm is 2-digit minute in hour in range 00 to 59;
+	     *   ss is 2-digit second in minute in range 00 to 60, in  in case of leap second;
+	     *   ['.' fff [fff]] is an optional 3-digit millisecond or 6-digit microsecond fraction;
+	     *   timezoneOffset is ('+' | '-') hhOffset ':' mmOffset, denoting the local timezone hour and minute offset w.r.t. UTC,
+	     *   in which '+' specifies an offset ahead of UTC and '-' specifies an offset behind UTC;
+	     *
+	     * Note 1: All components are expressed with leading zeros.
+	     * Note 2: 'Z' instead of timezoneOffset denotes a UTC time, i.e. zero time offset.
+	     * Note 3: The ss value may only be 60 when a leap second is inserted.
+	     *
+	     * Examples of such a date and time value are:
+	     * 2021-08-30T12:30:24Z (UTC date and time with second precision)
+	     * 2018-01-23T23:14:44.304827Z (UTC date and time with microsecond precision)
+	     * 1969-07-20T20:17:00Z (UTC date and time with second precision)
+	     * 1969-07-20T15:17:00-05:00 (local date and time with second precision for a timezone 5 hour behind UTC)
+	     * 1969-07-20T22:17:00+02:00 (local date and time with second precision for a timezone 2 hour ahead of UTC)
+	     *
+	     * TODO: Add constraint to verify ISO 8691 extended string encoding.
+	     */
     }
 
     attribute def Iso8601DateTime :> UtcTimeInstantValue {

--- a/sysml.library/Kernel Library/Clocks.kerml
+++ b/sysml.library/Kernel Library/Clocks.kerml
@@ -10,10 +10,11 @@ package Clocks {
 	private import Occurrences::Occurrence;
 	private import ControlFunctions::forAll;
 	
-	readonly feature defaultClock : Clock[1] {
+	readonly feature universalClock : Clock[1] {
 		doc
 		/*
-		 * defaultClock is a single Clock that can be used as a default.
+		 * universalClock is a single Clock that can be used as a default universal
+		 * time reference.
 		 */
 	}
 	
@@ -58,7 +59,7 @@ package Clocks {
 		 */
 		
 		in o : Occurrence[1];
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default localClock;
 		return timeInstant : NumericalValue[1];
 		
 		 inv startTimeConstraint {
@@ -106,7 +107,7 @@ package Clocks {
 		 */
 		
 		in o : Occurrence[1]; 
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default localClock;
 		return duration : NumericalValue =
 			TimeOf(o.endShot, clock) - TimeOf(o.startShot, clock);
 	}

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -32,7 +32,7 @@ package Objects {
 		composite subobjects: Object[0..*] subsets objects, suboccurrences {
 			doc
 			/*
-			 * The suboccurrences of this Object that are themselves Objects.
+			 * The suboccurrences of this Object that are also Objects.
 			 */
 		}
 		

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -29,6 +29,13 @@ package Objects {
 
 		feature self: Object redefines Occurrence::self;
 		
+		composite subobjects: Object[0..*] subsets objects, suboccurrences {
+			doc
+			/*
+			 * The suboccurrences of this Object that are themselves Objects.
+			 */
+		}
+		
 		step involvingPerformances: Performance[0..*] subsets performances {
 			doc
 			/*

--- a/sysml.library/Kernel Library/Objects.kerml
+++ b/sysml.library/Kernel Library/Objects.kerml
@@ -50,7 +50,7 @@ package Objects {
 			 */
 		}
 		
-		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences {
+		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences {
 			doc
 			/*
 			 * Performances that are owned by this object.

--- a/sysml.library/Kernel Library/Occurrences.kerml
+++ b/sysml.library/Kernel Library/Occurrences.kerml
@@ -11,6 +11,7 @@ package Occurrences {
 	private import ScalarValues::Natural;
 	private import ScalarValues::Boolean;
 	private import Links::*;
+	private import Clocks::*;
 	private import Collections::Set;
 	private import Collections::OrderedSet;
 	private import CollectionFunctions::contains;
@@ -43,6 +44,29 @@ package Occurrences {
 			 * Occurrence itself. However, this is overridden for ownedPerformances of Objects and
 			 * subperformances of Performances.
 			 */
+		}
+		
+		feature localClock : Clock[1] default universalClock  {
+			doc
+			/*
+			 * A local Clock to be used as the corresponding time reference for this Occurrence
+			 * and, by default, all ownedOccurrences. By default this is the singleton universalClock.
+			 */
+		}
+		
+		composite feature suboccurrences: Occurrence[0..*] subsets occurrences {
+			doc
+			/*
+			 * Composite suboccurrences of this Occurrence.
+			 */
+			 
+			 feature redefines localClock default (that as Occurrence).localClock {
+			 	doc
+			 	/*
+			 	 * The localClock of a suboccurrence defaults to the localClock of its containing
+			 	 * Occurrence.
+			 	 */
+			 }
 		}
 		
 		feature predecessors: Occurrence[0..*] subsets occurrences {

--- a/sysml.library/Kernel Library/Performances.kerml
+++ b/sysml.library/Kernel Library/Performances.kerml
@@ -43,7 +43,7 @@ package Performances {
 			 */
 		}
 		
-		composite step subperformances: Performance[0..*] subsets enclosedPerformances {
+		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences {
 			doc
 			/*
 			 * enclosedPerformances that are composite. 

--- a/sysml.library/Kernel Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Library/SpatialFrames.kerml
@@ -41,7 +41,7 @@ package SpatialFrames {
 		in point : Point[1];
 		in time : NumericalValue[1];
 		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return positionVector : ThreeVectorValue[1];
 		
 		inv positionTimePrecondition {
@@ -77,7 +77,7 @@ package SpatialFrames {
 	
 		in point : Point[1];
 		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return positionVector : ThreeVectorValue[1] =
 			PositionOf(point, clock.currentTime, frame, clock);
 	}
@@ -94,7 +94,7 @@ package SpatialFrames {
 		in point2 : Point[1];
 		in time : NumericalValue;
 		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return displacementVector : ThreeVectorValue[1] =
 			PositionOf(point2, time, frame, clock) - PositionOf(point1, time, frame, clock);
 			
@@ -121,7 +121,7 @@ package SpatialFrames {
 		in point1 : Point[1];
 		in point2 : Point[1];
 		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return displacementVector : ThreeVectorValue[1] =
 			DisplacementOf(point1, point2, clock.currentTime, frame, clock);
 	}
@@ -143,7 +143,7 @@ package SpatialFrames {
 		in point : Point[1];
 		in time : NumericalValue[1];
 		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return positionVector : CartesianThreeVectorValue[1];
 	}
 	
@@ -155,7 +155,7 @@ package SpatialFrames {
 	
 		in point : Point[1];
 		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return positionVector : CartesianThreeVectorValue[1];
 	}
 	
@@ -169,7 +169,7 @@ package SpatialFrames {
 		in point2 : Point[1];
 		in time : NumericalValue[1];
 		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return displacementVector : CartesianThreeVectorValue[1];
 	}
 		
@@ -182,7 +182,7 @@ package SpatialFrames {
 		in point1 : Point[1];
 		in point2 : Point[1];
 		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default defaultClock;
+		in clock : Clock[1] default frame.localClock;
 		return displacementVector : CartesianThreeVectorValue[1];
 	}
 		

--- a/sysml.library/Kernel Library/Triggers.kerml
+++ b/sysml.library/Kernel Library/Triggers.kerml
@@ -113,7 +113,7 @@ package Triggers {
 			doc
 			/*
 			 * The Clock to be used as the reference for the timeInstant. The default is
-			 * the localClock at the point of invocation of the function. 
+			 * the localClock, which will be bound when the function is invoked. 
 			 */
 		}
 		
@@ -163,7 +163,7 @@ package Triggers {
 			doc
 			/*
 			 * The Clock to be used as the reference for the time delay. The default is
-			 * the localClock at the point of invocation of the function. 
+			 * the localClock, which will be bound when the function is invoked. 
 			 */
 		}
 		

--- a/sysml.library/Kernel Library/Triggers.kerml
+++ b/sysml.library/Kernel Library/Triggers.kerml
@@ -109,11 +109,11 @@ package Triggers {
 			 */
 		}
 		
-		in feature clock : Clock[1] default defaultClock {
+		in feature clock : Clock[1] default localClock {
 			doc
 			/*
 			 * The Clock to be used as the reference for the timeInstant. The default is
-			 * the Clocks::defaultClock. 
+			 * the localClock at the point of invocation of the function. 
 			 */
 		}
 		
@@ -159,11 +159,11 @@ package Triggers {
 			 */
 		}
 		
-		in feature clock : Clock[1] default defaultClock {
+		in feature clock : Clock[1] default localClock {
 			doc
 			/*
 			 * The Clock to be used as the reference for the time delay. The default is
-			 * the Clocks::defaultClock.
+			 * the localClock at the point of invocation of the function. 
 			 */
 		}
 		

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -107,7 +107,7 @@ package Items {
 			 */
 		}
 		
-		abstract item subitems: Item[0..*] :> items {
+		abstract item subitems: Item[0..*] :> items, subobjects {
 			doc
 			/*
 			 * The Items that are composite subitems of this Item.
@@ -121,7 +121,7 @@ package Items {
 			 */
 		}
 		
-		abstract ref constraint checkedConstraints: ConstraintCheck[0..*] :> constraintChecks, enactedPerformances {
+		abstract constraint checkedConstraints: ConstraintCheck[0..*] :> constraintChecks, ownedPerformances {
 			doc
 			/*
 			 * Constraints that have been checked by this Item.

--- a/sysml/src/examples/Simple Tests/OccurrenceTest.sysml
+++ b/sysml/src/examples/Simple Tests/OccurrenceTest.sysml
@@ -3,9 +3,17 @@ package OccurrenceTest {
 		attribute a;
 		ref occurrence occ1 : Occ;
 		occurrence occ2 : Occ;
+		item x;
+		part y;
 		
 		individual snapshot s : Ind;
 		timeslice t;
+	}
+	
+	occurrence occ : Occ {
+		occurrence o1 : Occ;
+		ref occurrence o2 : Occ;
+		item z;
 	}
 
 	individual occurrence def Ind {

--- a/sysml/src/examples/Simple Tests/PartTest.sysml
+++ b/sysml/src/examples/Simple Tests/PartTest.sysml
@@ -7,6 +7,7 @@ package PartTest {
 		protected port c: C;
 		readonly attribute x[0..2];
 		derived ref attribute y :> x;
+		ref z : ScalarValues::Integer;
 	}
 	
 	abstract part def <xx> B {


### PR DESCRIPTION
This PR updates the model library to allow each occurrence to have a "local clock", which is used as the default clock for triggers within an occurrence. This update allows, for example, the following:
```
part context {
  // This defines a local clock used by default within the “context” part.
  part :>> localClock = Time::Clock();

  state behavior {
    entry; then S1;
    
    state S1;
    
    transition
      first S1
      // The time instant in the trigger is, by default, 
      // relative to context::localClock.
      accept at Iso8601DateTime("22-05-12T00:00:00")
      then S2;
    
    state S2;
  }
}
```

**Kernel Model Library**

1. _Clocks._ 
   - Rename `defaultClock` to `universalClock`.
   - Change the default for the `clock` parameter of `TimeOf` and `DurationOf` from `defaultClock` to `localClock`.
2. _Occurrences._
   - Add a `localClock` feature to `Occurrence` with `Clocks::universalClock` as its default.
   - Add a `suboccurrences` feature to `Occurrence` to include all composite suboccurrences of an occurrence and pass the `localClock` of an occurrence down as the default for the `localClock` of its `suboccurrences`.
3. _Objects._
   - Make `Object::subobjects` and `Object::ownedPerformances` subsets of `suboccurrences`.
4. _Performances._
   - Make `Performance::subperformances` a subset of `suboccurrences`.
6. _SpatialFrames._
   - Change the default for the `clock` parameter of various functions from `defaultClock` to `frame.localClock`.
7. _Triggers._
   - Change the default for the `clock` parameter of `TriggerAt` and `TriggerWhen` to their `localClock` (which, by default, will be bound to the `localClock` of some containing "context" of the usages of these functions).

**Systems Model Library**

1. _Items._
   - Make `Item::subitems` a subset of `subobjects`.
   - Make `Item::checkedConstraints` composite and a subset of `ownedPerformances`.

**Quantities and Units Domain Library**

1. _Time._
   - Rename `defaultClock` to `universalClock`, defaulting to `Clocks::universalClock`.
   - Change the default for the `clock` parameter of `TimeOf` and `DurationOf` from `defaultClock` to `localClock`.

**Geometry Domain Library**

1. _SpatialItem._
   - Update the existing declaration of `localClock` for `SpatialItem`  to redefine` Occurrences::localClock` and default to `Time::universalClock`. (Note that this cannot be done in `Item`, because the `Time` package is in the Quantities and Units Domain library.)

**Implicit Specializations**

The following are just the changes to the implicit specialization implementation. Unchanged rules are not included.

1. _FeatureAdapter._
   - A composite feature with a class type and an owning type that is a class or a feature with a class type specializes `Occurrence::suboccurrences`.
   - A composite feature with a structure type and an owning type that is a structure or a feature with a structure type specializes `Object::subobjects`.
3. _UsageAdapter._
   - By default, a usage has the same implicit specialization as for a feature. (This only applies for reference usages and bare usages with user-defined keywords.)
4. _OccurrenceUsageAdapter._
   - If an occurrence usage fits the requirements of being a suboccurrence (as generically for a feature), then it specializes `Occurrence::suboccurrences`. 
5. _ItemUsageAdapter._
   - If an item usage is a suboccurrence but not a subitem, then it specializes `Occurrence::suboccurrences`. (`Item::subitems` subsets `subobjects` which already subsets `suboccurrences`.)
6. _ActionUsageAdapter._
   - If an action usage is a suboccurrence but not a subaction, then it specializes `Occurrence::suboccurrences`. (`Action::subactions` subsets `subperformances` which already subsets `suboccurrences`.)
7. _ConstraintUsageAdapter._
   - If a constraint usage is composite and its owning type is an item definition or usage, then it specializes `Item::checkedConstraints`. (This fixes the required specialization for constraints, which was broken.)