### PR TITLE
ST6RI-589: Show conjugate port types (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -484,7 +484,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
             if (ft == null) continue;
             Type typ = ft.getType();
             if (typ == null) continue;
-            String typeName = typ.getName();
+            String typeName = typ.getEffectiveName();
             if (typeName == null) continue;
             if (added) {
                 sb.append(", ");


### PR DESCRIPTION
To render type names, it used getName() but it may be null if the types are inherits without their own name.  Use getEffectiveName() instead.