### PR TITLE
ST6RI-578 SysML2XMI error from ItemFlow::itemType setting delegate

### DIFF
--- a/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.expressions.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.owl
 Bundle-Vendor: My Company
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xpect.tests
 Bundle-SymbolicName: org.omg.kerml.xpect.tests;singleton:=true
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml.feature/feature.xml
+++ b/org.omg.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.feature"
       label="SysML v2 Feature"
-      version="0.26.0.qualifier"
+      version="0.27.0.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.omg.sysml.interactive.tests;singleton:=true
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Automatic-Module-Name: org.omg.sysml.interactive.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.interactive;bundle-version="0.3.2",

--- a/org.omg.sysml.interactive/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.interactive
 Bundle-SymbolicName: org.omg.sysml.interactive
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Export-Package: org.omg.sysml.interactive
 Require-Bundle: org.eclipse.emf.ecore,
  com.google.inject,

--- a/org.omg.sysml.jupyter.jupyterlab/package.json
+++ b/org.omg.sysml.jupyter.jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@systems-modeling/jupyterlab-sysml",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "A JupyterLab extension for system modeling using SysML",
   "repository": "github:Systems-Modeling/SysML-v2-Pilot-Implementation",
   "author": "SysML v2 Submission Team",

--- a/org.omg.sysml.jupyter.kernel/gradle.properties
+++ b/org.omg.sysml.jupyter.kernel/gradle.properties
@@ -1,2 +1,2 @@
 group=org.omg.sysml
-version=0.26.0-SNAPSHOT
+version=0.27.0-SNAPSHOT

--- a/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.plantuml
 Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization for Eclipse
 Bundle-SymbolicName: org.omg.sysml.plantuml.eclipse;singleton:=true
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Import-Package: net.sourceforge.plantuml.eclipse.utils;version="1.1.25.himi1",
  net.sourceforge.plantuml.ecore,
  net.sourceforge.plantuml.text,

--- a/org.omg.sysml.plantuml.feature/feature.xml
+++ b/org.omg.sysml.plantuml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.omg.sysml.plantuml.feature"
       label="SysML v2 PlantUML Visualization Feature"
-      version="0.26.0.qualifier"
+      version="0.27.0.qualifier"
       provider-name="SysML v2 Submission Team">
 
    <description url="http://www.example.com/description">

--- a/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization
 Bundle-SymbolicName: org.omg.sysml.plantuml
 Automatic-Module-Name: org.omg.sysml.plantuml
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Export-Package: org.omg.sysml.plantuml
 Import-Package: com.google.common.collect,
  com.google.inject;version="1.3.0",

--- a/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xpect.tests
 Bundle-SymbolicName: org.omg.sysml.xpect.tests;singleton:=true
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.2.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.xtext,

--- a/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.sysml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ui
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext/.launch/Save SysML2XMI.launch
+++ b/org.omg.sysml.xtext/.launch/Save SysML2XMI.launch
@@ -7,7 +7,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="1"/>
     </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.xtext.util.SysML2XMI"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml.xtext"/>

--- a/org.omg.sysml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-Version: 0.26.0.qualifier
+Bundle-Version: 0.27.0.qualifier
 Bundle-ClassPath: .,
  lib/sysml-v2-api-client-all.jar
 Bundle-SymbolicName: org.omg.sysml;singleton:=true

--- a/org.omg.sysml/src/org/omg/sysml/delegate/ItemFlow_itemType_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/ItemFlow_itemType_SettingDelegate.java
@@ -38,7 +38,6 @@ public class ItemFlow_itemType_SettingDelegate extends BasicDerivedListSettingDe
 	@Override
 	protected EList<Classifier> basicGet(InternalEObject owner) {
 		EList<Classifier> itemType = new NonNotifyingEObjectEList<>(Classifier.class, owner, eStructuralFeature.getFeatureID());
-		((ItemFlow)owner).getItemFeature().get(0).getType();
 		((ItemFlow)owner).getItemFeature().stream().
 			flatMap(f->f.getType().stream()).
 			filter(t->t instanceof Classifier).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <properties>
-    <revision>0.26.0-SNAPSHOT</revision>
+    <revision>0.27.0-SNAPSHOT</revision>
     <tycho-version>2.5.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse-repository>https://download.eclipse.org/releases/2021-09</eclipse-repository>


### PR DESCRIPTION
This pull request removes a spurious line from the `ItemFlow_itemType_SettingDelegate::basicGet` method that caused an `IndexOutOfBoundsException` during the derivation of the `itemType` property of an `ItemFlow`/`FlowConnectionUsage` with no item feature.