### PR TITLE
ST6RI-596:  Fixed to show flow connection usages

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -25,6 +25,7 @@
 package org.omg.sysml.plantuml;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -391,11 +392,9 @@ public class SysML2PlantUMLText {
     }
 
     private List<EObject> setupVisualizationMode(EObject eObj) {
-        List<EObject> eObjs = new ArrayList<EObject>(1);
-        eObjs.add(eObj);
         MODE mode = getMode(eObj);
         setMode(mode);
-        return eObjs;
+        return Arrays.asList(eObj);
     }
 
     private List<? extends EObject> matchMode(EObject eObj) {
@@ -415,7 +414,7 @@ public class SysML2PlantUMLText {
                 // This case "e" has owned elements belonging to the same diagram mode but e is NOT.
                 // So we choose the mode for owned elements.  E.g a package has some state machines.
                 setMode(mc);
-                return e.getOwnedElement();
+                return Arrays.asList(e);
             }
         }
         return setupVisualizationMode(eObj);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -36,6 +36,7 @@ import org.omg.sysml.lang.sysml.ActorMembership;
 import org.omg.sysml.lang.sysml.AnalysisCaseUsage;
 import org.omg.sysml.lang.sysml.AttributeUsage;
 import org.omg.sysml.lang.sysml.BindingConnector;
+import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.Definition;
@@ -302,6 +303,12 @@ public class VCompartment extends VStructure {
     @Override
     public String caseConnector(Connector c) {
     	addFeature(c, null);
+    	return "";
+    }
+
+    @Override
+    public String caseConnectionUsage(ConnectionUsage cu) {
+    	addFeature(cu, null);
     	return "";
     }
     

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.omg.sysml.lang.sysml.AnnotatingElement;
 import org.omg.sysml.lang.sysml.Annotation;
 import org.omg.sysml.lang.sysml.Comment;
+import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
 import org.omg.sysml.lang.sysml.Dependency;
 import org.omg.sysml.lang.sysml.Element;
@@ -179,6 +180,12 @@ public class VDefault extends VTraverser {
     public String caseConnector(Connector c) {
         addConnector(c, c.getName());
         return "";
+    }
+
+    @Override
+    public String caseConnectionUsage(ConnectionUsage cu) {
+    	addConnector(cu, null);
+    	return "";
     }
 
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -218,8 +218,8 @@ public class VPath extends VTraverser {
             this.f = f;
         }
         
-        public PCFeature(Feature f) {
-        	super(f);
+        public PCFeature(Subsetting ss, Feature f) {
+        	super(ss);
         	this.f = f;
         }
     }
@@ -473,7 +473,7 @@ public class VPath extends VTraverser {
             Feature sf = ss.getSubsettedFeature();
             List<FeatureChaining> fcs = sf.getOwnedFeatureChaining();
             if (fcs.isEmpty()) {
-                return new PCFeature(sf);
+                return new PCFeature(ss, sf);
             } else {
                 return new PCFeatureChain(sf);
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
@@ -599,11 +600,11 @@ public class VPath extends VTraverser {
 
     @Override
     public String caseType(Type typ) {
-    	if (checkVisited(typ)) return null;
         for (Specialization sp: typ.getOwnedSpecialization()) {
             Type g = sp.getGeneral();
             // Type s = sp.getSpecific();
             if (g == null) continue;
+            if (checkVisited(g)) continue;
             visit(g);
             // visit(s); // Typically this will cause double traverse but checkVisit() stops it..
         }
@@ -628,7 +629,7 @@ public class VPath extends VTraverser {
     @Override
     public String caseConnector(Connector c) {
         /* VTraverser.traverse() do not duplicatedly traverse features already visited.
-           Thus VPath visits ends without counting on travserse(). */
+           Thus VPath visits ends without counting on traverse(). */
         for (Feature f: c.getConnectorEnd()) {
             visit(f);
         }


### PR DESCRIPTION
This PR fixes the problem that does not render FlowConnectionUsages.   This is partly caused by the metamodel change and the visualizer was confused them as ActionUsage.  So we capture them with caseConnectionUsage() in VCompartment and VDefault.
