### PR TITLE
ST6RI-595 ItemFlow.getItemType can throw a null pointer exception

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/delegate/ItemFlow_itemType_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/ItemFlow_itemType_SettingDelegate.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.Classifier;
+import org.omg.sysml.lang.sysml.ItemFeature;
 import org.omg.sysml.lang.sysml.ItemFlow;
 import org.omg.sysml.util.NonNotifyingEObjectEList;
 
@@ -38,10 +39,13 @@ public class ItemFlow_itemType_SettingDelegate extends BasicDerivedListSettingDe
 	@Override
 	protected EList<Classifier> basicGet(InternalEObject owner) {
 		EList<Classifier> itemType = new NonNotifyingEObjectEList<>(Classifier.class, owner, eStructuralFeature.getFeatureID());
-		((ItemFlow)owner).getItemFeature().getType().stream().
-			filter(Classifier.class::isInstance).
-			map(Classifier.class::cast).
-			forEachOrdered(itemType::add);
+		ItemFeature itemFeature = ((ItemFlow)owner).getItemFeature();
+		if (itemFeature != null) {
+			itemFeature.getType().stream().
+				filter(Classifier.class::isInstance).
+				map(Classifier.class::cast).
+				forEachOrdered(itemType::add);
+		}
 		return itemType;
 	}
 

--- a/sysml.library/Systems Library/Connections.sysml
+++ b/sysml.library/Systems Library/Connections.sysml
@@ -77,7 +77,7 @@ package Connections {
 		 */
 	}
 	
-	abstract message flowConnections: FlowConnection[0..*] nonunique :> binaryConnections, transfers of Anything {
+	abstract message flowConnections: FlowConnection[0..*] nonunique :> binaryConnections, transfers {
 		doc
 		/*
 		 * flowConnections is the base feature of all FlowConnectionUsages.
@@ -87,7 +87,7 @@ package Connections {
 		end target: Occurrence[0..*] :>> FlowConnection::target, binaryConnections::target, transfers::target;
 	}
 	
-	abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, transfersBefore of Anything {
+	abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, transfersBefore {
 		doc
 		/*
 		 * successionFlowConnections is the base feature of all SuccessionFlowConnectionUsages.


### PR DESCRIPTION
Updates `ItemFlow_itemType_SettingDelegate` to check whether the `itemFeature` of an `ItemFlow` is null before getting the types of that feature.