### PR TITLE
ST6RI-594 Cannot resolve names in the lastly loaded resource in Jupyter

### DIFF
--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2JSON.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2JSON.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -98,7 +98,7 @@ public class KerML2JSON extends KerMLTraversalUtil {
 				} else if ("-g".equals(args[i])) {
 					this.isAddImplicitElements = true;
 				} else if ("-v".equals(args[i])) {
-					this.isVerbose = true;
+					this.setVerbose(true);
 				}
 				i++;
 			}
@@ -141,7 +141,7 @@ public class KerML2JSON extends KerMLTraversalUtil {
 		JsonElementProcessingFacade processingFacade = new JsonElementProcessingFacade();	
 		processingFacade.setTraversal(this.initialize(processingFacade));
 		processingFacade.setIsIncludeDerived(this.isAddDerivedElements);
-		processingFacade.setIsVerbose(this.isVerbose);
+		processingFacade.setIsVerbose(this.isVerbose());
 	}
 	
 	/**

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerML2XMI.java
@@ -78,7 +78,7 @@ public class KerML2XMI extends SysMLUtil {
 			}
 		};
 		
-		this.resourceSet.getResources().add(resource);
+		this.getResourceSet().getResources().add(resource);
 		return resource;
 	}
 	
@@ -112,7 +112,7 @@ public class KerML2XMI extends SysMLUtil {
 		this.resolveAllInputResources();
 		
 		Set<Resource> outputResources = new HashSet<Resource>();
- 		for (Object object: this.resourceSet.getResources().toArray()) {
+ 		for (Object object: this.getResourceSet().getResources().toArray()) {
 			Resource resource = (Resource)object;
 			Resource outputResource = this.createOutputResource(this.getOutputPath(resource.getURI().toFileString()));
 			outputResource.getContents().addAll(resource.getContents());

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLRepositorySaveUtil.java
@@ -134,7 +134,7 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 				} else if ("-g".equals(args[i])) {
 					this.isAddImplicitElements = true;
 				} else if ("-v".equals(args[i])) {
-					this.isVerbose = true;
+					this.setVerbose(true);
 				}
 				i++;
 			}
@@ -175,7 +175,7 @@ public class KerMLRepositorySaveUtil extends KerMLTraversalUtil {
 		
 		ApiElementProcessingFacade processingFacade = new ApiElementProcessingFacade(this.projectName, this.getBasePath());	
 		processingFacade.setTraversal(this.initialize(processingFacade));
-		processingFacade.setIsVerbose(this.isVerbose);
+		processingFacade.setIsVerbose(this.isVerbose());
 		processingFacade.setIsIncludeDerived(this.isAddDerivedElements);
 	}
 	

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLTraversalUtil.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/util/KerMLTraversalUtil.java
@@ -79,7 +79,7 @@ public class KerMLTraversalUtil extends SysMLUtil {
 	 * Traversal must be initialized before processing.
 	 */
 	public void process() {
-		for (Resource resource: this.inputResources) {
+		for (Resource resource: this.getInputResources()) {
 			for (EObject object : resource.getContents()) {
 				if (object instanceof Element) {
 					this.traversal.visit((Element) object);

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
@@ -219,8 +219,7 @@ public class SysMLInteractive extends SysMLUtil {
 		this.counter++;
 		try {
 			List<Membership> globalMemberships = 
-					resourceSet.getResources().stream().
-					filter(r->!inputResources.contains(r)).
+					this.getLibraryResources().stream().
 					flatMap(r->r.getContents().stream()).
 					filter(Namespace.class::isInstance).
 					flatMap(n->((Namespace)n).visibleMemberships(new BasicEList<>(), false, false).stream()).
@@ -324,7 +323,7 @@ public class SysMLInteractive extends SysMLUtil {
 			Element element = this.resolve(name);
 			if (element == null) {
 				return "ERROR:Couldn't resolve reference to Element '" + name + "'\n";
-			} else if (!inputResources.contains(element.eResource())) {
+			} else if (!this.isInputResource(element.eResource())) {
 				return "ERROR:'" + name + "' is a library element\n";
 			} else {
 				String modelName = element.getName() + " " + new Date();

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.parser.IParseResult;
@@ -93,6 +94,8 @@ public class SysMLInteractive extends SysMLUtil {
 	protected Traversal traversal;
 	
     protected SysML2PlantUMLSvc sysml2PlantUMLSvc;
+    
+    private Resource dummyResource;
 
     @Inject
 	private IGlobalScopeProvider scopeProvider;
@@ -125,13 +128,9 @@ public class SysMLInteractive extends SysMLUtil {
 	}
 	
 	public int next() {
-		createResource(this.counter);
+		this.resource = (XtextResource)this.createResource(counter + SYSML_EXTENSION);
 		this.addInputResource(this.resource);
 		return this.counter++;
-	}
-	
-	protected void createResource(int counter) {
-		this.resource = (XtextResource)this.createResource(counter + SYSML_EXTENSION);
 	}
 	
 	public XtextResource getResource() {
@@ -195,14 +194,17 @@ public class SysMLInteractive extends SysMLUtil {
 		}
 	}
 	
-	public Element resolve(String name) {
-		if (this.resource == null) {
-			// Create a dummy "local" resource so all library resources are part of global scope.
-			createResource(0);
-			this.resource.getContents().add(SysMLFactory.eINSTANCE.createNamespace());
+	private Resource getDummyResource() {
+		if (this.dummyResource == null) {
+			this.dummyResource = this.createResource("dummy" + SYSML_EXTENSION);
+			this.dummyResource.getContents().add(SysMLFactory.eINSTANCE.createNamespace());
 		}
+		return this.dummyResource;
+	}
+	
+	public Element resolve(String name) {
 		IScope scope = scopeProvider.getScope(
-				this.resource, 
+				this.getDummyResource(), 
 				SysMLPackage.eINSTANCE.getNamespace_Member(), 
 				Predicates.alwaysTrue());
 		IEObjectDescription description = scope.getSingleElement(

--- a/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/SysMLUtil.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -41,6 +42,8 @@ import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+
+import com.google.common.base.Predicates;
 
 
 /**
@@ -55,12 +58,12 @@ import org.omg.sysml.lang.sysml.SysMLPackage;
  */
 public abstract class SysMLUtil {
 
-	protected final ResourceSet resourceSet;
-	protected final Set<Resource> inputResources = new HashSet<Resource>();
-	protected final List<String> extensions = new ArrayList<String>();
-	protected final ResourceDescriptionsData index;
+	private final ResourceSet resourceSet;
+	private final Set<Resource> inputResources = new HashSet<Resource>();
+	private final List<String> extensions = new ArrayList<String>();
+	private final ResourceDescriptionsData index;
 	
-	protected boolean isVerbose = true;
+	private boolean isVerbose = true;
 	
 	protected SysMLUtil() {
 		this(new ResourceDescriptionsData(new ArrayList<>()));
@@ -93,13 +96,22 @@ public abstract class SysMLUtil {
 			System.out.println(line);
 		}
 	}
-	
+
+	/**
+	 * Get the managed resource set.
+	 * 
+	 * @return the resource set
+	 */
+    public ResourceSet getResourceSet() {
+        return resourceSet;
+    }
+    
 	/**
 	 * Add a resource to the Xtext index.
 	 * 
 	 * @param 	resource		the resource to be added
 	 */
-	protected void addResourceToIndex(Resource resource) {
+	public void addResourceToIndex(Resource resource) {
 		URI uri = resource.getURI();
 		IResourceServiceProvider resourceServiceProvider = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(uri);
 		Manager manager = resourceServiceProvider.getResourceDescriptionManager();
@@ -144,6 +156,26 @@ public abstract class SysMLUtil {
 		if (resource.getResourceSet() == this.resourceSet) {
 			this.inputResources.add(resource);
 		}
+	}
+	
+	/**
+	 * Return all the input resources.
+	 * 
+	 * @return the input resources.
+	 */
+	public Set<Resource> getInputResources() {
+		return this.inputResources;
+	}
+	
+	/**
+	 * Return all the library resources, that is, resources that are not input resources.
+	 * 
+	 * @return the library resources
+	 */
+	public Set<Resource> getLibraryResources() {
+		return this.getResourceSet().getResources().stream().
+				filter(Predicates.not(this::isInputResource)).
+				collect(Collectors.toSet());
 	}
 	
 	/**


### PR DESCRIPTION
Immediately after opening a Jupyter notebook, doing a `%show DerivationConnections` command results in an error because `DerivationConnections` cannot be resolved. This is because `DerivationConnections.syml` is the last library model loaded, so the resolution search starts with that resource in memory. However, the global scope provider is used for name resolution, and the starting resource for resolution is considered to be a local scope, not part of the global scope. As a result `DerivationConnections` is not resolved.

This pull request fixes the error by creating a dummy resource if the resolution of a magic command argument is attempted immediately after loading the libraries. The last library model is then no longer the last resource in the resource set, and, therefore is properly in global scope.

In addition, the encapsulation of `SysMLUtil` is improved by making its instance fields private (instead of public) and adding public access methods as appropriate. The `addResourceToIndex` method is also made public.