### PR TITLE
ST6RI-586 First end of a conditional succession being an inherited feature causes a warning

### DIFF
--- a/sysml/src/examples/Simple Tests/ActionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ActionTest.sysml
@@ -1,7 +1,17 @@
 package ActionTest {
+	action def A{ in x; }
+	
+	action a: A { 
+		first start;
+		
+		action b { in y = x; }
+		
+		bind x = b.y;
+	}
+	
 	attribute def S;
 	
-	action a {
+	action a1 {
 		first start;		
 		then merge m;
 		then accept S;


### PR DESCRIPTION
This pull request corrects the computation of the featuring type of an implicit connector/connection. This was causing the reported bug that, when the first end of a conditional succession (in the SysML textual notation) was an inherited feature, then a warning was reported on the second end.