### PR TITLE
ST6RI-601: Specialization relationships are not rendered properly with SHOWINHERITED style (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/PRelation.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/PRelation.java
@@ -25,12 +25,33 @@
 package org.omg.sysml.plantuml;
 
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Subsetting;
 
 class PRelation {
     public final InheritKey ik;
-    public final Element src;
-    public final Element dest;
+    private final Object src;
+    private final Object dest;
     public final Element rel;
+
+    public Element getSrcElement() {
+        if (src instanceof Element) {
+            return (Element) src;
+        } else {
+            return null;
+        }
+    }
+
+    public Element getDestElement() {
+        if (dest instanceof Element) {
+            return (Element) dest;
+        } else {
+            return null;
+        }
+    }
+
+    public boolean isInvalid() {
+        return src == null && dest == null;
+    }
 
     private String description;
     public String getDescription() {
@@ -40,8 +61,56 @@ class PRelation {
     	this.description = desc;
     }
 
+    private static String makeIdStr(Integer ii) {
+        return 'E' + ii.toString();
+    }
+
+    private String compElemId(SysML2PlantUMLText s2p, Element e) {
+        if (e == null) return "[*]";
+        Integer ii = s2p.getVPath().getId(ik, e);
+        if (ii == null) {
+            if (!s2p.checkId(e)) {
+                if (e instanceof Subsetting) {
+                    Subsetting ss = (Subsetting) e;
+                    e = ss.getSubsettedFeature();
+                    if (!s2p.checkId(e)) return null;
+                } else {
+                	return null;
+                }
+            }
+            ii = s2p.getId(e);
+        }
+        return makeIdStr(ii);
+    }
+
+    private String compId(SysML2PlantUMLText s2p, Object o) {
+        if (o instanceof Element) {
+            return compElemId(s2p, (Element) o);
+        } else if (o instanceof Integer) {
+            return makeIdStr((Integer) o);
+        } else {
+            return null;
+        }
+    }
+
+    public String compSrcId(SysML2PlantUMLText s2p) {
+        return compId(s2p, src);
+    }
+
+    public String compDestId(SysML2PlantUMLText s2p) {
+        return compId(s2p, dest);
+    }
+
     public PRelation(InheritKey ik, Element src, Element dest, Element rel, String description) {
         this.ik = ik;
+        this.src = src;
+        this.dest = dest;
+        this.rel = rel;
+        this.description = description;
+    }
+
+    public PRelation(Object src, Object dest, Element rel, String description) {
+        this.ik = null;
         this.src = src;
         this.dest = dest;
         this.rel = rel;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
@@ -55,7 +55,7 @@ public class VAction extends VDefault {
     }
 
     private void addAction(Type typ) {
-        if (!addRecLine(typ, true)) return;
+        if (addRecLine(typ, true) < 0) return;
         // addGeneralizations(typ);
         VActionMembers v = new VActionMembers(this);
         v.startAction(typ);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
@@ -47,7 +47,7 @@ public class VActionMembers extends VBehavior {
 
     public String caseFeature(Feature f) {
         if (VSSRMembers.isStateSpaceMember(f)) {
-            if (!addRecLine(f, true)) return null;
+            if (addRecLine(f, true) < 0) return null;
             VSSRMembers vs = new VSSRMembers(this);
             return vs.start(f);
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
@@ -67,8 +67,8 @@ public class VCase extends VTree {
 
     private String addCase(Type typ) {
         String name = getNameAnyway(typ);
-        addRecLine(name, typ, true);
-        addSpecializations(typ);
+        int id = addRecLine(name, typ, true);
+        addSpecializations(id, typ);
 
         VCaseMembers v = new VCaseMembers(this);
         v.processCase(typ);
@@ -83,15 +83,16 @@ public class VCase extends VTree {
         if ("obj".equals(name)) name = null;
         VRequirement vr = new VRequirement(this);
         List<VTree> subtrees = processCompartment(vr, ru);
+        int id = -1;
         if (subtrees != null || name != null) {
             if (name == null) {
-                addPUMLLine(ru, "comp usage ", " <U+00AB>objective<U+00BB> ", "");
+                id = addPUMLLine(ru, "comp usage ", " <U+00AB>objective<U+00BB> ", "");
             } else {
-                addPUMLLine(ru, "comp usage ", name, " <<objective>> ");
+                id = addPUMLLine(ru, "comp usage ", name, " <<objective>> ");
             }
             processSubtrees(vr, subtrees);
         }
-        addSpecializations(ru);
+        addSpecializations(id, ru);
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
@@ -72,12 +72,12 @@ public class VComposite extends VMixed {
     public String caseUsage(Usage f) {
         String featureText = getFeatureText(f);
         if (featureText.isEmpty()) return "";
-        addPUMLLine(f, "rec usage ", featureText);
+        int id = addPUMLLine(f, "rec usage ", featureText);
 
         VComposite vc = new VComposite(this);
         vc.traverse(f);
         vc.closeBlock();
-        addSpecializations(f);
+        addSpecializations(id, f);
 
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -115,11 +115,13 @@ public class VDefault extends VTraverser {
         }
     }
 
-    protected void addSpecializations(Type typ) {
+    protected void addSpecializations(int typId, Type typ) {
+        if (typId < 0) return;
         for (Specialization s: typ.getOwnedSpecialization()) {
             Type gt = s.getGeneral();
             if (gt == null) continue;
-            addPRelation(null, typ, gt, s, null);
+            PRelation pr = new PRelation(typId, gt, s, null);
+            addPRelation(pr);
         }
     }
 
@@ -137,7 +139,7 @@ public class VDefault extends VTraverser {
         return addPUMLLine(typ, keyword, name, styleString(typ));
     }
 
-    protected boolean addRecLine(String name, Type typ, boolean withStyle) {
+    protected int addRecLine(String name, Type typ, boolean withStyle) {
         String keyword;
         if (typ instanceof Usage) {
             keyword = "rec usage ";
@@ -145,14 +147,13 @@ public class VDefault extends VTraverser {
             keyword = "rec def ";
         }
         if (withStyle) {
-            addPUMLLine(typ, keyword, name);
+            return addPUMLLine(typ, keyword, name);
         } else {
-            addPUMLLine(typ, keyword, name, null);
+            return addPUMLLine(typ, keyword, name, null);
         }
-        return true;
     }
 
-    protected boolean addRecLine(Type typ, boolean withStyle) {
+    protected int addRecLine(Type typ, boolean withStyle) {
     	String name = getNameAnyway(typ);
         return addRecLine(name, typ, withStyle);
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
@@ -35,8 +35,8 @@ public class VStateMachine extends VDefault {
         if (isParallel) {
             name = name + "\\n" + "<b>parallel</b>";
         }
-        addRecLine(name, typ, withStyle);
-        addSpecializations(typ);
+        int id = addRecLine(name, typ, withStyle);
+        addSpecializations(id, typ);
         VStateMembers v = new VStateMembers(this);
         v.startStateUsage(typ);
         append("\n");

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -274,8 +274,8 @@ public abstract class VStructure extends VDefault {
     }
 
     protected boolean addType(Type typ, String name, String keyword) {
-        addPUMLLine(typ, keyword, name);
-        addSpecializations(typ);
+        int id = addPUMLLine(typ, keyword, name);
+        addSpecializations(id, typ);
         return true;
     }
 


### PR DESCRIPTION
In SHOWINHERITED style, inherited elements can be multiple and we cannot identify sources only with a element.  So I used node id to identify a source.