### PR TITLE
ST6RI-588 Usage::isComposite defaults to false instead of true

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
@@ -440,13 +440,13 @@ public class UsageImpl extends FeatureImpl implements Usage {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Default isComposite to false for Usages.  
+	 * Default isComposite to true (so isReference is false) for Usages.  
 	 * <!-- end-user-doc -->
 	 * @generated NOT
 	 */
 	protected UsageImpl() {
 		super();
-		isComposite = false;
+		isComposite = true;
 	}
 
 	/**


### PR DESCRIPTION
In the update for ST6RI-500, the default for the `isComposite` property of a `Usage` was inadvertently changed from `true` to `false`. This pull request restores the correct default.