### PR TITLE
ST6RI-568/569 Fix StatePerformance::acceptFirst, triggerDuring invariants; StateTransitionPerformance AcceptFirst -> TriggerDuring

### DIFF
--- a/sysml.library/Kernel Library/StatePerformances.kerml
+++ b/sysml.library/Kernel Library/StatePerformances.kerml
@@ -6,15 +6,17 @@ package StatePerformances {
 	 */
 
 	private import ScalarValues::Boolean;
+	private import ScalarValues::Natural;
 	private import TransitionPerformances::TransitionPerformance;
 	private import Occurrences::HappensDuring;
 	private import Transfers::Transfer;
+	private import Performances::Performance;
 	private import ControlPerformances::DecisionPerformance;
 	private import SequenceFunctions::*;
 	
 	behavior StatePerformance specializes DecisionPerformance {
-		feature isTriggerDuring: Boolean;
-		feature isAcceptFirst: Boolean;
+		feature isTriggerDuring: Boolean default true;
+		feature isAcceptFirst: Boolean default true;
 
 		abstract step middle[1..*] {
 			doc
@@ -32,9 +34,11 @@ package StatePerformances {
 		step do[1] subsets middle;
 		step exit[1];
 		
+		step nonDoMiddle[*] subsets middle = middle->excluding(do);
+
 		private succession entry[1] then middle[*];
-		private succession do.startShot[1] then middle.startShot[*];
-		private succession middle.endShot[*] then do.endShot[1];
+		private succession do.startShot[1] then nonDoMiddle.startShot[*];
+		private succession nonDoMiddle.endShot[*] then do.endShot[1];
 		private succession middle[*] then exit[1];
 
 		private inv { isEmpty(accepted) == isEmpty(acceptable) }
@@ -43,32 +47,33 @@ package StatePerformances {
 		feature accepted: Transfer[0..1] subsets acceptable;
 		
 		private succession do[1] then accepted.endShot[0..1];
-		private succession acceptFirst first accepted.endShot[0..1] then acceptable.endShot[*] {
-			inv { isAcceptFirst implies size(acceptFirst) == size(acceptable) }
-		}
-		private succession acceptable::endShot[*] then exit[1];
-		private connector triggerDuring: HappensDuring from acceptable.endShot[*] to self[1] {
-			inv { isTriggerDuring implies notEmpty(triggerDuring) }
-		}
+		private feature afNum: Natural [1] =
+			if ( not isAcceptFirst | isEmpty(acceptable)) ? 0 else size(acceptable)-1;
+		private succession acceptFirst[afNum] first accepted.endShot[0..1] then acceptable.endShot[*];
+		
+		private succession acceptable[*] then exit[1];
 	}
 	
 	behavior StateTransitionPerformance specializes TransitionPerformance {
-		feature isTriggerDuring: Boolean;
-		
+		feature isTriggerDuring: Boolean[1];
+		inv { not transitionLinkSource.isTriggerDuring | isTriggerDuring  }
+
 		in feature transitionLinkSource: StatePerformance redefines TransitionPerformance::transitionLinkSource {
-			feature redefines accepted[1];
+			feature redefines accepted;
+			feature redefines StatePerformance::acceptable;
 		}
+		private succession transitionLinkSource.nonDoMiddle[*] then Performance::self[1];
 		
-		feature trigger redefines TransitionPerformance::trigger {
+		feature acceptable: Transfer [*] subsets transitionLinkSource.acceptable;
+
+		feature trigger redefines TransitionPerformance::trigger subsets acceptable, transitionLinkSource.accepted {
 			feature redefines endShot;
 		}
 		
-		private binding transitionLinkSource.accepted[0..1] = trigger[1];
-		private connector linkAcceptFirst: HappensDuring from transitionLinkSource[0..1] to trigger.endShot[*] {
-			inv { transitionLinkSource.isAcceptFirst implies size(linkAcceptFirst) == size(trigger) }
-		}
+		private feature tdNum: Natural [1] = if not isTriggerDuring ? 0 else size(trigger);
+		private connector linkTriggerDuring: HappensDuring[tdNum] from trigger.endShot[*] to transitionLinkSource[0..1];
 		
 		private succession all transitionLinkSource.middle[1..*] then guard[*];
-		private succession guard[*] then transitionLinkSource.exit[1];		
+		private succession guard[*] then transitionLinkSource.exit[1];
 	}
 }

--- a/sysml.library/Kernel Library/TransitionPerformances.kerml
+++ b/sysml.library/Kernel Library/TransitionPerformances.kerml
@@ -6,18 +6,20 @@ package TransitionPerformances {
 	 */
 
 	private import ScalarValues::Boolean;
+	private import ScalarValues::Natural;
 	private import Occurrences::HappensBefore;
 	private import Performances::Performance;
 	private import Performances::Evaluation;
 	private import Transfers::Transfer;
 	private import ControlFunctions::allTrue;
+	private import SequenceFunctions::size;
 	
 	abstract behavior TransitionPerformance {
 		in step transitionLinkSource: Performance[1];
 		
 		feature trigger: Transfer[*];
-		expr guard[*];
-		step effect[*];
+		bool guard[*] subsets enclosedPerformances;
+		step effect[*] subsets enclosedPerformances;
 
 		feature transitionLink: HappensBefore[0..1];
 		
@@ -34,9 +36,11 @@ package TransitionPerformances {
 	}
 	
 	behavior NonStateTransitionPerformance specializes TransitionPerformance {
-		private succession transitionLinkSource[1] then trigger[*];
-		private succession transitionLinkSource[1] then guard[*];
-		
+		feature isTriggerAfter: Boolean default true;
+		private succession transitionLinkSource[1] then Performance::self[1];
+		private feature taNum: Natural [1] = if isTriggerAfter ? size(trigger) else 0;
+		private succession triggerAfter [taNum] first transitionLinkSource[0..1] then trigger.endShot[*];
+				
 		private succession all guard[*] then transitionLink.laterOccurrence[0..1];
 	}
 	


### PR DESCRIPTION
This pull request fixes errors and redundancies in StatePerformances.kerml and TransitionPerformances.kerml found when reviewing them for further enhnacements.

- Updates successions and constraints to account for HappensBefore being fully asymmetric now.  This includes adding StatePerformance::`nonDoMiddle` derived as middle minus do (these are the modeler-defined steps).

- Replaces invariants on features nested under the features (which would be satisfied by features having no values) with dynamic multiplicities on the features.

- Removes `isTriggerDuring` invariant in StatePerformance that was redundant with the one in TransitionPeformance. StatePerformance:`:isTriggerDuring` defaults to true to constrain all the corresponding TransitionPeformances to that, modelers can set it to false to set TransitionPeformances::`isTriggerDuring` if they want to.

- Adds default true to StatePerformances::`isTriggerDuring` and `isAcceptFirst`, now that we have defaults.
      
- Changes "::" to dots when they should be, or removing chaining entirely when not actually needed.

- StateTransitionPerformance:

  - Removes multiplicity on `transitionLinkSource`::`accepted`, which was requiring every transition to succeed (!).

  - Adds ::`acceptable `(subsetting `transitionLinkSource`'s and subset by `trigger`) for modelers to specialize with sufficient conditions.  Doing that with `trigger `as currently causes contradiction when more than one transition meets its trigger conditions.

  - Adds succession to ensure StateTransitionPerformances start after modeler-defined steps (`nonDoMiddle`) are finished.

  - Replaces binding on `trigger` that acted like subsetting (optional on one end) with subsets.

  - Reverses direction of HappensDuring connector and gives it the right name.

- Subsets TransitionPerformance::`guard`,`effect `from `enclosedPerformances` to ensure they happen during the transition.

- Loosens NonStateTransitionPerformance to enable triggers to arrive before `transitionLinkSource` ends, defaulting to current requirement that they arrive after.