### PR TITLE
ST6RI-594: Cannot resolve names in the lastly loaded resource in Jupyter

### DIFF
--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
@@ -78,7 +78,7 @@ public class KerML2XMI extends SysMLUtil {
 			}
 		};
 		
-		this.resourceSet.getResources().add(resource);
+		getResourceSet().getResources().add(resource);
 		return resource;
 	}
 	
@@ -112,7 +112,7 @@ public class KerML2XMI extends SysMLUtil {
 		this.resolveAllInputResources();
 		
 		Set<Resource> outputResources = new HashSet<Resource>();
- 		for (Object object: this.resourceSet.getResources().toArray()) {
+ 		for (Object object: getResourceSet().getResources().toArray()) {
 			Resource resource = (Resource)object;
 			Resource outputResource = this.createOutputResource(this.getOutputPath(resource.getURI().toFileString()));
 			outputResource.getContents().addAll(resource.getContents());

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
@@ -37,14 +37,18 @@ import java.util.Scanner;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.BasicEList;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceFactory;
 import org.eclipse.xtext.scoping.IGlobalScopeProvider;
 import org.eclipse.xtext.scoping.IScope;
 import org.eclipse.xtext.util.CancelIndicator;
@@ -102,6 +106,25 @@ public class SysMLInteractive extends SysMLUtil {
 	
 	@Inject
 	private IResourceValidator validator;
+
+    @Inject
+    private XtextResourceFactory xtextResourceFactory;
+
+	public XtextResource createNonPersistentXtextResource(String name) {
+		XtextResource xres = (XtextResource) xtextResourceFactory.createResource(URI.createURI(name));
+		getResourceSet().getResources().add(xres);
+		return xres;
+	}
+
+    private Resource dummyResource;
+
+    private Resource getDummyResource() {
+        if (dummyResource == null) {
+            this.dummyResource = new ResourceImpl(URI.createURI("dummy"));
+            getResourceSet().getResources().add(dummyResource);
+        }
+        return dummyResource;
+    }
 	
 	@Inject
 	private SysMLInteractive() {
@@ -119,13 +142,13 @@ public class SysMLInteractive extends SysMLUtil {
 			this.readAll(path + DOMAIN_LIBRARIES_DIRECTORY, false, SYSML_EXTENSION);
 		}
 	}
-	
+
 	public void setApiBasePath(String apiBasePath) {
 		this.apiBasePath = apiBasePath;
 	}
 	
 	public int next() {
-		this.resource = (XtextResource)this.createResource(this.counter + SYSML_EXTENSION);
+		this.resource = createNonPersistentXtextResource(this.counter + SYSML_EXTENSION);
 		this.addInputResource(this.resource);
 		return this.counter++;
 	}
@@ -192,27 +215,29 @@ public class SysMLInteractive extends SysMLUtil {
 	}
 	
 	public Element resolve(String name) {
-		List<Resource> resources = this.resourceSet.getResources();
-		if (!resources.isEmpty()) {
-			IScope scope = scopeProvider.getScope(
-					resources.get(resources.size() - 1), 
-					SysMLPackage.eINSTANCE.getNamespace_Member(), 
-					Predicates.alwaysTrue());
-			IEObjectDescription description = scope.getSingleElement(
-					this.qualifiedNameConverter.toQualifiedName(name));
-			if (description != null) {
-				EObject object = description.getEObjectOrProxy();
-				return object instanceof Element? (Element)object: null;
-			}
-		}
-		return null;
+            IScope scope = scopeProvider
+                .getScope(/* The specified resource, context, is EXCLUDED in the global scope
+                             because it is regarded as a local scope.  Thus we use
+                             a dummy resource to include all of the other resources
+                             in the scope. */
+                          getDummyResource(),
+                          SysMLPackage.eINSTANCE.getNamespace_Member(), 
+                          Predicates.alwaysTrue());
+            IEObjectDescription description = scope.getSingleElement(
+			this.qualifiedNameConverter.toQualifiedName(name));
+            if (description != null) {
+                EObject object = description.getEObjectOrProxy();
+                return object instanceof Element? (Element)object: null;
+            }
+            return null;
 	}
+
 	
 	public String listLibrary() {
 		this.counter++;
 		try {
 			List<Membership> globalMemberships = 
-					resourceSet.getResources().stream().
+					getResourceSet().getResources().stream().
 					filter(r->!inputResources.contains(r)).
 					flatMap(r->r.getContents().stream()).
 					filter(Namespace.class::isInstance).

--- a/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
@@ -55,7 +55,7 @@ import org.omg.sysml.lang.sysml.SysMLPackage;
  */
 public abstract class SysMLUtil {
 
-	protected final ResourceSet resourceSet;
+	private final ResourceSet resourceSet;
 	protected final Set<Resource> inputResources = new HashSet<Resource>();
 	protected final List<String> extensions = new ArrayList<String>();
 	protected final ResourceDescriptionsData index;
@@ -69,6 +69,7 @@ public abstract class SysMLUtil {
 	protected SysMLUtil(ResourceDescriptionsData resourceDescriptionData) {
 		SysMLPackage.eINSTANCE.getName();
 		this.resourceSet = new ResourceSetImpl();
+		//this.resourceSet = new XtextResourceSet();
 		this.resourceSet.getLoadOptions().put(XtextResource.OPTION_ENCODING, "UTF-8");
 		this.index = resourceDescriptionData;
 		ResourceDescriptionsData.ResourceSetAdapter.installResourceDescriptionsData(this.resourceSet, this.index);
@@ -93,13 +94,20 @@ public abstract class SysMLUtil {
 			System.out.println(line);
 		}
 	}
+
+	/**
+	 * Get the managed resource set
+	 */
+    public ResourceSet getResourceSet() {
+        return resourceSet;
+    }
 	
 	/**
 	 * Add a resource to the Xtext index.
 	 * 
 	 * @param 	resource		the resource to be added
 	 */
-	protected void addResourceToIndex(Resource resource) {
+	public void addResourceToIndex(Resource resource) {
 		URI uri = resource.getURI();
 		IResourceServiceProvider resourceServiceProvider = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(uri);
 		Manager manager = resourceServiceProvider.getResourceDescriptionManager();


### PR DESCRIPTION
The approach I took to resolve ST6RI-594 is that using a dummy resource as a context to get the global scope.  A dummy resource is created with a bogus URI (`new ResourceImpl(URI.createURI("dummy"))`) to prevent local file lookups.  SysMLInteractive.resolve() uses it for scopeProvider.getScope() to avoid exclusions from the local context.

I made a change how to create a Xtext resource by injecting xtextResourceFactory (createNonPersistentXtextResource).  The previous code relies on suffix matching and might make a problem in resource creations.

Also I created a getter for resouceSet, getResourceSet() in SysMLUtil.  So I made resourceSet private and I needed to modify KerML2XMI.createOutputResources().

I also made SysMLUtil.addResourceToIndex() public for other programs to put resources into the index.

