### PR TITLE
ST6RI-417 Reflective library models for abstract syntax

### DIFF
--- a/kerml/src/examples/Simple Tests/Filtering.kerml
+++ b/kerml/src/examples/Simple Tests/Filtering.kerml
@@ -18,18 +18,32 @@ package Filtering {
 	            level = 2;
 	        }
 	    }
+		composite feature system : System;
 	}
-	
+
 	package UpperLevelApprovals {
 	    import DesignModel::**;
-	    filter @Annotations::ApprovalAnnotation and 
-	           Annotations::ApprovalAnnotation::approved and 
+	    filter Annotations::ApprovalAnnotation::approved and 
 	           Annotations::ApprovalAnnotation::level > 1;
+	    
+	    struct Test :> System;
 	}
 	
 	package UpperLevelApprovals1 {
 	    import Annotations::**;
-	    import DesignModel::**[@ApprovalAnnotation and approved and level > 1];
+	    import DesignModel::**[@Structure][approved and level > 1];
+	    
+	    struct Test :> System;	    
+	}
+	
+ import KerML::*;
+	package Meta {
+		import DesignModel::*;
+		filter (Element::name == "System" and not Type::isAbstract) or 
+		       Feature::isComposite;
+		
+		struct Test :> System; 
+		feature :> system;
 	}
 
 }

--- a/org.omg.kerml.xpect.tests/library/KerML.kerml
+++ b/org.omg.kerml.xpect.tests/library/KerML.kerml
@@ -1,93 +1,454 @@
 package KerML {
-	doc
-	/*
-	 * This package contains a reflective KerML model of the KerML abstract syntax.
-	 * 
-	 * NOTE: This model is currently incomplete. It includes all KerML abstract syntax metaclasses,
-	 * but none of their properties.
-	 */
+	import ScalarValues::*;
+	import Kernel::*;
 	
-	metaclass Element;
-	metaclass Relationship :> Element;
+	package Root {
+		metaclass AnnotatingElement specializes Element {
+			feature annotation : Annotation[0..*];
+			derived feature annotatedElement : Element[1..*] redefines annotatedElement;
+		}		
+				
+		metaclass Annotation specializes Relationship {
+			feature annotatingElement : AnnotatingElement[1..1] redefines source;
+			feature annotatedElement : Element[1..1] redefines target, annotatedElement;
+			derived feature owningAnnotatedElement : Element[0..1] subsets annotatedElement, owningRelatedElement;
+		}		
+				
+		metaclass Comment specializes AnnotatingElement {
+			feature locale : String[0..1];
+			feature body : String[1..1];
+		}		
+				
+		metaclass Documentation specializes Comment {
+			derived feature documentedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		metaclass Element {
+			feature elementId : String[1..1];
+			feature aliasIds : String[0..*];
+			feature shortName : String[0..1];
+			feature name : String[0..1];
+			feature isImpliedIncluded : Boolean[1..1];
+			derived feature effectiveName : String[0..1];
+			derived feature qualifiedName : String[0..1];
+			
+			feature owningRelationship : Relationship[0..1];
+			composite feature ownedRelationship : Relationship[0..*];
+			derived feature owningMembership : OwningMembership[0..1] subsets owningRelationship;
+			derived feature owningNamespace : Namespace[0..1];
+			derived feature owner : Element[0..1];
+			derived feature ownedElement : Element[0..*];
+			derived feature documentation : Documentation[0..*] subsets ownedElement;
+			composite derived feature ownedAnnotation : Annotation[0..*] subsets ownedRelationship;
+			derived feature textualRepresentation : TextualRepresentation[0..*] subsets ownedElement;
+		}		
+				
+		metaclass Import specializes Relationship {
+			feature visibility : VisibilityKind[1..1];
+			feature importedMemberName : String[0..1];
+			feature isRecursive : Boolean[1..1];
+			feature isImportAll : Boolean[1..1];
+			
+			feature importedNamespace : Namespace[1..1] redefines target;
+			derived feature importOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Membership specializes Relationship {
+			feature memberShortName : String[0..1];
+			feature memberName : String[0..1];
+			feature visibility : VisibilityKind[1..1];
+			derived feature memberElementId : String[1..1];
+			
+			feature memberElement : Element[1..1] redefines target;
+			derived feature membershipOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Namespace specializes Element {
+			abstract derived feature membership : Membership[0..*];
+			composite derived feature ownedImport : Import[0..*] subsets ownedRelationship;
+			derived feature 'member' : Element[0..*];
+			derived feature ownedMember : Element[0..*] subsets 'member';
+			composite derived feature ownedMembership : Membership[0..*] subsets membership, ownedRelationship;
+			derived feature importedMembership : Membership[0..*] subsets membership;
+		}		
+				
+		metaclass OwningMembership specializes Membership {
+			derived feature ownedMemberElementId : String[1..1] redefines memberElementId;
+			derived feature ownedMemberShortName : String[0..1] redefines memberShortName;
+			derived feature ownedMemberName : String[0..1] redefines memberName;
+			
+			composite derived feature ownedMemberElement : Element[1..1] subsets ownedRelatedElement redefines memberElement;
+		}		
+				
+		metaclass Relationship specializes Element {
+			feature isImplied : Boolean[1..1];
+			
+			feature target : Element[0..*] subsets relatedElement;
+			feature source : Element[0..*] subsets relatedElement;
+			feature owningRelatedElement : Element[0..1] subsets relatedElement;
+			composite feature ownedRelatedElement : Element[0..*] subsets relatedElement;
+			derived feature relatedElement : Element[2..*];
+		}		
+				
+		metaclass TextualRepresentation specializes AnnotatingElement {
+			feature 'language' : String[1..1];
+			feature body : String[1..1];
+			
+			derived feature representedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		datatype VisibilityKind {
+			member feature 'private' : VisibilityKind[1];
+			member feature 'protected' : VisibilityKind[1];
+			member feature 'public' : VisibilityKind[1];
+		}
+				
+	}
 	
-	metaclass AnnotatingElement :> Element;
-	metaclass Annotation :> Relationship;
-	metaclass Comment :> AnnotatingElement;
-	metaclass Documentation :> Annotation;
-	metaclass TextualRepresentation :> AnnotatingElement;
+	package Core {
+		import Root::*;
+		
+		metaclass Classifier specializes Type {
+			composite derived feature ownedSubclassification : Subclassification[0..*] subsets ownedSpecialization;
+		}		
+				
+		metaclass Conjugation specializes Relationship {
+			feature originalType : Type[1..1] redefines target;
+			feature conjugatedType : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets conjugatedType, owningRelatedElement;
+		}		
+				
+		metaclass Differencing specializes Relationship {
+			feature differencingType : Type[1..1] redefines target;
+			derived feature typeDifferenced : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Disjoining specializes Relationship {
+			feature typeDisjoined : Type[1..1] redefines source;
+			feature disjoiningType : Type[1..1] redefines target;
+			derived feature owningType : Type[0..1] subsets typeDisjoined, owningRelatedElement;
+		}		
+				
+		metaclass EndFeatureMembership specializes FeatureMembership {
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Feature specializes Type {
+			feature isUnique : Boolean[1..1];
+			feature isOrdered : Boolean[1..1];
+			feature isComposite : Boolean[1..1];
+			feature isEnd : Boolean[1..1];
+			feature isDerived : Boolean[1..1];
+			feature isReadOnly : Boolean[1..1];
+			feature isPortion : Boolean[1..1];
+			feature direction : FeatureDirectionKind[0..1];
+			
+			derived feature owningType : Type[0..1] subsets owningNamespace, featuringType;
+			derived feature 'type' : Type[1..*];
+			composite derived feature ownedRedefinition : Redefinition[0..*] subsets ownedSubsetting;
+			composite derived feature ownedSubsetting : Subsetting[0..*] subsets ownedSpecialization;
+			derived feature owningFeatureMembership : FeatureMembership[0..1] subsets owningMembership;
+			derived feature endOwningType : Type[0..1] subsets owningType;
+			composite derived feature ownedTyping : FeatureTyping[0..*] subsets ownedSpecialization;
+			derived feature featuringType : Type[0..*];
+			composite derived feature ownedTypeFeaturing : TypeFeaturing[0..*] subsets ownedRelationship;
+			derived feature chainingFeature : Feature[0..*];
+			composite derived feature ownedFeatureInverting : FeatureInverting[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureChaining : FeatureChaining[0..*] subsets ownedRelationship;
+			composite derived feature ownedReferenceSubsetting : ReferenceSubsetting[0..1] subsets ownedSubsetting;
+		}		
+				
+		metaclass FeatureChaining specializes Relationship {
+			feature chainingFeature : Feature[1..1] redefines target;
+			derived feature featureChained : Feature[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		datatype FeatureDirectionKind {
+			member feature 'in' : FeatureDirectionKind[1];
+			member feature 'inout' : FeatureDirectionKind[1];
+			member feature 'out' : FeatureDirectionKind[1];
+		}
+				
+		metaclass FeatureInverting specializes Relationship {
+			feature featureInverted : Feature[1..1] redefines source;
+			feature invertingFeature : Feature[1..1] redefines target;
+			derived feature owningFeature : Feature[0..1] subsets owningRelatedElement, featureInverted;
+		}		
+				
+		metaclass FeatureMembership specializes OwningMembership, Featuring {
+			derived feature owningType : Type[1..1] redefines membershipOwningNamespace, 'type';
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberElement, 'feature';
+		}		
+				
+		metaclass FeatureTyping specializes Specialization {
+			feature typedFeature : Feature[1..1] redefines specific;
+			feature 'type' : Type[1..1] redefines general;
+			derived feature owningFeature : Feature[0..1] subsets typedFeature redefines owningType;
+		}		
+				
+		abstract metaclass Featuring specializes Relationship {
+			feature 'type' : Type[1..1] subsets relatedElement;
+			feature 'feature' : Feature[1..1] subsets relatedElement;
+		}		
+				
+		metaclass Intersecting specializes Relationship {
+			feature intersectingType : Type[1..1] redefines target;
+			derived feature typeIntersected : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Multiplicity specializes Feature;		
+				
+		metaclass Redefinition specializes Subsetting {
+			feature redefiningFeature : Feature[1..1] redefines subsettingFeature;
+			feature redefinedFeature : Feature[1..1] redefines subsettedFeature;
+		}		
+				
+		metaclass Specialization specializes Relationship {
+			feature general : Type[1..1] redefines target;
+			feature specific : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets specific, owningRelatedElement;
+		}		
+				
+		metaclass Subclassification specializes Specialization {
+			feature superclassifier : Classifier[1..1] redefines general;
+			feature 'subclassifier' : Classifier[1..1] redefines specific;
+			derived feature owningClassifier : Classifier[0..1] redefines owningType;
+		}		
+				
+		metaclass Subsetting specializes Specialization {
+			feature subsettedFeature : Feature[1..1] redefines general;
+			feature subsettingFeature : Feature[1..1] redefines specific;
+			derived feature owningFeature : Feature[1..1] subsets subsettingFeature redefines owningType;
+		}		
+				
+		metaclass Type specializes Namespace {
+			feature isAbstract : Boolean[1..1];
+			feature isSufficient : Boolean[1..1];
+			derived feature isConjugated : Boolean[1..1];
+			
+			composite derived feature ownedSpecialization : Specialization[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureMembership : FeatureMembership[0..*] subsets ownedMembership, featureMembership;
+			derived feature 'feature' : Feature[0..*] subsets 'member';
+			derived feature ownedFeature : Feature[0..*] subsets ownedMember;
+			derived feature input : Feature[0..*] subsets directedFeature;
+			derived feature output : Feature[0..*] subsets directedFeature;
+			derived feature inheritedMembership : Membership[0..*] subsets membership;
+			derived feature endFeature : Feature[0..*] subsets 'feature';
+			derived feature ownedEndFeature : Feature[0..*] subsets endFeature, ownedFeature;
+			composite derived feature ownedConjugator : Conjugation[0..1] subsets ownedRelationship;
+			derived feature inheritedFeature : Feature[0..*] subsets 'feature';
+			derived feature 'multiplicity' : Multiplicity[0..1] subsets 'member';
+			derived feature unioningType : Type[0..*];
+			composite derived feature ownedIntersecting : Intersecting[0..*] subsets ownedRelationship;
+			derived feature intersectingType : Type[0..*];
+			composite derived feature ownedUnioning : Unioning[0..*] subsets ownedRelationship;
+			composite derived feature ownedDisjoining : Disjoining[0..*] subsets ownedRelationship;
+			derived feature featureMembership : FeatureMembership[0..*];
+			derived feature differencingType : Type[0..*];
+			composite derived feature ownedDifferencing : Differencing[0..*] subsets ownedRelationship;
+			derived feature directedFeature : Feature[0..*] subsets 'feature';
+		}		
+				
+		metaclass TypeFeaturing specializes Featuring {
+			feature featureOfType : Feature[1..1] redefines source, 'feature';
+			feature featuringType : Type[1..1] redefines target, 'type';
+			derived feature owningFeatureOfType : Feature[0..1] subsets featureOfType, owningRelatedElement;
+		}		
+				
+		metaclass Unioning specializes Relationship {
+			feature unioningType : Type[1..1] redefines target;
+			derived feature typeUnioned : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+	}
 	
-	metaclass Import :> Relationship;
-	metaclass Membership :> Relationship;
-	metaclass Namespace :> Element;
-	
-	metaclass Type :> Namespace;
-	metaclass Multiplicity :> Feature;
-	metaclass FeatureMembership :> Membership, TypeFeaturing;
-	metaclass Specialization :> Relationship;
-	metaclass Conjugation :> Relationship;
-	metaclass Disjoining :> Relationship;
-	
-	metaclass Classifier :> Type;
-	metaclass Subclassification :> Specialization;
-	
-	metaclass Feature :> Type;
-	metaclass Subsetting :> Specialization;
-	metaclass Redefinition :> Subsetting;
-	metaclass FeatureTyping :> Specialization;
-	metaclass TypeFeaturing :> Relationship;
-	metaclass FeatureChaining :> Relationship;
-	metaclass EndFeatureMembersip :> FeatureMembership;
-	
-	metaclass Class :> Classifier;
-	metaclass DataType :> Classifier;
-	
-	metaclass Structure :> Class;
-	
-	metaclass Association :> Classifier, Relationship;
-	metaclass AssociationStructure :> Association, Structure;
-	
-	metaclass Connector :> Feature, Relationship;
-	metaclass BindingConnector :> Connector;
-	metaclass Succession :> Connector;
-	
-	metaclass Behavior :> Class;
-	metaclass Step :> Feature;
-	metaclass ParameterMembership :> FeatureMembership;
-	
-	metaclass Function :> Behavior;
-	metaclass Predicate :> Function;
-	metaclass Expression :> Step;
-	metaclass BooleanExpression :> Expression;
-	metaclass Invariant :> BooleanExpression;
-	metaclass ReturnParameterMembership :> ParameterMembership;
-	metaclass ResultExpressionMembership :> FeatureMembership;
-	
-	metaclass FeatureReferenceExpression :> Expression;
-	metaclass InvocationExpression :> Expression;
-	metaclass LiteralExpression :> Expression;
-	metaclass LiteralInteger :> LiteralExpression;
-	metaclass LiteralRational :> LiteralExpression;
-	metaclass LiteralBoolean :> LiteralExpression;
-	metaclass LiteralString :> LiteralExpression;
-	metaclass LiteralInfinity :> LiteralExpression;
-	metaclass NullExpression :> Expression;
-	metaclass OperatorExpression :> InvocationExpression;
-	metaclass FeatureChainExpression :> OperatorExpression;
-	metaclass CollectExpression :> OperatorExpression;
-	metaclass SelectExpression :> OperatorExpression;
-	
-	metaclass Interaction :> Behavior, Association;
-	metaclass ItemFlow :> Step, Connector;
-	metaclass SuccessionItemFlow :> ItemFlow, Succession;
-	
-	metaclass FeatureValue :> Membership;
-	
-	metaclass MultiplicityRange :> Multiplicity;
-	
-	metaclass Metaclass :> Structure;
-	metaclass MetadataFeature :> AnnotatingElement, Feature;
-	
-	metaclass Package :> Namespace;
-	metaclass ElementFilterMembership :> Membership;
-	
+	package Kernel {
+		import Core::*;
+		
+		metaclass Association specializes Classifier, Relationship {
+			derived feature relatedType : Type[2..*] redefines relatedElement;
+			derived feature sourceType : Type[0..1] subsets relatedType redefines source;
+			derived feature targetType : Type[1..*] subsets relatedType redefines target;
+			derived feature associationEnd : Feature[2..*] redefines endFeature;
+		}		
+				
+		metaclass AssociationStructure specializes Structure, Association;		
+				
+		metaclass Behavior specializes Class {
+			derived feature 'step' : Step[0..*] subsets 'feature';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass BindingConnector specializes Connector;		
+				
+		metaclass BooleanExpression specializes Expression {
+			derived feature 'predicate' : Predicate[1..1] redefines 'function';
+		}		
+				
+		metaclass Class specializes Classifier;		
+				
+		metaclass CollectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass Connector specializes Feature, Relationship {
+			feature isDirected : Boolean[1..1];
+			
+			derived feature relatedFeature : Feature[2..*] redefines relatedElement;
+			derived feature association : Association[1..*] redefines 'type';
+			derived feature connectorEnd : Feature[2..*] redefines endFeature;
+			derived feature sourceFeature : Feature[0..1] subsets relatedFeature redefines source;
+			derived feature targetFeature : Feature[1..*] subsets relatedFeature redefines target;
+		}		
+				
+		metaclass DataType specializes Classifier;		
+				
+		metaclass ElementFilterMembership specializes OwningMembership {
+			composite derived feature condition : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Expression specializes Step {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature 'function' : Function[1..1] redefines 'behavior';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass FeatureChainExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+			
+			derived feature targetFeature : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureReferenceExpression specializes Expression {
+			derived feature referent : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureValue specializes OwningMembership {
+			feature isInitial : Boolean[1..1];
+			feature isDefault : Boolean[1..1];
+			
+			derived feature featureWithValue : Feature[1..1] subsets membershipOwningNamespace;
+			composite derived feature value : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Function specializes Behavior {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature expression : Expression[0..*] subsets 'step';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass Interaction specializes Behavior, Association;		
+				
+		metaclass Invariant specializes BooleanExpression {
+			feature isNegated : Boolean[1..1];
+		}		
+				
+		metaclass InvocationExpression specializes Expression {
+			derived feature argument : Expression[0..*] subsets ownedFeature;
+		}		
+				
+		metaclass ItemFeature specializes Feature;		
+				
+		metaclass ItemFlow specializes Connector, Step {
+			derived feature itemType : Classifier[0..*];
+			derived feature targetInputFeature : Feature[0..1];
+			derived feature sourceOutputFeature : Feature[0..1];
+			derived feature itemFlowEnd : ItemFlowEnd[2..*] redefines connectorEnd;
+			derived feature itemFeature : ItemFeature[0..1] subsets ownedFeature;
+			derived feature itemFlowFeature : ItemFlowFeature[2..*];
+			derived feature 'interaction' : Interaction[1..*] redefines association, 'behavior';
+		}		
+				
+		metaclass ItemFlowEnd specializes Feature;		
+				
+		metaclass ItemFlowFeature specializes Feature;		
+				
+		metaclass LiteralBoolean specializes LiteralExpression {
+			feature value : Boolean[1..1];
+		}		
+				
+		metaclass LiteralExpression specializes Expression;		
+				
+		metaclass LiteralInfinity specializes LiteralExpression;		
+				
+		metaclass LiteralInteger specializes LiteralExpression {
+			feature value : Integer[1..1];
+		}		
+				
+		metaclass LiteralRational specializes LiteralExpression {
+			feature value : Real[1..1];
+		}		
+				
+		metaclass LiteralString specializes LiteralExpression {
+			feature value : String[1..1];
+		}		
+				
+		metaclass Metaclass specializes Structure;		
+				
+		metaclass MetadataFeature specializes AnnotatingElement, Feature {
+			derived feature 'metaclass' : Metaclass[1..1] redefines 'type';
+		}		
+				
+		metaclass MultiplicityRange specializes Multiplicity {
+			derived feature lowerBound : Expression[0..1] subsets bound;
+			derived feature upperBound : Expression[1..1] subsets bound;
+			abstract derived feature bound : Expression[1..2] redefines ownedMember;
+		}		
+				
+		metaclass NullExpression specializes Expression;		
+				
+		metaclass OperatorExpression specializes InvocationExpression {
+			feature operator : String[1..1];
+			
+			composite derived feature operand : Expression[0..*];
+		}		
+				
+		metaclass Package specializes Namespace {
+			derived feature filterCondition : Expression[0..*] subsets ownedMember;
+		}		
+				
+		metaclass ParameterMembership specializes FeatureMembership {
+			composite derived feature ownedMemberParameter : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Predicate specializes Function;		
+				
+		metaclass ReferenceSubsetting specializes Subsetting {
+			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
+			derived feature referencingFeature : Feature[1..1] redefines owningFeature, subsettingFeature;
+		}		
+				
+		metaclass ResultExpressionMembership specializes FeatureMembership {
+			composite derived feature ownedResultExpression : Expression[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass ReturnParameterMembership specializes ParameterMembership;		
+				
+		metaclass SelectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass SourceEnd specializes Feature;		
+				
+		metaclass Step specializes Feature {
+			derived feature 'behavior' : Behavior[1..*] redefines 'type';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass Structure specializes Class;		
+				
+		metaclass Succession specializes Connector {
+			derived feature transitionStep : Step[0..1] subsets ownedFeature;
+			derived feature triggerStep : Step[0..*];
+			derived feature effectStep : Step[0..*];
+			derived feature guardExpression : Expression[0..*];
+		}		
+				
+		metaclass SuccessionItemFlow specializes Succession, ItemFlow;		
+				
+		metaclass TargetEnd specializes Feature;		
+				
+	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MetadataTests_MetadataFeature_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MetadataTests_MetadataFeature_invalid.kerml.xt
@@ -37,27 +37,25 @@ XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
 END_SETUP 
 */
 package MetadataFeatureTest {
-	import ScalarValues::*;
-	import ControlFunctions::collect;
 	
 	metaclass A {
 		feature :>> annotatedElement : KerML::Feature;
-		feature x : Integer;
-		feature y : String;
-		feature z : Boolean;
+		feature x : ScalarValues::Integer;
+		feature y : ScalarValues::String;
+		feature z : ScalarValues::Boolean;
 		feature u {
-			feature v : Integer;
+			feature v : ScalarValues::Integer;
 		}
 	}
 	
-	function f { in x; return : Boolean; }
+	function f { in x; return : ScalarValues::Boolean; }
 	
 	// XPECT errors --> "Must be model-level evaluable" at "filter f(A::y);"
 	filter f(A::y);
 	// XPECT errors --> "Must be model-level evaluable" at "filter ~A::z;"
 	filter ~A::z;
-	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->collect {in x; x};"
-	filter A::y->collect {in x; x};
+	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->ControlFunctions::collect {in x; x};"
+	filter A::y->ControlFunctions::collect {in x; x};
 	// XPECT errors --> "Must be model-level evaluable" at "filter A(null, 1, "", false);"
 	filter A(null, 1, "", false);
 	

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -69,6 +69,7 @@ import org.omg.sysml.util.ImplicitGeneralizationMap
 import org.omg.sysml.lang.sysml.OwningMembership
 import org.omg.sysml.lang.sysml.ReferenceSubsetting
 import org.eclipse.emf.ecore.EObject
+import org.omg.sysml.expressions.util.EvaluationUtil
 
 /**
  * This class contains custom validation rules. 
@@ -285,24 +286,18 @@ class KerMLValidator extends AbstractKerMLValidator {
 	}
 	
 	def void checkMetadataAnnotatedElements(MetadataFeature mf) {
-		var annotatedElementFeatures = FeatureUtil.getAllSubsettingFeaturesIn(mf, mf.annotatedElementFeature);
+		var annotatedElementFeatures = FeatureUtil.getAllSubsettingFeaturesIn(mf, EvaluationUtil.getAnnotatedElementFeature(mf));
 		if (annotatedElementFeatures.exists[!abstract]) {
 			annotatedElementFeatures = annotatedElementFeatures.filter[!abstract].toList
 		}
 		if (!annotatedElementFeatures.empty) {
 			for (element: mf.annotatedElement) {
-				val metaclass = ExpressionUtil.getMetaclassOf(element)
+				val metaclass = ElementUtil.getMetaclassOf(element)
 				if (!annotatedElementFeatures.exists[f | f.type.forall[t | TypeUtil.conforms(metaclass, t)]]) {
 					error(INVALID_METADATA_FEATURE__BAD_ELEMENT_MSG.replace("{metaclass}", metaclass.name), mf, null, INVALID_METADATA_FEATURE__BAD_ELEMENT)
 				}
 			}
 		}
-	}
-	
-	def Feature getAnnotatedElementFeature(Element element) {
-		SysMLLibraryUtil.getLibraryType(element, 
-						ImplicitGeneralizationMap.getDefaultSupertypeFor(element.getClass(), "annotatedElement"))
-						as Feature
 	}
 	
 	def void checkMetadataBody(Type t) {

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
@@ -104,7 +104,7 @@ public class ExpressionEvaluationTest extends SysMLInteractiveTest {
 		SysMLInteractive instance = getSysMLInteractiveInstance();
 		process(instance, evalTest3);		
 		assertElement("AttributeUsage a1", instance.eval("p1.a1", "EvalTest3"));
-		assertElement("AttributeUsage a2", instance.eval("p1.a2", "EvalTest3"));
+		assertElement("OperatorExpression +", instance.eval("p1.a2", "EvalTest3"));
 		assertElement("LiteralInteger 11", instance.eval("p11.a1", "EvalTest3"));
 		assertElement("LiteralInteger 14", instance.eval("p11.a2", "EvalTest3"));
 		assertElement("LiteralInteger 12", instance.eval("p12.a1", "EvalTest3"));

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -41,7 +41,7 @@ import org.omg.sysml.lang.sysml.LiteralString;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OperatorExpression;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
-import org.omg.sysml.util.ExpressionUtil;
+import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.TypeUtil;
 
 public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
@@ -135,7 +135,7 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		Element target = instance.resolve(elementName);
 		assertNotNull(target);
 		
-		Feature metaclassFeature = ExpressionUtil.getMetaclassFeatureFor(target);
+		Feature metaclassFeature = ElementUtil.getMetaclassFeatureFor(target);
 		assertNotNull(metaclassFeature);
 		
 		return metaclassFeature;

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveUtil.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveUtil.java
@@ -16,8 +16,10 @@ import org.omg.sysml.lang.sysml.LiteralInteger;
 import org.omg.sysml.lang.sysml.LiteralRational;
 import org.omg.sysml.lang.sysml.LiteralString;
 import org.eclipse.emf.ecore.EClass;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.CalculationUsage;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.OperatorExpression;
 import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.Relationship;
@@ -45,14 +47,17 @@ public class SysMLInteractiveUtil {
 	}
 	
 	private static void formatElement(StringBuilder buffer, String indentation, Element element, String relationshipTag) {
-		String shortName = element.getShortName();
-		String name = nameOf(element);
-		buffer.append(indentation + 
-				relationshipTag + 
-				element.eClass().getName() + 
-				(shortName == null? "": " <" + shortName + ">") +
-				(name == null? "": " " + name) + 
-				" (" + element.getElementId() + ")\n");
+		buffer.append(indentation + relationshipTag + element.eClass().getName());		
+		if (EvaluationUtil.isMetaclassFeature(element)) {
+			formatElement(buffer, " ", ((MetadataFeature)element).getAnnotatedElement().get(0), "");
+		} else {		
+			String shortName = element.getShortName();
+			String name = nameOf(element);
+			buffer.append(
+					(shortName == null? "": " <" + shortName + ">") +
+					(name == null? "": " " + name) + 
+					" (" + element.getElementId() + ")\n");
+		}
 	}
 	
 	public static String nameOf(Element element) {

--- a/org.omg.sysml.jupyter.kernel/gradle.properties
+++ b/org.omg.sysml.jupyter.kernel/gradle.properties
@@ -1,2 +1,2 @@
 group=org.omg.sysml
-version=0.27.0-SNAPSHOT
+version=0.28.0-SNAPSHOT

--- a/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
@@ -1,93 +1,454 @@
 package KerML {
-	doc
-	/*
-	 * This package contains a reflective KerML model of the KerML abstract syntax.
-	 * 
-	 * NOTE: This model is currently incomplete. It includes all KerML abstract syntax metaclasses,
-	 * but none of their properties.
-	 */
+	private import ScalarValues::*;
+	import Kernel::*;
 	
-	metaclass Element;
-	metaclass Relationship :> Element;
+	package Root {
+		metaclass AnnotatingElement specializes Element {
+			feature annotation : Annotation[0..*];
+			derived feature annotatedElement : Element[1..*] redefines annotatedElement;
+		}		
+				
+		metaclass Annotation specializes Relationship {
+			feature annotatingElement : AnnotatingElement[1..1] redefines source;
+			feature annotatedElement : Element[1..1] redefines target, annotatedElement;
+			derived feature owningAnnotatedElement : Element[0..1] subsets annotatedElement, owningRelatedElement;
+		}		
+				
+		metaclass Comment specializes AnnotatingElement {
+			feature locale : String[0..1];
+			feature body : String[1..1];
+		}		
+				
+		metaclass Documentation specializes Comment {
+			derived feature documentedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		metaclass Element {
+			feature elementId : String[1..1];
+			feature aliasIds : String[0..*];
+			feature shortName : String[0..1];
+			feature name : String[0..1];
+			feature isImpliedIncluded : Boolean[1..1];
+			derived feature effectiveName : String[0..1];
+			derived feature qualifiedName : String[0..1];
+			
+			feature owningRelationship : Relationship[0..1];
+			composite feature ownedRelationship : Relationship[0..*];
+			derived feature owningMembership : OwningMembership[0..1] subsets owningRelationship;
+			derived feature owningNamespace : Namespace[0..1];
+			derived feature owner : Element[0..1];
+			derived feature ownedElement : Element[0..*];
+			derived feature documentation : Documentation[0..*] subsets ownedElement;
+			composite derived feature ownedAnnotation : Annotation[0..*] subsets ownedRelationship;
+			derived feature textualRepresentation : TextualRepresentation[0..*] subsets ownedElement;
+		}		
+				
+		metaclass Import specializes Relationship {
+			feature visibility : VisibilityKind[1..1];
+			feature importedMemberName : String[0..1];
+			feature isRecursive : Boolean[1..1];
+			feature isImportAll : Boolean[1..1];
+			
+			feature importedNamespace : Namespace[1..1] redefines target;
+			derived feature importOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Membership specializes Relationship {
+			feature memberShortName : String[0..1];
+			feature memberName : String[0..1];
+			feature visibility : VisibilityKind[1..1];
+			derived feature memberElementId : String[1..1];
+			
+			feature memberElement : Element[1..1] redefines target;
+			derived feature membershipOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Namespace specializes Element {
+			abstract derived feature membership : Membership[0..*];
+			composite derived feature ownedImport : Import[0..*] subsets ownedRelationship;
+			derived feature 'member' : Element[0..*];
+			derived feature ownedMember : Element[0..*] subsets 'member';
+			composite derived feature ownedMembership : Membership[0..*] subsets membership, ownedRelationship;
+			derived feature importedMembership : Membership[0..*] subsets membership;
+		}		
+				
+		metaclass OwningMembership specializes Membership {
+			derived feature ownedMemberElementId : String[1..1] redefines memberElementId;
+			derived feature ownedMemberShortName : String[0..1] redefines memberShortName;
+			derived feature ownedMemberName : String[0..1] redefines memberName;
+			
+			composite derived feature ownedMemberElement : Element[1..1] subsets ownedRelatedElement redefines memberElement;
+		}		
+				
+		metaclass Relationship specializes Element {
+			feature isImplied : Boolean[1..1];
+			
+			feature target : Element[0..*] subsets relatedElement;
+			feature source : Element[0..*] subsets relatedElement;
+			feature owningRelatedElement : Element[0..1] subsets relatedElement;
+			composite feature ownedRelatedElement : Element[0..*] subsets relatedElement;
+			derived feature relatedElement : Element[2..*];
+		}		
+				
+		metaclass TextualRepresentation specializes AnnotatingElement {
+			feature 'language' : String[1..1];
+			feature body : String[1..1];
+			
+			derived feature representedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		datatype VisibilityKind {
+			member feature 'private' : VisibilityKind[1];
+			member feature 'protected' : VisibilityKind[1];
+			member feature 'public' : VisibilityKind[1];
+		}
+				
+	}
 	
-	metaclass AnnotatingElement :> Element;
-	metaclass Annotation :> Relationship;
-	metaclass Comment :> AnnotatingElement;
-	metaclass Documentation :> Annotation;
-	metaclass TextualRepresentation :> AnnotatingElement;
+	package Core {
+		import Root::*;
+		
+		metaclass Classifier specializes Type {
+			composite derived feature ownedSubclassification : Subclassification[0..*] subsets ownedSpecialization;
+		}		
+				
+		metaclass Conjugation specializes Relationship {
+			feature originalType : Type[1..1] redefines target;
+			feature conjugatedType : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets conjugatedType, owningRelatedElement;
+		}		
+				
+		metaclass Differencing specializes Relationship {
+			feature differencingType : Type[1..1] redefines target;
+			derived feature typeDifferenced : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Disjoining specializes Relationship {
+			feature typeDisjoined : Type[1..1] redefines source;
+			feature disjoiningType : Type[1..1] redefines target;
+			derived feature owningType : Type[0..1] subsets typeDisjoined, owningRelatedElement;
+		}		
+				
+		metaclass EndFeatureMembership specializes FeatureMembership {
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Feature specializes Type {
+			feature isUnique : Boolean[1..1];
+			feature isOrdered : Boolean[1..1];
+			feature isComposite : Boolean[1..1];
+			feature isEnd : Boolean[1..1];
+			feature isDerived : Boolean[1..1];
+			feature isReadOnly : Boolean[1..1];
+			feature isPortion : Boolean[1..1];
+			feature direction : FeatureDirectionKind[0..1];
+			
+			derived feature owningType : Type[0..1] subsets owningNamespace, featuringType;
+			derived feature 'type' : Type[1..*];
+			composite derived feature ownedRedefinition : Redefinition[0..*] subsets ownedSubsetting;
+			composite derived feature ownedSubsetting : Subsetting[0..*] subsets ownedSpecialization;
+			derived feature owningFeatureMembership : FeatureMembership[0..1] subsets owningMembership;
+			derived feature endOwningType : Type[0..1] subsets owningType;
+			composite derived feature ownedTyping : FeatureTyping[0..*] subsets ownedSpecialization;
+			derived feature featuringType : Type[0..*];
+			composite derived feature ownedTypeFeaturing : TypeFeaturing[0..*] subsets ownedRelationship;
+			derived feature chainingFeature : Feature[0..*];
+			composite derived feature ownedFeatureInverting : FeatureInverting[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureChaining : FeatureChaining[0..*] subsets ownedRelationship;
+			composite derived feature ownedReferenceSubsetting : ReferenceSubsetting[0..1] subsets ownedSubsetting;
+		}		
+				
+		metaclass FeatureChaining specializes Relationship {
+			feature chainingFeature : Feature[1..1] redefines target;
+			derived feature featureChained : Feature[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		datatype FeatureDirectionKind {
+			member feature 'in' : FeatureDirectionKind[1];
+			member feature 'inout' : FeatureDirectionKind[1];
+			member feature 'out' : FeatureDirectionKind[1];
+		}
+				
+		metaclass FeatureInverting specializes Relationship {
+			feature featureInverted : Feature[1..1] redefines source;
+			feature invertingFeature : Feature[1..1] redefines target;
+			derived feature owningFeature : Feature[0..1] subsets owningRelatedElement, featureInverted;
+		}		
+				
+		metaclass FeatureMembership specializes OwningMembership, Featuring {
+			derived feature owningType : Type[1..1] redefines membershipOwningNamespace, 'type';
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberElement, 'feature';
+		}		
+				
+		metaclass FeatureTyping specializes Specialization {
+			feature typedFeature : Feature[1..1] redefines specific;
+			feature 'type' : Type[1..1] redefines general;
+			derived feature owningFeature : Feature[0..1] subsets typedFeature redefines owningType;
+		}		
+				
+		abstract metaclass Featuring specializes Relationship {
+			feature 'type' : Type[1..1] subsets relatedElement;
+			feature 'feature' : Feature[1..1] subsets relatedElement;
+		}		
+				
+		metaclass Intersecting specializes Relationship {
+			feature intersectingType : Type[1..1] redefines target;
+			derived feature typeIntersected : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Multiplicity specializes Feature;		
+				
+		metaclass Redefinition specializes Subsetting {
+			feature redefiningFeature : Feature[1..1] redefines subsettingFeature;
+			feature redefinedFeature : Feature[1..1] redefines subsettedFeature;
+		}		
+				
+		metaclass Specialization specializes Relationship {
+			feature general : Type[1..1] redefines target;
+			feature specific : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets specific, owningRelatedElement;
+		}		
+				
+		metaclass Subclassification specializes Specialization {
+			feature superclassifier : Classifier[1..1] redefines general;
+			feature 'subclassifier' : Classifier[1..1] redefines specific;
+			derived feature owningClassifier : Classifier[0..1] redefines owningType;
+		}		
+				
+		metaclass Subsetting specializes Specialization {
+			feature subsettedFeature : Feature[1..1] redefines general;
+			feature subsettingFeature : Feature[1..1] redefines specific;
+			derived feature owningFeature : Feature[1..1] subsets subsettingFeature redefines owningType;
+		}		
+				
+		metaclass Type specializes Namespace {
+			feature isAbstract : Boolean[1..1];
+			feature isSufficient : Boolean[1..1];
+			derived feature isConjugated : Boolean[1..1];
+			
+			composite derived feature ownedSpecialization : Specialization[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureMembership : FeatureMembership[0..*] subsets ownedMembership, featureMembership;
+			derived feature 'feature' : Feature[0..*] subsets 'member';
+			derived feature ownedFeature : Feature[0..*] subsets ownedMember;
+			derived feature input : Feature[0..*] subsets directedFeature;
+			derived feature output : Feature[0..*] subsets directedFeature;
+			derived feature inheritedMembership : Membership[0..*] subsets membership;
+			derived feature endFeature : Feature[0..*] subsets 'feature';
+			derived feature ownedEndFeature : Feature[0..*] subsets endFeature, ownedFeature;
+			composite derived feature ownedConjugator : Conjugation[0..1] subsets ownedRelationship;
+			derived feature inheritedFeature : Feature[0..*] subsets 'feature';
+			derived feature 'multiplicity' : Multiplicity[0..1] subsets 'member';
+			derived feature unioningType : Type[0..*];
+			composite derived feature ownedIntersecting : Intersecting[0..*] subsets ownedRelationship;
+			derived feature intersectingType : Type[0..*];
+			composite derived feature ownedUnioning : Unioning[0..*] subsets ownedRelationship;
+			composite derived feature ownedDisjoining : Disjoining[0..*] subsets ownedRelationship;
+			derived feature featureMembership : FeatureMembership[0..*];
+			derived feature differencingType : Type[0..*];
+			composite derived feature ownedDifferencing : Differencing[0..*] subsets ownedRelationship;
+			derived feature directedFeature : Feature[0..*] subsets 'feature';
+		}		
+				
+		metaclass TypeFeaturing specializes Featuring {
+			feature featureOfType : Feature[1..1] redefines source, 'feature';
+			feature featuringType : Type[1..1] redefines target, 'type';
+			derived feature owningFeatureOfType : Feature[0..1] subsets featureOfType, owningRelatedElement;
+		}		
+				
+		metaclass Unioning specializes Relationship {
+			feature unioningType : Type[1..1] redefines target;
+			derived feature typeUnioned : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+	}
 	
-	metaclass Import :> Relationship;
-	metaclass Membership :> Relationship;
-	metaclass Namespace :> Element;
-	
-	metaclass Type :> Namespace;
-	metaclass Multiplicity :> Feature;
-	metaclass FeatureMembership :> Membership, TypeFeaturing;
-	metaclass Specialization :> Relationship;
-	metaclass Conjugation :> Relationship;
-	metaclass Disjoining :> Relationship;
-	
-	metaclass Classifier :> Type;
-	metaclass Subclassification :> Specialization;
-	
-	metaclass Feature :> Type;
-	metaclass Subsetting :> Specialization;
-	metaclass Redefinition :> Subsetting;
-	metaclass FeatureTyping :> Specialization;
-	metaclass TypeFeaturing :> Relationship;
-	metaclass FeatureChaining :> Relationship;
-	metaclass EndFeatureMembersip :> FeatureMembership;
-	
-	metaclass Class :> Classifier;
-	metaclass DataType :> Classifier;
-	
-	metaclass Structure :> Class;
-	
-	metaclass Association :> Classifier, Relationship;
-	metaclass AssociationStructure :> Association, Structure;
-	
-	metaclass Connector :> Feature, Relationship;
-	metaclass BindingConnector :> Connector;
-	metaclass Succession :> Connector;
-	
-	metaclass Behavior :> Class;
-	metaclass Step :> Feature;
-	metaclass ParameterMembership :> FeatureMembership;
-	
-	metaclass Function :> Behavior;
-	metaclass Predicate :> Function;
-	metaclass Expression :> Step;
-	metaclass BooleanExpression :> Expression;
-	metaclass Invariant :> BooleanExpression;
-	metaclass ReturnParameterMembership :> ParameterMembership;
-	metaclass ResultExpressionMembership :> FeatureMembership;
-	
-	metaclass FeatureReferenceExpression :> Expression;
-	metaclass InvocationExpression :> Expression;
-	metaclass LiteralExpression :> Expression;
-	metaclass LiteralInteger :> LiteralExpression;
-	metaclass LiteralRational :> LiteralExpression;
-	metaclass LiteralBoolean :> LiteralExpression;
-	metaclass LiteralString :> LiteralExpression;
-	metaclass LiteralInfinity :> LiteralExpression;
-	metaclass NullExpression :> Expression;
-	metaclass OperatorExpression :> InvocationExpression;
-	metaclass FeatureChainExpression :> OperatorExpression;
-	metaclass CollectExpression :> OperatorExpression;
-	metaclass SelectExpression :> OperatorExpression;
-	
-	metaclass Interaction :> Behavior, Association;
-	metaclass ItemFlow :> Step, Connector;
-	metaclass SuccessionItemFlow :> ItemFlow, Succession;
-	
-	metaclass FeatureValue :> Membership;
-	
-	metaclass MultiplicityRange :> Multiplicity;
-	
-	metaclass Metaclass :> Structure;
-	metaclass MetadataFeature :> AnnotatingElement, Feature;
-	
-	metaclass Package :> Namespace;
-	metaclass ElementFilterMembership :> Membership;
-	
+	package Kernel {
+		import Core::*;
+		
+		metaclass Association specializes Classifier, Relationship {
+			derived feature relatedType : Type[2..*] redefines relatedElement;
+			derived feature sourceType : Type[0..1] subsets relatedType redefines source;
+			derived feature targetType : Type[1..*] subsets relatedType redefines target;
+			derived feature associationEnd : Feature[2..*] redefines endFeature;
+		}		
+				
+		metaclass AssociationStructure specializes Structure, Association;		
+				
+		metaclass Behavior specializes Class {
+			derived feature 'step' : Step[0..*] subsets 'feature';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass BindingConnector specializes Connector;		
+				
+		metaclass BooleanExpression specializes Expression {
+			derived feature 'predicate' : Predicate[1..1] redefines 'function';
+		}		
+				
+		metaclass Class specializes Classifier;		
+				
+		metaclass CollectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass Connector specializes Feature, Relationship {
+			feature isDirected : Boolean[1..1];
+			
+			derived feature relatedFeature : Feature[2..*] redefines relatedElement;
+			derived feature association : Association[1..*] redefines 'type';
+			derived feature connectorEnd : Feature[2..*] redefines endFeature;
+			derived feature sourceFeature : Feature[0..1] subsets relatedFeature redefines source;
+			derived feature targetFeature : Feature[1..*] subsets relatedFeature redefines target;
+		}		
+				
+		metaclass DataType specializes Classifier;		
+				
+		metaclass ElementFilterMembership specializes OwningMembership {
+			composite derived feature condition : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Expression specializes Step {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature 'function' : Function[1..1] redefines 'behavior';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass FeatureChainExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+			
+			derived feature targetFeature : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureReferenceExpression specializes Expression {
+			derived feature referent : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureValue specializes OwningMembership {
+			feature isInitial : Boolean[1..1];
+			feature isDefault : Boolean[1..1];
+			
+			derived feature featureWithValue : Feature[1..1] subsets membershipOwningNamespace;
+			composite derived feature value : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Function specializes Behavior {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature expression : Expression[0..*] subsets 'step';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass Interaction specializes Behavior, Association;		
+				
+		metaclass Invariant specializes BooleanExpression {
+			feature isNegated : Boolean[1..1];
+		}		
+				
+		metaclass InvocationExpression specializes Expression {
+			derived feature argument : Expression[0..*] subsets ownedFeature;
+		}		
+				
+		metaclass ItemFeature specializes Feature;		
+				
+		metaclass ItemFlow specializes Connector, Step {
+			derived feature itemType : Classifier[0..*];
+			derived feature targetInputFeature : Feature[0..1];
+			derived feature sourceOutputFeature : Feature[0..1];
+			derived feature itemFlowEnd : ItemFlowEnd[2..*] redefines connectorEnd;
+			derived feature itemFeature : ItemFeature[0..1] subsets ownedFeature;
+			derived feature itemFlowFeature : ItemFlowFeature[2..*];
+			derived feature 'interaction' : Interaction[1..*] redefines association, 'behavior';
+		}		
+				
+		metaclass ItemFlowEnd specializes Feature;		
+				
+		metaclass ItemFlowFeature specializes Feature;		
+				
+		metaclass LiteralBoolean specializes LiteralExpression {
+			feature value : Boolean[1..1];
+		}		
+				
+		metaclass LiteralExpression specializes Expression;		
+				
+		metaclass LiteralInfinity specializes LiteralExpression;		
+				
+		metaclass LiteralInteger specializes LiteralExpression {
+			feature value : Integer[1..1];
+		}		
+				
+		metaclass LiteralRational specializes LiteralExpression {
+			feature value : Real[1..1];
+		}		
+				
+		metaclass LiteralString specializes LiteralExpression {
+			feature value : String[1..1];
+		}		
+				
+		metaclass Metaclass specializes Structure;		
+				
+		metaclass MetadataFeature specializes AnnotatingElement, Feature {
+			derived feature 'metaclass' : Metaclass[1..1] redefines 'type';
+		}		
+				
+		metaclass MultiplicityRange specializes Multiplicity {
+			derived feature lowerBound : Expression[0..1] subsets bound;
+			derived feature upperBound : Expression[1..1] subsets bound;
+			abstract derived feature bound : Expression[1..2] redefines ownedMember;
+		}		
+				
+		metaclass NullExpression specializes Expression;		
+				
+		metaclass OperatorExpression specializes InvocationExpression {
+			feature operator : String[1..1];
+			
+			composite derived feature operand : Expression[0..*];
+		}		
+				
+		metaclass Package specializes Namespace {
+			derived feature filterCondition : Expression[0..*] subsets ownedMember;
+		}		
+				
+		metaclass ParameterMembership specializes FeatureMembership {
+			composite derived feature ownedMemberParameter : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Predicate specializes Function;		
+				
+		metaclass ReferenceSubsetting specializes Subsetting {
+			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
+			derived feature referencingFeature : Feature[1..1] redefines owningFeature, subsettingFeature;
+		}		
+				
+		metaclass ResultExpressionMembership specializes FeatureMembership {
+			composite derived feature ownedResultExpression : Expression[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass ReturnParameterMembership specializes ParameterMembership;		
+				
+		metaclass SelectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass SourceEnd specializes Feature;		
+				
+		metaclass Step specializes Feature {
+			derived feature 'behavior' : Behavior[1..*] redefines 'type';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass Structure specializes Class;		
+				
+		metaclass Succession specializes Connector {
+			derived feature transitionStep : Step[0..1] subsets ownedFeature;
+			derived feature triggerStep : Step[0..*];
+			derived feature effectStep : Step[0..*];
+			derived feature guardExpression : Expression[0..*];
+		}		
+				
+		metaclass SuccessionItemFlow specializes Succession, ItemFlow;		
+				
+		metaclass TargetEnd specializes Feature;		
+				
+	}
 }

--- a/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
@@ -1,129 +1,530 @@
 package SysML {
-	doc
-	/*
-	 * This package contains a reflective SysML model of the SysML abstract syntax.
-	 * 
-	 * NOTE: This model is currently incomplete. It includes all SysML abstract syntax metaclasses,
-	 * but none of their properties.
-	 */
-
-	import KerML::*;
-
-	metadata def Dependency :> Relationship;
+	private import ScalarValues::*;
+	import KerML::Kernel::*;
 	
-	metadata def Definition :> Classifier;
-	metadata def Usage :> Feature;
-	metadata def ReferenceUsage :> Usage;
-	metadata def VariantMembership :> Membership;
-	
-	metadata def EnumerationDefinition :> AttributeDefinition;
-	metadata def EnumerationUsage :> AttributeUsage;
-	
-	metadata def AttributeDefinition :> Definition, DataType;
-	metadata def AttributeUsage :> Usage;
-	
-	metadata def OccurrenceDefinition :> Definition, Class;
-	metadata def OccurrenceUsage :> Usage;
-	metadata def LifeClass :> Class;
-	metadata def PortioningFeature :> Feature;
-	metadata def EventOccurrenceUsage :> OccurrenceUsage;
-	
-	metadata def ItemDefinition :> OccurrenceDefinition, Structure;
-	metadata def ItemUsage :> OccurrenceUsage;
-	
-	metadata def MetadataDefinition :> ItemDefinition, Metaclass;
-	metadata def MetadataUsage :> ItemDefinition, MetadataFeature;
-	
-	metadata def PartDefinition :> ItemDefinition;
-	metadata def PartUsage :> ItemUsage;
-	
-	metadata def PortDefinition :> OccurrenceDefinition, Structure;
-	metadata def ConjugatePortDefinition :> PortDefinition;
-	metadata def PortUsage :> OccurrenceUsage;
-	metadata def PortConjuation :> Conjugation;
-	metadata def ConjugatePortTyping :> FeatureTyping;
-	
-	metadata def ConnectionDefinition :> PartDefinition, AssociationStructure;
-	abstract metadata def ConnectorAsUsage :> Connector, Usage;
-	metadata def BindingConnectorAsUsage :> BindingConnector, ConnectorAsUsage;
-	metadata def SuccessionAsUsage :> Succession, ConnectorAsUsage;
-	metadata def ConnectionUsage :> PartUsage, ConnectorAsUsage;
-	metadata def FlowConnectionUsage :> ItemFlow, ConnectionUsage;
-	metadata def SuccessionFlowConnectionUsage :> SuccessionItemFlow, ConnectionUsage;
-	
-	metadata def InterfaceDefinition :> ConnectionDefinition;
-	metadata def InterfaceUsage :> ConnectionUsage;
-	
-	metadata def AllocationDefinition :> ConnectionDefinition;
-	metadata def AllocationUsage :> ConnectionUsage;
-	
-	metadata def ActionDefinition :> OccurrenceDefinition, Behavior;
-	metadata def ActionUsage :> OccurrenceUsage, Step;
-	metadata def PerformActionUsage :> EventOccurrenceUsage, ActionUsage;
-	metadata def SendActionUsage :> ActionUsage;
-	metadata def AcceptActionUsage :> ActionUsage;
-	metadata def ControlNode :> ActionUsage;
-	metadata def MergeNode :> ControlNode;
-	metadata def DecisionNode :> ControlNode;
-	metadata def ForkNode :> ControlNode;
-	metadata def JoinNode :> ControlNode;
-	metadata def AssignmentActionUsage :> ActionUsage;
-	metadata def IfActionUsage :> ActionUsage;
-	abstract metadata def LoopActionUsage :> ActionUsage;
-	metadata def WhileLoopActionUsage :> LoopActionUsage;
-	metadata def ForLoopActionUsage :> LoopActionUsage;
-	metadata def TriggerInvocationExpression :> InvocationExpression;
-	
-	metadata def StateDefinition :> ActionDefinition;
-	metadata def StateUsage :> ActionUsage;
-	metadata def ExhibitStateUsage :> PerformActionUsage, StateUsage;
-	metadata def TransitionUsage :> ActionUsage;
-	metadata def StateSubactionMembership :> FeatureMembership;
-	metadata def TransitionFeatureMembership :> FeatureMembership;
-	
-	metadata def CalculationDefinition :> ActionDefinition, Function;
-	metadata def CalculationUsage :> ActionUsage, Expression;
-	
-	metadata def ConstraintDefinition :> OccurrenceDefinition, Predicate;
-	metadata def ConstraintUsage :> OccurrenceUsage, BooleanExpression;
-	metadata def AssertConstraintUsage :> ConstraintUsage, Invariant;
-	
-	metadata def RequirementDefinition :> ConstraintDefinition;
-	metadata def RequirementUsage :> ConstraintUsage;
-	metadata def SatisfyRequirementUsage :> RequirementUsage, AssertConstraintUsage;
-	metadata def SubjectMembership :> FeatureMembership;
-	metadata def ActorMembership :> FeatureMembership;
-	metadata def StakeholderMembership :> FeatureMembership;
-	metadata def RequirementConstraintMembership :> FeatureMembership;
-	
-	metadata def ConcernDefinition :> RequirementDefinition;
-	metadata def ConcernUsage :> RequirementUsage;
-	metadata def FramedConcernMembership :> RequirementConstraintMembership;
-	
-	metadata def CaseDefinition :> CalculationDefinition;
-	metadata def CaseUsage :> CalculationUsage;
-	metadata def ObjectiveMembership :> FeatureMembership;
-	
-	metadata def AnalysisCaseDefinition :> CaseDefinition;
-	metadata def AnalysisCaseUsage :> CaseUsage;
-	
-	metadata def VerificationCaseDefinition :> CaseDefinition;
-	metadata def VerificationCaseUsage :> CaseUsage;
-	metadata def RequirementVerificationMembership :> FeatureMembership;
-	
-	metadata def UseCaseDefinition :> CaseDefinition;
-	metadata def UseCaseUsage :> CaseUsage;
-	metadata def IncludeUseCaseUsage :> PerformActionUsage, UseCaseUsage;
-	
-	metadata def ViewDefinition :> PartDefinition;
-	metadata def ViewUsage :> PartUsage;
-	metadata def Expose :> Import;
-	
-	metadata def ViewpointDefinition :> RequirementDefinition;
-	metadata def ViewpointUsage :> RequirementUsage;
-	
-	metadata def RenderingDefinition :> PartDefinition;
-	metadata def RenderingUsage :> PartUsage;
-	metadata def ViewRenderingMembership :> FeatureMembership;
+	metadata def AcceptActionUsage specializes ActionUsage {
+		derived ref item receiverArgument : Expression[1..1];
+		derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference;
+		derived ref item payloadArgument : Expression[0..1];
+	}		
+			
+	metadata def ActionDefinition specializes Behavior, OccurrenceDefinition {
+		derived ref item 'action' : ActionUsage[0..*] subsets step, usage;
+	}		
+			
+	metadata def ActionUsage specializes Step, OccurrenceUsage {
+		derived ref item actionDefinition : Behavior[1..*] redefines behavior, occurrenceDefinition;
+	}		
+			
+	metadata def ActorMembership specializes ParameterMembership {
+		derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def AllocationDefinition specializes ConnectionDefinition {
+		derived ref item 'allocation' : AllocationUsage[0..*] subsets usage;
+	}		
+			
+	metadata def AllocationUsage specializes ConnectionUsage {
+		derived ref item allocationDefinition : AllocationDefinition[1..*] redefines connectionDefinition;
+	}		
+			
+	metadata def AnalysisCaseDefinition specializes CaseDefinition {
+		derived ref item analysisAction : ActionUsage[0..*] subsets 'action';
+		derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature;
+	}		
+			
+	metadata def AnalysisCaseUsage specializes CaseUsage {
+		derived ref item analysisAction : ActionUsage[0..*] subsets feature;
+		derived ref item analysisCaseDefinition : AnalysisCaseDefinition[1..1] redefines caseDefinition;
+		derived ref item resultExpression : Expression[0..1] subsets ownedFeature;
+	}		
+			
+	metadata def AssertConstraintUsage specializes ConstraintUsage, Invariant {
+		derived ref item assertedConstraint : ConstraintUsage[1..1];
+	}		
+			
+	metadata def AssignmentActionUsage specializes ActionUsage {
+		derived ref item targetArgument : Expression[1..1];
+		derived ref item valueExpression : Expression[1..1];
+		derived ref item referent : Feature[1..1] subsets member;
+	}		
+			
+	metadata def AttributeDefinition specializes DataType, Definition;		
+			
+	metadata def AttributeUsage specializes Usage {
+		attribute isReference : Boolean[1..1] redefines isReference;
+		
+		derived ref item attributeDefinition : DataType[1..*] redefines definition;
+	}		
+			
+	metadata def BindingConnectorAsUsage specializes BindingConnector, ConnectorAsUsage;		
+			
+	metadata def CalculationDefinition specializes Function, ActionDefinition {
+		derived ref item calculation : CalculationUsage[0..*] subsets 'action', expression;
+	}		
+			
+	metadata def CalculationUsage specializes Expression, ActionUsage {
+		derived ref item calculationDefinition : Function[1..1] redefines function, actionDefinition;
+	}		
+			
+	metadata def CaseDefinition specializes CalculationDefinition {
+		derived ref item objectiveRequirement : RequirementUsage[0..1] subsets ownedRequirement;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, ownedUsage;
+		derived ref item actorParameter : PartUsage[0..*] subsets parameter, ownedPart;
+	}		
+			
+	metadata def CaseUsage specializes CalculationUsage {
+		derived ref item objectiveRequirement : RequirementUsage[0..1] subsets nestedRequirement;
+		derived ref item caseDefinition : CaseDefinition[1..1] redefines calculationDefinition;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, nestedUsage;
+		derived ref item actorParameter : PartUsage[0..*] subsets nestedPart, parameter;
+	}		
+			
+	metadata def ConcernDefinition specializes RequirementDefinition;		
+			
+	metadata def ConcernUsage specializes RequirementUsage {
+		derived ref item concernDefinition : ConcernDefinition[1..1] redefines requirementDefinition;
+	}		
+			
+	metadata def ConjugatedPortDefinition specializes PortDefinition {
+		derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace;
+		derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator;
+	}		
+			
+	metadata def ConjugatedPortTyping specializes FeatureTyping {
+//		ref item portDefinition : PortDefinition[1..1] subsets target;
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type;
+	}		
+			
+	metadata def ConnectionDefinition specializes AssociationStructure, PartDefinition {
+		derived ref item connectionEnd : Usage[2..*] redefines associationEnd;
+	}		
+			
+	metadata def ConnectionUsage specializes ConnectorAsUsage, PartUsage {
+		derived ref item connectionDefinition : AssociationStructure[1..*] subsets itemDefinition redefines association;
+	}		
+			
+	abstract metadata def ConnectorAsUsage specializes Usage, Connector;		
+			
+	metadata def ConstraintDefinition specializes OccurrenceDefinition, Predicate;		
+			
+	metadata def ConstraintUsage specializes BooleanExpression, OccurrenceUsage {
+		derived ref item constraintDefinition : Predicate[1..1] redefines predicate;
+	}		
+			
+	abstract metadata def ControlNode specializes ActionUsage;		
+			
+	metadata def DecisionNode specializes ControlNode;		
+			
+	metadata def Definition specializes Classifier {
+		attribute isVariation : Boolean[1..1];
+		
+		derived ref item ownedUsage : Usage[0..*] subsets ownedFeature, usage;
+		derived ref item ownedPort : PortUsage[0..*] subsets ownedUsage;
+		derived ref item directedUsage : Usage[0..*] subsets usage, directedFeature;
+		derived ref item usage : Usage[0..*] subsets feature;
+		derived ref item ownedState : StateUsage[0..*] subsets ownedAction;
+		derived ref item ownedConstraint : ConstraintUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage;
+		derived ref item ownedRequirement : RequirementUsage[0..*] subsets ownedConstraint;
+		derived ref item ownedCalculation : CalculationUsage[0..*] subsets ownedAction;
+		derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
+		derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] subsets ownedCase;
+		derived ref item 'variant' : Usage[0..*] subsets ownedMember;
+		derived ref item ownedCase : CaseUsage[0..*] subsets ownedCalculation;
+		derived ref item ownedReference : ReferenceUsage[0..*] subsets ownedUsage;
+		derived ref item ownedAction : ActionUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedConnection : ConnectorAsUsage[0..*] subsets ownedPart;
+		derived ref item ownedItem : ItemUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedPart : PartUsage[0..*] subsets ownedItem;
+		derived ref item ownedInterface : InterfaceUsage[0..*] subsets ownedConnection;
+		derived ref item ownedAttribute : AttributeUsage[0..*] subsets ownedUsage;
+		derived ref item ownedView : ViewUsage[0..*] subsets ownedPart;
+		derived ref item ownedViewpoint : ViewpointUsage[0..*] subsets ownedRequirement;
+		derived ref item ownedRendering : RenderingUsage[0..*] subsets ownedPart;
+		derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] subsets ownedCase;
+		derived ref item ownedEnumeration : EnumerationUsage[0..*] subsets ownedAttribute;
+		derived ref item ownedAllocation : AllocationUsage[0..*] subsets ownedConnection;
+		derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement;
+		derived ref item ownedOccurrence : OccurrenceUsage[0..*] subsets ownedUsage;
+		derived ref item ownedUseCase : UseCaseUsage[0..*] subsets ownedCase;
+		derived ref item ownedFlow : FlowConnectionUsage[0..*] subsets ownedConnection;
+		derived ref item ownedMetadata : MetadataUsage[0..*] subsets ownedItem;
+	}		
+			
+	metadata def Dependency specializes Relationship {
+		ref item client : Element[1..*] redefines source;
+		ref item supplier : Element[1..*] redefines target;
+	}		
+			
+	metadata def EnumerationDefinition specializes AttributeDefinition {
+		attribute isVariation : Boolean[1..1] redefines isVariation;
+		
+		derived ref item enumeratedValue : EnumerationUsage[0..*] redefines 'variant';
+	}		
+			
+	metadata def EnumerationUsage specializes AttributeUsage {
+		derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition;
+	}		
+			
+	metadata def EventOccurrenceUsage specializes OccurrenceUsage {
+		derived ref item eventOccurrence : OccurrenceUsage[1..1];
+	}		
+			
+	metadata def ExhibitStateUsage specializes StateUsage, PerformActionUsage {
+		derived ref item exhibitedState : StateUsage[1..1] redefines performedAction;
+	}		
+			
+	metadata def Expose specializes Import {
+		attribute isImportAll : Boolean[1..1] redefines isImportAll;
+	}		
+			
+	metadata def FlowConnectionDefinition specializes Interaction, ActionDefinition, ConnectionDefinition;		
+			
+	metadata def FlowConnectionUsage specializes ConnectionUsage, ItemFlow, ActionUsage {
+		derived ref item flowConnectionDefinition : Interaction[1..*] redefines actionDefinition, interaction, connectionDefinition;
+	}		
+			
+	metadata def ForLoopActionUsage specializes LoopActionUsage {
+		derived ref item seqArgument : Expression[1..1];
+		derived ref item loopVariable : ReferenceUsage[1..1];
+	}		
+			
+	metadata def ForkNode specializes ControlNode;		
+			
+	metadata def FramedConcernMembership specializes RequirementConstraintMembership {
+		attribute kind : RequirementConstraintKind[1..1] redefines kind;
+		
+		derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint;
+		derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint;
+	}		
+			
+	metadata def IfActionUsage specializes ActionUsage {
+		derived ref item elseAction : ActionUsage[0..1];
+		derived ref item thenAction : ActionUsage[1..1];
+		derived ref item ifArgument : Expression[1..1];
+	}		
+			
+	metadata def IncludeUseCaseUsage specializes UseCaseUsage, PerformActionUsage {
+		derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction;
+	}		
+			
+	metadata def InterfaceDefinition specializes ConnectionDefinition {
+		derived ref item interfaceEnd : PortUsage[2..*] redefines connectionEnd;
+	}		
+			
+	metadata def InterfaceUsage specializes ConnectionUsage {
+		derived ref item interfaceDefinition : InterfaceDefinition[1..*] redefines connectionDefinition;
+	}		
+			
+	metadata def ItemDefinition specializes Structure, OccurrenceDefinition;		
+			
+	metadata def ItemUsage specializes OccurrenceUsage {
+		derived ref item itemDefinition : Structure[1..*] subsets occurrenceDefinition;
+	}		
+			
+	metadata def JoinNode specializes ControlNode;		
+			
+	metadata def LifeClass specializes Class;		
+			
+	abstract metadata def LoopActionUsage specializes ActionUsage {
+		derived ref item bodyAction : ActionUsage[1..1];
+	}		
+			
+	metadata def MergeNode specializes ControlNode;		
+			
+	metadata def MetadataDefinition specializes ItemDefinition, Metaclass;		
+			
+	metadata def MetadataUsage specializes ItemUsage, MetadataFeature {
+		derived ref item metadataDefinition : Metaclass[1..1] redefines itemDefinition, metaclass;
+	}		
+			
+	metadata def ObjectiveMembership specializes FeatureMembership {
+		derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def OccurrenceDefinition specializes Definition, Class {
+		attribute isIndividual : Boolean[1..1];
+		
+		derived ref item lifeClass : LifeClass[0..1] subsets ownedMember;
+	}		
+			
+	metadata def OccurrenceUsage specializes Usage {
+		attribute isIndividual : Boolean[1..1];
+		attribute portionKind : PortionKind[0..1];
+		
+		derived ref item occurrenceDefinition : Class[1..*] redefines definition;
+		derived ref item portioningFeature : PortioningFeature[0..1] subsets ownedFeature;
+		derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition;
+	}		
+			
+	metadata def PartDefinition specializes ItemDefinition;		
+			
+	metadata def PartUsage specializes ItemUsage {
+		derived ref item partDefinition : PartDefinition[1..*] subsets itemDefinition;
+	}		
+			
+	metadata def PerformActionUsage specializes ActionUsage, EventOccurrenceUsage {
+		derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence;
+	}		
+			
+	metadata def PortConjugation specializes Conjugation {
+		ref item originalPortDefinition : PortDefinition[1..1] redefines originalType;
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType;
+	}		
+			
+	metadata def PortDefinition specializes OccurrenceDefinition, Structure {
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember;
+	}		
+			
+	metadata def PortUsage specializes OccurrenceUsage {
+		derived ref item portDefinition : PortDefinition[1..*] redefines occurrenceDefinition;
+	}		
+			
+	enum def PortionKind {
+		enum 'timeslice';
+		enum 'snapshot';
+	}
+			
+	metadata def PortioningFeature specializes Feature {
+		derived attribute portionKind : PortionKind[1..1];
+	}		
+			
+	metadata def ReferenceUsage specializes Usage {
+		derived attribute isReference : Boolean[1..1] redefines isReference;
+	}		
+			
+	metadata def RenderingDefinition specializes PartDefinition {
+		derived ref item 'rendering' : RenderingUsage[0..*] subsets usage;
+	}		
+			
+	metadata def RenderingUsage specializes PartUsage {
+		derived ref item renderingDefinition : RenderingDefinition[1..1] redefines partDefinition;
+	}		
+			
+	enum def RequirementConstraintKind {
+		enum assumption;
+		enum 'requirement';
+	}
+			
+	metadata def RequirementConstraintMembership specializes FeatureMembership {
+		attribute kind : RequirementConstraintKind[1..1];
+		
+		derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature;
+		derived ref item referencedConstraint : ConstraintUsage[1..1];
+	}		
+			
+	metadata def RequirementDefinition specializes ConstraintDefinition {
+		attribute reqId : String[0..1] redefines shortName;
+		derived attribute text : String[0..*];
+		
+		derived ref item assumedConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item requiredConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, ownedUsage;
+		derived ref item framedConcern : ConcernUsage[0..*] subsets requiredConstraint;
+		derived ref item actorParameter : PartUsage[0..*] subsets ownedPart, parameter;
+		derived ref item stakeholderParameter : PartUsage[0..*] subsets ownedPart, parameter;
+	}		
+			
+	metadata def RequirementUsage specializes ConstraintUsage {
+		attribute reqId : String[0..1] redefines shortName;
+		derived attribute text : String[0..*];
+		
+		derived ref item requirementDefinition : RequirementDefinition[1..1] redefines constraintDefinition;
+		derived ref item requiredConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item assumedConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, nestedUsage;
+		derived ref item framedConcern : ConcernUsage[0..*] subsets requiredConstraint;
+		derived ref item actorParameter : PartUsage[0..*] subsets nestedPart, parameter;
+		derived ref item stakeholderParameter : PartUsage[0..*] subsets nestedPart, parameter;
+	}		
+			
+	metadata def RequirementVerificationMembership specializes RequirementConstraintMembership {
+		attribute kind : RequirementConstraintKind[1..1] redefines kind;
+		
+		derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint;
+		derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint;
+	}		
+			
+	metadata def SatisfyRequirementUsage specializes RequirementUsage, AssertConstraintUsage {
+		derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint;
+		derived ref item satisfyingFeature : Feature[1..1];
+	}		
+			
+	metadata def SendActionUsage specializes ActionUsage {
+		derived ref item receiverArgument : Expression[1..1];
+		derived ref item payloadArgument : Expression[1..1];
+	}		
+			
+	metadata def StakeholderMembership specializes ParameterMembership {
+		derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def StateDefinition specializes ActionDefinition {
+		attribute isParallel : Boolean[1..1];
+		
+		derived ref item 'state' : StateUsage[0..*] subsets step;
+		derived ref item entryAction : ActionUsage[0..1];
+		derived ref item doAction : ActionUsage[0..1];
+		derived ref item exitAction : ActionUsage[0..1];
+	}		
+			
+	enum def StateSubactionKind {
+		enum 'entry';
+		enum 'do';
+		enum 'exit';
+	}
+			
+	metadata def StateSubactionMembership specializes FeatureMembership {
+		attribute kind : StateSubactionKind[1..1];
+		
+		derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def StateUsage specializes ActionUsage {
+		attribute isParallel : Boolean[1..1];
+		
+		derived ref item stateDefinition : Behavior[1..*] redefines actionDefinition;
+		derived ref item entryAction : ActionUsage[0..1];
+		derived ref item doAction : ActionUsage[0..1];
+		derived ref item exitAction : ActionUsage[0..1];
+	}		
+			
+	metadata def SubjectMembership specializes ParameterMembership {
+		derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def SuccessionAsUsage specializes ConnectorAsUsage, Succession;		
+			
+	metadata def SuccessionFlowConnectionUsage specializes SuccessionItemFlow, FlowConnectionUsage;		
+			
+	enum def TransitionFeatureKind {
+		enum trigger;
+		enum guard;
+		enum effect;
+	}
+			
+	metadata def TransitionFeatureMembership specializes FeatureMembership {
+		attribute kind : TransitionFeatureKind[1..1];
+		
+		derived item transitionFeature : Step[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def TransitionUsage specializes ActionUsage {
+		derived ref item source : ActionUsage[1..1];
+		derived ref item target : ActionUsage[1..1];
+		derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature;
+		derived ref item guardExpression : Expression[0..*] subsets ownedFeature;
+		derived ref item effectAction : ActionUsage[0..*] subsets feature;
+		derived ref item 'succession' : Succession[1..1] subsets ownedMember;
+	}		
+			
+	metadata def TriggerInvocationExpression specializes InvocationExpression {
+		attribute kind : TriggerKind[1..1];
+	}		
+			
+	enum def TriggerKind {
+		enum 'when';
+		enum 'at';
+		enum 'after';
+	}
+			
+	metadata def Usage specializes Feature {
+		attribute isVariation : Boolean[1..1];
+		derived attribute isReference : Boolean[1..1];
+		
+		derived ref item nestedUsage : Usage[0..*] subsets ownedFeature, usage;
+		derived ref item owningUsage : Usage[0..1] subsets owningType;
+		derived ref item owningDefinition : Definition[0..1] subsets owningType;
+		derived ref item nestedPort : PortUsage[0..*] subsets nestedUsage;
+		derived ref item nestedAction : ActionUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedState : StateUsage[0..*] subsets nestedAction;
+		derived ref item nestedConstraint : ConstraintUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage;
+		derived ref item nestedRequirement : RequirementUsage[0..*] subsets nestedConstraint;
+		derived ref item nestedCalculation : CalculationUsage[0..*] subsets nestedAction;
+		derived ref item directedUsage : Usage[0..*] subsets usage, directedFeature;
+		derived ref item nestedCase : CaseUsage[0..*] subsets nestedCalculation;
+		derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] subsets nestedCase;
+		derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
+		derived ref item usage : Usage[0..*] subsets feature;
+		derived ref item 'variant' : Usage[0..*] subsets ownedMember;
+		derived ref item nestedReference : ReferenceUsage[0..*] subsets nestedUsage;
+		derived ref item nestedConnection : ConnectorAsUsage[0..*] subsets nestedPart;
+		derived ref item nestedItem : ItemUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedPart : PartUsage[0..*] subsets nestedItem;
+		derived ref item nestedInterface : InterfaceUsage[0..*] subsets nestedConnection;
+		derived ref item nestedAttribute : AttributeUsage[0..*] subsets nestedUsage;
+		derived ref item nestedView : ViewUsage[0..*] subsets nestedPart;
+		derived ref item nestedViewpoint : ViewpointUsage[0..*] subsets nestedRequirement;
+		derived ref item nestedRendering : RenderingUsage[0..*] subsets nestedPart;
+		derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] subsets nestedCase;
+		derived ref item nestedEnumeration : EnumerationUsage[0..*] subsets nestedAttribute;
+		derived ref item nestedAllocation : AllocationUsage[0..*] subsets nestedConnection;
+		derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement;
+		derived ref item nestedOccurrence : OccurrenceUsage[0..*] subsets nestedUsage;
+		derived ref item definition : Classifier[1..*] redefines type;
+		derived ref item nestedUseCase : UseCaseUsage[0..*] subsets nestedCase;
+		derived ref item nestedFlow : FlowConnectionUsage[0..*] subsets nestedConnection;
+		derived ref item nestedMetadata : MetadataUsage[0..*] subsets nestedItem;
+	}		
+			
+	metadata def UseCaseDefinition specializes CaseDefinition {
+		derived ref item includedUseCase : UseCaseUsage[0..*];
+	}		
+			
+	metadata def UseCaseUsage specializes CaseUsage {
+		derived ref item useCaseDefinition : UseCaseDefinition[1..1] redefines caseDefinition;
+		derived ref item includedUseCase : UseCaseUsage[0..*];
+	}		
+			
+	metadata def VariantMembership specializes OwningMembership {
+		derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement;
+	}		
+			
+	metadata def VerificationCaseDefinition specializes CaseDefinition {
+		derived ref item verifiedRequirement : RequirementUsage[0..*];
+	}		
+			
+	metadata def VerificationCaseUsage specializes CaseUsage {
+		derived ref item verificationCaseDefinition : VerificationCaseDefinition[1..1] subsets caseDefinition;
+		derived ref item verifiedRequirement : RequirementUsage[0..*];
+	}		
+			
+	metadata def ViewDefinition specializes PartDefinition {
+		derived ref item 'view' : ViewUsage[0..*] subsets usage;
+		derived ref item satisfiedViewpoint : ViewpointUsage[0..*] subsets ownedUsage;
+		derived ref item viewRendering : RenderingUsage[0..1] subsets ownedUsage;
+		derived ref item viewCondition : Expression[0..*] subsets ownedMember;
+	}		
+			
+	metadata def ViewRenderingMembership specializes FeatureMembership {
+		derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature;
+		derived ref item referencedRendering : RenderingUsage[1..1];
+	}		
+			
+	metadata def ViewUsage specializes PartUsage {
+		derived ref item viewDefinition : ViewDefinition[1..1] redefines partDefinition;
+		derived ref item satisfiedViewpoint : ViewpointUsage[0..*] subsets nestedUsage;
+		derived ref item exposedNamespace : Namespace[0..*];
+		derived ref item viewRendering : RenderingUsage[0..1] subsets nestedUsage;
+		derived ref item viewCondition : Expression[0..*] subsets ownedMember;
+		derived ref item viewedElement : Element[0..*];
+	}		
+			
+	metadata def ViewpointDefinition specializes RequirementDefinition {
+		derived ref item viewpointStakeholder : PartUsage[0..*];
+	}		
+			
+	metadata def ViewpointUsage specializes RequirementUsage {
+		derived ref item viewpointDefinition : ViewpointDefinition[1..1] redefines requirementDefinition;
+		derived ref item viewpointStakeholder : PartUsage[0..*];
+	}		
+			
+	metadata def WhileLoopActionUsage specializes LoopActionUsage {
+		derived ref item whileArgument : Expression[1..1];
+		derived ref item untilArgument : Expression[0..1];
+	}		
+			
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/MetadataUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/MetadataUsage_Invalid.sysml.xt
@@ -49,31 +49,29 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 END_SETUP 
 */
 package Test {
-	import ScalarValues::*;
-	import ControlFunctions::collect;
 	
 	metadata def A {
 		ref :>> annotatedElement : SysML::AttributeUsage;
-		attribute x : Integer;
-		attribute y : String;
-		attribute z : Boolean;
+		attribute x : ScalarValues::Integer;
+		attribute y : ScalarValues::String;
+		attribute z : ScalarValues::Boolean;
 		attribute u {
-			attribute v : Integer;
+			attribute v : ScalarValues::Integer;
 		}
 	}
 	
-	calc def f { x : Boolean; }
+	calc def f { x : ScalarValues::Boolean; }
 	
 	// XPECT errors --> "Must be model-level evaluable" at "filter f(A::y);"
 	filter f(A::y);
 	// XPECT errors --> "Must be model-level evaluable" at "filter ~A::z;"
 	filter ~A::z;
-	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->collect {in ref x; x};"
-	filter A::y->collect {in ref x; x};
+	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->ControlFunctions::collect {in ref x; x};"
+	filter A::y->ControlFunctions::collect {in ref x; x};
 	// XPECT errors --> "Must be model-level evaluable" at "filter A(null, 1, "", false);"
 	filter A(null, 1, "", false);
 	
-	enum def E :> String {
+	enum def E :> ScalarValues::String {
 		enum e = "e";
 	}
 	

--- a/org.omg.sysml/.launch/Generate MOF2KerMLText.launch
+++ b/org.omg.sysml/.launch/Generate MOF2KerMLText.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.omg.sysml/xtend-gen/org/omg/sysml/generation/MOF2KerMLText.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.generation.MOF2KerMLText"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="SysML.uml&#10;&quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library/Kernel Libraries/Kernel Semantic Library/KerML.kerml}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:org.omg.sysml/src/org/omg/sysml/generation}"/>
+</launchConfiguration>

--- a/org.omg.sysml/.launch/Generate MOF2SysMLText.launch
+++ b/org.omg.sysml/.launch/Generate MOF2SysMLText.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.omg.sysml/xtend-gen/org/omg/sysml/generation/MOF2SysMLText.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.generation.MOF2SysMLText"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.omg.sysml"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="SysML.uml&#10;&quot;${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library/Systems Library/SysML.sysml}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:org.omg.sysml/src/org/omg/sysml/generation}"/>
+</launchConfiguration>

--- a/org.omg.sysml/.launch/Prepare Metamodel Packages.launch
+++ b/org.omg.sysml/.launch/Prepare Metamodel Packages.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2m.qvt.oml.QvtTransformation">
+    <booleanAttribute key="org.eclipse.m2m.qvt.oml.interpreter.clearContents1" value="true"/>
+    <booleanAttribute key="org.eclipse.m2m.qvt.oml.interpreter.clearContents2" value="true"/>
+    <mapAttribute key="org.eclipse.m2m.qvt.oml.interpreter.configurationProperties"/>
+    <intAttribute key="org.eclipse.m2m.qvt.oml.interpreter.elemCount" value="2"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.featureName1" value=""/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.featureName2" value=""/>
+    <booleanAttribute key="org.eclipse.m2m.qvt.oml.interpreter.isInrementalUpdate" value="false"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.module" value="platform:/resource/org.omg.sysml/transforms/PrepareMetamodelPackages.qvto"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.targetModel1" value="platform:/resource/org.omg.sysml/model/Export/Track_4_-_Metamodel_Development.uml"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.targetModel2" value="platform:/resource/org.omg.sysml/model/Export/SysML.uml"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.targetType1" value="NEW_MODEL"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.targetType2" value="NEW_MODEL"/>
+    <stringAttribute key="org.eclipse.m2m.qvt.oml.interpreter.traceFile" value="platform:/resource/org.omg.sysml/model/Export/SysML.PrepareMetamodelPackages.qvtotrace"/>
+    <booleanAttribute key="org.eclipse.m2m.qvt.oml.interpreter.useTraceFile" value="false"/>
+</launchConfiguration>

--- a/org.omg.sysml/model/SysML.uml
+++ b/org.omg.sysml/model/SysML.uml
@@ -746,7 +746,7 @@ general ->
       </specification>
     </ownedRule>
     <generalization xmi:id="4e892f3f-f416-4249-a2cf-49da9cd9991d" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
-    <ownedAttribute xmi:id="4c3c66de-b2c3-40e1-9037-18bfb5a18c19" name="stateDefinition" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isOrdered="true" isDerived="true" redefinedProperty="1f2423e8-9b61-4497-af7c-8de89dbda20c" association="546ddf66-c707-46a0-8983-112e7fb3f760">
+    <ownedAttribute xmi:id="4c3c66de-b2c3-40e1-9037-18bfb5a18c19" name="stateDefinition" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isOrdered="true" isDerived="true" redefinedProperty="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b" association="546ddf66-c707-46a0-8983-112e7fb3f760">
       <ownedComment xmi:id="f919b2f1-0e5c-4a7b-9110-95e1e5d02c13" annotatedElement="4c3c66de-b2c3-40e1-9037-18bfb5a18c19">
         <body>&lt;p>The Behaviors that are the types of this StateUsage. Nominally, these would be StateDefinitions, but non-Activity Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p></body>
       </ownedComment>
@@ -2540,7 +2540,7 @@ else
 &lt;p>An ItemUsage must subset, directly or indirectly, the base ItemUsage &lt;code>items&lt;/code> from the Systems model library.&lt;/p></body>
     </ownedComment>
     <generalization xmi:id="de1189c6-e20d-47bf-b11d-b80a40b6ec31" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
-    <ownedAttribute xmi:id="18ab486b-757f-4c4d-8569-01e9cf669e5f" name="itemDefinition" visibility="public" type="eabb05a5-3e97-41e1-9668-d9bf801193a6" isOrdered="true" isDerived="true" redefinedProperty="201738a1-0499-47ef-8c07-ab15564d86c0" association="e1e0ea17-ed4b-46fd-ae36-0596aa463ba4">
+    <ownedAttribute xmi:id="18ab486b-757f-4c4d-8569-01e9cf669e5f" name="itemDefinition" visibility="public" type="eabb05a5-3e97-41e1-9668-d9bf801193a6" isOrdered="true" isDerived="true" redefinedProperty="48d91227-fa8b-4b65-a4f8-d27701f010c0" association="e1e0ea17-ed4b-46fd-ae36-0596aa463ba4">
       <ownedComment xmi:id="d8522bde-8470-4d49-b0d9-149a8edd4083" annotatedElement="18ab486b-757f-4c4d-8569-01e9cf669e5f">
         <body>&lt;p>The Structures that are the &lt;code>definitions&lt;/code> of this ItemUsage. Nominally, these are ItemDefinitions, but other kinds of Kernel Structures are also allowed, to permit use of Structures from the Kernel Library.&lt;/p></body>
       </ownedComment>
@@ -2597,7 +2597,7 @@ else
       </specification>
     </ownedRule>
     <generalization xmi:id="ec4ad4e0-e51b-4489-884d-f81dc9af4856" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
-    <ownedAttribute xmi:id="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e" name="portDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" isOrdered="true" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="69486941-f79d-4a72-b385-244a7bb06b8d">
+    <ownedAttribute xmi:id="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e" name="portDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" isOrdered="true" isDerived="true" redefinedProperty="48d91227-fa8b-4b65-a4f8-d27701f010c0" association="69486941-f79d-4a72-b385-244a7bb06b8d">
       <ownedComment xmi:id="b102bcc2-b61d-4490-9735-be10e3d280b5" annotatedElement="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e">
         <body>&lt;p>The &lt;code>types&lt;/code> of this PortUsage, which must all be PortDefinitions.&lt;/p></body>
       </ownedComment>
@@ -3026,7 +3026,7 @@ endif</body>
 &lt;p>An AttributeUsage must subset, directly or indirectly, the base AttributeUsage &lt;code>attributeValues&lt;/code> from the Systems model library.&lt;/p></body>
     </ownedComment>
     <generalization xmi:id="b8aca072-99c0-40f8-a375-a93a71933c33" general="46068009-84f1-4001-a9bb-fc03fd6a381c"/>
-    <ownedAttribute xmi:id="0e5e08ee-b091-4594-bce0-e3cf0d351488" name="attributeDefinition" visibility="public" type="8fb1addf-512a-4250-97a3-5fb06485a999" isOrdered="true" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="9358a6ec-830f-4b6b-8f4a-ff481b52fe55">
+    <ownedAttribute xmi:id="0e5e08ee-b091-4594-bce0-e3cf0d351488" name="attributeDefinition" visibility="public" type="8fb1addf-512a-4250-97a3-5fb06485a999" isOrdered="true" isDerived="true" redefinedProperty="201738a1-0499-47ef-8c07-ab15564d86c0" association="9358a6ec-830f-4b6b-8f4a-ff481b52fe55">
       <ownedComment xmi:id="7ec935e2-04df-4e7c-8406-158cf6695da3" annotatedElement="0e5e08ee-b091-4594-bce0-e3cf0d351488">
         <body>&lt;p>The DataTypes that are the types of this AttributeUsage. Nominally, these are AttributeDefinitions, but other kinds of kernel DataTypes are also allowed, to permit use of DataTypes from the Kernel Library.&lt;/p></body>
       </ownedComment>
@@ -5091,7 +5091,7 @@ endif endif endif</body>
       <ownedComment xmi:id="862d4115-5aae-4a59-b957-f27a4fe3c0b6" annotatedElement="077a3948-ff80-405a-b769-123a0a235d1f">
         <body>&lt;p>The Feature that this FeatureMembership relates to its &lt;code>owningType&lt;/code>, making it an &lt;code>ownedFeature&lt;/code> of the &lt;code>owningType&lt;/code>.&lt;/p></body>
       </ownedComment>
-      <lowerValue xmi:type="uml:LiteralInteger" xmi:id="16b88811-93e7-402f-804c-cd1179a63d95" name="" visibility="public"/>
+      <lowerValue xmi:type="uml:LiteralInteger" xmi:id="16b88811-93e7-402f-804c-cd1179a63d95" name="" visibility="public" value="1"/>
       <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1931599f-0123-49f8-aacf-7e7f9e003a09" name="" visibility="public" value="1"/>
     </ownedAttribute>
   </packagedElement>
@@ -6224,7 +6224,7 @@ endif</body>
       <ownedComment xmi:id="1a2957db-12f0-41ee-899c-fde650c7b39e" annotatedElement="7db21a79-717f-4f97-b646-7e6ab9106c43">
         <body>&lt;p>The Real value that is the result of evaluating this Expression.&lt;/p></body>
       </ownedComment>
-      <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml#double"/>
+      <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
     </ownedAttribute>
   </packagedElement>
   <packagedElement xmi:type="uml:Association" xmi:id="688933df-72ee-4c19-bbdd-04b161fffa61" name="" visibility="public" memberEnd="a42a34a1-0748-4b76-b3b6-a6770814f850 f7b8fa23-31d7-4311-9742-5754a2260720">

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,12 +22,20 @@
 package org.omg.sysml.adapter;
 
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.omg.sysml.lang.sysml.Annotation;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.FeatureTyping;
+import org.omg.sysml.lang.sysml.MetadataFeature;
+import org.omg.sysml.lang.sysml.SysMLFactory;
+import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.ElementUtil;
 
 public class ElementAdapter extends AdapterImpl {
 	
 	protected Class<?> kind;
 	protected boolean isTransformed = false;
+	
+	private MetadataFeature metaclassFeature = null;
 	
 	public ElementAdapter(Element element) {
 		super();
@@ -42,6 +50,28 @@ public class ElementAdapter extends AdapterImpl {
 	public boolean isAdapterForType(Object object) {
 		return kind.isInstance(object);
 	}
+	
+	// Metaclass Feature
+	
+	public MetadataFeature getMetaclassFeature() {
+		if (metaclassFeature == null) {
+			Element element = getTarget();
+			Type metaclass = ElementUtil.getMetaclassOf(element);
+			if (metaclass != null) {
+				metaclassFeature = SysMLFactory.eINSTANCE.createMetadataFeature();
+				FeatureTyping typing = SysMLFactory.eINSTANCE.createFeatureTyping();
+				typing.setType(metaclass);
+				Annotation annotation = SysMLFactory.eINSTANCE.createAnnotation();
+				annotation.setAnnotatingElement(metaclassFeature);
+				annotation.setAnnotatedElement(element);
+				metaclassFeature.getOwnedRelationship().add(typing);
+				metaclassFeature.getOwnedRelationship().add(annotation);
+			}
+		}
+		return metaclassFeature;
+	}
+		
+	// Transformation
 
 	public boolean isTransformed() {
 		return isTransformed;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
@@ -27,7 +27,6 @@ import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
 import org.omg.sysml.lang.sysml.SysMLPackage;
-import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
 import org.omg.sysml.util.ExpressionUtil;
 import org.omg.sysml.util.TypeUtil;
 
@@ -44,13 +43,11 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 	
 	// Caching
 	
-	public static final String SELF_REFERENCE_FEATURE = "Base::Anything::self";
-	
 	private Feature selfReferenceFeature = null;
 	
 	public Feature getSelfReferenceFeature() {
 		if (selfReferenceFeature == null) {
-			selfReferenceFeature = (Feature)SysMLLibraryUtil.getLibraryType(getTarget(), SELF_REFERENCE_FEATURE);
+			selfReferenceFeature = ExpressionUtil.getSelfReferenceFeature(getTarget());
 		}
 		return selfReferenceFeature;
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.omg.sysml.lang.sysml.MetadataFeature;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
@@ -295,6 +296,7 @@ public class TypeAdapter extends NamespaceAdapter {
 						map(expr->expr.evaluate(target)).
 						filter(results->results != null && !results.isEmpty()).
 						map(results->results.get(0)).
+						map(EvaluationUtil::getMetaclassReferenceOf).
 						filter(Type.class::isInstance).
 						map(Type.class::cast).
 						forEachOrdered(baseTypes::add);

--- a/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
@@ -93,7 +93,7 @@ public class ModelLevelExpressionEvaluator {
 	
 	public EList<Element> evaluateInvocation(InvocationExpression expression, Element target) {
 		LibraryFunction function = libraryFunctionFactory.getLibraryFunction(expression.getFunction());
-		return function == null? null: function.invoke(expression, target, this);
+		return function == null? EvaluationUtil.singletonList(expression): function.invoke(expression, target, this);
 	}
 	
 	public EList<Element> evaluateFeature(Feature feature, Type type) {

--- a/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
@@ -103,7 +103,7 @@ public class ModelLevelExpressionEvaluator {
 			// Evaluate feature with a feature chain.
 			return evaluateFeatureChain(feature.getChainingFeature(), type);
 			
-		} else if (type instanceof MetadataFeature && TypeUtil.conforms(feature, EvaluationUtil.getAnnotatedElementFeature(feature))) {
+		} else if (type instanceof MetadataFeature && TypeUtil.conforms(feature, EvaluationUtil.getAnnotatedElementFeature(((MetadataFeature)type)))) {
 			// Evaluate "annotatedElement" feature.
 			return EvaluationUtil.results(((MetadataFeature)type).getAnnotatedElement());
 			

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/AndFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/AndFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -33,8 +33,8 @@ public class AndFunction extends BooleanFunction {
 	}
 	
 	@Override
-	protected EList<Element> binaryBooleanOp(boolean x, boolean y) {
-		return EvaluationUtil.booleanResult(x & y);
+	protected EList<Element> binaryBooleanOp(Boolean x, Boolean y) {
+		return EvaluationUtil.booleanResult(x == Boolean.TRUE & y == Boolean.TRUE);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ArithmeticFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ArithmeticFunction.java
@@ -67,7 +67,7 @@ public abstract class ArithmeticFunction implements LibraryFunction {
 			   x instanceof Integer && y instanceof Double? binaryRealOp((Integer)x, (Double)y):
 			   x instanceof Double && y instanceof Double? binaryRealOp((Double)x, (Double)y):
 			   x instanceof String && y instanceof String? binaryStringOp((String)x, (String)y):
-			   null;
+			   EvaluationUtil.singletonList(invocation);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/AsFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/AsFunction.java
@@ -24,11 +24,11 @@ package org.omg.sysml.expressions.functions;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.ElementUtil;
-import org.omg.sysml.util.TypeUtil;
 
 public class AsFunction extends BaseFunction {
 
@@ -37,25 +37,24 @@ public class AsFunction extends BaseFunction {
 		return "as";
 	}
 	
-	protected static boolean isTypeOrMetatype(Element context, Element element, Type targetType) {
-		return isType(context, element, targetType) ||
-			   TypeUtil.conforms(ElementUtil.getMetaclassOf(element), targetType);
-	}
-	
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Type targetType = getTypeArgument(invocation);
+		Type targetType = EvaluationUtil.getTypeArgument(invocation);
 		if (targetType != null) {
 			EList<Element> values = evaluator.evaluateArgument(invocation, 0, target);
 			if (values != null) {
 				EList<Element> results = new BasicEList<>();
-				values.stream().
-					filter(value->isTypeOrMetatype(invocation, value, targetType)).
-					forEachOrdered(results::add);
+				for (Element value: values) {
+					if (EvaluationUtil.isType(invocation, value, targetType)) {
+						results.add(value);
+					} else if (EvaluationUtil.isMetatype(value, targetType)) {
+						results.add(ElementUtil.getMetaclassFeatureFor(value));
+					}
+				}
 				return results;
 			}
 		}
-		return null;
+		return EvaluationUtil.singletonList(invocation);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/AsFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/AsFunction.java
@@ -27,7 +27,7 @@ import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.util.ExpressionUtil;
+import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.TypeUtil;
 
 public class AsFunction extends BaseFunction {
@@ -39,7 +39,7 @@ public class AsFunction extends BaseFunction {
 	
 	protected static boolean isTypeOrMetatype(Element context, Element element, Type targetType) {
 		return isType(context, element, targetType) ||
-			   TypeUtil.conforms(ExpressionUtil.getMetaclassOf(element), targetType);
+			   TypeUtil.conforms(ElementUtil.getMetaclassOf(element), targetType);
 	}
 	
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/BaseFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/BaseFunction.java
@@ -21,41 +21,7 @@
 
 package org.omg.sysml.expressions.functions;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.eclipse.emf.common.util.EList;
-import org.omg.sysml.expressions.util.EvaluationUtil;
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.InvocationExpression;
-import org.omg.sysml.lang.sysml.LiteralExpression;
-import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.util.TypeUtil;
-
 public abstract class BaseFunction implements LibraryFunction {
-
-	protected static Type getTypeArgument(InvocationExpression invocation) {
-		EList<Feature> ownedFeatures = invocation.getOwnedFeature();
-		if (ownedFeatures.size() >= 2) {
-			EList<Type> types = ownedFeatures.get(1).getType();
-			if (!types.isEmpty()) {
-				return types.get(0);
-			}
-		}
-		return null;
-	}
-	
-	protected static List<Type> getType(Element context, Element element) {
-		return element instanceof LiteralExpression? Collections.singletonList(EvaluationUtil.getPrimitiveType(context, element.eClass())):
-			   element instanceof Feature? ((Feature)element).getType():
-			   Collections.emptyList();
-	}
-	
-	protected static boolean isType(Element context, Element element, Type type) {
-		return getType(context, element).stream().
-				anyMatch(elementType->TypeUtil.conforms(elementType, type));
-	}
 
 	@Override
 	public String getPackageName() {

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/BooleanFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/BooleanFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,11 +29,11 @@ import org.omg.sysml.lang.sysml.InvocationExpression;
 
 public abstract class BooleanFunction implements LibraryFunction {
 	
-	protected EList<Element> unaryBooleanOp(boolean x) {
+	protected EList<Element> unaryBooleanOp(Boolean x) {
 		return null;
 	}
 	
-	protected EList<Element> binaryBooleanOp(boolean x, boolean y) {
+	protected EList<Element> binaryBooleanOp(Boolean x, Boolean y) {
 		return null;
 	}
 	
@@ -46,9 +46,9 @@ public abstract class BooleanFunction implements LibraryFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		Boolean x_bool = evaluator.booleanValue(invocation, 0, target);
 		Boolean y_bool = evaluator.booleanValue(invocation, 1, target);
-		return x_bool != null && y_bool != null? binaryBooleanOp(x_bool, y_bool):
-			   x_bool != null && EvaluationUtil.numberOfArgs(invocation) == 1? unaryBooleanOp(x_bool):
-			   null;
+		EList<Element> results = EvaluationUtil.numberOfArgs(invocation) == 1? unaryBooleanOp(x_bool):
+			binaryBooleanOp(x_bool, y_bool);
+		return results == null? EvaluationUtil.singletonList(invocation): results;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalAndFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalAndFunction.java
@@ -20,13 +20,7 @@
  *******************************************************************************/
 package org.omg.sysml.expressions.functions;
 
-import org.eclipse.emf.common.util.EList;
-import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
-import org.omg.sysml.expressions.util.EvaluationUtil;
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.InvocationExpression;
-
-public class ConditionalAndFunction extends ControlFunction {
+public class ConditionalAndFunction extends ConditionalLogicalFunction {
 
 	@Override
 	public String getOperatorName() {
@@ -34,19 +28,13 @@ public class ConditionalAndFunction extends ControlFunction {
 	}
 
 	@Override
-	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Boolean firstValue = evaluator.booleanValue(invocation, 0, target);
-		if (firstValue != null) {
-			if (!firstValue) {
-				return EvaluationUtil.booleanResult(false);
-			} else {
-				Boolean secondValue = evaluator.booleanExpressionValue(invocation, 1, target);
-				if (secondValue != null) {
-					return EvaluationUtil.booleanResult(secondValue);
-				}
-			}
-		}
-		return null;
+	protected boolean firstValueTest(Boolean firstValue) {
+		return firstValue != Boolean.TRUE;
+	}
+
+	@Override
+	protected boolean firstValueResult() {
+		return false;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalImpliesFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalImpliesFunction.java
@@ -20,13 +20,7 @@
  *******************************************************************************/
 package org.omg.sysml.expressions.functions;
 
-import org.eclipse.emf.common.util.EList;
-import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
-import org.omg.sysml.expressions.util.EvaluationUtil;
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.InvocationExpression;
-
-public class ConditionalImpliesFunction extends ControlFunction {
+public class ConditionalImpliesFunction extends ConditionalLogicalFunction {
 
 	@Override
 	public String getOperatorName() {
@@ -34,19 +28,13 @@ public class ConditionalImpliesFunction extends ControlFunction {
 	}
 
 	@Override
-	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Boolean firstValue = evaluator.booleanValue(invocation, 0, target);
-		if (firstValue != null) {
-			if (!firstValue) {
-				return EvaluationUtil.booleanResult(true);
-			} else {
-				Boolean secondValue = evaluator.booleanExpressionValue(invocation, 1, target);
-				if (secondValue != null) {
-					return EvaluationUtil.booleanResult(secondValue);
-				}
-			}
-		}
-		return null;
+	protected boolean firstValueTest(Boolean firstValue) {
+		return firstValue != Boolean.TRUE;
+	}
+
+	@Override
+	protected boolean firstValueResult() {
+		return true;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalLogicalFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalLogicalFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,19 +26,21 @@ import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 
-public class ConditionalFunction extends ControlFunction {
-
-	@Override
-	public String getOperatorName() {
-		return "if";
-	}
+public abstract class ConditionalLogicalFunction extends ControlFunction {
+	
+	protected abstract boolean firstValueTest(Boolean firstValue);
+	protected abstract boolean firstValueResult();
 
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Boolean test = evaluator.booleanValue(invocation, 0, target);
-		return test == null? EvaluationUtil.singletonList(invocation):
-			   test? evaluator.expressionValue(invocation, 1, target):
-			   evaluator.expressionValue(invocation, 2, target);
+		Boolean firstValue = evaluator.booleanValue(invocation, 0, target);
+		if (firstValueTest(firstValue)) {
+			return EvaluationUtil.booleanResult(firstValueResult());
+		} else {
+			Boolean secondValue = evaluator.booleanExpressionValue(invocation, 1, target);
+			return secondValue == null? EvaluationUtil.singletonList(invocation):
+				EvaluationUtil.booleanResult(secondValue);
+		}		
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalOrFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ConditionalOrFunction.java
@@ -20,13 +20,7 @@
  *******************************************************************************/
 package org.omg.sysml.expressions.functions;
 
-import org.eclipse.emf.common.util.EList;
-import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
-import org.omg.sysml.expressions.util.EvaluationUtil;
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.InvocationExpression;
-
-public class ConditionalOrFunction extends ControlFunction {
+public class ConditionalOrFunction extends ConditionalLogicalFunction {
 
 	@Override
 	public String getOperatorName() {
@@ -34,19 +28,13 @@ public class ConditionalOrFunction extends ControlFunction {
 	}
 
 	@Override
-	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Boolean firstValue = evaluator.booleanValue(invocation, 0, target);
-		if (firstValue != null) {
-			if (firstValue) {
-				return EvaluationUtil.booleanResult(true);
-			} else {
-				Boolean secondValue = evaluator.booleanExpressionValue(invocation, 1, target);
-				if (secondValue != null) {
-					return EvaluationUtil.booleanResult(secondValue);
-				}
-			}
-		}
-		return null;
+	protected boolean firstValueTest(Boolean firstValue) {
+		return firstValue == Boolean.TRUE;
+	}
+
+	@Override
+	protected boolean firstValueResult() {
+		return true;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/DotFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/DotFunction.java
@@ -24,6 +24,7 @@ package org.omg.sysml.expressions.functions;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.InvocationExpression;
@@ -64,7 +65,7 @@ public class DotFunction extends ControlFunction {
 				return result;
 			}
 		}
-		return null;
+		return EvaluationUtil.singletonList(invocation);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/EqualsFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/EqualsFunction.java
@@ -38,7 +38,8 @@ public class EqualsFunction extends BaseFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> x = evaluator.evaluateArgument(invocation, 0, target);
 		EList<Element> y = evaluator.evaluateArgument(invocation, 1, target);
-		return x == null || y == null? null: EvaluationUtil.booleanResult(EvaluationUtil.equal(x, y));
+		Boolean result = x == null || y == null? null: EvaluationUtil.equal(x, y);
+		return result == null? EvaluationUtil.singletonList(invocation): EvaluationUtil.booleanResult(result);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/IncludesFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/IncludesFunction.java
@@ -37,8 +37,9 @@ public class IncludesFunction extends SequenceFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
 		Element value = evaluator.argumentValue(invocation, 1, target);
-		return list == null && value == null? null: 
-			EvaluationUtil.booleanResult(list.stream().anyMatch(x->EvaluationUtil.equal(x, value)));
+		Boolean result = list == null && value == null? null: list.stream().anyMatch(x->EvaluationUtil.equal(x, value));
+		return result == null? EvaluationUtil.singletonList(invocation): 
+			EvaluationUtil.booleanResult(result);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/IndexFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/IndexFunction.java
@@ -38,7 +38,7 @@ public class IndexFunction extends BaseFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
 		Integer index = evaluator.integerValue(invocation, 1, target);
-		return list == null || index == null? null:
+		return list == null || index == null? EvaluationUtil.singletonList(invocation):
 			   index == null || index < 1 || index > list.size()? EvaluationUtil.nullList():
 			   EvaluationUtil.singletonList(list.get(index - 1));
 	}

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsEmptyFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsEmptyFunction.java
@@ -36,7 +36,7 @@ public class IsEmptyFunction extends SequenceFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
-		return list == null? null: EvaluationUtil.booleanResult(list.isEmpty());
+		return list == null? EvaluationUtil.singletonList(invocation): EvaluationUtil.booleanResult(list.isEmpty());
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsTypeFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsTypeFunction.java
@@ -43,7 +43,7 @@ public class IsTypeFunction extends BaseFunction {
 				return EvaluationUtil.booleanResult(!values.isEmpty() && isType(invocation, values.get(0), testedType));
 			}
 		}
-		return null;
+		return EvaluationUtil.singletonList(invocation);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsTypeFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/IsTypeFunction.java
@@ -36,11 +36,11 @@ public class IsTypeFunction extends BaseFunction {
 	
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
-		Type testedType = getTypeArgument(invocation);
+		Type testedType = EvaluationUtil.getTypeArgument(invocation);
 		if (testedType != null) {
 			EList<Element> values = evaluator.evaluateArgument(invocation, 0, target);
 			if (values != null) {
-				return EvaluationUtil.booleanResult(!values.isEmpty() && isType(invocation, values.get(0), testedType));
+				return EvaluationUtil.booleanResult(!values.isEmpty() && EvaluationUtil.isType(invocation, values.get(0), testedType));
 			}
 		}
 		return EvaluationUtil.singletonList(invocation);

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ListConcatFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ListConcatFunction.java
@@ -24,6 +24,7 @@ package org.omg.sysml.expressions.functions;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 
@@ -37,18 +38,15 @@ public class ListConcatFunction extends BaseFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
-		if (list == null) {
-			return null;
-		} else {
+		if (list != null) {
 			EList<Element> result = new BasicEList<>(list);
 			list = evaluator.evaluateArgument(invocation, 1, target);
-			if (list == null) {
-				return null;
-			} else {
+			if (list != null) {
 				result.addAll(list);
 				return result;
 			}
-		}
+		}		
+		return EvaluationUtil.singletonList(invocation);
 	}
-
+	
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotEmptyFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotEmptyFunction.java
@@ -36,7 +36,8 @@ public class NotEmptyFunction extends SequenceFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
-		return list == null? null: EvaluationUtil.booleanResult(!list.isEmpty());
+		return list == null? EvaluationUtil.singletonList(invocation): 
+			EvaluationUtil.booleanResult(!list.isEmpty());
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotEqualsFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotEqualsFunction.java
@@ -38,7 +38,8 @@ public class NotEqualsFunction extends BaseFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> x = evaluator.evaluateArgument(invocation, 0, target);
 		EList<Element> y = evaluator.evaluateArgument(invocation, 1, target);
-		return x == null || y == null? null: EvaluationUtil.booleanResult(!EvaluationUtil.equal(x, y));
+		Boolean result = x == null || y == null? null: !EvaluationUtil.equal(x, y);
+		return result == null? EvaluationUtil.singletonList(invocation): EvaluationUtil.booleanResult(result);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/NotFunction.java
@@ -33,8 +33,8 @@ public class NotFunction extends BooleanFunction {
 	}
 	
 	@Override
-	protected EList<Element> unaryBooleanOp(boolean x) {
-		return EvaluationUtil.booleanResult(!x);
+	protected EList<Element> unaryBooleanOp(Boolean x) {
+		return EvaluationUtil.booleanResult(x != Boolean.TRUE);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/NullCoalescingFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/NullCoalescingFunction.java
@@ -22,6 +22,7 @@ package org.omg.sysml.expressions.functions;
 
 import org.eclipse.emf.common.util.EList;
 import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 
@@ -35,7 +36,7 @@ public class NullCoalescingFunction extends ControlFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
-		return list == null? null:
+		return list == null? EvaluationUtil.singletonList(invocation):
 			   list.isEmpty()? evaluator.expressionValue(invocation, 1, target):
 			   list;
 	}

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/OrFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/OrFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -33,8 +33,8 @@ public class OrFunction extends BooleanFunction {
 	}
 	
 	@Override
-	protected EList<Element> binaryBooleanOp(boolean x, boolean y) {
-		return EvaluationUtil.booleanResult(x | y);
+	protected EList<Element> binaryBooleanOp(Boolean x, Boolean y) {
+		return EvaluationUtil.booleanResult(x == Boolean.TRUE | y == Boolean.TRUE);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ProdFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ProdFunction.java
@@ -45,7 +45,7 @@ public class ProdFunction implements LibraryFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
 		if (list == null) {
-			return null;
+			return EvaluationUtil.singletonList(invocation);
 		} else {
 			int intResult = 1;
 			Double realResult = null;
@@ -53,7 +53,7 @@ public class ProdFunction implements LibraryFunction {
 				if (element instanceof LiteralInteger) {
 					int value = ((LiteralInteger)element).getValue();
 					if (realResult != null) {
-						realResult += value;
+						realResult *= value;
 					} else {
 						intResult *= value;
 					}
@@ -63,7 +63,7 @@ public class ProdFunction implements LibraryFunction {
 					}
 					realResult *= ((LiteralRational)element).getValue();
 				} else {
-					return null;
+					return EvaluationUtil.singletonList(invocation);
 				}
 			}
 			return realResult == null? 

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/SizeFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/SizeFunction.java
@@ -36,7 +36,8 @@ public class SizeFunction extends SequenceFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
-		return list == null? null: EvaluationUtil.integerResult(list.size());
+		return list == null? EvaluationUtil.singletonList(invocation): 
+			EvaluationUtil.integerResult(list.size());
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/StringLengthFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/StringLengthFunction.java
@@ -42,7 +42,7 @@ public class StringLengthFunction implements LibraryFunction {
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		String x = evaluator.stringValue(invocation, 0, target);
-		return x == null? null: EvaluationUtil.integerResult(x.length());
+		return x == null? EvaluationUtil.singletonList(invocation): EvaluationUtil.integerResult(x.length());
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/StringSubstringFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/StringSubstringFunction.java
@@ -44,7 +44,7 @@ public class StringSubstringFunction implements LibraryFunction {
 		String x = evaluator.stringValue(invocation, 0, target);
 		Integer lower = evaluator.integerValue(invocation, 1, target);
 		Integer upper = evaluator.integerValue(invocation, 2, target);
-		return x == null || lower == null || upper == null? null:
+		return x == null || lower == null || upper == null? EvaluationUtil.singletonList(invocation):
 			   lower < 1 || upper > x.length() || lower > upper + 1 ? EvaluationUtil.nullList(): 
 			   EvaluationUtil.stringResult(x.substring(lower - 1, upper));
 	}

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/SumFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/SumFunction.java
@@ -45,7 +45,7 @@ public class SumFunction implements LibraryFunction {
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
 		if (list == null) {
-			return null;
+			return EvaluationUtil.singletonList(invocation);
 		} else {
 			int intResult = 0;
 			Double realResult = null;
@@ -63,7 +63,7 @@ public class SumFunction implements LibraryFunction {
 					}
 					realResult += ((LiteralRational)element).getValue();
 				} else {
-					return null;
+					return EvaluationUtil.singletonList(invocation);
 				}
 			}
 			return realResult == null? 

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/XorFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/XorFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -28,13 +28,13 @@ import org.omg.sysml.lang.sysml.Element;
 public class XorFunction extends BooleanFunction {
 
 	@Override
-	public String[] getOperatorNames() {
-		return new String[]{"'^^'", "xor"};
+	public String getOperatorName() {
+		return "xor";
 	}
 	
 	@Override
-	protected EList<Element> binaryBooleanOp(boolean x, boolean y) {
-		return EvaluationUtil.booleanResult(x ^ y);
+	protected EList<Element> binaryBooleanOp(Boolean x, Boolean y) {
+		return EvaluationUtil.booleanResult(x == Boolean.TRUE ^ y == Boolean.TRUE);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/util/EvaluationUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/util/EvaluationUtil.java
@@ -47,16 +47,16 @@ import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
 import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.FeatureUtil;
+import org.omg.sysml.util.ImplicitGeneralizationMap;
 import org.omg.sysml.util.TypeUtil;
 
 import com.google.common.base.Predicates;
 
 public class EvaluationUtil {
 
-	public static final String ANNOTATED_ELEMENT_FEATURE = "Metaobjects::Metaobject::annotatingElement";
-	
-	public static Feature getAnnotatedElementFeature(Element context) {
-		return (Feature)SysMLLibraryUtil.getLibraryType(context, ANNOTATED_ELEMENT_FEATURE);
+	public static Feature getAnnotatedElementFeature(MetadataFeature context) {
+		return (Feature)SysMLLibraryUtil.getLibraryType(context, 
+				ImplicitGeneralizationMap.getDefaultSupertypeFor(context.getClass(), "annotatedElement"));
 	}
 	
 	public static Type getPrimitiveType(Element context, EClass eClass) {

--- a/org.omg.sysml/src/org/omg/sysml/generation/MOF2KerMLText.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/generation/MOF2KerMLText.xtend
@@ -195,39 +195,11 @@ class MOF2KerMLText {
 	}
 	
 	def toPropertyList(List<? extends org.eclipse.uml2.uml.Property> properties) {
-		toNameList(properties.filter[isNavigable].toList)
+		properties.filter[isNavigable].toList.toNameList
 	}
 	
-	def toNameList(List<? extends NamedElement> elements) {
-		var result = "";		
-		if (!elements.empty) {
-			for (element: elements) {
-				val name = element.toName
-				if (name != "" ) {
-					if (result !== "") {
-						result += ", "
-					}
-					result += name
-				}
-			}
-		}
-		result
-	}
-	
-	def toQualifiedNameList(List<? extends NamedElement> elements) {
-		var result = "";		
-		if (!elements.empty) {
-			for (element: elements) {
-				val qualifiedName = element.qualifiedName
-				if (qualifiedName !== null) {
-					if (result !== "") {
-						result += ", "
-					}
-					result += qualifiedName
-				}
-			}
-		}
-		result
+	def String toNameList(List<? extends NamedElement> elements) {
+		'''«FOR element: elements SEPARATOR ", "»«element.toName»«ENDFOR»'''
 	}
 	
 	def String getReservedWords() {
@@ -241,7 +213,7 @@ class MOF2KerMLText {
 		 nonunique not null of or ordered out package portion predicate private 
 		 protected public readonly references redefines redefinition relationship rep 
 		 return specialization specializes step struct subclassifier subset subsets 
-		 subtype succession then to true type typed typing unions xor"
+		 subtype succession then to true type typed typing unions xor "
 	}
 	
 	def toName(NamedElement element) {

--- a/org.omg.sysml/src/org/omg/sysml/generation/MOF2KerMLText.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/generation/MOF2KerMLText.xtend
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2022 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.generation
+
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.uml2.uml.resources.util.UMLResourcesUtil
+import org.eclipse.emf.common.util.URI
+import org.eclipse.uml2.uml.Model
+import org.eclipse.uml2.uml.MultiplicityElement
+import java.util.List
+import org.eclipse.uml2.uml.NamedElement
+import java.util.Comparator
+import java.util.Collections
+import org.eclipse.uml2.uml.Enumeration
+import org.eclipse.uml2.uml.EnumerationLiteral
+import java.nio.file.Files
+import java.nio.file.Path
+
+class MOF2KerMLText {
+	
+	final ResourceSet resourceSet;
+	
+	new() {
+		resourceSet = new ResourceSetImpl()
+		UMLResourcesUtil.init(this.resourceSet)
+	}
+	
+	private static class ElementNameComparator implements Comparator<NamedElement> {
+		
+		override compare(NamedElement o1, NamedElement o2) {
+			return o1.name.compareTo(o2.name)
+		}
+		
+	}
+	
+	def generate(String inputPath, String outputPath) {
+		write(outputPath, generate(inputPath))
+	}
+	
+	def generate(String inputPath) {
+		System.out.println("Reading " + inputPath + "...")
+		val mofResource = resourceSet.getResource(URI.createFileURI(inputPath), true)
+		var model = mofResource.contents.get(0) as Model
+		generate(model)
+	}
+	
+	def generate(Model model) {
+		'''
+		package KerML {
+			private import ScalarValues::*;
+			import Kernel::*;
+			
+			package Root {
+				«model.getPackage("Root").toPackageBody»
+			}
+			
+			package Core {
+				import Root::*;
+				
+				«model.getPackage("Core").toPackageBody»
+			}
+			
+			package Kernel {
+				import Core::*;
+				
+				«model.getPackage("Kernel").toPackageBody»
+			}
+		}
+		'''
+	}
+	
+	static def getPackage(org.eclipse.uml2.uml.Package package_, String memberName) {
+		package_.packagedElements.findFirst[it instanceof org.eclipse.uml2.uml.Package && name == memberName] as org.eclipse.uml2.uml.Package
+	}
+	
+	def String toPackage(org.eclipse.uml2.uml.Package package_) {
+		'''
+		package «nameOf(package_)» {			
+			«package_.toPackageBody»
+		}
+		'''
+	}
+	
+	def toPackageBody(org.eclipse.uml2.uml.Package package_) {
+		var List<NamedElement> members = <NamedElement>newArrayList(package_.ownedMembers.filter[!name.empty].toList);
+		Collections.sort(members, new ElementNameComparator)
+		'''
+		«FOR member: members»
+			«IF member instanceof Enumeration»
+				«member.toEnumeration»
+			«ELSEIF member instanceof org.eclipse.uml2.uml.Class»
+				«member.toMetaclass»
+			«ELSEIF member instanceof org.eclipse.uml2.uml.Package»
+				import «member.name»::*;
+				«member.toPackage»
+			«ENDIF»	
+					
+		«ENDFOR»				
+		'''		
+	}
+	
+	def toEnumeration(Enumeration enumeration) {
+		'''
+		datatype «nameOf(enumeration)» {
+			«FOR literal: enumeration.ownedLiterals»
+				member feature «nameOf(literal)» : «nameOf(enumeration)»[1];
+			«ENDFOR»
+		}
+		'''
+	}
+	
+	def toMetaclass(org.eclipse.uml2.uml.Class class_) {
+		toMetaclass(class_, "metaclass")
+	}
+		
+	def toMetaclass(org.eclipse.uml2.uml.Class class_, String keyword) {
+		var attributes = class_.attributes.filter[association === null]
+		var associationEnds = class_.attributes.filter[association !== null]
+		'''
+		«IF class_.abstract»abstract «ENDIF»«keyword» «nameOf(class_)»«class_.toSubclassification»«IF class_.attributes.empty»;		
+		«ELSE» {
+			«attributes.toFeatures»
+			«IF !attributes.empty && !associationEnds.empty»
+			
+			«ENDIF»
+			«associationEnds.toFeatures»
+		}		
+		«ENDIF»		
+		'''
+	}
+	
+	def toFeatures(Iterable<org.eclipse.uml2.uml.Property> properties) {
+		'''
+		«FOR property: properties.filter[!isDerived]»
+			«property.toFeature»
+		«ENDFOR»
+		«FOR property: properties.filter[isDerived]»
+			«property.toFeature»
+		«ENDFOR»
+		'''		
+	}
+	
+	def toSubclassification(org.eclipse.uml2.uml.Class class_) {
+		var superclasses = class_.superClasses.toNameList
+		'''«IF !superclasses.empty» specializes «superclasses»«ENDIF»'''
+	}
+	
+	def toFeature(org.eclipse.uml2.uml.Property property) {
+		toFeature(property, property.isComposite, "feature")
+	}
+	
+	def toFeature(org.eclipse.uml2.uml.Property property, boolean isComposite, String keyword) {
+		'''
+		«IF property.derivedUnion»abstract «ENDIF»«IF isComposite»composite «ENDIF»«IF property.readOnly»readonly «ENDIF»«IF property.derived»derived «ENDIF»«keyword» «nameOf(property)» : «property.type.name»«property.toMultiplicity»«property.toSubsets»«property.toRedefines»;
+		'''
+	}
+	
+	def toMultiplicity(MultiplicityElement multiplicity) {
+		'''[«multiplicity.lower»..«multiplicity.upper==-1?"*":multiplicity.upper»]'''
+	}
+	
+	def toSubsets(org.eclipse.uml2.uml.Property property) {
+		val subsettedProperties = property.subsettedProperties.toPropertyList
+		'''«IF !subsettedProperties.empty» subsets «subsettedProperties»«ENDIF»'''
+	}
+	
+	def toRedefines(org.eclipse.uml2.uml.Property property) {
+		var redefinedProperties = property.redefinedProperties.toPropertyList
+		if ("annotatedElement".equals(property.name)) {
+			redefinedProperties = 
+				if (redefinedProperties.empty) "annotatedElement"
+				else redefinedProperties + ", annotatedElement"
+		}
+		'''«IF !redefinedProperties.empty» redefines «redefinedProperties»«ENDIF»'''
+	}
+	
+	def toPropertyList(List<? extends org.eclipse.uml2.uml.Property> properties) {
+		toNameList(properties.filter[isNavigable].toList)
+	}
+	
+	def toNameList(List<? extends NamedElement> elements) {
+		var result = "";		
+		if (!elements.empty) {
+			for (element: elements) {
+				val name = element.toName
+				if (name != "" ) {
+					if (result !== "") {
+						result += ", "
+					}
+					result += name
+				}
+			}
+		}
+		result
+	}
+	
+	def toQualifiedNameList(List<? extends NamedElement> elements) {
+		var result = "";		
+		if (!elements.empty) {
+			for (element: elements) {
+				val qualifiedName = element.qualifiedName
+				if (qualifiedName !== null) {
+					if (result !== "") {
+						result += ", "
+					}
+					result += qualifiedName
+				}
+			}
+		}
+		result
+	}
+	
+	def String getReservedWords() {
+		// Note: Every word must be preceded and followed by a space.
+	   " about abstract alias all and as assign assoc behavior binding bool by chains 
+		 class classifier comment composite conjugate conjugates conjugation connector 
+		 datatype default derived differences disjoining disjoint doc element else end 
+		 expr false feature featured featuring filter first flow for from function 
+		 hastype if intersects implies import in inout interaction inv inverse 
+		 inverting istype language member metaclass metadata multiplicity namespace 
+		 nonunique not null of or ordered out package portion predicate private 
+		 protected public readonly references redefines redefinition relationship rep 
+		 return specialization specializes step struct subclassifier subset subsets 
+		 subtype succession then to true type typed typing unions xor"
+	}
+	
+	def toName(NamedElement element) {
+		if (element instanceof EnumerationLiteral) element.enumeration.name + "::" + nameOf(element)
+		else nameOf(element)
+	}
+	
+	def nameOf(NamedElement element) {
+		var name = element.name;
+		name =
+			if (name === null || name.isEmpty) ""
+			else if (reservedWords.indexOf(" " + name + " ") < 0) name
+			else "'" + name + "'"
+	}
+	
+	def static write(String outputPath, CharSequence text) {
+		System.out.println("Writing " + outputPath + "...")
+		Files.newBufferedWriter(Path.of(outputPath)).append(text).close()
+	}
+	
+	static def void main(String[] args) {
+		if (args.length >= 2) {
+			new MOF2KerMLText().generate(args.get(0), args.get(1))
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/generation/MOF2SysMLText.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/generation/MOF2SysMLText.xtend
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2022 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.generation
+
+import org.omg.sysml.generation.MOF2KerMLText
+import org.eclipse.uml2.uml.DataType
+import org.eclipse.uml2.uml.Model
+import org.eclipse.uml2.uml.Enumeration
+
+class MOF2SysMLText extends MOF2KerMLText {
+	
+	override generate(Model model) {
+		'''
+		package SysML {
+			private import ScalarValues::*;
+			import KerML::Kernel::*;
+			
+			«model.getPackage("Systems").toPackageBody»
+			
+		}
+		'''
+	}
+	
+	override toEnumeration(Enumeration enumeration) {
+		'''
+		enum def «nameOf(enumeration)» {
+			«FOR literal: enumeration.ownedLiterals»
+				enum «nameOf(literal)»;
+			«ENDFOR»
+		}
+		'''
+	}
+	
+	override toMetaclass(org.eclipse.uml2.uml.Class class_) {
+		toMetaclass(class_, "metadata def")
+	}
+		
+	override toFeature(org.eclipse.uml2.uml.Property property) {
+		if (property.type instanceof DataType) {
+			toFeature(property, false, "attribute")
+		} else {
+			toFeature(property, false, if (property.isComposite) "item" else "ref item")
+		}
+	}
+	
+	override String getReservedWords() {
+		// Note: Every word must be preceded and followed by a space.
+	   " about abstract accept action actor after alias all allocate allocation 
+		 analysis and as assign assert assoc assume at attribute bind binding block 
+		 by calc case comment concern connect connection constraint decide def 
+		 default defined dependency derived do doc else end entry enum event exhibit 
+		 exit expose filter first flow for fork frame from hastype if implies import 
+		 in include individual inout interface istype item join language loop merge 
+		 message metadata nonunique not objective occurrence of or ordered out 
+		 package parallel part perform port private protected public readonly 
+		 redefines ref references render rendering rep require requirement return 
+		 satisfy send snapshot specializes stakeholder state subject subsets 
+		 succession then timeslice to transition until use variant variation 
+		 verification verify via view viewpoint when while xor "
+	}
+	
+	static def void main(String[] args) {
+		if (args.length >= 2) {
+			new MOF2SysMLText().generate(args.get(0), args.get(1))
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/generation/SysML.uml
+++ b/org.omg.sysml/src/org/omg/sysml/generation/SysML.uml
@@ -1,0 +1,8648 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_B3lO8EQmEe22v6M5Q5J7KQ" name="sysml" URI="http://www.omg.org/spec/SysML/2.0">
+  <packagedElement xmi:type="uml:Package" xmi:id="_B3l2AEQmEe22v6M5Q5J7KQ" name="Core">
+    <packagedElement xmi:type="uml:Association" xmi:id="4e619474-5ded-4862-991f-700a493ced6e" name="" visibility="public" memberEnd="cc61e3eb-73e2-4836-a445-33c2c6a1013c 8fe48f98-83c5-4f3f-a581-d91448105000">
+      <ownedEnd xmi:id="cc61e3eb-73e2-4836-a445-33c2c6a1013c" name="typeWithFeature" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="4e619474-5ded-4862-991f-700a493ced6e">
+        <ownedComment xmi:id="cbf60124-9d98-40de-b34e-032bc2b06f2f" annotatedElement="cc61e3eb-73e2-4836-a445-33c2c6a1013c">
+          <body>&lt;p>A Type that owns or inherits a FeatureMembership Relationship with the &lt;code>feature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9fff8571-72b5-498a-a0cc-6105e15157a6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="122ec273-2e84-4003-bdde-420af56d36be" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="98366e7d-ec7d-4b16-b0f5-b8ecdb20e459" name="" visibility="public" memberEnd="9c14a46a-333c-4d3c-91eb-da46ce999b0a 3ca86033-0058-4060-9c47-55615e79c06e">
+      <ownedEnd xmi:id="3ca86033-0058-4060-9c47-55615e79c06e" name="conjugator" visibility="public" type="0700b3ef-921a-4677-a325-db5e475a9240" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="98366e7d-ec7d-4b16-b0f5-b8ecdb20e459">
+        <ownedComment xmi:id="29e54d23-bbf0-45f0-bc8a-111df6a8d82c" annotatedElement="3ca86033-0058-4060-9c47-55615e79c06e">
+          <body>&lt;p>The Conjugation corresponding to the &lt;code>conjugatedType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="30eb0301-9684-41e4-ab90-28d9767e09b8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a925d8f0-6275-4e14-9f8b-264e1e2144d0" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e518ae28-4418-421b-a3a7-c7b965107e04" name="" visibility="public" memberEnd="f8a1f93f-9df4-4a69-87e9-c7953b995b8c 19afeeec-e3dc-4b97-a9cf-32a4873f33c9">
+      <ownedEnd xmi:id="19afeeec-e3dc-4b97-a9cf-32a4873f33c9" name="inheritingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="a30aa520-08d8-4370-937a-bfdf0d24795f" association="e518ae28-4418-421b-a3a7-c7b965107e04">
+        <ownedComment xmi:id="3a5adfc0-3ae1-4cbe-bafe-c8d297b3a048" annotatedElement="19afeeec-e3dc-4b97-a9cf-32a4873f33c9">
+          <body>&lt;p>The Type that inherits the &lt;code>inheritedMembership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="93517368-10e9-4595-832c-097b835db17c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a066cdd4-3d95-415a-86a2-952c6ba46540" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e17d07b1-306e-4ecd-9e27-1e24970f7e86" name="" visibility="public" memberEnd="96b9fc9e-2547-4f5a-b114-4b5ec9f01a77 77c1ed60-89c8-47d0-9615-bfcce38ed603"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="0700b3ef-921a-4677-a325-db5e475a9240" name="Conjugation" visibility="public">
+      <ownedComment xmi:id="e6917641-5287-4fba-825e-d655e1201aff" annotatedElement="0700b3ef-921a-4677-a325-db5e475a9240">
+        <body>&lt;p>Conjugation is a Relationship between two types in which the &lt;code>conjugatedType&lt;/code> inherits all the Features of the &lt;code>originalType&lt;/code>, but with all &lt;code>input&lt;/code> and &lt;code>output&lt;/code> Features reversed. That is, any Features with a FeatureMembership with &lt;code>direction&lt;/code> &lt;em>in&lt;/em> relative to the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>out&lt;/em> relative to the &lt;code>conjugatedType&lt;/code> and, similarly, Features with &lt;code>direction&lt;/code> &lt;em>out&lt;/em> in the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>in&lt;/em> in the &lt;code>originalType&lt;/code>. Features with &lt;code>direction&lt;/code> &lt;em>inout&lt;/em>, or with no &lt;code>direction&lt;/code>, in the &lt;code>originalType&lt;/code>, are inherited without change.&lt;/p>
+
+&lt;p>A Type may participate as a &lt;code>conjugatedType&lt;/code> in at most one Conjugation relationship, and such a Type may not also be the &lt;code>specific&lt;/code> Type in any Generalization relationship.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="d0fd8686-5a96-4490-831c-4dc2c48341d9" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="1a94208b-8320-4353-a599-b68806aed393" name="originalType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="de47bd7f-ba3d-402e-850b-d49eb622702d">
+        <ownedComment xmi:id="b30aede2-a81d-4c96-ab46-8601ae2f405e" annotatedElement="1a94208b-8320-4353-a599-b68806aed393">
+          <body>&lt;p>The Type to be conjugated.&lt;/P></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9cdc0fe1-53ab-499a-bdb7-3a46351ac865" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="db088c7d-ac3e-435c-ac43-423dff95650a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9c14a46a-333c-4d3c-91eb-da46ce999b0a" name="conjugatedType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="98366e7d-ec7d-4b16-b0f5-b8ecdb20e459">
+        <ownedComment xmi:id="d3b0e442-23ab-4a7b-b0bf-85cca8f29506" annotatedElement="9c14a46a-333c-4d3c-91eb-da46ce999b0a">
+          <body>&lt;p>The Type that is the result of applying Conjugation to the &lt;code>originalType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8954adf9-5dcf-49a0-a572-4c06f756c55d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a48c7f5d-6e6d-43e7-bf68-c17c11170935" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9ff6b50f-f460-482b-87eb-ee1e2b945f99" name="owningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="9c14a46a-333c-4d3c-91eb-da46ce999b0a 53d1b371-a5c5-4812-87a8-a61e672f7314" association="7056904b-1e7f-4ad0-a58e-4f09bdcbcd3a">
+        <ownedComment xmi:id="5d1b805d-333a-4298-a7b1-ba9aff3fc265" annotatedElement="9ff6b50f-f460-482b-87eb-ee1e2b945f99">
+          <body>&lt;p>The &lt;code>conjugatedType&lt;/code> of this Type that is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e62da26-5495-4a79-a076-8d819b8fdc0b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4ba3d453-97d0-4dec-bf69-fd9970505f72" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="4e5f8972-c473-4bc0-8edf-bb508993d08e" name="Type" visibility="public">
+      <ownedComment xmi:id="57beb593-6ed1-4d70-820b-e55bd97d808a" annotatedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <body>&lt;p>A Type is a Namespace that is the most general kind of Element supporting the semantics of classification. A Type may be a Classifier or a Feature, defining conditions on what is classified by the Type (see also the description of &lt;code>isSufficient&lt;/code>).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="ff79e95d-385d-4926-9397-610b753a6b12" name="typeOwnedSpecialization" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="f39bf72c-2074-4698-9f25-688650a7f271" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedSpecialization = ownedRelationship->selectByKind(Specialization)->
+    select(g | g.special = self)
+    </body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="34487690-4e7f-47a9-8d41-b976a9b945ce" name="typeMultiplicity" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="1f150da5-24a8-4ffa-9b4c-4cf38a9c938a" annotatedElement="34487690-4e7f-47a9-8d41-b976a9b945ce">
+          <body>&lt;p>The &lt;code>multiplicity&lt;/code> of this Type is all its &lt;code>features&lt;/code> that are Multiplicities. (There must be at most one.)&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="449cf0b2-507d-438e-9ff4-d0d5facfe2e8" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>multiplicity = feature->select(oclIsKindOf(Multiplicity))</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="ef969b3f-6880-40ce-be92-e4b1b6d84181" name="typeOwnedFeatureMembership" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="3e533ac8-4463-4eeb-8b8b-1bdae7a194b1" annotatedElement="ef969b3f-6880-40ce-be92-e4b1b6d84181">
+          <body>&lt;p>The &lt;code>ownedFeatureMemberships&lt;/code> of a Type are its &lt;code>ownedMemberships&lt;/code> that are FeatureMemberships.&lt;/code></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c4368395-bb8d-409f-bddd-da68bed946b3" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedFeatureMembership = ownedRelationship->selectByKind(FeatureMembership)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="383d9f44-7dce-4a83-bbcd-f683b0c66c7f" name="typeOwnedConjugator" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="101ae55f-960d-4958-ba65-a2c7bd508d2c" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>let ownedConjugators: Sequence(Conjugator) = 
+    ownedRelationship->selectByKind(Conjugation) in
+    ownedConjugators->size() = 1 and
+    ownedConjugator = ownedConjugators->at(1)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="ed0661d4-7d9e-45cc-83ef-d1d6be343426" name="typeOutput" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="9d6e0f54-ba48-47c7-bf31-89abcb2964d8" annotatedElement="ed0661d4-7d9e-45cc-83ef-d1d6be343426">
+          <body>&lt;p>If this Type is conjugated, then its &lt;code>outputs&lt;/code> are the &lt;code>inputs&lt;/code> of the &lt;code>originalType&lt;/code>. Otherwise, its &lt;code>outputs&lt;/code> are all &lt;code>features&lt;/code> with FeatureMembership &lt;code>direction&lt;/code> of &lt;code>out&lt;/code> or &lt;code>inout&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="3ea7d254-eae5-42b8-bad7-662bbb451398" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>output =
+    if isConjugated then 
+        conjugator.originalType.input
+    else 
+        feature->select(direction = out or direction = inout)
+    endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="50437a6a-9f0a-4b0e-b828-eafa35d6ad54" name="typeInput" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="b21684a5-35ab-4b1c-9fff-2aea10bd46fe" annotatedElement="50437a6a-9f0a-4b0e-b828-eafa35d6ad54">
+          <body>&lt;p>If this Type is conjugated, then its &lt;code>inputs&lt;/code> are the &lt;code>outputs&lt;/code> of the &lt;code>originalType&lt;/code>. Otherwise, its &lt;code>inputs&lt;/code> are all &lt;code>features&lt;/code> with FeatureMembership &lt;code>direction&lt;/code> of &lt;code>in&lt;/code> or &lt;code>inout&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="1b97991a-0cb3-404a-acdc-03661ba67b50" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>input = 
+    if isConjugated then 
+        conjugator.originalType.output
+    else 
+        feature->select(direction = _'in' or direction = inout)
+    endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="6c16ef4d-8a24-4f8c-b753-daae2afa66da" name="typeInheritedMembership" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="f486d938-be2d-4c67-8f63-1359c80bb010" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>inheritedMembership = inheritedMemberships(Set{})</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="5e5a9aa2-0736-44c7-ad58-3a35e2f6e7a8" name="typeDisjointType" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="47d4da23-31f0-4de6-bf18-5bfb44df2b4f" name="" visibility="public">
+          <language>English</language>
+          <body>disjointType = disjoiningTypeDisjoining.disjoiningType</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="2e190174-5c09-4447-ba4a-8b121a2fb2f7" name="typeSpecializesAnything" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="39f2dc78-8746-4cde-b68c-d8cbe2e1a64e" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::Anything)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="19be55ee-7bc2-40a8-9708-42dfec9ad986" name="typeDirectedFeature" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="715376b2-cd2d-4999-b2a2-711b579d5914" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>directedFeature = feature->select(direction &lt;> null)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="c39ee6c0-80a1-469d-b49d-52abe72e8fa2" name="typeFeature" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="0a644fab-11e6-412c-9a28-2b802af0df35" annotatedElement="c39ee6c0-80a1-469d-b49d-52abe72e8fa2">
+          <body>&lt;p>The &lt;code>features&lt;/code> of a Type are the &lt;code>ownedMemberFeatures&lt;/code> of its &lt;code>featureMemberships&lt;/code>.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="a00dfb9d-9cda-49a3-a98c-70954608bbf3" name="" visibility="public">
+          <language>English</language>
+          <body>feature = featureMembership.ownedMemberFeature</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="f8b31aec-9365-41f2-a5f8-88cef9b82355" name="typeFeatureMembership" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="69ff0afb-3315-4c05-9a6a-81a2e79d5501" annotatedElement="f8b31aec-9365-41f2-a5f8-88cef9b82355">
+          <body>&lt;p>The &lt;code>featureMemberships&lt;/code> of a Type is the union of the &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are FeatureMemberships.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="105c27c4-4501-42f9-9208-9d40dd92df98" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>featureMembership = ownedMembership->union(
+    inheritedMembership->selectByKind(FeatureMembership))</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="4311c465-4768-4ee2-83a8-cb81e703310d" name="typeOwnedFeature" visibility="public">
+        <ownedComment xmi:id="a55e1887-9192-499a-b43d-9dbe9fa9e342" annotatedElement="4311c465-4768-4ee2-83a8-cb81e703310d">
+          <body>&lt;p>The &lt;code>ownedFeatures&lt;/code> of a Type are the &lt;code>ownedMemberFeatures&lt;/code> of its &lt;code>ownedFeatureMemberships&lt;/code>.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="5ef8aa49-0fc2-444a-a3a2-0799a667f0f7" name="" visibility="public">
+          <language>English</language>
+          <body>ownedFeature = ownedFeatureMembership.ownedMemberFeature</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="b74736ea-8d47-41bf-84c9-538fbcd35469" name="typeValidateIntersectingTypesNotSelf" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="3039c760-b498-47f8-aa09-f70224afb471" annotatedElement="b74736ea-8d47-41bf-84c9-538fbcd35469">
+          <body>&lt;p>A Type cannot be one of its own &lt;code>intersectingTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="6b13eaf1-84d1-44b4-832f-324ecddaea7e" name="" visibility="public">
+          <language>English</language>
+          <body>intersectingType->excludes(self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="5856fbdb-809b-4ea0-9bd0-1aed831c8c0c" name="typeValidateunioningTypesNotSelf" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="438da03d-c6e9-48f5-8d8f-4f66848e6d06" annotatedElement="5856fbdb-809b-4ea0-9bd0-1aed831c8c0c">
+          <body>&lt;p>A Type cannot be one of its own &lt;code>unioningTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="59a0f268-72cc-4098-a228-c22d023b8f20" name="" visibility="public">
+          <language>English</language>
+          <body>unioningType->excludes(self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="2a12988b-e742-4739-a5e8-1783704e1669" name="typeValidateDifferencingTypesNotSelf" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="fa082930-dc06-4c78-b8ac-2e6307712e30" annotatedElement="2a12988b-e742-4739-a5e8-1783704e1669">
+          <body>&lt;p>A Type cannot be one of its own &lt;code>differencingTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="f04586d2-be27-4afc-9954-1b15531993d2" name="" visibility="public">
+          <language>English</language>
+          <body>differencingType->excludes(self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="6405d04f-3cb2-458c-b8e9-18aed8bb4360" name="typeDifferencingType" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="78a8c831-8e21-4149-8edb-140e8adc7d8e" annotatedElement="6405d04f-3cb2-458c-b8e9-18aed8bb4360">
+          <body>&lt;p>The &lt;code>differencingTypes&lt;/code> of a Type are the &lt;code>differencingTypes&lt;/code> of its &lt;code>ownedDifferencings&lt;/code>, in the same order.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="764d2784-f5d6-455c-8abe-60b6c289bea3" name="" visibility="public">
+          <language>English</language>
+          <body>differencingType = ownedDifferencing.differencingType</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="c7cf7f65-11b7-4d79-ab55-549b2b539513" name="typeUnioningType" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="1c1c7f2e-bf7f-4fca-be6a-18832204d23c" annotatedElement="c7cf7f65-11b7-4d79-ab55-549b2b539513">
+          <body>&lt;p>The &lt;code>unioningTypes&lt;/code> of a Type are the &lt;code>unioningTypes&lt;/code> of its &lt;code>ownedUnionings&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="bbc4fc93-2266-4097-86c9-c42f20bee1f4" name="" visibility="public">
+          <language>English</language>
+          <body>unioningType = ownedUnioning.unioningType</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="d5ccc02f-3a7b-449a-8fa1-5735982e3c74" name="typeIntersectingType" visibility="public" constrainedElement="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+        <ownedComment xmi:id="153ced4a-96ea-4307-b214-aabb0a5add4f" annotatedElement="d5ccc02f-3a7b-449a-8fa1-5735982e3c74">
+          <body>&lt;p>The &lt;code>intersectingTypes&lt;/code> of a Type are the &lt;code>intersectingTypes&lt;/code> of its &lt;code>ownedIntersectings&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="37773205-bd9f-4a51-8aaa-cd7b61a4fb20" name="" visibility="public">
+          <language>English</language>
+          <body>intersectingType = ownedIntersecting.intersectingType</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="b5a2bf16-d780-4e1c-b292-186e69689473" general="732bd40e-fb64-42e2-8663-8fcee1dac982"/>
+      <ownedAttribute xmi:id="d65bfe47-3744-4fb9-a371-dc053aabfccd" name="ownedSpecialization" visibility="public" type="57982b55-8eb5-404e-8e46-e2e7b774a2b0" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="4ed80006-8937-46a9-bea5-caf85682af75 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="77258d7e-6bf1-4380-beb8-7a6db52bede7">
+        <ownedComment xmi:id="1132193c-70df-4128-967f-671d229a0e8d" annotatedElement="d65bfe47-3744-4fb9-a371-dc053aabfccd">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Type that are Specializations, for which the Type is the &lt;code>specific&lt;/code> Type.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5875f8d9-6691-422d-b651-7e39d2518bfc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="69dbcacc-843a-4115-9e35-5a4ea89ae16b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ffadf08a-7517-4eb0-8cb7-602addfe782f" name="ownedFeatureMembership" visibility="public" type="387c1ace-4ad1-44eb-b8b5-bfe420975a97" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="ec58580f-851c-4202-a5c6-27b2ec9ac376 b669780b-9354-418a-8996-25a9ce4a716b c056ca13-346f-46f4-b73e-d631bd031423" association="3da7524b-b56c-40a8-b2eb-e7003088de43">
+        <ownedComment xmi:id="4481d735-140a-4cae-b8a9-c74ce5e17d88" annotatedElement="ffadf08a-7517-4eb0-8cb7-602addfe782f">
+          <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this Type that are FeatureMemberships, for which the Type is the &lt;code>owningType&lt;/code>. Each such FeatureMembership identifies an &lt;code>ownedFeature&lt;/code> of the Type.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2ff72dd9-33ed-4842-bf51-5e1bdd1ef3be" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="431cdd98-e4ed-41fe-9b47-536765b86779" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8fe48f98-83c5-4f3f-a581-d91448105000" name="feature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="4e619474-5ded-4862-991f-700a493ced6e">
+        <ownedComment xmi:id="6cb183d3-5e6b-472d-8389-694a77a17ba7" annotatedElement="8fe48f98-83c5-4f3f-a581-d91448105000">
+          <body>&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>featureMemberships&lt;/code> of this Type.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="932d792e-1827-46f9-9cdd-584925c42ca5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="18f20341-72b0-4b03-8351-0b800913b7b1" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ea59f6ae-8a27-4163-a651-91da11bbfa67" name="ownedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="4f16dcf2-4258-41d7-a3c5-62770d9e0b31">
+        <ownedComment xmi:id="211dd34e-0d97-44ed-bf98-4052f95825d7" annotatedElement="ea59f6ae-8a27-4163-a651-91da11bbfa67">
+          <body>&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of this Type.&lt;/code>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b891d52f-869e-40ba-9789-8802011fbb1f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="95e31fe6-a2a8-4333-9a58-e34420d914f2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="3b5717ec-fb61-4c3c-8879-87f9a3194605" name="input" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="ee47daa4-a81f-4204-b23b-bfc54283691f" association="0318c38c-c817-4237-8267-2645fc0e5bf3">
+        <ownedComment xmi:id="0f5b25e5-b85f-44cd-925b-e776ab004434" annotatedElement="3b5717ec-fb61-4c3c-8879-87f9a3194605">
+          <body>&lt;p>All &lt;code>features&lt;/code> related to this Type by FeatureMemberships that have &lt;code>direction&lt;/code> &lt;code>in&lt;code> or &lt;code>inout&lt;code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a812e94a-b29b-4b34-ac5e-88831a125224" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="86f2da59-5205-4e87-bb53-8c7ecebd8ea1" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b458eea7-79b9-4c8f-a066-b9d0dbd03ec8" name="output" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="ee47daa4-a81f-4204-b23b-bfc54283691f" association="5bfc08f0-c4e5-4bd6-9129-4d121cdff1b2">
+        <ownedComment xmi:id="9a31d84e-e296-454c-99a2-79e9a5ab53bd" annotatedElement="b458eea7-79b9-4c8f-a066-b9d0dbd03ec8">
+          <body>&lt;p>All &lt;code>features&lt;/code> related to this Type by FeatureMemberships that have &lt;code>direction&lt;/code> &lt;code>out&lt;code> or &lt;code>inout&lt;code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="84fd72e7-3567-497d-bea9-291915b23b85" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="53605470-24ce-41e0-8ac7-ab439caef2f7" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="481c3c0d-a747-440b-b0bf-6eec80319ffc" name="isAbstract" visibility="public">
+        <ownedComment xmi:id="70611b14-4dde-4293-8794-db3db9b4d72a" annotatedElement="481c3c0d-a747-440b-b0bf-6eec80319ffc">
+          <body>&lt;p>Indicates whether instances of this Type must also be instances of at least one of its specialized Types.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="ce12dc5a-83fc-44a5-bc93-9eb818d92844" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f8a1f93f-9df4-4a69-87e9-c7953b995b8c" name="inheritedMembership" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" isDerived="true" subsettedProperty="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634" association="e518ae28-4418-421b-a3a7-c7b965107e04">
+        <ownedComment xmi:id="d15cdd27-1d2e-4b4d-ae8c-e757cafcb782" annotatedElement="f8a1f93f-9df4-4a69-87e9-c7953b995b8c">
+          <body>&lt;p>All Memberships inherited by this Type via Generalization or Conjugation. These are included in the derived union for the &lt;code>memberships&lt;/code> of the Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bce5ea4b-8a32-4487-9b97-5cefe8c97eb0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a9a7a08b-2fa9-4f4c-a9e1-8a53c3f0c8dc" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a845e308-0fa7-49d9-9d90-152949ecf7e1" name="endFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="4bcbfc49-bacd-4efe-a7f0-119b708bbdaf">
+        <ownedComment xmi:id="430537fc-d9dc-4893-8fb0-93e4f6c00a3d" annotatedElement="a845e308-0fa7-49d9-9d90-152949ecf7e1">
+          <body>&lt;p>All &lt;code>features&lt;/code> related to this Type by EndFeatureMemberships.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="95b90e73-0a8d-4dee-952f-855fa2799202" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="59bf70fe-9bdd-43e3-a0e3-45880b6651af" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="96b9fc9e-2547-4f5a-b114-4b5ec9f01a77" name="ownedEndFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="a845e308-0fa7-49d9-9d90-152949ecf7e1 ea59f6ae-8a27-4163-a651-91da11bbfa67" association="e17d07b1-306e-4ecd-9e27-1e24970f7e86">
+        <ownedComment xmi:id="f267a64c-26f6-4005-b316-6eb9b91e54cf" annotatedElement="96b9fc9e-2547-4f5a-b114-4b5ec9f01a77">
+          <body>&lt;p>All &lt;code>endFeatures&lt;/code> of this Type that are &lt;code>ownedFeatures&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ae979c7a-b98a-4af1-8534-b56f1a280533" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f22fa713-6874-4cd7-a7a7-823a2b7f27c2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="93ddd220-4af3-46c5-aa6d-221ac645bd1d" name="isSufficient" visibility="public">
+        <ownedComment xmi:id="cc361d67-2bb7-4462-ae8d-4946f0fe7a4a" annotatedElement="93ddd220-4af3-46c5-aa6d-221ac645bd1d">
+          <body>&lt;p>Whether all things that meet the classification conditions of this Type must be classified by the Type.&lt;/p>
+
+&lt;p>(A Type&amp;nbsp;gives conditions that must be met by whatever it classifies, but when &lt;code>isSufficient&lt;/code> is false, things may meet those conditions but still not be classified by the Type. For example, a Type &lt;code>&lt;em>Car&lt;/em>&lt;/code> that is not sufficient could require everything it classifies to have four wheels, but not all four wheeled things would need to be cars. However, if the type &lt;code>&lt;em>Car&lt;/em>&lt;/code> were sufficient, it would classify all four-wheeled things.)&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="6f04779b-0029-4ad6-a6bb-a94aae99d8ad" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a41e0e5b-2f38-490c-ba49-036643b528f4" name="ownedConjugator" visibility="public" type="0700b3ef-921a-4677-a325-db5e475a9240" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 3ca86033-0058-4060-9c47-55615e79c06e" association="7056904b-1e7f-4ad0-a58e-4f09bdcbcd3a">
+        <ownedComment xmi:id="364f078b-ca16-4653-a271-bb8a6c7a3e64" annotatedElement="a41e0e5b-2f38-490c-ba49-036643b528f4">
+          <body>&lt;p>A Conjugation owned by this Type for which the Type is the &lt;code>originalType&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b1fb534e-323d-4d88-a246-f276b81d9a2f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="409b9849-3b78-4ee1-aa0a-44f18faa3939" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ee21c59f-4e16-4815-bd37-cffebd5f1b3e" name="isConjugated" visibility="public" isDerived="true">
+        <ownedComment xmi:id="c03d62c7-8c77-428d-8c2a-baf9ae89ba20" annotatedElement="ee21c59f-4e16-4815-bd37-cffebd5f1b3e">
+          <body>&lt;p>Indicates whether this Type has an &lt;code>ownedConjugator&lt;/code>. (See Conjugation.)&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="69e265a6-d371-4570-8146-c8e0f54f6c13" name="inheritedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="aad4e8ec-6356-4e76-869f-d7e13e659a79">
+        <ownedComment xmi:id="1453787a-1a16-4911-a524-91070a8aef09" annotatedElement="69e265a6-d371-4570-8146-c8e0f54f6c13">
+          <body>&lt;p>All the &lt;code>memberFeatures&lt;/code> of the &lt;code>inheritedMemberships&lt;/code> of this Type.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c2b83d39-81c2-43df-9b0b-abc46d2b840e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="090ebe75-1e60-42e9-9b7e-98f97dc4852e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cb478b2f-7312-412f-8a6e-84567fc2391e" name="multiplicity" visibility="public" type="50f20a49-7ff4-48b1-aac0-8f6ee31b322f" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="010f880b-1eb5-4c5d-a8f4-4fc507ab0398">
+        <ownedComment xmi:id="d3c08679-09b4-49d8-a85c-6d0f55d4debf" annotatedElement="cb478b2f-7312-412f-8a6e-84567fc2391e">
+          <body>&lt;p>The one &lt;code>member&lt;/code> (at most) of this Type that is a Multiplicity, which constrains the cardinality of the Type. A &lt;code>multiplicity&lt;/code> can be owned or inherited. If it is owned, the &lt;code>multiplicity&lt;/code> must redefine the &lt;code>multiplicity&lt;/code> (if it has one) of any &lt;code>general&lt;/code> Type of a &lt;code>Generalization&lt;/code> of this Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="155ccd41-368c-4d2d-a90e-ff9223a5f927" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fe16d477-e25c-4e80-bde4-d92c329acb3f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="168e1cd6-0b19-4677-823d-905d7fad3b40" name="unioningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isDerived="true" association="c38c5572-8297-4603-88d2-dbd472d3d22a">
+        <ownedComment xmi:id="03f6dfae-893b-4df1-bf7d-f11c74d72229" annotatedElement="168e1cd6-0b19-4677-823d-905d7fad3b40">
+          <body>&lt;p>The interpretations of a Type with code>unioningTypes&lt;/code> are asserted to be the same as those of all the &lt;code>unioningTypes&lt;/code> together, which are the Types  derived from the &lt;code>unioningType&lt;/code> of the &lt;code>ownedUnionings&lt;/code> of this Type.  For example, a Classifier for people might be the union of Classifiers for all the sexes. Similarly, a feature for people's children might be the union of features dividing them in the same ways as people in general.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ead2fa48-38ce-4fda-b9ce-f51ee643f8fd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e53c7594-4ac1-4333-943b-8df75f6ae1fa" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="92ab0f3d-b26f-4497-ba6a-1ffb46704d9b" name="ownedIntersecting" visibility="public" type="99b14ebc-9aed-4137-9c55-755bba106570" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="06ab200c-b8f6-438a-a846-cc80923fcfe7">
+        <ownedComment xmi:id="2d042151-afc1-41e6-97e5-8a970177161f" annotatedElement="92ab0f3d-b26f-4497-ba6a-1ffb46704d9b">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Type that are Intersectings, have the Type as their &lt;code>typeIntersected&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="175aa3c7-e1d0-433b-8efc-da04e275a941" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5cb88db4-fea5-4ffd-af0f-f719eaa5950a" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="27a9fafe-1ba5-45f7-a063-7bf97be980e8" name="intersectingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isDerived="true" association="6a704912-6a7e-47cd-9e98-f9f8712143fd">
+        <ownedComment xmi:id="f920a6d3-a06a-4bd2-81ba-85b960660581" annotatedElement="27a9fafe-1ba5-45f7-a063-7bf97be980e8">
+          <body>&lt;p>The interpretations of a Type with code>intersectingTypes&lt;/code> are asserted to be those in common among the &lt;code>intersectingTypes&lt;/code>, which are the Types derived from the &lt;code>intersectingType&lt;/code> of the &lt;code>ownedIntersectings&lt;/code> of this Type.  For example, a Classifier might be an intersection of Classifiers for people of a particular sex and of a particular nationality.  Similarly, a feature for people's children of a particular sex might be the intersection of a feature for their children and a Classifier for people of that sex (because the interpretations of the children feature that identify those of that sex are also interpretations of the Classifier for that sex).&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="73c1da13-d644-4c33-bb10-b8da4ef9b799" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="210554f7-e8e1-4415-995e-f38b6fcd69f6" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f731d3dc-a39d-4a0a-aac5-587dc33c4186" name="ownedUnioning" visibility="public" type="116d1d35-732b-4d36-a215-2bdca9032293" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="6587f943-389a-4000-a9ac-f93f0805490f">
+        <ownedComment xmi:id="71a9d86f-dd17-4492-80b6-81137e3d0db5" annotatedElement="f731d3dc-a39d-4a0a-aac5-587dc33c4186">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Type that are Unionings, having the Type as their &lt;code>typeUnioned&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3824ee59-8b12-4c45-92ed-ee3bebffd594" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0cead3ce-30f2-4852-949a-8ba3b1ea72e3" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4effb986-d628-43eb-88c4-4d182c61bbc5" name="ownedDisjoining" visibility="public" type="544b8eca-7cea-4781-b2d2-410d352d29cd" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 84ff749d-1772-4449-b192-d4d04a8aefcb" association="37e6acd2-40a4-4ad8-814c-d360fc8bb929">
+        <ownedComment xmi:id="2529f235-55a6-45bb-9202-a8e3fbae7fc3" annotatedElement="4effb986-d628-43eb-88c4-4d182c61bbc5">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Type that are Disjoinings, for which the Type is the &lt;code>typeDisjoined&lt;/code> Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1c7a4754-1122-47dc-b7af-eb5844729afe" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="48d3738f-7713-49ff-9b9c-a0cd204569fb" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b669780b-9354-418a-8996-25a9ce4a716b" name="featureMembership" visibility="public" type="387c1ace-4ad1-44eb-b8b5-bfe420975a97" isOrdered="true" isDerived="true" association="56d168d2-f619-4817-8609-fa6b85954af0">
+        <ownedComment xmi:id="949ca398-07a1-4c6d-b7d5-53fa362e371d" annotatedElement="b669780b-9354-418a-8996-25a9ce4a716b">
+          <body>&lt;p>The FeatureMemberships for &lt;code>features&lt;/code> of this Type, which include all &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are FeatureMemberships (but does &lt;em>not&lt;/em> include any &lt;code>importedMemberships&lt;/code>).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="09aa1aee-545b-4686-8a28-ec4919c3a058" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d133c166-4409-410b-9cd6-833f7d1d0f2e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="40171618-9e0f-43a6-8faa-bb6c2a6642c9" name="differencingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isDerived="true" association="c809f6c8-a17c-45e5-9bcc-575dea0b36a5">
+        <ownedComment xmi:id="f94cd0a1-4e2a-401b-9cc7-3dd351095a15" annotatedElement="40171618-9e0f-43a6-8faa-bb6c2a6642c9">
+          <body>&lt;p>The interpretations of a Type with &lt;code>differencingTypes&lt;/code> are asserted to be those of the first of those Types, but not including those of the remaining types. For example, a Classifier might be the difference of a Classifier for people and another for people of a particular nationality, leaving people who are not of that nationality. Similarly, a feature of people might be the difference between a feature for their children and a Classifier for people of a particular sex, identifying their children not of that sex (because the interpretations of the children feature that identify those of that sex are also interpretations of the Classifier for that sex).&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="93424ebb-fbb1-4dba-8c23-53aa4694ce1d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="47aec917-cb21-4d8e-9a3a-e4331677c632" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="363b5f13-6a3a-41c0-9160-010d73c6beb2" name="ownedDifferencing" visibility="public" type="7b996a20-4abc-464d-b3a2-0c43aa886490" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 1807da4c-d8f2-454f-911f-8a98c3302238" association="97eff77d-cec8-4b8c-8940-9caf54371062">
+        <ownedComment xmi:id="dcd784c7-8ab1-4590-ba4e-77c790b4ad2c" annotatedElement="363b5f13-6a3a-41c0-9160-010d73c6beb2">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Type that are Differencings, having this Type as their &lt;code>typeDifferenced&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="468523bb-32e8-48c1-8e11-e6168e21fb38" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7180f76c-28d6-4cb9-885d-08023901e058" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ee47daa4-a81f-4204-b23b-bfc54283691f" name="directedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="431c1a4f-8a50-4537-aeea-9db448315ba8">
+        <ownedComment xmi:id="f7fe6b43-7248-453c-a832-dac44ccf4be9" annotatedElement="ee47daa4-a81f-4204-b23b-bfc54283691f">
+          <body>&lt;p>The &lt;code>features&lt;/code> of this Type that have a non-null &lt;code>direction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="239e7f53-030c-4bc9-9541-8348613aad33" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="42dc2a4d-ce76-401f-b979-dda8af0f2954" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="1eff65fe-604a-4bbc-bded-299c99c83e75" name="visibleMemberships" visibility="public" bodyCondition="8ab6d558-d912-442d-bfa6-5fd538aa8aa4" redefinedOperation="f4285a30-2753-41d1-a00b-79fbc140cff0">
+        <ownedComment xmi:id="0df1965a-3c49-4058-9d57-2fb241bab6b7" annotatedElement="1eff65fe-604a-4bbc-bded-299c99c83e75">
+          <body>&lt;p>The visible Memberships of a Type include  &lt;code>inheritedMemberships&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="8ab6d558-d912-442d-bfa6-5fd538aa8aa4" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="55a09e63-9981-46e2-87ef-d4782b30c62d" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let visibleInheritedMemberships : Sequence(Membership) = 
+    inheritedMemberships(excluded)->
+        select(includeAll or visibility = VisibilityKind::public) in
+self.oclAsType(Namespace).visibleMemberships(excluded, isRecursive, includeAll)->
+    union(visibleInheritedMemberships)</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="76d4db38-0ce9-427c-be49-a7496183090d" name="excluded" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fdb855b2-903a-4e31-9514-e695e8a4225b" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="273a03c8-9348-4806-a6ee-150e5e391b7f" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="e814badc-d94f-4d30-a776-f20fac36565a" name="isRecursive" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="f47fcc39-6f3b-4d59-89c4-8b2e6314f235" name="includeAll" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="a3c8aaf7-e2e8-4d67-8760-cd16aeac3886" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fd84b9c7-edde-42ae-9cb9-b6c8210f2226" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d7ec2c79-2151-4447-8e19-51db3bdc2bbb" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="b476f328-f34d-4e24-8729-694c28fe42cf" name="inheritedMemberships" visibility="public">
+        <ownedComment xmi:id="65022e4f-ff3e-4055-b234-d4649a12dd72" annotatedElement="b476f328-f34d-4e24-8729-694c28fe42cf">
+          <body>&lt;p>Return the inherited Memberships of this Type, excluding those supertypes in the &lt;code>excluded&lt;/code> set.&lt;/code></body>
+        </ownedComment>
+        <ownedParameter xmi:id="d6e5c3d0-2655-4b7d-89f6-10ce13b8f35f" name="excluded" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ce0e090b-b0b3-4454-9d81-2f90c176a7fa" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f70d317b-5167-4aae-a24b-663f2be09967" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="7bc9036c-4435-414f-918a-f7f26f23932d" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2e4da62e-e1dc-4463-af6d-541bf962af25" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ea88f285-e302-46f3-9950-962ec92c25b6" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="a9909308-b231-4b9e-89be-b4b913c53eaa" name="directionOf" visibility="public" bodyCondition="cca1c3b1-ad36-457a-8859-e620e0bfe34a">
+        <ownedComment xmi:id="a92bf893-31cc-4487-aecc-6db3a8d3c09f" annotatedElement="a9909308-b231-4b9e-89be-b4b913c53eaa">
+          <body>&lt;p>If the given feature is a feature of this type, then return its direction relative to this type, taking conjugation into account.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="cca1c3b1-ad36-457a-8859-e620e0bfe34a" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="a4854b51-9821-48aa-ab51-ec5e6557cfd4" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if input->includes(feature) and output->includes(feature) then 
+    FeatureDirectionKind::inout
+else if input->includes(feature) then 
+    FeatureDirectionKind::_'in'
+else if output->includes(feature) then 
+    FeatureDirectionKind::out
+else 
+    null 
+endif endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="9e2001ff-bed1-4444-b677-de24a51ee926" name="feature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+        <ownedParameter xmi:id="85d75098-1190-4e37-a35f-6a27f43c80dd" name="" visibility="public" type="1fb9436a-0c88-4c70-8d2b-ad0e3e39f930" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a925daa0-be00-47d6-9f56-375b18a3e9be" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6072c956-48c8-413f-a711-f0aeea3c7f82" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="b9629656-f9c6-4124-8585-a6ecee26cc08" name="allSupertypes" visibility="public" bodyCondition="417fb19d-de21-40b3-8f17-17b0cf625935">
+        <ownedComment xmi:id="630dcaea-6418-48ed-8a7f-97f5c1c469ee" annotatedElement="b9629656-f9c6-4124-8585-a6ecee26cc08">
+          <body>&lt;p>Return all Types related to this Type as supertypes directly or transitively by Generalization Relationships.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="417fb19d-de21-40b3-8f17-17b0cf625935" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="45ad8561-206f-416e-bc5e-f3804ee0280b" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization->
+    closure(general.ownedSpecialization).general->
+    including(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="684a9f28-42db-4d16-906c-399678c08b95" name="result" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4eb06615-bf24-4667-95d6-3477a23b199b" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="def14b88-7f87-4c4d-8d15-3d3f1f451c45" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="fdb9a37c-62ef-45fc-ae1e-b90cf2f6b80c" name="" visibility="public" memberEnd="60057a5e-bbd3-47ef-a196-f92331986f69 54e06fce-d930-402e-a444-06c0beed5c85">
+      <ownedEnd xmi:id="54e06fce-d930-402e-a444-06c0beed5c85" name="differencedDifferencing" visibility="public" type="7b996a20-4abc-464d-b3a2-0c43aa886490" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="fdb9a37c-62ef-45fc-ae1e-b90cf2f6b80c">
+        <ownedComment xmi:id="a28de50f-7b63-4dd2-9257-9978452b59a4" annotatedElement="54e06fce-d930-402e-a444-06c0beed5c85">
+          <body>&lt;p>The Differencings that identify this Type as their &lt;code>differencingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="df16b50f-faa7-430f-8887-6ca0e479c99e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="49bc5e7a-a528-40c1-b7c2-98b292c69dee" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="56d168d2-f619-4817-8609-fa6b85954af0" name="" visibility="public" memberEnd="b669780b-9354-418a-8996-25a9ce4a716b e89c4dc4-6d61-42d7-864f-86f1fda41a67">
+      <ownedEnd xmi:id="e89c4dc4-6d61-42d7-864f-86f1fda41a67" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" association="56d168d2-f619-4817-8609-fa6b85954af0">
+        <ownedComment xmi:id="9971d18a-80dd-4e8f-82bf-70458309b4f3" annotatedElement="e89c4dc4-6d61-42d7-864f-86f1fda41a67">
+          <body>&lt;p>A Type that owns or inherits the &lt;code>featureMembership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="78338fa1-c023-4624-b28b-6cdf0af160c7" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c763b0e2-e2ca-413b-a5f6-2fb7058d5976" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c8a3b9fc-928b-4695-8303-0651dddb9530" name="" visibility="public" memberEnd="db88a7ad-ac20-4c44-9b19-26b4444dac25 4ed80006-8937-46a9-bea5-caf85682af75">
+      <ownedEnd xmi:id="4ed80006-8937-46a9-bea5-caf85682af75" name="specialization" visibility="public" type="57982b55-8eb5-404e-8e46-e2e7b774a2b0" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="c8a3b9fc-928b-4695-8303-0651dddb9530">
+        <ownedComment xmi:id="2360b00e-36b7-4756-974d-5b50e825f5d0" annotatedElement="4ed80006-8937-46a9-bea5-caf85682af75">
+          <body>&lt;p>The Specializations with a certain &lt;code>specific&lt;/code> Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3397be0e-74a3-4193-b2f8-4d597b012816" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b82bb011-3946-4d29-b7bb-8c582dd213b0" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7056904b-1e7f-4ad0-a58e-4f09bdcbcd3a" name="" visibility="public" memberEnd="a41e0e5b-2f38-490c-ba49-036643b528f4 9ff6b50f-f460-482b-87eb-ee1e2b945f99"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="c38c5572-8297-4603-88d2-dbd472d3d22a" name="" visibility="public" memberEnd="168e1cd6-0b19-4677-823d-905d7fad3b40 2d581ec3-1e7f-44b4-93b6-10a3e3a7873a">
+      <ownedEnd xmi:id="2d581ec3-1e7f-44b4-93b6-10a3e3a7873a" name="unionedType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" association="c38c5572-8297-4603-88d2-dbd472d3d22a">
+        <ownedComment xmi:id="4904a7c8-5895-46b1-9c42-a08771d08aa0" annotatedElement="2d581ec3-1e7f-44b4-93b6-10a3e3a7873a">
+          <body>&lt;p>The Types that include this one among their &lt;code>unioningTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="db255472-b832-4e2a-b5d9-01ebdcd65386" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1216c8f9-59fe-405a-92aa-30d760423144" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3da7524b-b56c-40a8-b2eb-e7003088de43" name="" visibility="public" memberEnd="ffadf08a-7517-4eb0-8cb7-602addfe782f 89d79872-2232-49db-a020-d8cf07f6e1c9"/>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="1fb9436a-0c88-4c70-8d2b-ad0e3e39f930" name="FeatureDirectionKind" visibility="public">
+      <ownedComment xmi:id="04a0a283-76a4-44d4-a691-0ccea05bb0c9" annotatedElement="1fb9436a-0c88-4c70-8d2b-ad0e3e39f930">
+        <body>&lt;p>FeatureDirectionKind enumerates the possible kinds of &lt;code>direction&lt;/code> that a Feature may be given as a member of a Type.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedLiteral xmi:id="139f908e-f9a6-4178-9d1c-cf78b6a1637a" name="in" visibility="public">
+        <ownedComment xmi:id="396b22df-47bd-47fe-bed1-b5f06f9ebc35" annotatedElement="139f908e-f9a6-4178-9d1c-cf78b6a1637a">
+          <body>&lt;p>Values&amp;nbsp;of the Feature on each&amp;nbsp;instance of its domain are&amp;nbsp;determined&amp;nbsp;externally to that instance and&amp;nbsp;used internally.&lt;/p>
+</body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="b91d53cf-dedb-4dc0-a05d-31f0f5572305" name="inout" visibility="public">
+        <ownedComment xmi:id="8559ee84-3c41-4aec-afa3-18a696d18822" annotatedElement="b91d53cf-dedb-4dc0-a05d-31f0f5572305">
+          <body>&lt;p>Values&amp;nbsp;of the Feature on each&amp;nbsp;instance are&amp;nbsp;determined either as&amp;nbsp;&lt;em>in&lt;/em> or &lt;em>out&lt;/em>&amp;nbsp;directions, or both.&lt;/p>
+</body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="4380cf0d-4a99-4890-85d8-64b172dc1af1" name="out" visibility="public">
+        <ownedComment xmi:id="0a510f17-f5af-435a-b948-723354557968" annotatedElement="4380cf0d-4a99-4890-85d8-64b172dc1af1">
+          <body>&lt;p>Values of the Feature on each instance of its domain are&amp;nbsp;determined internally to that instance and used externally.&lt;/p>
+</body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="545d910b-407f-4424-b0d6-dffe63b73f26" name="" visibility="public" memberEnd="4217a922-d3b8-4556-be58-8f1922062604 a6df8227-9adc-4e74-990a-02070b6dcd05">
+      <ownedEnd xmi:id="a6df8227-9adc-4e74-990a-02070b6dcd05" name="generalization" visibility="public" type="57982b55-8eb5-404e-8e46-e2e7b774a2b0" redefinedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="545d910b-407f-4424-b0d6-dffe63b73f26">
+        <ownedComment xmi:id="ca5d90ba-7cf3-4b54-9f33-3cc2e0a6d7b6" annotatedElement="a6df8227-9adc-4e74-990a-02070b6dcd05">
+          <body>&lt;p>The Specializations with a certain &lt;code>general&lt;code> Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9e5c075c-e488-4eb0-b5c0-512443f0eac1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="642e4b0f-0577-4863-aca2-55494bb43935" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6a704912-6a7e-47cd-9e98-f9f8712143fd" name="" visibility="public" memberEnd="27a9fafe-1ba5-45f7-a063-7bf97be980e8 81b6a728-e565-4a5f-b3f9-eabf53818b7d">
+      <ownedEnd xmi:id="81b6a728-e565-4a5f-b3f9-eabf53818b7d" name="intersectedType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" association="6a704912-6a7e-47cd-9e98-f9f8712143fd">
+        <ownedComment xmi:id="4f73e417-6cdd-4778-9f7c-ee244a391cbc" annotatedElement="81b6a728-e565-4a5f-b3f9-eabf53818b7d">
+          <body>&lt;p>The Types that include this one among their &lt;code>intersectingTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="52ce4f79-9741-4923-b82e-8b0b64e4272d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="045b5a94-91fc-49da-a522-1a95053f8f76" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="387c1ace-4ad1-44eb-b8b5-bfe420975a97" name="FeatureMembership" visibility="public">
+      <ownedComment xmi:id="6408491d-1391-4e43-8e60-e16a65f85048" annotatedElement="387c1ace-4ad1-44eb-b8b5-bfe420975a97">
+        <body>&lt;p>FeatureMembership is an OwningMembership for a Feature in a Type that is also a Featuring Relationship between the Feature and the Type, in which the &lt;code>featuringType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featureOfType&lt;/code> is the &lt;code>target&lt;/code>. A FeatureMembership is always owned by its &lt;code>owningType&lt;/code>, which is the &lt;code>featuringType&lt;/code> for the FeatureMembership considered as a Featuring.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="0f5e6eb1-bae3-4064-8b16-7f925c727f46" general="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d"/>
+      <generalization xmi:id="a4254b22-5d60-4e57-a983-7c271c1d3333" general="f32ea62b-dfe6-495e-a8cf-4ea54a106321"/>
+      <ownedAttribute xmi:id="89d79872-2232-49db-a020-d8cf07f6e1c9" name="owningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="cfd14843-bce5-4ee1-8fb3-a2fdd0237258 cbdf8984-806e-484e-84fb-8f4d90fc17db" subsettedProperty="e89c4dc4-6d61-42d7-864f-86f1fda41a67" association="3da7524b-b56c-40a8-b2eb-e7003088de43">
+        <ownedComment xmi:id="ffcf1067-f4d7-4745-bdc9-3941789c5e56" annotatedElement="89d79872-2232-49db-a020-d8cf07f6e1c9">
+          <body>&lt;p>The Type that owns this FeatureMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3309d002-5de6-4268-8a29-1a4f61ce6050" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c1e35bc6-4878-4e41-a9e3-133e38ae50ed" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="077a3948-ff80-405a-b769-123a0a235d1f" name="ownedMemberFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" aggregation="composite" isDerived="true" redefinedProperty="50d115dd-9fe9-4a0c-8d67-bcca24186f18 824e2b65-f787-4e43-8359-ba531816c433" association="77ec8e9e-dc35-45b5-b3ac-964b7e3114d3">
+        <ownedComment xmi:id="862d4115-5aae-4a59-b957-f27a4fe3c0b6" annotatedElement="077a3948-ff80-405a-b769-123a0a235d1f">
+          <body>&lt;p>The Feature that this FeatureMembership relates to its &lt;code>owningType&lt;/code>, making it an &lt;code>ownedFeature&lt;/code> of the &lt;code>owningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="16b88811-93e7-402f-804c-cd1179a63d95" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1931599f-0123-49f8-aacf-7e7f9e003a09" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7b996a20-4abc-464d-b3a2-0c43aa886490" name="Differencing" visibility="public">
+      <ownedComment xmi:id="552ed716-2c6d-46c9-9eb8-623b70ce951f" annotatedElement="7b996a20-4abc-464d-b3a2-0c43aa886490">
+        <body>&lt;p>Differencing is a Relationship that makes its &lt;code>differencingType&lt;/code> one of the &lt;code>differencingTypes&lt;/code> of its &lt;code>typeDifferenced&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="f5605430-885e-4aa7-816a-78191c1ce45d" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="5d50682e-85a8-4d86-89c0-b7f1f8f9c3a9" name="typeDifferenced" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314" association="97eff77d-cec8-4b8c-8940-9caf54371062">
+        <ownedComment xmi:id="b6f42127-fb16-4a0c-b5ac-d6e6f33158ab" annotatedElement="5d50682e-85a8-4d86-89c0-b7f1f8f9c3a9">
+          <body>&lt;p>Type with interpretations partly determined by &lt;code>differencingType&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c78458d7-ddb1-4963-9b4d-5ebe4fed7051" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bf4e95ba-e280-4378-ade5-dc7c97a8e9b1" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="60057a5e-bbd3-47ef-a196-f92331986f69" name="differencingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="fdb9a37c-62ef-45fc-ae1e-b90cf2f6b80c">
+        <ownedComment xmi:id="6e022c93-0ade-48c4-99b2-abf463c057fc" annotatedElement="60057a5e-bbd3-47ef-a196-f92331986f69">
+          <body>&lt;p>Type that partly determines interpretations of &lt;code>typeDifferenced&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4bcb9dcd-399f-4057-96bd-0bbcb14fb569" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="22cce416-24ec-48fc-a134-96188c8c48ba" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="77ec8e9e-dc35-45b5-b3ac-964b7e3114d3" name="" visibility="public" memberEnd="077a3948-ff80-405a-b769-123a0a235d1f b2830939-3d87-40dc-8acf-ed3f043eba1a"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="544b8eca-7cea-4781-b2d2-410d352d29cd" name="Disjoining" visibility="public">
+      <ownedComment xmi:id="efb0f617-0625-421e-ba41-2627f7ab1476" annotatedElement="544b8eca-7cea-4781-b2d2-410d352d29cd">
+        <body>&lt;p>A Disjoining is a Relationship between Types asserted to have interpretations that are not shared (disjoint) between them, identified as &lt;code>typeDisjoined&lt;/code> and &lt;code>disjoiningType&lt;/code>. For example, a Classifier for mammals is disjoint from a Classifier for minerals, and a Feature for people&amp;#39;s parents is disjoint from a Feature for their children. &lt;/code>&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="ac6705bf-b14d-42f1-888c-f9740799069a" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="dc199e07-faba-4a89-92cf-e7d09c7367b8" name="typeDisjoined" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="792d4fa4-0416-4d15-9c4c-9e5ec08b1c43">
+        <ownedComment xmi:id="e1a5ace8-0eb0-452e-9593-3176b780fe7e" annotatedElement="dc199e07-faba-4a89-92cf-e7d09c7367b8">
+          <body>&lt;p>Type asserted to be disjoint with the &lt;code>disjoiningType&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b16fd27f-fda6-4728-adb9-e602621f528e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c6bba848-1270-46c3-bb20-9c172797f7b6" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a1c012b7-a865-473f-bae6-95ae09cad478" name="disjoiningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="0ae84d99-b81f-4ff5-8234-0a30efdcdb4f">
+        <ownedComment xmi:id="3d1d36c1-9d0f-4f30-bfc6-42b328ff920e" annotatedElement="a1c012b7-a865-473f-bae6-95ae09cad478">
+          <body>&lt;p>Type asserted to be disjoint with the &lt;code>typeDisjoined&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="090cd2fe-6439-4d74-a473-7e26fdcf7d14" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5db9a92f-de06-47a2-b856-036d134c3ab7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="20efeaad-00cc-4d5d-8af6-9517ec8c3ff1" name="owningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="dc199e07-faba-4a89-92cf-e7d09c7367b8 53d1b371-a5c5-4812-87a8-a61e672f7314" association="37e6acd2-40a4-4ad8-814c-d360fc8bb929">
+        <ownedComment xmi:id="0295a71d-3069-4bf4-b275-bc89ac34f127" annotatedElement="20efeaad-00cc-4d5d-8af6-9517ec8c3ff1">
+          <body>&lt;p>A &lt;code>typeDisjoined&lt;/code> that is also an &lt;code>owningRelatedElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b653c3d0-9102-4fc2-82e0-656c3e2e6462" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cdbfddf3-28ab-4909-beb0-7e0174671e4d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="431c1a4f-8a50-4537-aeea-9db448315ba8" name="" visibility="public" memberEnd="ee47daa4-a81f-4204-b23b-bfc54283691f 9eb39b11-03b6-45e0-999a-25ee6e6dda75">
+      <ownedEnd xmi:id="9eb39b11-03b6-45e0-999a-25ee6e6dda75" name="typeWithDirectedFeature" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="431c1a4f-8a50-4537-aeea-9db448315ba8">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f604df59-5594-414d-9dee-482b382766b2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4a544a90-e979-4f9d-90ed-f24fb181d68b" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="97eff77d-cec8-4b8c-8940-9caf54371062" name="" visibility="public" memberEnd="5d50682e-85a8-4d86-89c0-b7f1f8f9c3a9 363b5f13-6a3a-41c0-9160-010d73c6beb2"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="99b14ebc-9aed-4137-9c55-755bba106570" name="Intersecting" visibility="public">
+      <ownedComment xmi:id="45bcc9d7-8daf-4951-b07f-78b8298140f1" annotatedElement="99b14ebc-9aed-4137-9c55-755bba106570">
+        <body>&lt;p>Intersecting is a Relationship that makes its &lt;code>intersectingType&lt;/code> one of the &lt;code>intersectingTypes&lt;/code> of its &lt;code>typeIntersected&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="86b4a983-248e-4729-b117-a760d64d1790" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="ca22c723-296e-45e0-b9d0-4ff2da3c8aa9" name="typeIntersected" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314" association="06ab200c-b8f6-438a-a846-cc80923fcfe7">
+        <ownedComment xmi:id="88b1461e-5717-4b03-b813-6b6d279d2e93" annotatedElement="ca22c723-296e-45e0-b9d0-4ff2da3c8aa9">
+          <body>&lt;p>Type with interpretations partly determined by &lt;code>intersectingType&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="df900910-cecf-412f-a587-f037dc7add03" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e127a2c0-1d37-42fe-8f45-bd80cae9915f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c9f60119-85ce-4e47-9031-c7b06c030fc0" name="intersectingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="a1937093-977f-4b99-a0cd-375b24e0afd6">
+        <ownedComment xmi:id="a9d3071d-0864-4f55-b265-29b2f4bf9f66" annotatedElement="c9f60119-85ce-4e47-9031-c7b06c030fc0">
+          <body>&lt;p>Type that partly determines interpretations of &lt;code>typeIntersected&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a6ea5dee-70b9-42dd-a1ee-98b352dce0bb" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="36e8f0b1-832d-4da8-96a6-1f99630fc894" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="792d4fa4-0416-4d15-9c4c-9e5ec08b1c43" name="" visibility="public" memberEnd="84ff749d-1772-4449-b192-d4d04a8aefcb dc199e07-faba-4a89-92cf-e7d09c7367b8">
+      <ownedEnd xmi:id="84ff749d-1772-4449-b192-d4d04a8aefcb" name="disjoiningTypeDisjoining" visibility="public" type="544b8eca-7cea-4781-b2d2-410d352d29cd" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="792d4fa4-0416-4d15-9c4c-9e5ec08b1c43">
+        <ownedComment xmi:id="a2ee1db9-e389-47ad-9ebe-e173bce00275" annotatedElement="84ff749d-1772-4449-b192-d4d04a8aefcb">
+          <body>&lt;p>The Disjoinings that identify this Type as their &lt;code>typeDisjoined&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0c03fb47-7f36-49c2-aec5-3eaecae74c4b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="02318614-4602-4dc1-a227-f95a82e271de" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a1937093-977f-4b99-a0cd-375b24e0afd6" name="" visibility="public" memberEnd="c9f60119-85ce-4e47-9031-c7b06c030fc0 6be73ce1-992e-41e6-91cb-533eeb378cb1">
+      <ownedEnd xmi:id="6be73ce1-992e-41e6-91cb-533eeb378cb1" name="intersectedIntersecting" visibility="public" type="99b14ebc-9aed-4137-9c55-755bba106570" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="a1937093-977f-4b99-a0cd-375b24e0afd6">
+        <ownedComment xmi:id="a1351b06-4923-481d-a4e6-30f9112c80f2" annotatedElement="6be73ce1-992e-41e6-91cb-533eeb378cb1">
+          <body>&lt;p>The Intersectings that identify this Type as their &lt;code>intersectingType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f6cccc83-f343-41cc-9edd-d59400bcc5e3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c8b1e028-c12f-44d1-b611-2f2b33deaa59" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="06ab200c-b8f6-438a-a846-cc80923fcfe7" name="" visibility="public" memberEnd="92ab0f3d-b26f-4497-ba6a-1ffb46704d9b ca22c723-296e-45e0-b9d0-4ff2da3c8aa9"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="77258d7e-6bf1-4380-beb8-7a6db52bede7" name="" visibility="public" memberEnd="d65bfe47-3744-4fb9-a371-dc053aabfccd 521c8366-388f-410c-a57b-5256934269b5"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="37e6acd2-40a4-4ad8-814c-d360fc8bb929" name="" visibility="public" memberEnd="4effb986-d628-43eb-88c4-4d182c61bbc5 20efeaad-00cc-4d5d-8af6-9517ec8c3ff1"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="57982b55-8eb5-404e-8e46-e2e7b774a2b0" name="Specialization" visibility="public">
+      <ownedComment xmi:id="042032eb-7284-486c-a634-6f3309f4a1ee" annotatedElement="57982b55-8eb5-404e-8e46-e2e7b774a2b0">
+        <body>&lt;p>Specialization is a Relationship between two Types that requires all instances of the &lt;code>specific&lt;/code> type to also be instances of the &lt;code>general&lt;/code> Type (i.e., the set of instances of the &lt;code>specific&lt;/code> Type is a &lt;em>subset&lt;/em> of those of the &lt;code>general&lt;/code> Type, which might be the same set).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="d0a8fce4-5b56-4fe9-88d7-7195a6d0df30" name="generalizationSpecificNotConjugated" visibility="public" constrainedElement="57982b55-8eb5-404e-8e46-e2e7b774a2b0">
+        <ownedComment xmi:id="f344d5b6-3438-4ba4-a50f-c78a5f1dea7b" annotatedElement="d0a8fce4-5b56-4fe9-88d7-7195a6d0df30">
+          <body>&lt;p>The &lt;code>specific&lt;/code> Type of a Generalization cannot be a conjugated Type.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="b33443a2-10f0-40e3-b759-c3b4c1e9e7d9" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>not specific.isConjugated</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="9a7eeca7-6ad7-40d3-91cb-b239d201e1ba" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="521c8366-388f-410c-a57b-5256934269b5" name="owningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="db88a7ad-ac20-4c44-9b19-26b4444dac25 53d1b371-a5c5-4812-87a8-a61e672f7314" association="77258d7e-6bf1-4380-beb8-7a6db52bede7">
+        <ownedComment xmi:id="aef1f0fb-464e-4b75-818f-13b8b2fa9c4b" annotatedElement="521c8366-388f-410c-a57b-5256934269b5">
+          <body>&lt;p>The Type that is the &lt;code>specific&lt;/code> Type of this Specialization and owns it as its &lt;code>owningRelatedElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="004a4c29-5912-49b2-b745-95a990105c6c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d78a7c4e-ff8b-4c7f-a06e-d8b3e0303890" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4217a922-d3b8-4556-be58-8f1922062604" name="general" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="545d910b-407f-4424-b0d6-dffe63b73f26">
+        <ownedComment xmi:id="67c988ba-d891-4443-b1bf-1d1a64430998" annotatedElement="4217a922-d3b8-4556-be58-8f1922062604">
+          <body>&lt;p>A Type with a superset of all instances of the &lt;code>specific&lt;/code> Type, which might be the same set.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="387e8b9d-6196-4eb1-b64f-da8d5a344d3c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="de3ce987-7c11-4fec-9c74-9b828935e120" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="db88a7ad-ac20-4c44-9b19-26b4444dac25" name="specific" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="c8a3b9fc-928b-4695-8303-0651dddb9530">
+        <ownedComment xmi:id="f8c9ac8a-7ceb-4ffa-ab6f-3c3aa66e0c87" annotatedElement="db88a7ad-ac20-4c44-9b19-26b4444dac25">
+          <body>&lt;p>A Type with a subset of all instances of the &lt;code>general&lt;/code> Type, which might be the same set.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e42a7de0-2735-457c-9636-0ba7528ba440" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f5100ab8-91b4-45ad-a867-e003238d44c0" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="de47bd7f-ba3d-402e-850b-d49eb622702d" name="" visibility="public" memberEnd="1a94208b-8320-4353-a599-b68806aed393 1e635a71-0f38-409d-854d-73411323bde4">
+      <ownedEnd xmi:id="1e635a71-0f38-409d-854d-73411323bde4" name="conjugation" visibility="public" type="0700b3ef-921a-4677-a325-db5e475a9240" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="de47bd7f-ba3d-402e-850b-d49eb622702d">
+        <ownedComment xmi:id="18adc07c-b6e9-4371-bdd7-15ab9fd5ae39" annotatedElement="1e635a71-0f38-409d-854d-73411323bde4">
+          <body>&lt;p>The Conjugations with a certain Type as the &lt;code>originalType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cc40495c-0b09-40a0-9767-cca7971b155e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1373ec67-4c14-4dbe-abc1-86a8dfa4d7c9" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6587f943-389a-4000-a9ac-f93f0805490f" name="" visibility="public" memberEnd="629ec32d-2e6f-4e6f-bf94-11706b3dfeab f731d3dc-a39d-4a0a-aac5-587dc33c4186"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="c809f6c8-a17c-45e5-9bcc-575dea0b36a5" name="" visibility="public" memberEnd="40171618-9e0f-43a6-8faa-bb6c2a6642c9 224be8b4-0f7a-4301-9ac6-855bcf0da4dd">
+      <ownedEnd xmi:id="224be8b4-0f7a-4301-9ac6-855bcf0da4dd" name="differencedType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" association="c809f6c8-a17c-45e5-9bcc-575dea0b36a5">
+        <ownedComment xmi:id="7b16a7fd-1546-4202-b785-83fef79c1eea" annotatedElement="224be8b4-0f7a-4301-9ac6-855bcf0da4dd">
+          <body>&lt;p>The Types that include this one among their &lt;code>differencingTypes&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6c0d51f8-8110-47bf-b602-13bf9211157b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6aa6fbed-566d-47df-860e-31f5511576c7" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0ae84d99-b81f-4ff5-8234-0a30efdcdb4f" name="" visibility="public" memberEnd="a1c012b7-a865-473f-bae6-95ae09cad478 10ff666b-b399-44b8-af49-702adc0048e4">
+      <ownedEnd xmi:id="10ff666b-b399-44b8-af49-702adc0048e4" name="disjoinedTypeDisjoining" visibility="public" type="544b8eca-7cea-4781-b2d2-410d352d29cd" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="0ae84d99-b81f-4ff5-8234-0a30efdcdb4f">
+        <ownedComment xmi:id="36a00738-d08b-4369-985a-7af901c17548" annotatedElement="10ff666b-b399-44b8-af49-702adc0048e4">
+          <body>&lt;p>The Disjoinings that identify this Type as their &lt;code>disjoiningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8e617140-c371-45a6-afa0-a6ce58f119f7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="87e13b32-a68b-4066-90f0-4d8d5d87ac5f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="50f20a49-7ff4-48b1-aac0-8f6ee31b322f" name="Multiplicity" visibility="public">
+      <ownedComment xmi:id="30f0be86-48f0-4290-9d28-7ef0b83ae828" annotatedElement="50f20a49-7ff4-48b1-aac0-8f6ee31b322f">
+        <body>&lt;p>A Multiplicity is a Feature whose co-domain is a set of natural numbers that includes the number&amp;nbsp;of sequences determined below, based on the kind of&amp;nbsp;typeWithMultiplicity:&lt;/p>
+
+&lt;ul>
+	&lt;li>Classifiers: minimal sequences (the single length sequences of the Classifier).&lt;/li>
+	&lt;li>Features: sequences with the same feature-pair head.&amp;nbsp; In the case of Features with Classifiers as domain and co-domain, these sequences are pairs, with the first element in&amp;nbsp;a single-length sequence of the domain Classifier (head of the pair), and the number of pairs with the same first element being among the Multiplicity co-domain numbers.&lt;/li>
+&lt;/ul>
+
+&lt;p>Multiplicity co-domains (in models) can be specified by Expression that might vary in their results. If the &lt;code>typeWithMultiplicity&lt;/code> is a Classifier, the domain of the Multiplicity shall be &lt;em>Anything&lt;/em>.  If the &lt;code>typeWithMultiplicity&lt;/code> is a Feature,  the Multiplicity shall have the same domain as the &lt;code>typeWithMultiplicity&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="6b491354-131a-48e2-8694-6acacfa7ce2f" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="116d1d35-732b-4d36-a215-2bdca9032293" name="Unioning" visibility="public">
+      <ownedComment xmi:id="4e329136-21ae-4cf5-8ff2-85125df76cce" annotatedElement="116d1d35-732b-4d36-a215-2bdca9032293">
+        <body>&lt;p>Unioning is a Relationship that makes its &lt;code>unioningType&lt;/code> one of the &lt;code>unioningTypes&lt;/code> of its &lt;code>typeUnioned&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c839d942-dd01-4c9c-8eba-a51672de6b5d" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="629ec32d-2e6f-4e6f-bf94-11706b3dfeab" name="typeUnioned" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314" association="6587f943-389a-4000-a9ac-f93f0805490f">
+        <ownedComment xmi:id="e80e2d3c-fe18-453d-aa5a-6e73c99f4afb" annotatedElement="629ec32d-2e6f-4e6f-bf94-11706b3dfeab">
+          <body>&lt;p>Type with interpretations partly determined by &lt;code>unioningType&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cef289df-0835-4ed3-b5c7-a702d98efa3d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a15f871b-f28a-468f-a3b0-03249a3dc573" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9f33469c-5982-4583-97c4-4f00d06f1b36" name="unioningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="a2299534-8d1b-49ec-8dcb-af1cbaf7a71f">
+        <ownedComment xmi:id="bf075c4f-67a7-43de-8810-cabec275e195" annotatedElement="9f33469c-5982-4583-97c4-4f00d06f1b36">
+          <body>&lt;p>Type that partly determines interpretations of &lt;code>typeUnioned&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c4e709ad-f84f-4723-96c0-2541038bb792" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="04b48243-b68a-4069-b57a-6628d3ae05ce" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5bfc08f0-c4e5-4bd6-9129-4d121cdff1b2" name="" visibility="public" memberEnd="b458eea7-79b9-4c8f-a066-b9d0dbd03ec8 874bf985-15a2-416b-b1f2-433973f07fae">
+      <ownedEnd xmi:id="874bf985-15a2-416b-b1f2-433973f07fae" name="typeWithOutput" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="5bfc08f0-c4e5-4bd6-9129-4d121cdff1b2">
+        <ownedComment xmi:id="7c98dae0-be3d-4fc3-a867-45584276eb17" annotatedElement="874bf985-15a2-416b-b1f2-433973f07fae">
+          <body>&lt;p>A Type with a certain &lt;code>input&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="773ad055-59cf-4f43-b5b7-5da5623fbcdb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b1ef1162-5fd3-46ba-8df4-1b300064b3f9" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a2299534-8d1b-49ec-8dcb-af1cbaf7a71f" name="" visibility="public" memberEnd="9f33469c-5982-4583-97c4-4f00d06f1b36 38065073-665a-46b3-ac65-e779f4b25fb1">
+      <ownedEnd xmi:id="38065073-665a-46b3-ac65-e779f4b25fb1" name="unionedUnioning" visibility="public" type="116d1d35-732b-4d36-a215-2bdca9032293" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="a2299534-8d1b-49ec-8dcb-af1cbaf7a71f">
+        <ownedComment xmi:id="cea3193d-f7ba-4e7a-abb4-d5d6ab43767d" annotatedElement="38065073-665a-46b3-ac65-e779f4b25fb1">
+          <body>&lt;p>The Unionings that identify all these Types as their &lt;code>unioningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e908432b-e6ca-42ec-81f6-63cf4cb85d1a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d18ff1ee-36c6-458b-b5b4-4ac8dafa565f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4bcbfc49-bacd-4efe-a7f0-119b708bbdaf" name="" visibility="public" memberEnd="a845e308-0fa7-49d9-9d90-152949ecf7e1 d071e7ea-2566-41c5-9eff-acc7a2507370">
+      <ownedEnd xmi:id="d071e7ea-2566-41c5-9eff-acc7a2507370" name="typeWithEndFeature" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="4bcbfc49-bacd-4efe-a7f0-119b708bbdaf">
+        <ownedComment xmi:id="d3acfd5b-8cae-4c8a-ac18-421764017574" annotatedElement="d071e7ea-2566-41c5-9eff-acc7a2507370">
+          <body>&lt;p>A Type that has an EndFeatureMembership in which the &lt;code>endFeature&lt;/code> is a &lt;code>memberFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="92e5babd-ff80-4fb4-a9ea-79023b531278" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8b801ac1-828e-4522-842e-37534f79b76e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="aad4e8ec-6356-4e76-869f-d7e13e659a79" name="" visibility="public" memberEnd="69e265a6-d371-4570-8146-c8e0f54f6c13 a9857460-2dca-4b2f-be25-c5fef118c3c3">
+      <ownedEnd xmi:id="a9857460-2dca-4b2f-be25-c5fef118c3c3" name="inheritingType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="aad4e8ec-6356-4e76-869f-d7e13e659a79">
+        <ownedComment xmi:id="a1f6646d-813a-4a95-acfe-d7a692e24354" annotatedElement="a9857460-2dca-4b2f-be25-c5fef118c3c3">
+          <body>&lt;p>A Type that has an &lt;code>inheritedMembership&lt;/code> with the &lt;code>inheritedFeature&lt;/code> as its &lt;code>memberFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bddd1d66-36d0-4134-af41-3e5e45c31c0e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d30c7537-f526-4957-96e2-00822500d0b2" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4f16dcf2-4258-41d7-a3c5-62770d9e0b31" name="" visibility="public" memberEnd="ea59f6ae-8a27-4163-a651-91da11bbfa67 4e18e321-e8e9-4751-a149-4c1cf2245b7a"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="0318c38c-c817-4237-8267-2645fc0e5bf3" name="" visibility="public" memberEnd="3b5717ec-fb61-4c3c-8879-87f9a3194605 cfb08ed7-eefd-494b-b840-5285202ccba8">
+      <ownedEnd xmi:id="cfb08ed7-eefd-494b-b840-5285202ccba8" name="typeWithInput" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="0318c38c-c817-4237-8267-2645fc0e5bf3">
+        <ownedComment xmi:id="fc7d0fce-b7fb-4e15-b15d-40ba93924385" annotatedElement="cfb08ed7-eefd-494b-b840-5285202ccba8">
+          <body>&lt;p>A Type with a certain &lt;code>output&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8d5074a8-0e3a-45f3-b8d3-404c0b095c32" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2b939d76-d1ba-476f-9f3f-01980ae3390f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1080ea47-758c-4f64-ac8b-95aac1b2c580" name="" visibility="public" memberEnd="56d0de12-8eef-4d84-8cbb-f754663ed226 42372418-3f63-4e47-baa1-4035ead2d928"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="afc92317-29d4-4c39-b0f9-30019cd69c8b" name="" visibility="public" memberEnd="7537c16f-8968-42b7-bf42-d7e7ae6cfeee 10aa2871-4318-4d93-aa42-d81688d3cba3">
+      <ownedEnd xmi:id="10aa2871-4318-4d93-aa42-d81688d3cba3" name="supersetting" visibility="public" type="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56" subsettedProperty="a6df8227-9adc-4e74-990a-02070b6dcd05" association="afc92317-29d4-4c39-b0f9-30019cd69c8b">
+        <ownedComment xmi:id="8e98994c-8f09-4c09-af67-bb16f4ba4356" annotatedElement="10aa2871-4318-4d93-aa42-d81688d3cba3">
+          <body>&lt;p>The Subsettings with a certain Feature as the &lt;code>subsettedFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f3687f1d-5630-4381-9887-7905c53c6d54" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="02aee68f-9283-47c5-be41-5fb728ac79d1" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7f60f971-3958-4bd6-a1db-4fb6df161220" name="" visibility="public" memberEnd="89301e23-4221-4e3e-9d33-5d1f1be4a0bd 41bcda86-45ad-49c4-a552-81c282cabfc1">
+      <ownedEnd xmi:id="89301e23-4221-4e3e-9d33-5d1f1be4a0bd" name="typing" type="38d72c05-06ba-4112-bd58-c4519c98d654" subsettedProperty="4ed80006-8937-46a9-bea5-caf85682af75" association="7f60f971-3958-4bd6-a1db-4fb6df161220">
+        <ownedComment xmi:id="fddc27d5-c8ce-41b0-9143-848b2fd775ed" annotatedElement="89301e23-4221-4e3e-9d33-5d1f1be4a0bd">
+          <body>&lt;p>The FeatureTypings for which a certain Feature is the &lt;code>typedFeature&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="56b92a77-6067-43b1-99bf-81b804172493" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="82d5d922-48ea-4870-a996-37186caa5111" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f4af4bb1-5b34-44a1-a89d-04cd7ef827c6" name="" visibility="public" memberEnd="19d0efea-dfcb-490d-96a1-8cf8d7c3d4bb bd5b2d2b-8ef0-447d-b2f0-2f01573214fa">
+      <ownedEnd xmi:id="bd5b2d2b-8ef0-447d-b2f0-2f01573214fa" name="featureOfType" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" association="f4af4bb1-5b34-44a1-a89d-04cd7ef827c6">
+        <ownedComment xmi:id="6049029f-259b-406e-832a-1426deb1c481" annotatedElement="bd5b2d2b-8ef0-447d-b2f0-2f01573214fa">
+          <body>&lt;p>The Features for which a certain Type is a &lt;code>featuringType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2e3852ff-d1c0-4fa8-aa88-bbaa7cf27094" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="33e083a3-cc05-4384-97ab-1e147fa1ce1a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6f824388-297d-4f3f-b68b-40aacbc18205" name="" visibility="public" memberEnd="8627f6e3-1ebb-4b3a-b829-d9923e876aa4 b727584c-d321-46a6-ab44-17b1304bc1b6">
+      <ownedEnd xmi:id="8627f6e3-1ebb-4b3a-b829-d9923e876aa4" name="typedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" association="6f824388-297d-4f3f-b68b-40aacbc18205">
+        <ownedComment xmi:id="22b2aa6b-d06d-4a90-95b6-e3b0ed388bc1" annotatedElement="8627f6e3-1ebb-4b3a-b829-d9923e876aa4">
+          <body>&lt;p>The Features for which a certain Type is a &lt;code>type&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e96e71aa-2acf-4cfb-96c6-8a7aaaa5ead6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d4284505-ed9f-4b98-9755-bb7bc28e10f0" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="cc60399b-b003-4ec0-9bc5-9188053e8ac9" name="" visibility="public" memberEnd="0c9f1849-0def-4882-9b31-44d9d5dd02f4 ff2e9a40-2ac4-4c75-8c2c-e1424d0be9f5">
+      <ownedEnd xmi:id="ff2e9a40-2ac4-4c75-8c2c-e1424d0be9f5" name="owningFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="cddd2eb1-4d1e-439c-bc90-88583bfeb153" association="cc60399b-b003-4ec0-9bc5-9188053e8ac9">
+        <ownedComment xmi:id="b34bce0d-74c5-461f-a277-eee684d78db8" annotatedElement="ff2e9a40-2ac4-4c75-8c2c-e1424d0be9f5">
+          <body>&lt;p>The Feature that owns this Redefinition relationship, which must also be its &lt;code>redefiningFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="752ebd03-50ca-49d0-b2d4-26b962174211" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="00f4cf16-b8d8-4519-9635-2b0daa5e2bb2" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ea196dae-61d5-4bc5-972d-088841627f34" name="" visibility="public" memberEnd="4350f5dd-3fd1-4ce9-895d-f7e4f4e902d0 4da3743e-dd11-414d-a775-95bd95243319"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="010f880b-1eb5-4c5d-a8f4-4fc507ab0398" name="" visibility="public" memberEnd="cb478b2f-7312-412f-8a6e-84567fc2391e c8a51c42-87a5-4b94-ac31-df1e0c2d653a">
+      <ownedEnd xmi:id="c8a51c42-87a5-4b94-ac31-df1e0c2d653a" name="typeWithMultiplicity" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="010f880b-1eb5-4c5d-a8f4-4fc507ab0398">
+        <ownedComment xmi:id="bb1b5045-257d-4045-8396-7972d8c579bf" annotatedElement="c8a51c42-87a5-4b94-ac31-df1e0c2d653a">
+          <body>&lt;p>The Type whose cardinality is constrained by the &lt;code>multiplicity&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5d338963-e499-4832-9653-2371897aaf11" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d1bbd795-f7be-443e-a994-764fba994246" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="86092e96-6637-4ea4-8965-7a0310fee87e" name="" visibility="public" memberEnd="6107f867-d1c9-45cc-916c-efb1105ecb31 b4178cbf-12d6-41ea-aeab-0b2d045a2b73">
+      <ownedComment xmi:id="66ea4dfe-910e-4c41-8e44-912171176c00" annotatedElement="86092e96-6637-4ea4-8965-7a0310fee87e">
+        <body>&lt;p>Relationship for chainedFeatures.&lt;/p></body>
+      </ownedComment>
+      <ownedEnd xmi:id="b4178cbf-12d6-41ea-aeab-0b2d045a2b73" name="chainedFeatureChaining" visibility="public" type="dde0979c-8cf4-466f-8563-b2ab2f194c42" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="86092e96-6637-4ea4-8965-7a0310fee87e">
+        <ownedComment xmi:id="744bd775-373a-4b09-91cc-aac3f60d6c16" annotatedElement="b4178cbf-12d6-41ea-aeab-0b2d045a2b73">
+          <body>&lt;p>The FeatureChainings that identify this Feature as their &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5f8932e0-e41b-444c-ad72-09771ce63bb7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="75d48cb6-13fa-4e6f-89de-45481a7d2026" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ac68c7fd-e497-41ba-ad43-6d58ec597ecf" name="" visibility="public" memberEnd="d536c4ac-f8ed-475e-9750-bc30806712a4 3fa62c18-c9b0-4087-b8cf-da609129f725">
+      <ownedEnd xmi:id="3fa62c18-c9b0-4087-b8cf-da609129f725" name="typingByType" visibility="public" type="38d72c05-06ba-4112-bd58-c4519c98d654" subsettedProperty="a6df8227-9adc-4e74-990a-02070b6dcd05" association="ac68c7fd-e497-41ba-ad43-6d58ec597ecf">
+        <ownedComment xmi:id="f85f359d-1070-491e-aa69-e2fa85377433" annotatedElement="3fa62c18-c9b0-4087-b8cf-da609129f725">
+          <body>&lt;p>The FeatureTyping relating this Type to a Feature.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8529b47b-384b-4842-ad16-c387c23e6954" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="565c8438-9b94-4ce5-9b07-2037f5ba3250" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c00ebefa-55b3-4aec-90f7-3d0d363f45b4" name="" visibility="public" memberEnd="dfd4554b-6c8f-4890-a543-3bb963a687cf ee1901d4-008f-452d-99fe-ae3c23ec2e2d">
+      <ownedEnd xmi:id="dfd4554b-6c8f-4890-a543-3bb963a687cf" name="invertingFeatureInverting" visibility="public" type="fe28e281-93bf-44fd-bd17-8eb003a4c1cc" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="c00ebefa-55b3-4aec-90f7-3d0d363f45b4">
+        <ownedComment xmi:id="7761578b-9e43-42d5-8ddb-0a9051adc148" annotatedElement="dfd4554b-6c8f-4890-a543-3bb963a687cf">
+          <body>&lt;p>The FeatureInvertings that identify this Feature as their &lt;code>featureInverted&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="30c133e0-726a-4c4b-b282-feb5f5297540" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9a067ff0-136d-48d4-a7bc-540af4042da5" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a2779097-61e4-4127-afa7-fddb0cc6ecef" name="" visibility="public" memberEnd="fcd09804-1b64-4b15-8178-88b85a84cabe 92b93b27-977b-4779-95a9-fe80ff4bd455"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="f32ea62b-dfe6-495e-a8cf-4ea54a106321" name="Featuring" visibility="public" isAbstract="true">
+      <ownedComment xmi:id="9ab5473a-4d7a-4d7b-8d4b-b58a9e5c4319" annotatedElement="f32ea62b-dfe6-495e-a8cf-4ea54a106321">
+        <body>&lt;p>Featuring is a Relationship between a Type and a Feature that is featured by that Type. Every instance in the domain of the &lt;code>feature&lt;/code> must be classified by the &lt;code>type&lt;/code>. This means that sequences that are classified by the &lt;code>feature&lt;/code> must have a prefix subsequence that is classified by the &lt;code>type&lt;/code>.&lt;/p>
+
+&lt;p>Featuring is abstract and does not commit to which of &lt;code>feature&lt;/code> or &lt;code>type&lt;/code> are the source or target. This commitment is made in the subclasses of Featuring, TypeFeaturing and FeatureMembership, which are directed differently.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="3121c8cb-6a8a-464c-bd83-8ea448adc31e" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="cbdf8984-806e-484e-84fb-8f4d90fc17db" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="f2878011-8ea5-4911-8abb-d7cbda17096c">
+        <ownedComment xmi:id="e27bf7d3-838f-42a4-a693-23d61345a7fb" annotatedElement="cbdf8984-806e-484e-84fb-8f4d90fc17db">
+          <body>&lt;p>The Type that features the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a1097268-bacd-41e3-ad7f-abbd7fa9d44a" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2902ad41-9bd3-4167-a29b-f5afc9421f96" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="824e2b65-f787-4e43-8359-ba531816c433" name="feature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="71c84d6c-06c4-4269-bf6b-f9457599cb7e">
+        <ownedComment xmi:id="95d6ab6f-1bf5-4760-a381-52e44bd0c667" annotatedElement="824e2b65-f787-4e43-8359-ba531816c433">
+          <body>&lt;p>The Feature that is featured by the &lt;code>featuringType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cb32db22-affe-4183-bcf7-5f4dc642f316" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2094ca27-52d6-4724-8871-f3957b042dd0" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="282f7b0d-28ff-4044-a2c0-3c4b181f41ce" name="" visibility="public" memberEnd="4d938e84-5350-4b24-bdcd-6591091d85be 56554315-3b03-4792-8b39-a70f691ef89c">
+      <ownedEnd xmi:id="56554315-3b03-4792-8b39-a70f691ef89c" name="subsetting" visibility="public" type="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56" subsettedProperty="4ed80006-8937-46a9-bea5-caf85682af75" association="282f7b0d-28ff-4044-a2c0-3c4b181f41ce">
+        <ownedComment xmi:id="6869bbec-4468-4ab2-a400-67b3688e761d" annotatedElement="56554315-3b03-4792-8b39-a70f691ef89c">
+          <body>&lt;p>The Subsettings with a certain Feature as the &lt;code>subsettingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e373e7b7-8803-4924-8073-e7e35105f8f5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e2dc4507-59d1-4f0f-865e-6b267f527650" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1e0e4611-ca36-47d3-b839-094e1f226695" name="" visibility="public" memberEnd="315842cc-a938-4b0b-a4f8-e6a582856183 1a743f54-d4fb-4258-ae0e-f9607ef8ad16">
+      <ownedEnd xmi:id="1a743f54-d4fb-4258-ae0e-f9607ef8ad16" name="chainedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" association="1e0e4611-ca36-47d3-b839-094e1f226695">
+        <ownedComment xmi:id="fc88c069-25d0-4926-96b5-85cdcf21ea4c" annotatedElement="1a743f54-d4fb-4258-ae0e-f9607ef8ad16">
+          <body>&lt;p>The Features that have a particular &lt;code>chainingFeature&lt;/code> in their Feature chain, whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aec773cd-f36c-4576-b629-6b8f658bac5f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e8c55c89-d5f4-4ccd-bf4b-dc98bbbee13e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" name="Feature" visibility="public">
+      <ownedComment xmi:id="b715d5b5-e088-48d8-ac2b-c56fb8115ea3" annotatedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <body>&lt;p>A Feature is a Type that classifies sequences of multiple things (in the universe). These must concatenate a sequence drawn from the intersection of the Feature&amp;#39;s &lt;code>featuringTypes&lt;/code> (&lt;em>domain&lt;/em>) with a sequence drawn from the intersection of its &lt;code>types&lt;/code> (&lt;em>co-domain&lt;/em>), treating (co)domains as sets of sequences. The domain of Features that do not have any &lt;code>featuringTypes&lt;/code> is the same as if it were the library Type Anything. A Feature&amp;#39;s &lt;code>types&lt;/code> include at least Anything, which can be narrowed to other Classifiers by Redefinition.&lt;/p>
+
+&lt;p>In the simplest cases, a Feature&amp;#39;s &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> are Classifiers, its sequences being pairs (length = 2), with the first element drawn from the Feature&amp;#39;s domain and the second element from its co-domain (the Feature &amp;quot;value&amp;quot;). Examples include cars paired with wheels, people paired with other people, and cars paired with numbers&amp;nbsp;representing the car length.&lt;/p>
+
+&lt;p>Since Features are Types, their &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> can be Features. When both are, Features classify sequences of at least four elements (length &amp;gt; 3), otherwise at least three (length &amp;gt; 2). The &lt;code>featuringTypes&lt;/code> of &lt;em>nested&lt;/em> Features are Features.&lt;/p>
+
+&lt;p>The values of a Feature with &lt;code>chainingFeatures&lt;/code> are the same as values of the last Feature in the chain, which can be found by starting with values of the first Feature, then from those values to values of the second feature, and so on, to values of the last feature.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="95fb73c0-f2cf-4a4f-8e6f-0f43c6c6b2d8" name="featureOwnedRedefinitions" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="7f3c66d0-6efc-4598-b523-5ba72a9c48b0" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedRedefinition = ownedSubsetting->selectByKind(Redefinition)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="882e3ced-c500-4af8-9210-1e653bbf04fc" name="featureOwnedTypeFeaturing" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="9bd192c2-13d9-4c04-8a96-e44b24f43272" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedTypeFeaturing = ownedRelationship->selectByKind(TypeFeaturing)->
+    select(tf | tf.featureOfType = self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="fd80527e-78e1-4054-9493-236ba12463f2" name="featureOwnedSubsettings" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ece88fb8-9583-4421-add4-4c6847481415" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedSubsetting = ownedGeneralization->selectByKind(Subsetting)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="818354b5-ceac-4026-9e0f-29ac7cede3e5" name="featureIsComposite" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="bd3e1dd0-77c0-4d27-a496-4d284e067929" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isComposite = owningFeatureMembership &lt;> null and owningFeatureMembership.isComposite</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="5236627b-936e-49cc-9af5-14d40cd2800c" name="featureOwnedTyping" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="974fa604-bf42-4aff-b772-72a8f8e27c2e" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedTyping = ownedGeneralization->selectByKind(FeatureTyping)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="85eabf3f-60b7-4c74-8b01-57cc04fb8744" name="featureType" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <ownedComment xmi:id="915e9df7-c0ef-4327-8f77-c99355bde247" annotatedElement="85eabf3f-60b7-4c74-8b01-57cc04fb8744">
+          <body>&lt;p>If a Feature has &lt;code>chainingFeatures&lt;/code>, then its &lt;code>types&lt;/code> are the same as the last &lt;code>chainingFeature&lt;/code>. Otherwise its &lt;code>types&lt;/code> are the union of the &lt;code>types&lt;/code> of its &lt;code>ownedTypings&lt;/code> and the &lt;code>types&lt;/code> of the &lt;code>subsettedFeatures&lt;/code> of its &lt;code>ownedSubsettings&lt;/code>, with all redundant supertypes removed.&lt;/p>.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="523b8fde-d2ea-425d-b0d9-d9cd1823e715" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body></body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="8bc29cd3-5012-4a4a-8fcc-5694fba52961" name="featureIsEnd" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="245ff180-2804-4fd2-96a6-4a75b983b294" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isEnd = owningFeatureMembership &lt;> null and owningFeatureMembership.oclIsKindOf(EndFeatureMembership)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="31d51b2b-3619-463c-bbfa-08af4cba947d" name="featureMultiplicityDomain" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <ownedComment xmi:id="e9989195-87d3-4851-99de-c934618dad79" annotatedElement="31d51b2b-3619-463c-bbfa-08af4cba947d">
+          <body>&lt;p>If a Feature has a &lt;code>multiplicity&lt;/code>, then the &lt;code>featuringTypes&lt;/code> of the &lt;code>multiplicity&lt;/code> must be the same as those of the Feature itself.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="b03c53be-951b-4c95-a2e7-a7f5acb34b90" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>multiplicity &lt;> null implies multiplicity.featuringType = featuringType </body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="9f9bacb0-9b7e-40da-8c90-bcdce4f5295a" name="featureRequiredSpecialization" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <ownedComment xmi:id="12207064-5993-4969-8af7-ce80783f32b6" annotatedElement="9f9bacb0-9b7e-40da-8c90-bcdce4f5295a">
+          <body>&lt;p>A Feature must directly or indirectly specialize &lt;code>Base::things&lt;/code> from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="78db8292-fdee-4550-8441-59151358eb56" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>allSupertypes()->includes(KernelLibrary::things)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="ce8cdde6-f3f5-4d7f-aba8-79ae87db854e" name="featureChainingFeaturesNotSelf" visibility="public">
+        <ownedComment xmi:id="28f40ed4-9d45-4d91-a4fd-0752a65e581b" annotatedElement="ce8cdde6-f3f5-4d7f-aba8-79ae87db854e">
+          <body>&lt;p>A Feature cannot be one of its own &lt;code>chainingFeatures&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="63003499-f3aa-46f8-be67-fff11c1364ba" name="" visibility="public">
+          <language>English</language>
+          <body>chainingFeatures->excludes(self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="ddc63b08-591d-4876-8247-66e51eb99a84" name="featureOwnedFeatureChaining" visibility="public">
+        <ownedComment xmi:id="5fa2285f-c49b-4751-8af7-50fbc0745386" annotatedElement="ddc63b08-591d-4876-8247-66e51eb99a84">
+          <body>&lt;p>The &lt;code>ownedFeatureChainings&lt;/code> of this Feature are the &lt;code>ownedRelationships&lt;/code> that are FeatureChainings.&lt;/code></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cb81077b-dec2-43b4-baf8-fbecbb1c99e7" name="" visibility="public">
+          <language>English</language>
+          <body>ownedFeatureChaining = ownedRelationship->selectByKind(FeatureChaining)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="ff9a9925-f630-4e50-a4a3-4ec270145254" name="featureChainingFeature" visibility="public">
+        <ownedComment xmi:id="954e9faf-cad2-4567-8604-329c97251ce3" annotatedElement="ff9a9925-f630-4e50-a4a3-4ec270145254">
+          <body>&lt;p>The &lt;code>chainingFeatures&lt;/code> of a Feature are the &lt;code>chainingFeatures&lt;/code> of its &lt;code>ownedFeatureChainings&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="f7567e12-5e65-4264-9951-df5fb1d2dae9" name="" visibility="public">
+          <language>English</language>
+          <body>chainingFeature = ownedFeatureChaining.chainingFeature</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="6d0b6dcf-2f6b-449e-b81a-ed6cce0548b4" name="featureIsDerived" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="99f5d412-3be1-46c4-a8ca-6a39fea605f0" name="" visibility="public">
+          <language>English</language>
+          <body>chainingfeatureChainings->notEmpty() implies (owningFeatureMembership &lt;> null implies owningFeatureMembership.isDerived)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="f02fd3ad-9768-43e7-ac6e-c8f1c2f685a7" name="featureChainingFeatureNot1" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c3e79fab-0992-4f3b-a4d2-4fc09b0c651c" name="" visibility="public">
+          <language>English</language>
+          <body>chainingFeatures->size() &lt;> 1</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="75ae75dc-78b1-4943-8619-8aba81d41185" name="featureInverseFeatures" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="47c426b4-ba71-4eb2-819c-2d39877eceda" name="" visibility="public">
+          <language>English</language>
+          <body>inverseFeature = invertingFeatureInverting.featureInverse</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="6b353d48-5413-4789-ba3e-f5f187564c15" name="featureInvertedFeature" visibility="public" constrainedElement="124e57c2-e7ac-4bbd-8ae3-b74186c4259c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="1a5c2e07-5261-4646-bee4-c7e645f62f0f" name="" visibility="public">
+          <language>English</language>
+          <body>invertedFeature = invertedFeatureInverting.featureInverted</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="48c15abc-52db-4cc7-8e72-1f4f37d4c194" general="4e5f8972-c473-4bc0-8edf-bb508993d08e"/>
+      <ownedAttribute xmi:id="4e18e321-e8e9-4751-a149-4c1cf2245b7a" name="owningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c c1a0b88f-cde6-41fb-b4cb-ab881827eef7 19d0efea-dfcb-490d-96a1-8cf8d7c3d4bb" association="4f16dcf2-4258-41d7-a3c5-62770d9e0b31">
+        <ownedComment xmi:id="b595cd26-5a0d-46d9-9d53-769ea5e1ce54" annotatedElement="4e18e321-e8e9-4751-a149-4c1cf2245b7a">
+          <body>&lt;p>The Type that is the &lt;code>owningType&lt;/code> of the &lt;code>owningFeatureMembership&lt;/code> of this Type.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4939518a-3152-4495-b324-1697eee4cd00" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="aa3555d8-fa69-44ad-9b1f-ae2e2baf136e" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="771e901f-0b6e-4fca-a24d-55df2c14091b" name="isUnique" visibility="public">
+        <ownedComment xmi:id="e8aa3dce-9f70-4414-8f67-c694bdf378bb" annotatedElement="771e901f-0b6e-4fca-a24d-55df2c14091b">
+          <body>&lt;p>Whether or not values for this Feature must have no duplicates or not.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="e376dc58-6616-4025-9177-173f3eb96efa" name="" visibility="public" value="true"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a51abe1e-d8e0-4d55-a939-e47404a711e9" name="isOrdered" visibility="public">
+        <ownedComment xmi:id="72b38644-cb34-43b7-aac2-8548bc68b4f6" annotatedElement="a51abe1e-d8e0-4d55-a939-e47404a711e9">
+          <body>&lt;p>Whether an order exists for the values of this Feature or not.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="78ce9b8e-bbaf-4734-945f-a6f80202b75a" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b727584c-d321-46a6-ab44-17b1304bc1b6" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isDerived="true" association="6f824388-297d-4f3f-b68b-40aacbc18205">
+        <ownedComment xmi:id="ddc6eef2-4afd-458c-94ae-7a24eb08d6f4" annotatedElement="b727584c-d321-46a6-ab44-17b1304bc1b6">
+          <body>&lt;p>Types that restrict the values of this Feature, such that the values must be instances of all the types. The types of a Feature are derived from its &lt;code>ownedFeatureTypings&lt;/code> and the &lt;code>types&lt;/code> of its &lt;code>ownedSubsettings&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="718da35c-ac3b-4630-810f-5046a2ed85b9" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f1915c59-bf17-48b5-8b4b-464a120e96de" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0c9f1849-0def-4882-9b31-44d9d5dd02f4" name="ownedRedefinition" visibility="public" type="e23ad491-fe87-4830-8d63-a0bc8f5e953a" aggregation="composite" isDerived="true" subsettedProperty="f859c856-58ff-4e98-965d-c1366e9427f2" association="cc60399b-b003-4ec0-9bc5-9188053e8ac9">
+        <ownedComment xmi:id="5499720e-6e3d-4ff9-9780-009acf7179b5" annotatedElement="0c9f1849-0def-4882-9b31-44d9d5dd02f4">
+          <body>&lt;p>The &lt;code>ownedSubsettings&lt;/code> of this Feature that are Redefinitions, for which the Feature is the &lt;code>redefiningFeature&lt;/code>.&lt;/p>
+
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d0063753-ad94-4cc6-89fd-44bff3bd99fe" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="25f4a0e0-3b01-4940-a18d-c1201a73e699" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f859c856-58ff-4e98-965d-c1366e9427f2" name="ownedSubsetting" visibility="public" type="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56" aggregation="composite" isDerived="true" subsettedProperty="d65bfe47-3744-4fb9-a371-dc053aabfccd 56554315-3b03-4792-8b39-a70f691ef89c" association="992f3f49-a8bb-4c15-a718-7db7ca370255">
+        <ownedComment xmi:id="bb8ab179-bf00-4c66-8ac0-4f7f18d6c72e" annotatedElement="f859c856-58ff-4e98-965d-c1366e9427f2">
+          <body>&lt;p>The &lt;code>ownedGeneralizations&lt;/code> of this Feature that are Subsettings, for which the Feature is the &lt;code>subsettingFeature&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e1e92bd-26fe-465f-900d-7490e9984e55" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5d5794b1-3628-42d6-b538-cc2df017ff33" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b2830939-3d87-40dc-8acf-ed3f043eba1a" name="owningFeatureMembership" visibility="public" type="387c1ace-4ad1-44eb-b8b5-bfe420975a97" isDerived="true" subsettedProperty="4e9a7462-c2c0-42cd-a715-dc21395cc779 352ca786-8a01-41ef-a044-2706c71bfa13 001f651d-a444-4281-8401-3d8f65276508" association="77ec8e9e-dc35-45b5-b3ac-964b7e3114d3">
+        <ownedComment xmi:id="ba213c4a-5377-434b-b02d-3535d8e4e532" annotatedElement="b2830939-3d87-40dc-8acf-ed3f043eba1a">
+          <body>&lt;p>The FeatureMembership that owns this Feature as an &lt;code>ownedMemberFeature&lt;/code>, determining its &lt;code>owningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e414ac4e-5b8d-4473-b207-2f0dca04a1b1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ee5639b1-3571-467b-ad2b-69e5941829db" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="86c8bd76-d1c5-4cd4-b6a0-c2e0d6f179d6" name="isComposite" visibility="public">
+        <ownedComment xmi:id="3cdcb08f-564b-4a63-a54c-66aa1a7741a2" annotatedElement="86c8bd76-d1c5-4cd4-b6a0-c2e0d6f179d6">
+          <body>&lt;p>Whether the Feature is a composite &lt;code>feature&lt;/code> of its &lt;code>featuringType&lt;/code>. If so, the values of the Feature cannot exist after the instance of the &lt;code>featuringType&lt;/code> no longer does.&lt;/p>.
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="e551b4c5-d21e-43b2-ad14-6124bc6f643d" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="dcbe60cb-6270-4318-a82e-e50be82b3258" name="isEnd" visibility="public">
+        <ownedComment xmi:id="7046f3d2-449e-4202-b023-8782d9667865" annotatedElement="dcbe60cb-6270-4318-a82e-e50be82b3258">
+          <body>&lt;p>Whether or not the this Feature is an end Feature, requiring a different interpretation of the &lt;code>multiplicity&lt;/code> of the Feature.&lt;/p>
+
+&lt;p>An end Feature is always considered to map each domain entity to a single co-domain entity, whether or not a Multiplicity is given for it. If a Multiplicity is given for an end Feature, rather than giving the co-domain cardinality for the Feature as usual, it specifies a cardinality constraint for &lt;em>navigating&lt;/em> across the &lt;code>endFeatures&lt;/code> of the &lt;code>featuringType&lt;/code> of the end Feature. That is, if a Type has &lt;em>n&lt;/em> &lt;code>endFeatures&lt;/code>, then the Multiplicity of any one of those end Features constrains the cardinality of the set of values of that Feature when the values of the other &lt;em>n-1&lt;/em> end Features are held fixed.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="3b403f94-277f-4dc2-9506-9e2bd183857b" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="77c1ed60-89c8-47d0-9615-bfcce38ed603" name="endOwningType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" subsettedProperty="d071e7ea-2566-41c5-9eff-acc7a2507370 4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="e17d07b1-306e-4ecd-9e27-1e24970f7e86">
+        <ownedComment xmi:id="57487fa0-bbb1-4eb3-bf12-bc99839add28" annotatedElement="77c1ed60-89c8-47d0-9615-bfcce38ed603">
+          <body>&lt;p>The Type that is related to this Feature by an EndFeatureMembership in which the Feature is an &lt;code>ownedMemberFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ec92399b-9bef-4c1c-8b81-10854e4c3c08" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="681da7bc-d701-4a8e-bcad-97ee6c600064" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fcd09804-1b64-4b15-8178-88b85a84cabe" name="ownedTyping" visibility="public" type="38d72c05-06ba-4112-bd58-c4519c98d654" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="d65bfe47-3744-4fb9-a371-dc053aabfccd 89301e23-4221-4e3e-9d33-5d1f1be4a0bd" association="a2779097-61e4-4127-afa7-fddb0cc6ecef">
+        <ownedComment xmi:id="5e9e83e6-9b0b-453f-afd5-7b2941288d15" annotatedElement="fcd09804-1b64-4b15-8178-88b85a84cabe">
+          <body>&lt;p>The &lt;code>ownedGeneralizations&lt;/code> of this Feature that are FeatureTypings, for which the Feature is the &lt;code>typedFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e3c30ea-0f77-4771-84a4-e360828242a6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d6c7b05a-fe3a-4709-99c6-452a577f133b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="19d0efea-dfcb-490d-96a1-8cf8d7c3d4bb" name="featuringType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isDerived="true" association="f4af4bb1-5b34-44a1-a89d-04cd7ef827c6">
+        <ownedComment xmi:id="5d20dc0a-0a42-4099-a561-2f75354bcab6" annotatedElement="19d0efea-dfcb-490d-96a1-8cf8d7c3d4bb">
+          <body>&lt;p>Types that feature this Feature, such that any instance in the domain of the Feature must be classified by all of these Types, including at least all the &lt;code>featuringTypes&lt;/code> of its &lt;code>ownedTypeFeaturings&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cc4703c6-e4f8-46c2-9494-d7eec1e18838" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ea967ec8-a83a-47fc-94c5-a3cee75c7fe4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4350f5dd-3fd1-4ce9-895d-f7e4f4e902d0" name="ownedTypeFeaturing" visibility="public" type="93188b57-52eb-495f-a50e-c37d01391718" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 352ca786-8a01-41ef-a044-2706c71bfa13" association="ea196dae-61d5-4bc5-972d-088841627f34">
+        <ownedComment xmi:id="c43bcab4-06c4-47d1-a130-a9afca903f74" annotatedElement="4350f5dd-3fd1-4ce9-895d-f7e4f4e902d0">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Feature that are TypeFeaturings, for which the Feature is the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f3757cbd-35d9-4d6e-97be-47779beda2d3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2d400c06-3f36-4c4c-a0ea-1f029c5dd8c4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="51e4db3b-824c-4dfb-9520-1914ef00a003" name="isDerived" visibility="public">
+        <ownedComment xmi:id="2e648720-94d5-44e7-8985-1e376c7d4900" annotatedElement="51e4db3b-824c-4dfb-9520-1914ef00a003">
+          <body>&lt;p>Whether the values of this Feature&amp;nbsp;can always be computed from the values of other Features.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="c8f0342d-3396-411e-8c5e-94165748bb5f" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="315842cc-a938-4b0b-a4f8-e6a582856183" name="chainingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isUnique="false" isDerived="true" association="1e0e4611-ca36-47d3-b839-094e1f226695">
+        <ownedComment xmi:id="977c1c94-754b-459b-a8c1-2a9005f74dfa" annotatedElement="315842cc-a938-4b0b-a4f8-e6a582856183">
+          <body>&lt;p>The Features that are chained together to determine the values of this Feature, derived from the &lt;code>chainingFeatures&lt;/code> of the &lt;code>ownedFeatureChainings&lt;/code> of this Feature, in the same order. The values of a Feature with chainingFeatures are the same as values of the last Feature in the chain, which can be found by starting with the values of the first Feature (for each instance of the original Feature's domain), then on each of those to the values of the second Feature in chainingFeatures, and so on, to values of the last Feature. The Features related to a Feature by a FeatureChaining are identified as its chainingFeatures.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1d9d5d43-761a-409e-8d2e-4ea87347dcfc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="62e9fe58-7362-443a-910e-2b20792ec8e3" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="35f8df14-8a34-4794-be77-6e1fb2ca9652" name="ownedFeatureInverting" visibility="public" type="fe28e281-93bf-44fd-bd17-8eb003a4c1cc" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 dfd4554b-6c8f-4890-a543-3bb963a687cf" association="42622d2b-233d-4573-a4a0-d81cb1022c2c">
+        <ownedComment xmi:id="130b76b3-3880-44d6-8262-9d0393492e37" annotatedElement="35f8df14-8a34-4794-be77-6e1fb2ca9652">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Feature that are FeatureInvertings, for which the Feature is the &lt;code>featureInverted&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7eb7730a-30e4-452a-93f0-234f582f7d83" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5edecf32-0979-41d1-9737-a17daf17a309" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="56d0de12-8eef-4d84-8cbb-f754663ed226" name="ownedFeatureChaining" visibility="public" type="dde0979c-8cf4-466f-8563-b2ab2f194c42" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="1080ea47-758c-4f64-ac8b-95aac1b2c580">
+        <ownedComment xmi:id="5823d9e9-09ad-4261-9fa7-b0cae698161f" annotatedElement="56d0de12-8eef-4d84-8cbb-f754663ed226">
+          <body>&lt;p>The FeatureChainings that are among the &lt;code>ownedRelationships&lt;/owned> of this Feature (identify their &lt;code>featureChained&lt;/code> also as an &lt;code>owningRelatedElement&lt;/code>).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f2a0678f-8935-4a6e-bb6a-1ef00db3a7f0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="80dda5bb-238d-4439-9a31-28d389ae14c9" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f8011c92-167f-418e-8b5f-d96fa135d9bb" name="isReadOnly" visibility="public">
+        <ownedComment xmi:id="d6aae4b4-7195-4a4b-aa59-6c17384861cc" annotatedElement="f8011c92-167f-418e-8b5f-d96fa135d9bb">
+          <body>&lt;p>Whether the values of this Feature can change over the lifetime of an instance of the domain.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="1250a34c-8db2-445e-8393-4527f27b13a0" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="67004a48-f339-4787-bf36-fc04542c5f49" name="isPortion" visibility="public">
+        <ownedComment xmi:id="62d753b7-5ba2-4826-aa2e-f3af973611bb" annotatedElement="67004a48-f339-4787-bf36-fc04542c5f49">
+          <body>&lt;p>Whether the values of this Feature are contained in the space and time of instances of the Feature&amp;#39;s domain.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="75e3b062-7f62-4b6a-bfcb-ed9269e8bb26" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="28b41120-f0bd-4a91-8bb2-c41f9f3e6562" name="direction" visibility="public" type="1fb9436a-0c88-4c70-8d2b-ad0e3e39f930">
+        <ownedComment xmi:id="2244caac-1303-47ae-8e78-a74d06e4fdb7" annotatedElement="28b41120-f0bd-4a91-8bb2-c41f9f3e6562">
+          <body>&lt;p>Determines how values of this Feature are determined or used (see FeatureDirectionKind).&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="febbed19-1a70-456b-9701-123ddfe92763" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="047ba1e4-6583-42c3-bbe3-50c0cf2a04bd" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ab4e40c2-bc63-4d9f-82e2-1cb625616d10" name="ownedReferenceSubsetting" visibility="public" type="6f8dba76-c940-4351-9052-c7b90e0663d8" aggregation="composite" isDerived="true" subsettedProperty="f859c856-58ff-4e98-965d-c1366e9427f2" association="e792bd50-071f-4a2d-81d0-feeb333f183f">
+        <ownedComment xmi:id="d86c02ee-0aae-46a8-99ba-fbe8a0ea442d" annotatedElement="ab4e40c2-bc63-4d9f-82e2-1cb625616d10">
+          <body>&lt;p>The one &lt;code>ownedSubsetting&lt;/code> of this Feature, if any, that is a ReferenceSubsetting, for which the Feature is the &lt;code>referencingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8608e134-024f-413a-8759-68b23947248e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="461ccc72-8e47-4d35-a1da-a5009acc02e2" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="a1fc2ef3-d570-48e6-95db-9059f6aadd25" name="directionFor" visibility="public" bodyCondition="742b68bc-2063-4855-bcc1-e2bb5375a30c">
+        <ownedComment xmi:id="b8f02ac7-6521-4296-9a50-f509c5f3e86f" annotatedElement="a1fc2ef3-d570-48e6-95db-9059f6aadd25">
+          <body>&lt;p>Return the &lt;code>directionOf&lt;/code> this Feature relative to the given &lt;code>type&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="742b68bc-2063-4855-bcc1-e2bb5375a30c" name="directionForBody" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="45e2f94d-6a54-41b7-8880-05fa1de1b7e8" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>type.directionOf(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="a827f05b-e69b-4a4b-b9ac-cde690a86e5d" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e"/>
+        <ownedParameter xmi:id="d0cfd3b8-1e19-4e77-978d-ceeb358b6159" name="" visibility="public" type="1fb9436a-0c88-4c70-8d2b-ad0e3e39f930" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e48b20a-5574-4b56-b3b5-808dae69e5dd" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="44e812fb-b7d8-4695-a987-12e399bb11f8" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="b0d0834e-c917-42e5-9b25-fdb6934c25bd" name="isFeaturedWithin" visibility="public" bodyCondition="573d2299-f618-4224-8446-12e1e6ec5502">
+        <ownedComment xmi:id="617656da-ba43-475f-9c35-55ad8fd9a23d" annotatedElement="b0d0834e-c917-42e5-9b25-fdb6934c25bd">
+          <body>&lt;p>Return whether this Feature has the given &lt;code>type&lt;/code> as a direct or indirect &lt;code>featuringType&lt;/code>. If &lt;code>type&lt;/code> is null, then check if this Feature is implicitly directly or indirectly featured in &lt;em>Base::Anything&lt;/em>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="573d2299-f618-4224-8446-12e1e6ec5502" name="isFeaturedWithIn_Body" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="100cff8f-9470-4bcc-90ca-974f99a7b301" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>type = null and feature.featuringType->isEmpty() or
+    type &lt;> null and feature.featuringType->includes(type) or
+    feature.featuringType->exists(t |
+        t.oclIsKindOf(Feature) and
+        t.oclAsType(Feature).isFeaturedWithin(type)) </body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="9c8d0089-b505-42a5-aa6c-bc8b321e4686" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d35d183a-4d4d-435f-b508-d383a13c9de1" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e0f80dc0-cbdd-491d-8574-2bd00ade0d78" name="" visibility="public" value="1"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="807b71e3-fef1-4b14-a43d-6d8739789c12" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="2274accb-8aa7-4f56-afd9-77d2c99ed318" name="effectiveName" visibility="public" bodyCondition="e4c4a832-c7cb-4136-99b5-114f3021f806" redefinedOperation="a047ae2c-0109-4d52-9cef-b13139830170">
+        <ownedComment xmi:id="f3695476-da11-482e-be29-4b3a5f91d2be" annotatedElement="2274accb-8aa7-4f56-afd9-77d2c99ed318">
+          <body>&lt;p>If a Feature has no &lt;code>name&lt;/code>, then its effective name is given by the effective name of the Feature returned by &lt;code>namingFeature&lt;/code>, if any.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="e4c4a832-c7cb-4136-99b5-114f3021f806" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="13d828c8-2441-4a25-8b08-66a2e4184895" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if name &lt;> null then
+    name
+else
+    let namingFeature : Feature = namingFeature() in
+    if namingFeature = null then
+        null
+    else
+        namingFeature.effectiveName()
+    endif
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="f14d3ee6-1db8-4cdf-a55b-ceddfe91975e" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fa8f5743-809f-4765-a69d-581963872b9b" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="28b1b9a8-797a-455f-8682-2bc82de1ed84" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="c8e0dccb-213e-4fda-ad2b-2ef20ec73ab4" name="namingFeature" visibility="public" bodyCondition="dd2fba16-73cd-4288-ab5d-d9e79fb174f1">
+        <ownedComment xmi:id="78afae95-2c6f-469f-9c5c-5f4f58881e54" annotatedElement="c8e0dccb-213e-4fda-ad2b-2ef20ec73ab4">
+          <body>&lt;p>By default, the naming feature of a Feature is given by its first redefined Feature, if any.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="dd2fba16-73cd-4288-ab5d-d9e79fb174f1" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="138b956f-99f8-4cf4-869c-b9c1e7e92069" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let redefinitions : Sequence(Redefinition) = ownedRedefinition in
+if redefinitions->isEmpty() then
+    null
+else
+    redefinitions->at(1).redefinedFeature
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="48cf1f52-3203-4adb-abd9-b2cccdf8fdb7" name="" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="70296001-4d49-4768-a20a-268c5b68442d" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6fe2d8f1-a01c-4b5e-b654-9d5de9a21415" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="38d72c05-06ba-4112-bd58-c4519c98d654" name="FeatureTyping" visibility="public">
+      <ownedComment xmi:id="a04b6ec6-6bf1-4728-92bf-c0bd55394739" annotatedElement="38d72c05-06ba-4112-bd58-c4519c98d654">
+        <body>&lt;p>FeatureTyping is Specialization in which the &lt;code>specific&lt;/code> Type is a Feature. This means the set of instances of the (specific) &lt;code>typedFeature&lt;/code> is a subset of the set of instances of the (general) &lt;code>type&lt;/code>. In the simplest case, the &lt;code>type&lt;/code> is a Classifier, whereupon the &lt;code>typedFeature&lt;/code> subset has instances interpreted as sequences ending in things (in the modeled universe) that are instances of the Classifier.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="2706ae20-77b1-4cf8-9ff8-2809201de1d0" general="57982b55-8eb5-404e-8e46-e2e7b774a2b0"/>
+      <ownedAttribute xmi:id="41bcda86-45ad-49c4-a552-81c282cabfc1" name="typedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="db88a7ad-ac20-4c44-9b19-26b4444dac25" association="7f60f971-3958-4bd6-a1db-4fb6df161220">
+        <ownedComment xmi:id="a862bb42-b34a-4740-a26d-6fc07df78dda" annotatedElement="41bcda86-45ad-49c4-a552-81c282cabfc1">
+          <body>&lt;p>The Feature that has its Type determined by this FeatureTyping.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9cff64d7-6cdf-4e43-837c-908ba179db63" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="73e6535f-a068-45a3-a3a3-357a4560581a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d536c4ac-f8ed-475e-9750-bc30806712a4" name="type" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="4217a922-d3b8-4556-be58-8f1922062604" association="ac68c7fd-e497-41ba-ad43-6d58ec597ecf">
+        <ownedComment xmi:id="a1c92d76-559f-4397-8283-e31d0862c17a" annotatedElement="d536c4ac-f8ed-475e-9750-bc30806712a4">
+          <body>&lt;p>The Type that is being applied by this FeatureTyping.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c3d71701-0bff-4541-a737-0c119244ff0d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d1eab272-2f27-47e2-baf7-2b91a4d5f2a7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="92b93b27-977b-4779-95a9-fe80ff4bd455" name="owningFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" redefinedProperty="521c8366-388f-410c-a57b-5256934269b5" subsettedProperty="41bcda86-45ad-49c4-a552-81c282cabfc1" association="a2779097-61e4-4127-afa7-fddb0cc6ecef">
+        <ownedComment xmi:id="776c3776-2f3f-4954-86fb-654729667d16" annotatedElement="92b93b27-977b-4779-95a9-fe80ff4bd455">
+          <body>&lt;p>The Feature that owns this FeatureTyping (which must also be the &lt;code>typedFeature&lt;/code>).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="db7bb99b-f7ea-460f-8748-3607b0c6ad01" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="85efa3ea-cbfd-4759-9b7c-8e6bef90933d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="992f3f49-a8bb-4c15-a718-7db7ca370255" name="" visibility="public" memberEnd="cddd2eb1-4d1e-439c-bc90-88583bfeb153 f859c856-58ff-4e98-965d-c1366e9427f2"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="e792bd50-071f-4a2d-81d0-feeb333f183f" name="" visibility="public" memberEnd="ab4e40c2-bc63-4d9f-82e2-1cb625616d10 568bfd45-c088-4cf6-b582-fc7a9e714d1e"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="f6a24d76-1e48-43a8-8995-6e7a7ce7be7e" name="EndFeatureMembership" visibility="public">
+      <ownedComment xmi:id="8816cf68-869d-4ae7-8d7a-b4d71ebf01cb" annotatedElement="f6a24d76-1e48-43a8-8995-6e7a7ce7be7e">
+        <body>&lt;p>EndFeatureMembership is a FeatureMembership that requires its &lt;code>memberFeature&lt;/code> be owned and have &lt;code>isEnd = true&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="2b609a9c-8911-4e3a-b0f7-6824147f2a04" name="endFeatureMembershipIsEnd" visibility="public">
+        <ownedComment xmi:id="cece55fd-05de-4cb6-9b6b-bddeb7711d47" annotatedElement="2b609a9c-8911-4e3a-b0f7-6824147f2a04">
+          <body>&lt;p>The &lt;code>ownedMemberFeature&lt;/code> of an EndFeatureMembership must be an end Feature.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="88f9b674-f878-4205-b074-5625a0c2b48c" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMemberFeature.isEnd</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="6adc0061-4e1a-4df7-9929-2d1f5e50c9b6" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="a1ce3d0c-8371-416f-bfca-59bbfdf94cf9" name="ownedMemberFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="5f1b4316-412a-42c9-b63e-57113c23b98c">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7ba2ee56-440a-4cfd-9f86-3714d8a21ae5" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="201cea6b-e5b8-4c02-bc6a-8017dd43b05e" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fe28e281-93bf-44fd-bd17-8eb003a4c1cc" name="FeatureInverting" visibility="public">
+      <ownedComment xmi:id="6b22c605-1415-4ae2-a34b-06bff6e55ec2" annotatedElement="fe28e281-93bf-44fd-bd17-8eb003a4c1cc">
+        <body>&lt;p>A FeatureInverting is a Relationship between Features asserting that their interpretations (sequences) are the reverse of each other, identified as &lt;code>featureInverted&lt;/code> and &lt;code>invertingFeature&lt;/code>. For example, a Feature identifying each person's parents is the inverse of a Feature identifying each person's children.  A person identified as a parent of another will identify that other as one of their children.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="8d64e9be-0ae4-42db-a5d5-5f63ebf5ff83" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="ee1901d4-008f-452d-99fe-ae3c23ec2e2d" name="featureInverted" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="c00ebefa-55b3-4aec-90f7-3d0d363f45b4">
+        <ownedComment xmi:id="616f5256-a9ad-4a29-838a-eda9243398b2" annotatedElement="ee1901d4-008f-452d-99fe-ae3c23ec2e2d">
+          <body>&lt;p>Feature that is an the inverse of &lt;code>invertingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="468b7c82-47a6-4fbb-b786-15913dea664b" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="14a658f1-aee1-4ac2-83ed-3ab5e95772c7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="18d3a749-7193-4370-9a9f-38f57eac4c71" name="invertingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="1083037c-bbfb-4e78-afa2-a1b8acc4b45d">
+        <ownedComment xmi:id="a039fbaf-a3a2-4a7b-8e60-b5ece59ba524" annotatedElement="18d3a749-7193-4370-9a9f-38f57eac4c71">
+          <body>&lt;p>Feature that is an inverse of &lt;code>invertedFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="19bac199-72f8-4005-b9de-85328fbb4b41" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4ddcae37-cdbe-4869-a17d-6e24c87c04b4" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0debc59d-e1b1-435c-97a7-b63b7ce07303" name="owningFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314 ee1901d4-008f-452d-99fe-ae3c23ec2e2d" association="42622d2b-233d-4573-a4a0-d81cb1022c2c">
+        <ownedComment xmi:id="94f8c823-795b-4393-a520-f2543d4b5f81" annotatedElement="0debc59d-e1b1-435c-97a7-b63b7ce07303">
+          <body>&lt;p>A &lt;code>featureInverted&lt;/code> that is also an &lt;code>owningRelatedElement&lt;code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0ab60753-3416-4085-a2dc-092262f75078" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b3c994c-284e-41f9-b8bc-818c99c5f3aa" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="42622d2b-233d-4573-a4a0-d81cb1022c2c" name="" visibility="public" memberEnd="35f8df14-8a34-4794-be77-6e1fb2ca9652 0debc59d-e1b1-435c-97a7-b63b7ce07303"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="e23ad491-fe87-4830-8d63-a0bc8f5e953a" name="Redefinition" visibility="public">
+      <ownedComment xmi:id="11bbc386-38ec-4241-a7e2-5e090fb12c5d" annotatedElement="e23ad491-fe87-4830-8d63-a0bc8f5e953a">
+        <body>&lt;p>Redefinition specializes&amp;nbsp;Subsetting to require&amp;nbsp;the &lt;code>redefinedFeature&lt;/code> and the&amp;nbsp;&lt;code>redefiningFeature&lt;/code> to have the same values (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>). This means any restrictions on the &lt;code>redefiningFeature&lt;/code>, such as &lt;code>type&lt;/code> or &lt;code>multiplicity&lt;/code>, also apply to the &lt;code>redefinedFeature&lt;/code> (on each instance of the &lt;code>owningType&lt;/code> of the redefining Feature), and vice versa. The &lt;code>redefinedFeature&lt;/code> might have&amp;nbsp;values for instances of the &lt;code>owningType&lt;/code> of the &lt;code>redefiningFeature&lt;/code>, but only as instances of the &lt;code>owningType&lt;/code> of the &lt;code>redefinedFeature&lt;/code> that happen to also be instances of the &lt;code>owningType&lt;/code> of the &lt;code>redefiningFeature&lt;/code>. This is supported by the constraints inherited from&amp;nbsp;Subsetting on the domains of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code>. However, these constraints are narrowed for Redefinition to require the &lt;code>owningTypes&lt;/code> of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code> to be different and the &lt;code>redefinedFeature&lt;/code> to&amp;nbsp;not be imported into the &lt;code>owningNamespace&lt;/code> of the &lt;code>redefiningFeature&lt;/code>.&amp;nbsp;This&amp;nbsp;enables&amp;nbsp;the &lt;code>redefiningFeature&lt;/code> to have the same name as the &lt;code>redefinedFeature&lt;/code> if desired.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="16cb2d42-f1ca-4d33-b374-73f3550106d0" general="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56"/>
+      <ownedAttribute xmi:id="71ce9eeb-30d1-4f6e-b9b3-b619acca795f" name="redefiningFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="4d938e84-5350-4b24-bdcd-6591091d85be" association="4026e06e-97eb-4fb0-bd99-3e6259d4ea6a">
+        <ownedComment xmi:id="7a257a77-beee-4e76-8521-ba6d0b474a7b" annotatedElement="71ce9eeb-30d1-4f6e-b9b3-b619acca795f">
+          <body>&lt;p>The Feature that is redefining the &lt;code>redefinedFeature&lt;/code> of this Redefinition.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="57c0129b-f493-4edf-90ab-2ff21ec4a6c3" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ea794821-299a-45d1-b998-558bcc3c825d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b3f4a72c-2626-4937-8407-ed75b911f42d" name="redefinedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="7537c16f-8968-42b7-bf42-d7e7ae6cfeee" association="ca4f437a-ff0a-4f03-b57e-c8da73775d50">
+        <ownedComment xmi:id="614e84ee-dbe1-4d9e-bb5d-4583cd409a30" annotatedElement="b3f4a72c-2626-4937-8407-ed75b911f42d">
+          <body>&lt;p>The Feature that is redefined by the &lt;code>redefiningFeature&lt;/code> of this Redefinition.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="42309b9d-3de1-440c-9093-2a230f851824" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3f095fc1-4267-4224-bf37-d38d64f06b45" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f2878011-8ea5-4911-8abb-d7cbda17096c" name="" visibility="public" memberEnd="cbdf8984-806e-484e-84fb-8f4d90fc17db c056ca13-346f-46f4-b73e-d631bd031423">
+      <ownedEnd xmi:id="c056ca13-346f-46f4-b73e-d631bd031423" name="featuringOfType" visibility="public" type="f32ea62b-dfe6-495e-a8cf-4ea54a106321" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="f2878011-8ea5-4911-8abb-d7cbda17096c">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="908bb26b-817d-4504-a2a0-0dde5523fadd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8cfae2de-ba2b-4521-b2ae-283a9b446e67" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5f1b4316-412a-42c9-b63e-57113c23b98c" name="" visibility="public" memberEnd="a1ce3d0c-8371-416f-bfca-59bbfdf94cf9 956c00a7-b096-4556-afd5-f717a52166d6">
+      <ownedEnd xmi:id="956c00a7-b096-4556-afd5-f717a52166d6" name="owningEndFeatureMembership" visibility="public" type="f6a24d76-1e48-43a8-8995-6e7a7ce7be7e" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="5f1b4316-412a-42c9-b63e-57113c23b98c">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="04fb82ff-3cd6-4e60-9808-9985d35a718e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0f56a465-bde9-4b2e-8d18-b5a055ae8012" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ca4f437a-ff0a-4f03-b57e-c8da73775d50" name="" visibility="public" memberEnd="b3f4a72c-2626-4937-8407-ed75b911f42d fda739ee-459e-4b24-b3c8-d55b2b954579">
+      <ownedEnd xmi:id="fda739ee-459e-4b24-b3c8-d55b2b954579" name="redefining" visibility="public" type="e23ad491-fe87-4830-8d63-a0bc8f5e953a" subsettedProperty="10aa2871-4318-4d93-aa42-d81688d3cba3" association="ca4f437a-ff0a-4f03-b57e-c8da73775d50">
+        <ownedComment xmi:id="5b703e03-1186-42d4-bb96-c1f6a8dc4026" annotatedElement="fda739ee-459e-4b24-b3c8-d55b2b954579">
+          <body>&lt;p>The Redefinitions with a certain Feature as the &lt;code>redefinedFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="afc443df-a236-4b2e-ac0d-4eab33518977" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="70e8378b-9b43-4a2a-8b28-eefa15bd439a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="93188b57-52eb-495f-a50e-c37d01391718" name="TypeFeaturing" visibility="public">
+      <ownedComment xmi:id="2a2cd309-6754-4785-904f-eb662ab654d7" annotatedElement="93188b57-52eb-495f-a50e-c37d01391718">
+        <body>&lt;p>A TypeFeaturing is a Featuring Relationship in which the &lt;code>featureOfType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featuringType&lt;/code> is the target. A TypeFeaturing may be owned by its &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="6881d0d0-53b5-4e89-b025-8a6d354dc640" general="f32ea62b-dfe6-495e-a8cf-4ea54a106321"/>
+      <ownedAttribute xmi:id="d69886a9-8496-419b-9548-87123a69276e" name="featureOfType" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3 824e2b65-f787-4e43-8359-ba531816c433" association="7bb2c90a-5091-4d9f-9d05-9405a0d94b56">
+        <ownedComment xmi:id="67c30a8d-4613-4da9-8577-20854ce3aa3d" annotatedElement="d69886a9-8496-419b-9548-87123a69276e">
+          <body>&lt;p>The Feature that is featured by the &lt;code>featuringType&lt;/code>. It is the &lt;code>source&lt;/code> of the Relationship.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="88e191b2-b412-4c77-b1e2-d1a8722c837f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="69955a08-f669-44ba-9578-48b3baa83443" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="35bbd9c9-aebc-48ac-ace8-77da98de6170" name="featuringType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f cbdf8984-806e-484e-84fb-8f4d90fc17db" association="6ae58ce8-e624-4de5-95c0-ffd19a6e3830">
+        <ownedComment xmi:id="c1a08a54-ccf0-446c-a427-d859b5a0e444" annotatedElement="35bbd9c9-aebc-48ac-ace8-77da98de6170">
+          <body>&lt;p>The Type that features the &lt;code>featureOfType&lt;/code>. It is the &lt;code>target&lt;/code> of the Relationship.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fba7368a-025c-4ea4-a947-0a0347e13a3f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ac3c4068-0ef7-44d4-b9f1-8868045ce42f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4da3743e-dd11-414d-a775-95bd95243319" name="owningFeatureOfType" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="d69886a9-8496-419b-9548-87123a69276e 53d1b371-a5c5-4812-87a8-a61e672f7314" association="ea196dae-61d5-4bc5-972d-088841627f34">
+        <ownedComment xmi:id="f889defb-e8c0-427e-9265-6a72dcac203c" annotatedElement="4da3743e-dd11-414d-a775-95bd95243319">
+          <body>&lt;p>The Feature that owns this TypeFeaturing and is also the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b259b7fb-1f4b-441a-9a03-99faefbbcdda" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f5c39b56-f5db-4895-a5ff-18ccfca1ba03" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="71c84d6c-06c4-4269-bf6b-f9457599cb7e" name="" visibility="public" memberEnd="824e2b65-f787-4e43-8359-ba531816c433 001f651d-a444-4281-8401-3d8f65276508">
+      <ownedEnd xmi:id="001f651d-a444-4281-8401-3d8f65276508" name="featuring" visibility="public" type="f32ea62b-dfe6-495e-a8cf-4ea54a106321" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="71c84d6c-06c4-4269-bf6b-f9457599cb7e">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c1dab507-152c-4f00-aaf6-28c812562faf" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="87278494-cfcd-4fce-a62e-1e0529d114c8" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6ae58ce8-e624-4de5-95c0-ffd19a6e3830" name="" visibility="public" memberEnd="35bbd9c9-aebc-48ac-ace8-77da98de6170 78f69a3a-bf59-4399-a6ef-82a71f44bb00">
+      <ownedEnd xmi:id="78f69a3a-bf59-4399-a6ef-82a71f44bb00" name="typeFeaturingOfType" visibility="public" type="93188b57-52eb-495f-a50e-c37d01391718" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc c056ca13-346f-46f4-b73e-d631bd031423" association="6ae58ce8-e624-4de5-95c0-ffd19a6e3830">
+        <ownedComment xmi:id="88af3f04-3524-4bf8-8c5c-ef56014d66d9" annotatedElement="78f69a3a-bf59-4399-a6ef-82a71f44bb00">
+          <body>&lt;p>The TypeFeaturings for which a certain Type is the &lt;code>featuringType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="af41733a-3b0c-4b2a-b3ab-9719f9659ada" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="be76db92-dfe9-4352-909e-1bef30159ea2" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4026e06e-97eb-4fb0-bd99-3e6259d4ea6a" name="" visibility="public" memberEnd="71ce9eeb-30d1-4f6e-b9b3-b619acca795f da982179-f911-4d63-af45-07e18974758b">
+      <ownedEnd xmi:id="da982179-f911-4d63-af45-07e18974758b" name="redefinition" visibility="public" type="e23ad491-fe87-4830-8d63-a0bc8f5e953a" subsettedProperty="56554315-3b03-4792-8b39-a70f691ef89c" association="4026e06e-97eb-4fb0-bd99-3e6259d4ea6a">
+        <ownedComment xmi:id="47782072-459d-4476-b1a8-509a6106545d" annotatedElement="da982179-f911-4d63-af45-07e18974758b">
+          <body>&lt;p>The Redefinitions with a certain Feature as the &lt;code>redefiningFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c60c8c80-66a4-4d52-8311-514cf2198d0b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="aee7f2bb-c376-4e39-9473-07caf25edd8c" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1083037c-bbfb-4e78-afa2-a1b8acc4b45d" name="" visibility="public" memberEnd="18d3a749-7193-4370-9a9f-38f57eac4c71 3c8d3a68-3b74-4611-933c-b219f0f3fdc3">
+      <ownedEnd xmi:id="3c8d3a68-3b74-4611-933c-b219f0f3fdc3" name="invertedFeatureInverting" visibility="public" type="fe28e281-93bf-44fd-bd17-8eb003a4c1cc" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="1083037c-bbfb-4e78-afa2-a1b8acc4b45d">
+        <ownedComment xmi:id="3f6bd75c-08bb-45c2-9296-df94047b868e" annotatedElement="3c8d3a68-3b74-4611-933c-b219f0f3fdc3">
+          <body>&lt;p>The FeatureInvertings that identify this Feature as their &lt;code>invertingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ef107b1a-a985-49e3-9cb7-6fe8d26b6189" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3c178b81-32ac-4180-ac3f-03d405ec33bc" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56" name="Subsetting" visibility="public">
+      <ownedComment xmi:id="8dfaee85-a4b7-4eb1-bb3a-64b2f996fb44" annotatedElement="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56">
+        <body>&lt;p>Subsetting is Generalization in which the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> Types that are Features. This means all values of the &lt;code>subsettingFeature&lt;/code> (on instances of its domain, i.e., the intersection of its &lt;code>featuringTypes&lt;/code>) are values of the &lt;code>subsettedFeature&lt;/code> on instances of its domain.&amp;nbsp; To support this,&amp;nbsp;the domain&amp;nbsp;of the &lt;code>subsettingFeature&lt;/code> must be the same or specialize (at least indirectly) the&amp;nbsp;domain&amp;nbsp;of the &lt;code>subsettedFeature&lt;/code> (via Generalization), and the range (intersection of a Feature&amp;#39;s &lt;code>types&lt;/code>) of the &lt;code>subsettingFeature&lt;/code> must specialize the range of the &lt;code>subsettedFeature&lt;/code>.&amp;nbsp;The &lt;code>subsettedFeature&lt;/code> is imported into the &lt;code>owningNamespace&lt;/code> of the &lt;code>subsettingFeature&lt;/code> (if it is not already in that namespace), requiring the names of the &lt;code>subsettingFeature&lt;/code> and &lt;code>subsettedFeature&lt;/code> to be different.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="2583f403-db8c-4489-be99-fda2f9450065" general="57982b55-8eb5-404e-8e46-e2e7b774a2b0"/>
+      <ownedAttribute xmi:id="7537c16f-8968-42b7-bf42-d7e7ae6cfeee" name="subsettedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="4217a922-d3b8-4556-be58-8f1922062604" association="afc92317-29d4-4c39-b0f9-30019cd69c8b">
+        <ownedComment xmi:id="7882bafb-7f8e-4d60-8aad-a6b3278e8a56" annotatedElement="7537c16f-8968-42b7-bf42-d7e7ae6cfeee">
+          <body>&lt;p>The Feature that is subsetted by the &lt;code>subsettingFeature&lt;/code> of this Subsetting.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="374d9e2d-b052-4c55-9131-f77634c19c78" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b1f09315-eca8-44f7-9f84-3e84aaa2ef55" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4d938e84-5350-4b24-bdcd-6591091d85be" name="subsettingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="db88a7ad-ac20-4c44-9b19-26b4444dac25" association="282f7b0d-28ff-4044-a2c0-3c4b181f41ce">
+        <ownedComment xmi:id="07d77865-eff1-4fd0-9804-27047926eb8c" annotatedElement="4d938e84-5350-4b24-bdcd-6591091d85be">
+          <body>&lt;p>The Feature that is a subset of the &lt;code>subsettedFeature&lt;/code> of this Subsetting.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="15e34247-8048-482a-87b1-5d03ea7c6e20" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="391ee681-d096-420b-af2f-80a312e7be20" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cddd2eb1-4d1e-439c-bc90-88583bfeb153" name="owningFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" redefinedProperty="521c8366-388f-410c-a57b-5256934269b5" subsettedProperty="4d938e84-5350-4b24-bdcd-6591091d85be" association="992f3f49-a8bb-4c15-a718-7db7ca370255">
+        <ownedComment xmi:id="29235a1a-7e8e-41e0-960e-cdf54cbbdab0" annotatedElement="cddd2eb1-4d1e-439c-bc90-88583bfeb153">
+          <body>&lt;p>The Feature that owns this Subsetting relationship, which must also be its &lt;code>subsettingFeature&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5dd25d4c-454b-4c8f-a6c8-2a5f64e90cec" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="37b64c10-80b7-4e0f-9490-0bc9b020e6db" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7bb2c90a-5091-4d9f-9d05-9405a0d94b56" name="" visibility="public" memberEnd="d69886a9-8496-419b-9548-87123a69276e 352ca786-8a01-41ef-a044-2706c71bfa13">
+      <ownedEnd xmi:id="352ca786-8a01-41ef-a044-2706c71bfa13" name="typeFeaturing" visibility="public" type="93188b57-52eb-495f-a50e-c37d01391718" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238 001f651d-a444-4281-8401-3d8f65276508" association="7bb2c90a-5091-4d9f-9d05-9405a0d94b56">
+        <ownedComment xmi:id="c1a7058e-fe98-494e-807b-16227924e8af" annotatedElement="352ca786-8a01-41ef-a044-2706c71bfa13">
+          <body>&lt;p>The TypeFeaturings for which a certain Feature is the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bdf7e4d1-12ee-48a5-b79b-55a279b11a0c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cd2ca2b5-753c-45ec-a9c6-6f6c7f2a0b45" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="dde0979c-8cf4-466f-8563-b2ab2f194c42" name="FeatureChaining" visibility="public">
+      <ownedComment xmi:id="5ff72ab3-0139-431a-aadf-72504c2c2a6a" annotatedElement="dde0979c-8cf4-466f-8563-b2ab2f194c42">
+        <body>&lt;p>FeatureChaining is a Relationship that makes its target Feature one of the &lt;code>chainingFeatures&lt;/code> of its owning Feature.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="563946bb-e63d-4c29-8f06-a71bd2f07768" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="6107f867-d1c9-45cc-916c-efb1105ecb31" name="chainingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="86092e96-6637-4ea4-8965-7a0310fee87e">
+        <ownedComment xmi:id="bfb20b4b-1413-4ea6-b934-c85dd1bd8ca1" annotatedElement="6107f867-d1c9-45cc-916c-efb1105ecb31">
+          <body>&lt;p>The Feature whose values partly determine values of &lt;code>featureChained&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c68b9f77-40db-4410-8052-44c791296b79" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fc7f5f41-b9fb-4019-b27c-e5884b7fecae" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="42372418-3f63-4e47-baa1-4035ead2d928" name="featureChained" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314" association="1080ea47-758c-4f64-ac8b-95aac1b2c580">
+        <ownedComment xmi:id="ef13e2f5-8c79-49dd-b33d-d447e254efc1" annotatedElement="42372418-3f63-4e47-baa1-4035ead2d928">
+          <body>&lt;p>The Feature whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6d1e6234-801d-466a-a3e5-e7962f165dab" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5084b4dd-1d62-4e7b-bf5e-06fe54ff639a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="764a97d5-f9d8-47cc-b486-87ffd2500582" name="" visibility="public" memberEnd="4cb7c84e-b94c-407a-9c19-84d0e6fa7f48 ec6e49c8-99c6-4dd7-91c8-3231140b6ebb">
+      <ownedEnd xmi:id="ec6e49c8-99c6-4dd7-91c8-3231140b6ebb" name="superclassification" visibility="public" type="d57b0c8d-0740-490d-9e11-7dd559103ee2" subsettedProperty="a6df8227-9adc-4e74-990a-02070b6dcd05" association="764a97d5-f9d8-47cc-b486-87ffd2500582">
+        <ownedComment xmi:id="cd87e7da-b600-4e2d-9d18-48c76c4794fb" annotatedElement="ec6e49c8-99c6-4dd7-91c8-3231140b6ebb">
+          <body>&lt;p>The Subclassifications with a certain &lt;code>superclassifier&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6bcb4390-c610-454d-aaff-fb3aa8b699c4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="44decaf8-a59f-42a6-905d-1eda17e26d65" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" name="Classifier" visibility="public">
+      <ownedComment xmi:id="0b512d9c-1285-4bb3-9713-cc6867887e03" annotatedElement="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da">
+        <body>&lt;p>A Classifier is a Type for model elements that classify:&lt;/p>
+
+&lt;ul>
+	&lt;li>Things&amp;nbsp;(in the universe) regardless of how Features relate them.&amp;nbsp; These are&amp;nbsp;sequences of exactly one&amp;nbsp;thing (sequence of length 1).&lt;/li>
+	&lt;li>How the above&amp;nbsp;things are related by Features. These are sequences of multiple things (length &amp;gt; 1).&lt;/li>
+&lt;/ul>
+
+&lt;p>Classifiers that classify relationships (sequence length &amp;gt; 1) must also classify the things at the end of those&amp;nbsp;sequences (sequence length =1).&amp;nbsp; Because of this, Classifiers specializing Features cannot classify anything (any sequences).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="2e4016ec-eb08-4b86-bcb7-ef0d0ae2214a" name="classifierOwnedSuperclassings" visibility="public" constrainedElement="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4126a025-8af6-4655-be9d-8cb878b3e5a0" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedSuperclassing = ownedGeneralization->intersection(superclassing)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="f5035085-8840-469a-ad2a-bb3de3c6fbd4" name="classiferMultiplicityDomain" visibility="public" constrainedElement="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da">
+        <ownedComment xmi:id="3a6473d7-2451-468f-9530-c6ca7161d5bc" annotatedElement="f5035085-8840-469a-ad2a-bb3de3c6fbd4">
+          <body>&lt;p>If a Classifier has a &lt;code>multiplicity&lt;/code>, then the &lt;code>multiplicity&lt;/code> shall have no &lt;code>featuringTypes&lt;/code> (meaning that its domain is implicitly &lt;em>Base::Anything&lt;/em>).&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="87afdf1b-6a9d-4495-bca4-77bde4fa7bf9" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>multiplicity &lt;> null implies multiplicity.featuringType->isEmpty()</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="332599cd-67c3-4d3a-898f-b3c9e214405d" general="4e5f8972-c473-4bc0-8edf-bb508993d08e"/>
+      <ownedAttribute xmi:id="f88318ca-67c0-4399-914e-2105cf31cb17" name="ownedSubclassification" visibility="public" type="d57b0c8d-0740-490d-9e11-7dd559103ee2" aggregation="composite" isDerived="true" subsettedProperty="d65bfe47-3744-4fb9-a371-dc053aabfccd" association="d68af7ed-17cd-4fb0-afce-60e83cbfc73c">
+        <ownedComment xmi:id="0f1f6652-5c8e-4238-a4fd-b4c9816320d0" annotatedElement="f88318ca-67c0-4399-914e-2105cf31cb17">
+          <body>&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this Classifier that are Subclassifications, for which this Classifier is the &lt;code>subclassifier&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5a21d592-7ed7-4bfc-ade2-56baf3075957" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2ab334e6-5c59-4d9c-b059-fbc05528127a" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d57b0c8d-0740-490d-9e11-7dd559103ee2" name="Subclassification" visibility="public">
+      <ownedComment xmi:id="2ecf452e-e931-4de6-a1a2-8330226e9399" annotatedElement="d57b0c8d-0740-490d-9e11-7dd559103ee2">
+        <body>&lt;p>Subclassification is Specialization in which both the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> Types are Classifiers. This means all instances of the specific Classifier are also instances of the general Classifier.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="b7628784-e826-4d5f-88fd-e8270d4d0366" general="57982b55-8eb5-404e-8e46-e2e7b774a2b0"/>
+      <ownedAttribute xmi:id="4cb7c84e-b94c-407a-9c19-84d0e6fa7f48" name="superclassifier" visibility="public" type="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" redefinedProperty="4217a922-d3b8-4556-be58-8f1922062604" association="764a97d5-f9d8-47cc-b486-87ffd2500582">
+        <ownedComment xmi:id="b4ee7339-c511-4a2c-8de2-4e9637a6d08a" annotatedElement="4cb7c84e-b94c-407a-9c19-84d0e6fa7f48">
+          <body>&lt;p>The more general Classifier in this Subclassification.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0ec11686-b969-48fd-bdc6-57087ea1e083" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e1a2ad81-5cf0-4a2e-9c1d-3b47e61568ca" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b0843db5-f4cc-415f-baca-4b046a6bc530" name="subclassifier" visibility="public" type="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" redefinedProperty="db88a7ad-ac20-4c44-9b19-26b4444dac25" association="7c87c21d-bf7c-4439-88ec-e8b29e56443a">
+        <ownedComment xmi:id="9e82a64c-67ac-4ba0-9596-0e5746f63caf" annotatedElement="b0843db5-f4cc-415f-baca-4b046a6bc530">
+          <body>&lt;p>The more specific Classifier in this Subclassification.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9f373591-198d-4ced-b5b6-a0e66fb2cc6f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1704dfbc-340c-40e4-8084-05213d782780" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cc7543ff-83db-4aed-a234-dde8566d02f3" name="owningClassifier" visibility="public" type="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" isDerived="true" redefinedProperty="521c8366-388f-410c-a57b-5256934269b5" association="d68af7ed-17cd-4fb0-afce-60e83cbfc73c">
+        <ownedComment xmi:id="6ecf36cf-5a62-45bf-bb2c-301b6a676c60" annotatedElement="cc7543ff-83db-4aed-a234-dde8566d02f3">
+          <body>&lt;p>The Classfier that owns this Subclassification relationship, which must also be its &lt;code>subclassifier&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ca5728da-547b-48ed-ac8e-c925852f5d39" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cefdce33-08a4-4580-bc5f-6e403553ca27" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d68af7ed-17cd-4fb0-afce-60e83cbfc73c" name="" visibility="public" memberEnd="cc7543ff-83db-4aed-a234-dde8566d02f3 f88318ca-67c0-4399-914e-2105cf31cb17"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="7c87c21d-bf7c-4439-88ec-e8b29e56443a" name="" visibility="public" memberEnd="b0843db5-f4cc-415f-baca-4b046a6bc530 2e016baa-0654-45a9-bb36-8603bc366a6c">
+      <ownedEnd xmi:id="2e016baa-0654-45a9-bb36-8603bc366a6c" name="subclassification" visibility="public" type="d57b0c8d-0740-490d-9e11-7dd559103ee2" subsettedProperty="4ed80006-8937-46a9-bea5-caf85682af75" association="7c87c21d-bf7c-4439-88ec-e8b29e56443a">
+        <ownedComment xmi:id="9e2c7583-c9f3-4347-9a80-b169c2dcbfee" annotatedElement="2e016baa-0654-45a9-bb36-8603bc366a6c">
+          <body>&lt;p>The Subclassifications with a certain &lt;code>subclassifier&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c2597dee-8584-414a-b5cf-12409108aaab" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="780a3256-14bf-4d37-a012-5723dc4dbdb7" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_B3l2AUQmEe22v6M5Q5J7KQ" name="Kernel">
+    <packagedElement xmi:type="uml:Association" xmi:id="65a228b0-db5b-4858-b985-6dcb38d3c62f" name="" visibility="public" memberEnd="1142b319-9e22-4f1b-9c92-ef4be7a186a1 00b54418-f509-4dd9-8201-d8b6768a367d">
+      <ownedEnd xmi:id="00b54418-f509-4dd9-8201-d8b6768a367d" name="owningFilter" visibility="public" type="225d1887-4b68-4a37-8298-6e7a8aa96f71" isDerived="true" subsettedProperty="4e9a7462-c2c0-42cd-a715-dc21395cc779" association="65a228b0-db5b-4858-b985-6dcb38d3c62f">
+        <ownedComment xmi:id="942344a2-c99a-470d-a8ab-0d971e69ac51" annotatedElement="00b54418-f509-4dd9-8201-d8b6768a367d">
+          <body>&lt;p>The ElementFilterMembership that owns the &lt;code>condition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f2ca22cf-fbc6-4c14-9e84-24128318ae07" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f06a4dfd-75ce-4649-8b93-77f395344cd9" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="69125898-9b34-4d62-9b3d-8011cff440ba" name="Package" visibility="public">
+      <ownedComment xmi:id="ed0b8e59-3ab8-4476-a4a2-5a7e92ef56cc" annotatedElement="69125898-9b34-4d62-9b3d-8011cff440ba">
+        <body>&lt;p>A Package is a Namespace used to group Elements, without any instance-level semantics. It may have one or more model-level evaluable &lt;code>filterCondition&lt;/code> Expressions used to filter its &lt;code>importedMemberships&lt;/code>. Any imported &lt;code>member&lt;/code> must meet all of the &lt;code>filterConditions&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="04a12dea-e563-46b1-9895-6597a4f1bbd0" name="packageOwnedMembershipVisibility" visibility="public" constrainedElement="69125898-9b34-4d62-9b3d-8011cff440ba">
+        <ownedComment xmi:id="2719e325-7c95-45a5-a9cc-a2c5d9d82f24" annotatedElement="04a12dea-e563-46b1-9895-6597a4f1bbd0">
+          <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of a Package must not have a &lt;code>visibility&lt;/code> of &lt;code>protected&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c9c05b32-618c-47e2-b20c-e63125caa48b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMembership->forAll(visibility &lt;> VisibilityKind::protected)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="80aee604-d023-41bb-94ad-13f56dae7997" name="packageImportVisibility" visibility="public" constrainedElement="69125898-9b34-4d62-9b3d-8011cff440ba">
+        <ownedComment xmi:id="be1179e9-09ca-414f-b6ab-5ac9185ee129" annotatedElement="80aee604-d023-41bb-94ad-13f56dae7997">
+          <body>&lt;p>The &lt;code>ownedImports&lt;/code> of a Package must not have a &lt;code>visibility&lt;/code> of &lt;code>protected&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="23f72a23-8f37-42dd-b890-1b352237ecff" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedImport->forAll(visibility &lt;> VisibilityKind::protected)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="e151bb8c-ce74-4fc1-b1ca-3f4189fc9031" general="732bd40e-fb64-42e2-8663-8fcee1dac982"/>
+      <ownedAttribute xmi:id="078df6ac-e5f0-4983-96ec-eb29b28691f7" name="filterCondition" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="95be54ba-4383-4d8d-80d0-7cbbe97d72b8">
+        <ownedComment xmi:id="56025ee0-5698-4fa3-8c19-e35e0b6f1ffd" annotatedElement="078df6ac-e5f0-4983-96ec-eb29b28691f7">
+          <body>&lt;p>The model-level evaluable Boolean Expressions used to filter the &lt;code>members&lt;/code> of this Package, derived as those &lt;code>ownedMembers&lt;/code> of the Package that are owned via ElementFilterMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="733f0d2f-80cd-4d1b-9647-1f8127663110" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d0473577-4be8-4825-b37e-5dff68ce48da" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="026aaeda-7e70-4bee-addc-11c3dd8ccdad" name="importedMemberships" visibility="public" bodyCondition="b5f32381-a0ce-4b38-a6af-28ac696ce327" redefinedOperation="65d39ffc-24e5-4d71-a8c3-ec34112bf2c6">
+        <ownedComment xmi:id="70b55188-fe2b-46f7-bf8b-a76cca5a2576" annotatedElement="026aaeda-7e70-4bee-addc-11c3dd8ccdad">
+          <body>&lt;p>Exclude Elements that do not meet all the &lt;code>filterConditions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="b5f32381-a0ce-4b38-a6af-28ac696ce327" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="614db138-88d2-4217-96e0-c7e7d18fb8d4" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>self.oclAsType(Namespace).importedMemberships(excluded)->
+    select(m | self.includeAsMember(m.memberElement))</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="0e017270-a169-44c6-b07a-8a0a153e9d6a" name="excluded" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="70f5c147-9d84-4f89-84c8-d34f90ff4513" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6d24dd41-f93f-4d2d-86f6-eceef14eba1f" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="b10c087a-3a1e-4f81-9767-f3c31282afe1" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="60500c0f-ea4b-4d53-a6fc-e99f71b6fb23" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="af93656a-11b1-4f9d-9688-4624b3ac8971" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="9a88ca25-7a2f-454b-a104-579c23bfdcb4" name="includeAsMember" visibility="public" bodyCondition="6a195d46-b689-4b34-9cc0-85a2aa7dea6b">
+        <ownedComment xmi:id="b622f3a5-2649-4e3a-ad2f-b345c71829be" annotatedElement="9a88ca25-7a2f-454b-a104-579c23bfdcb4">
+          <body>&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the &lt;code>filterConditions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="6a195d46-b689-4b34-9cc0-85a2aa7dea6b" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="dde20907-d89a-4d3a-b287-f5d0283701ff" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let metadataAnnotations: Sequence(AnnotatingElement) = 
+    element.ownedAnnotation.annotatingElement->
+        select(oclIsKindOf(AnnotatingFeature)) in
+    self.filterCondition->forAll(cond | 
+        metadataAnnotations->exists(elem | 
+            self.checkCondition(elem, cond)))</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="a9e45d30-2968-4a44-98f4-a7953b0420e5" name="element" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="a1c8b97b-79dd-4581-b04d-2f825a8ab6eb" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="e0c2dc1d-a2c8-46aa-88d9-4c84fbe64c7f" name="checkCondition" visibility="public" bodyCondition="1359202d-5f88-4e7a-b0b2-5ad78aa3febe">
+        <ownedComment xmi:id="a00e97c7-bd6a-42ec-8960-3d82d46c5c38" annotatedElement="e0c2dc1d-a2c8-46aa-88d9-4c84fbe64c7f">
+          <body>&lt;p>Model-level evaluate the given &lt;code>condition&lt;/code> Expression with the given &lt;code>element&lt;/code> as its target. If the result is a LiteralBoolean, return its &lt;code>value&lt;/code>. Otherwise return &lt;code>false&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="1359202d-5f88-4e7a-b0b2-5ad78aa3febe" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="38ed6487-9f2f-4552-882e-fdea207dddf5" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let results: Sequence(Element) = condition.evaluate(element) in
+    result->size() = 1 and
+    results->at(1).oclIsKindOf(LiteralBoolean) and 
+    results->at(1).oclAsType(LiteralBoolean).value</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="be2192bb-db34-4c0b-9796-5bdd8f3bdf69" name="element" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="80324471-c6df-49de-a8b9-25523e07dd35" name="condition" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+        <ownedParameter xmi:id="e8219e68-2870-4ec3-8692-d87e48e7aabb" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="225d1887-4b68-4a37-8298-6e7a8aa96f71" name="ElementFilterMembership" visibility="public">
+      <ownedComment xmi:id="f92449a6-fbe9-4912-876d-7116cf73b0f9" annotatedElement="225d1887-4b68-4a37-8298-6e7a8aa96f71">
+        <body>&lt;p>ElementFilterMembership is a Mambership between a Namespace and a model-level evaluable Boolean Expression, asserting that imported &lt;code>members&lt;/code> of the Namespace should be filtered using the &lt;code>condition&lt;/code> Expression. A general Namespace does not define any specific filtering behavior, but such behavior may be defined for various specialized kinds of Namespaces.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="daed1c7d-d112-4c23-aa9b-ad4400876ea4" name="elementFilterIsModelLevelEvaluable" visibility="public" constrainedElement="225d1887-4b68-4a37-8298-6e7a8aa96f71">
+        <ownedComment xmi:id="3254a925-e823-4092-b11a-974f0cd0914a" annotatedElement="daed1c7d-d112-4c23-aa9b-ad4400876ea4">
+          <body>&lt;p>The &lt;code>condition&lt;/code> Expression must be model-level evaluable.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="7282f749-7f62-4760-93c9-1e74bbfb5cfc" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>condition.isModelLevelEvaluable</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="deb69e37-c13b-436e-bc11-7795698702be" name="elementFilterIsBoolean" visibility="public" constrainedElement="225d1887-4b68-4a37-8298-6e7a8aa96f71">
+        <ownedComment xmi:id="8185372d-d158-4b83-b708-9c877c5e24f9" annotatedElement="deb69e37-c13b-436e-bc11-7795698702be">
+          <body>&lt;p>The &lt;code>result&lt;/code> Feature of the &lt;code>condition&lt;/code> Expression must have &lt;em>ScalarValues::Boolean&lt;/em> as a &lt;code>type&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cb6a7fac-9c9a-45af-89e0-04f0f09da232" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="3ca984d0-bdb6-4f73-add1-abd57e236231" general="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d"/>
+      <ownedAttribute xmi:id="1142b319-9e22-4f1b-9c92-ef4be7a186a1" name="condition" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" aggregation="composite" isDerived="true" redefinedProperty="50d115dd-9fe9-4a0c-8d67-bcca24186f18" association="65a228b0-db5b-4858-b985-6dcb38d3c62f">
+        <ownedComment xmi:id="233e840f-9730-4c8c-bb9f-181ede493ca0" annotatedElement="1142b319-9e22-4f1b-9c92-ef4be7a186a1">
+          <body>&lt;p>The model-level evaluable Boolean Expression used to filter the &lt;code>members&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> of this ElementFilterMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0d4f57da-216b-45c5-8f89-ad772fdd4784" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fc63c783-31f3-4a3f-90cb-3522ec3f41a0" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="95be54ba-4383-4d8d-80d0-7cbbe97d72b8" name="" visibility="public" memberEnd="078df6ac-e5f0-4983-96ec-eb29b28691f7 dc8a45e0-10e3-49ee-8108-50e17ebfe3c1">
+      <ownedEnd xmi:id="dc8a45e0-10e3-49ee-8108-50e17ebfe3c1" name="conditionedPackage" visibility="public" type="69125898-9b34-4d62-9b3d-8011cff440ba" isDerived="true" subsettedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="95be54ba-4383-4d8d-80d0-7cbbe97d72b8">
+        <ownedComment xmi:id="f9e5305f-908d-43b4-820e-f7c1bbc73bf8" annotatedElement="dc8a45e0-10e3-49ee-8108-50e17ebfe3c1">
+          <body>&lt;p>The Package that has a certain Expression as a &lt;code>filterCondition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d18d120c-df48-4708-ad16-283b8a5c63f8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="049c120c-ef2d-4429-8465-e093265c0406" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="19920a63-7648-49b9-9666-eb0dcfbde515" name="Class" visibility="public">
+      <ownedComment xmi:id="3c4bd0ed-676b-41af-91d3-e0c915baba72" annotatedElement="19920a63-7648-49b9-9666-eb0dcfbde515">
+        <body>&lt;p>A Class is a Classifier of things (in the universe) that can be distinguished without regard to how they are related to other things (via Features). This means multiple things classified by the same Class can be distinguished, even&amp;nbsp;when they are related&amp;nbsp;other things in exactly the same way.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="75d7e119-d5b7-46ef-94ab-f0f53c4d480e" annotatedElement="19920a63-7648-49b9-9666-eb0dcfbde515">
+        <body>&lt;p>Classes serve to subdivide Classifiers into two kinds of objects: those that have some definition beyond their property values and those that are defined entirely by their values. Classes are the first kind. Two objects that are classified by a given Class can have entirely identical descriptions and properties and still be treated as separate. Classes are intended for the construction of models representing real world things which can be separate entities even if all measurable properties are the same.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="064d5f6b-a0af-43fe-9c9d-489cca0ab902" name="classClassifiesOccurrence" visibility="public" constrainedElement="19920a63-7648-49b9-9666-eb0dcfbde515">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4116f3bf-ab2b-40b8-a7f8-218f0f24ab25" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::Occurrence)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="284fefd7-bbaa-4e6b-9e14-9def8a4bcd7d" name="classValidSpecialization" visibility="public" constrainedElement="19920a63-7648-49b9-9666-eb0dcfbde515">
+        <ownedComment xmi:id="82cd473a-26d7-483a-8832-7447e69553ae" annotatedElement="284fefd7-bbaa-4e6b-9e14-9def8a4bcd7d">
+          <body>&lt;p>A &lt;code>Class&lt;/code> must not specialize a &lt;code>DataType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="08230a8f-a6b9-4c0a-a19a-908644edaece" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="0f8332e0-0ede-430e-ba9c-d0898115951e" general="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="aedf255c-3058-40de-837e-0444956079a2" name="AssociationStructure" visibility="public">
+      <ownedRule xmi:id="4f8a9a19-dfee-4e40-80aa-ec7a97d9e877" name="associationStructureClassifiesLinkObject" visibility="public" constrainedElement="aedf255c-3058-40de-837e-0444956079a2">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ac405d2d-2490-4d23-af86-89f83a828fc9" name="" visibility="public">
+          <language>OCL</language>
+          <body>allSupertypes()->includes(Kernel Library::LinkObject)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="727e0071-1e5d-45ee-ae85-8c524639dfb1" general="eabb05a5-3e97-41e1-9668-d9bf801193a6"/>
+      <generalization xmi:id="afed898c-bd81-40e7-a94d-590521b4a315" general="86a283c4-fc00-49a6-af2c-f85043eadd9f"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0b832cd3-480c-4dec-bf7a-b82a6cce9828" name="" visibility="public" memberEnd="df13089f-294a-43e0-b318-e2d07cf436bf 6e9540ec-23f8-4d8b-86da-4cad39875ccf">
+      <ownedEnd xmi:id="6e9540ec-23f8-4d8b-86da-4cad39875ccf" name="targetAssociation" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" isDerived="true" subsettedProperty="6e9540ec-23f8-4d8b-86da-4cad39875ccf 9b40b97e-7de2-4abc-9e5e-dbfb67e3e1d5" association="0b832cd3-480c-4dec-bf7a-b82a6cce9828">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a22aa4d6-d2de-4041-aa98-68d48ed626dc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="95afefe6-b97d-497d-88a2-1fbb7a3e420a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a97dee50-5701-4697-a95e-649081e1bd72" name="" visibility="public" memberEnd="b4c63537-a47e-42ac-b1c8-6104f658a664 9a988e7d-d6e1-400d-8fbb-41795d3edaaa">
+      <ownedEnd xmi:id="9a988e7d-d6e1-400d-8fbb-41795d3edaaa" name="sourceAssociation" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" isDerived="true" subsettedProperty="9b40b97e-7de2-4abc-9e5e-dbfb67e3e1d5 1807da4c-d8f2-454f-911f-8a98c3302238" association="a97dee50-5701-4697-a95e-649081e1bd72">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="314a7bbf-8a96-42b5-84a9-4c3da369a9d8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e3b06966-887c-4686-a3b4-9743611ab3c8" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="86a283c4-fc00-49a6-af2c-f85043eadd9f" name="Association" visibility="public">
+      <ownedComment xmi:id="c51cd534-c8d4-44fb-8a29-a13f6779a039" annotatedElement="86a283c4-fc00-49a6-af2c-f85043eadd9f">
+        <body>&lt;p>An Association is a Relationship and a Classifier to enable classification of links between things (in the universe). The co-domains (&lt;code>types&lt;/code>) of the &lt;code>associationEnd&lt;/code> Features are the &lt;code>relatedTypes&lt;/code>, as co-domain and participants (linked things) of an Association identify each other.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="461b297c-d1dd-4f4b-b7fd-f65b2a1cfaa4" name="associationRelatedTypes" visibility="public" constrainedElement="86a283c4-fc00-49a6-af2c-f85043eadd9f">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c9342e0b-405e-4452-b6b6-51cd5198e9e4" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>relatedTypes = associationEnd.type</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="57817504-f161-4fb3-9a7d-865aac1ab0fa" name="AssociationLink" visibility="public" constrainedElement="86a283c4-fc00-49a6-af2c-f85043eadd9f">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="39fe9f0c-8fcb-465f-b4ad-03897f618973" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>let numend : Natural = associationEnd->size() in
+    allSupertypes()->includes(
+        if numend = 2 then Kernel Library::BinaryLink
+        else Kernel Library::Link)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="f0d55b94-3783-4661-8fd0-4bc03f9e7f33" name="AssociationStructureIntersection" visibility="public" constrainedElement="86a283c4-fc00-49a6-af2c-f85043eadd9f">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="3ce3352e-cdf0-460d-ba4f-bbae0c71a1af" name="" visibility="public">
+          <language>English</language>
+          <body>oclIsKindOf(Structure) = oclIsKindOf(AssociationStructure)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="d6385327-d50b-43f8-b65b-8ec6d55f69c2" name="associationClassifiesLink" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c908b662-ee46-4dc5-be95-8c79a1ea8024" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::Link)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="d7e6efad-8738-49d5-9752-358783b3af2b" general="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da"/>
+      <generalization xmi:id="30b704ca-516c-4961-abb4-5c1fc51a879b" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="d73d35b2-4798-48a1-8e2f-61265e3d8812" name="relatedType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isOrdered="true" isUnique="false" isDerived="true" redefinedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="f2b2b3cf-58f6-4ee0-807f-71f4c57e57d3">
+        <ownedComment xmi:id="52a1f6e0-54e6-42f8-91e1-8a6faf065261" annotatedElement="d73d35b2-4798-48a1-8e2f-61265e3d8812">
+          <body>&lt;p>The &lt;code>types&lt;/code> of the &lt;code>endFeatures&lt;/code> of the Association, which are the &lt;code>relatedElements&lt;/code> of the Association considered as a Relationship.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a077cf66-25b7-4558-a240-3d9235ea5341" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2c94181d-f0d5-4c4a-9e2d-bb4c08c71b2a" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b4c63537-a47e-42ac-b1c8-6104f658a664" name="sourceType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="d73d35b2-4798-48a1-8e2f-61265e3d8812" association="a97dee50-5701-4697-a95e-649081e1bd72">
+        <ownedComment xmi:id="a9fc500a-fe57-4025-b4f8-ca0163b5aff5" annotatedElement="b4c63537-a47e-42ac-b1c8-6104f658a664">
+          <body>&lt;p>The source &lt;code>relatedType&lt;/code> for this Association. If this is a binary Association, then the &lt;code>sourceType&lt;/code> is the first &lt;code>relatedType&lt;/code>, and the first &lt;code>associationEnd&lt;/code> of the Association must redefine the &lt;code>source&lt;/code> Feature of the Association &lt;em>BinaryLink&lt;/em> from the Kernel Library. If this Association is not binary, then it has no &lt;code>sourceType&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ecfca0b3-192e-4ae6-85de-8cd89ff137f5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e746a2d8-62ec-466d-845d-70c8a3ce66f9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="df13089f-294a-43e0-b318-e2d07cf436bf" name="targetType" visibility="public" type="4e5f8972-c473-4bc0-8edf-bb508993d08e" isDerived="true" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" subsettedProperty="d73d35b2-4798-48a1-8e2f-61265e3d8812" association="0b832cd3-480c-4dec-bf7a-b82a6cce9828">
+        <ownedComment xmi:id="bae5f1ea-947c-4750-932a-7306ba70c6af" annotatedElement="df13089f-294a-43e0-b318-e2d07cf436bf">
+          <body>&lt;p>The target &lt;code>relatedTypes&lt;/code> for this Association. This includes all the &lt;code>relatedTypes&lt;/code> other than the &lt;code>sourceType&lt;/code>. If this is a binary Association, then the &lt;code>associationEnds&lt;/code> corresponding to the &lt;code>relatedTypes&lt;/code> must all redefine the &lt;code>target&lt;/code> Feature of the Association &lt;em>BinaryLink&lt;/em> from the Kernel Library.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b9085bbe-46d9-4f8a-92c3-3ec7df891228" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4d6326d3-7fd8-4558-9807-61e3ba8ed58f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7efc19cd-ce11-459e-bbe5-d6ca25e0d9c9" name="associationEnd" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" redefinedProperty="a845e308-0fa7-49d9-9d90-152949ecf7e1" association="5147ad3c-b31a-48ac-8f72-a795f8c2ca07">
+        <ownedComment xmi:id="7eb8bb06-d743-4518-acc6-a90239de7b2c" annotatedElement="7efc19cd-ce11-459e-bbe5-d6ca25e0d9c9">
+          <body>&lt;p>The &lt;code>features&lt;/code> of the Association that identify the things that can be related by it. An Association must have at least two &lt;code>associationEnds&lt;/code>. When it has exactly two, the Association is called a &lt;em>binary&lt;/em> Association.&lt;/p> 
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="a7b369fe-e7c3-415b-9dc5-dca2f2ff66e5" annotatedElement="7efc19cd-ce11-459e-bbe5-d6ca25e0d9c9">
+          <body>&lt;p>The ends of the Association determine which elements are eligible to be related by instances of the Association.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7de2c755-b94b-436e-a3ac-c0b1f003e03b" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c89fc4cf-0230-4bf9-864c-e18d06f7661d" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f2b2b3cf-58f6-4ee0-807f-71f4c57e57d3" name="" visibility="public" memberEnd="d73d35b2-4798-48a1-8e2f-61265e3d8812 9b40b97e-7de2-4abc-9e5e-dbfb67e3e1d5">
+      <ownedEnd xmi:id="9b40b97e-7de2-4abc-9e5e-dbfb67e3e1d5" name="association" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" isDerived="true" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="f2b2b3cf-58f6-4ee0-807f-71f4c57e57d3">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ac908b60-5b01-48b1-a7d2-4d062dee7f0c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b4c1ec74-b58d-4c54-b21d-184aa843979a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5147ad3c-b31a-48ac-8f72-a795f8c2ca07" name="" visibility="public" memberEnd="7efc19cd-ce11-459e-bbe5-d6ca25e0d9c9 6530016d-adb1-4acf-83f8-64a441c36f3e">
+      <ownedEnd xmi:id="6530016d-adb1-4acf-83f8-64a441c36f3e" name="associationWithEnd" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" isDerived="true" subsettedProperty="d071e7ea-2566-41c5-9eff-acc7a2507370" association="5147ad3c-b31a-48ac-8f72-a795f8c2ca07">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a3e77bac-7f7c-469b-9f49-32e22357f2c2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ec550006-d209-426f-a0c9-c0a1c34883ba" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="293a8084-6bbb-46f9-86b2-30c8a7166a4a" name="BooleanExpression" visibility="public">
+      <ownedComment xmi:id="2082adba-fcf9-451f-b728-2fe4ff169beb" annotatedElement="293a8084-6bbb-46f9-86b2-30c8a7166a4a">
+        <body>&lt;p>A BooleanExpression is a Boolean-valued Expression whose type is a Predicate. It represents a logical condition resulting from the evaluation of the Predicate.&lt;/p>
+
+&lt;p>A BooleanExpression must subset, directly or indirectly, the Expression &lt;em>booleanEvaluations&lt;/em> from the Base model library, which is typed by the base Predicate &lt;em>BooleanEvaluation&lt;/em>. As a result, a BooleanExpression must always be typed by BooleanEvaluation or a subclass of BooleanEvaluation.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="d7055e8c-031f-4352-a92b-091567006488" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <ownedAttribute xmi:id="db1dde5e-5547-4d92-939b-d44296f28e1e" name="predicate" visibility="public" type="dda34dab-e901-4ff2-b8d1-0800b55c803c" isDerived="true" redefinedProperty="fa2d0459-19c1-4516-ae3f-4d6dceebe431" association="775d96b0-5f97-4209-9aba-c15b9fa0b33f">
+        <ownedComment xmi:id="4dfefc54-2bdd-4235-90d4-8ec1c5511fac" annotatedElement="db1dde5e-5547-4d92-939b-d44296f28e1e">
+          <body>&lt;p>The Predicate that types the Expression.&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="c809941c-a9e7-4542-b681-40f52c6a5475" annotatedElement="db1dde5e-5547-4d92-939b-d44296f28e1e">
+          <body>&lt;p>The Predicate that types the Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7afe365f-0483-4984-8d83-3c1318e91ee5" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b5bf104-dd4f-4926-bc58-e7891d51126a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e0a535a3-0f42-4798-9214-9980a1cbaa54" name="ReturnParameterMembership" visibility="public">
+      <ownedComment xmi:id="28968f85-ba57-4632-9f69-3f5227a4fb0b" annotatedElement="e0a535a3-0f42-4798-9214-9980a1cbaa54">
+        <body>&lt;p>A ReturnParameterMembership is a ParameterMembership that indicates that the &lt;code>memberParameter&lt;/code> is the &lt;code>result&lt;/code> parameter of a Function or Expression. The &lt;code>direction&lt;/code> of the &lt;code>memberParameter&lt;/code> must be &lt;code>out&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="e3938e31-718a-48ed-af6e-8a9cc3586923" general="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="dda34dab-e901-4ff2-b8d1-0800b55c803c" name="Predicate" visibility="public">
+      <ownedComment xmi:id="527c6648-e201-4070-ac3d-44a88927c7c4" annotatedElement="dda34dab-e901-4ff2-b8d1-0800b55c803c">
+        <body>&lt;p>A Predicate is a Function whose &lt;code>result&lt;/code> Parameter has type &lt;em>Boolean&lt;/em> and multiplicity 1..1.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="37163cd9-61fa-4049-8c19-5982e751b8ec" annotatedElement="dda34dab-e901-4ff2-b8d1-0800b55c803c">
+        <body>A Predicate is a Function whose result is a Boolean true or false value. These are typically used to test logical statements about modeled objects.</body>
+      </ownedComment>
+      <generalization xmi:id="def76133-e023-4ccf-9554-04c4a6fce2b9" general="29b2aa40-d30d-41a0-9030-891c06fc9924"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="775d96b0-5f97-4209-9aba-c15b9fa0b33f" name="" visibility="public" memberEnd="db1dde5e-5547-4d92-939b-d44296f28e1e 81024738-6b78-42ed-99d6-5133b0f840e1">
+      <ownedEnd xmi:id="81024738-6b78-42ed-99d6-5133b0f840e1" name="typedBooleanExpression" visibility="public" type="293a8084-6bbb-46f9-86b2-30c8a7166a4a" isDerived="true" subsettedProperty="8dd7c22c-b05f-4eae-b36f-15870a385730" association="775d96b0-5f97-4209-9aba-c15b9fa0b33f">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f59aed1e-305b-4d00-b76c-686d915d88dd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="054e6f28-7fbc-46cd-beaa-beac696aa975" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1b51ec71-10a2-4699-bfdc-e890d607b68b" name="" visibility="public" memberEnd="7413c86e-1cfb-4727-b275-a5fafde797fa 938b7976-b666-4fc3-95f6-ce5646e2ea54">
+      <ownedEnd xmi:id="938b7976-b666-4fc3-95f6-ce5646e2ea54" name="computedFunction" visibility="public" type="29b2aa40-d30d-41a0-9030-891c06fc9924" subsettedProperty="25696705-71e7-4f65-aead-1d106b54640c" association="1b51ec71-10a2-4699-bfdc-e890d607b68b">
+        <ownedComment xmi:id="65b904b1-0bba-41e2-8fc1-65b787234e5b" annotatedElement="938b7976-b666-4fc3-95f6-ce5646e2ea54">
+          <body>&lt;p>The Functions that hasve a certain &lt;code>expression&lt;/code> as a step.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c8bf0295-7b05-4ebd-8007-385365b87b14" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7ab484a8-5b5f-43b5-b0b4-936df9d7d5d4" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="29b2aa40-d30d-41a0-9030-891c06fc9924" name="Function" visibility="public">
+      <ownedComment xmi:id="b523165c-240b-4d61-90e8-b39f29f08ca0" annotatedElement="29b2aa40-d30d-41a0-9030-891c06fc9924">
+        <body>&lt;p>A Function is a Behavior that has a single &lt;code>out&lt;/code> &lt;code>parameter&lt;/code> that is identified as its &lt;code>result&lt;/code>. Any other &lt;code>parameters&lt;/code> of a Function than the &lt;code>result&lt;/code> must have direction &lt;code>in&lt;/code>. A Function represents the performance of a calculation that produces the values of its &lt;code>result&lt;/code> parameter. This calculation may be decomposed into Expressions that are &lt;code>steps&lt;/code> of the Function.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="9f847177-ed0d-4b38-b84b-84d4d62fa7bf" general="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba"/>
+      <ownedAttribute xmi:id="7413c86e-1cfb-4727-b275-a5fafde797fa" name="expression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="c559f3c7-96bd-45da-a2c7-1770af2759aa" association="1b51ec71-10a2-4699-bfdc-e890d607b68b">
+        <ownedComment xmi:id="c77e75fd-e18d-433d-bf92-25a38f1d12b9" annotatedElement="7413c86e-1cfb-4727-b275-a5fafde797fa">
+          <body>&lt;p>The Expressions that are steps in the calculation of the &lt;code>result&lt;/code> of this Function.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="6eb9ee6c-70cf-4da3-ad52-c74beb57c45d" annotatedElement="7413c86e-1cfb-4727-b275-a5fafde797fa">
+          <body>&lt;p>The set of expressions that represent computational steps or parts of a system of equations within the Function.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="25856b6e-b1f8-48e6-8138-358e854097ef" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d9023333-02f9-4264-a474-aae313158c60" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="752c2d1b-1d95-4e23-ad58-ac1d635c76d8" name="result" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 b458eea7-79b9-4c8f-a066-b9d0dbd03ec8" association="add2aadb-f2dc-4003-8bb6-a2ac76c71507">
+        <ownedComment xmi:id="26860f3d-81f4-4e77-b67f-2c344fe87dff" annotatedElement="752c2d1b-1d95-4e23-ad58-ac1d635c76d8">
+          <body>&lt;p>The &lt;code>result&lt;/code> parameter of the Function, derived as the single &lt;code>parameter&lt;/code> of the Function with direction &lt;code>out&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="1d0451aa-d117-47ef-89e5-ab8bae76ea60" annotatedElement="752c2d1b-1d95-4e23-ad58-ac1d635c76d8">
+          <body>&lt;p>The object or value that is the result of evaluating the Function.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="dcf9c2e8-1156-4809-83ef-93d6577cb6ce" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="343fa5bb-040b-4f07-9c62-bf80494dfe63" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="868bfb7f-f733-4169-af79-b08c348695b9" name="isModelLevelEvaluable" visibility="public" isDerived="true">
+        <ownedComment xmi:id="aaa7e445-83ed-404c-9b66-3583bfe9b65c" annotatedElement="868bfb7f-f733-4169-af79-b08c348695b9">
+          <body>&lt;p>Whether this Function can be used as the &lt;code>function&lt;/code> of a model-level evaluable InvocationExpression.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e8a20af6-2a0f-49f9-9cae-ba3760a7f13e" name="Invariant" visibility="public">
+      <ownedComment xmi:id="85fbc309-864f-4dbb-ab4f-6103f6944967" annotatedElement="e8a20af6-2a0f-49f9-9cae-ba3760a7f13e">
+        <body>&lt;p>An Invariant is a BooleanExpression that is asserted to have a specific Boolean result value. If &lt;code>isNegated = false&lt;/code>, then the Invariant must subset, directly or indirectly, the BooleanExpression &lt;em>trueEvaluations&lt;/em> from the Kernel library, meaning that the result is asserted to be true. If &lt;code>isNegated = true&lt;/code>, then the Invariant must subset, directly or indirectly, the BooleanExpression &lt;em>falseEvaluations&lt;/em> from the Kernel library, meaning that the result is asserted to be false.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="6308e4b7-06e4-44d1-a190-31a045bb0eca" general="293a8084-6bbb-46f9-86b2-30c8a7166a4a"/>
+      <ownedAttribute xmi:id="3ea1e4ea-ccf8-4255-8148-9d225543e785" name="isNegated" visibility="public">
+        <ownedComment xmi:id="3227b924-3b18-4f4d-9d09-9d52704de0c7" annotatedElement="3ea1e4ea-ccf8-4255-8148-9d225543e785">
+          <body>&lt;p>Whether this Invariant is asserted to be false rather than true.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="1bb8ff4a-9f4e-4b6a-99be-cfc187f1d697" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="add2aadb-f2dc-4003-8bb6-a2ac76c71507" name="" visibility="public" memberEnd="752c2d1b-1d95-4e23-ad58-ac1d635c76d8 3962e3db-ce3a-4596-b41a-67336a85131a">
+      <ownedEnd xmi:id="3962e3db-ce3a-4596-b41a-67336a85131a" name="computingFunction" visibility="public" type="29b2aa40-d30d-41a0-9030-891c06fc9924" isDerived="true" subsettedProperty="9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a" association="add2aadb-f2dc-4003-8bb6-a2ac76c71507">
+        <ownedComment xmi:id="704bf93c-ed79-4fab-a706-d060104aeff3" annotatedElement="3962e3db-ce3a-4596-b41a-67336a85131a">
+          <body>&lt;p>The Functions that have a certain Feature its owned or inherited &lt;code>result&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="36ea7bb5-e2a3-4e67-80ca-251650ace1d8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ba719255-a91c-4e88-89b4-3e07373a7aac" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d5de2f0f-e6f0-457c-ae0d-90b2a89ce674" name="ResultExpressionMembership" visibility="public">
+      <ownedComment xmi:id="d8772ad8-d0ac-4734-a591-ad8cdb0a031a" annotatedElement="d5de2f0f-e6f0-457c-ae0d-90b2a89ce674">
+        <body>&lt;p>A ResultExpressionMembership is a FeatureMembership that indicates that the &lt;code>ownedResultExpression&lt;/code> provides the result values for the Function or Expression that owns it. The owning Function or Expression must contain a BindingConnector between the &lt;code>result&lt;/code> parameter of the &lt;code>ownedResultExpression&lt;/code> and the &lt;code>result&lt;/code> parameter of the Function or Expression.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="46076236-b832-4fca-b271-93a019b56c17" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="bef5aa0b-9bbd-4c21-9de6-9c42092555aa" name="ownedResultExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="8b8adea4-4ce5-4a09-98c6-2270c5180f8c">
+        <ownedComment xmi:id="d9097838-6efd-4eef-89ca-982371053119" annotatedElement="bef5aa0b-9bbd-4c21-9de6-9c42092555aa">
+          <body>&lt;p>The Expression that provides the result for the owner of the ResultExpressionMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="87b47129-fa11-4c79-8a86-76e947e741f0" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8d66cc60-d2d6-4908-9c5b-7108313a7747" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e145f3b1-d33b-4c34-ab7e-32762b46580c" name="" visibility="public" memberEnd="fa2d0459-19c1-4516-ae3f-4d6dceebe431 8dd7c22c-b05f-4eae-b36f-15870a385730">
+      <ownedEnd xmi:id="8dd7c22c-b05f-4eae-b36f-15870a385730" name="typedExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="f160608e-ca2e-4daa-9b89-f6dad7620456" association="e145f3b1-d33b-4c34-ab7e-32762b46580c">
+        <ownedComment xmi:id="f0d96baa-bc57-4a8b-98fb-10c5a1b8c986" annotatedElement="8dd7c22c-b05f-4eae-b36f-15870a385730">
+          <body>&lt;p>The Expressions that are typed by a certain &lt;code>function&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="14fbb402-b1fb-461a-8af1-b1ec16741410" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e6ee2b66-355f-4ee6-b836-5d1b5747c4f6" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="55a6ae65-1c2f-42a6-a5e5-14db4d20214d" name="" visibility="public" memberEnd="20def006-bff2-41d2-9bb5-caabe9d21b63 26ac0248-0f25-4f87-9c74-6b9a56a03dea">
+      <ownedEnd xmi:id="26ac0248-0f25-4f87-9c74-6b9a56a03dea" name="computingExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="58f50343-0f2e-4d6c-891c-20350eaf6937" association="55a6ae65-1c2f-42a6-a5e5-14db4d20214d">
+        <ownedComment xmi:id="4eeaecb5-f460-48ac-b45b-b710387af21c" annotatedElement="26ac0248-0f25-4f87-9c74-6b9a56a03dea">
+          <body>&lt;p>The Expressions that have a certain Feature its owned or inherited &lt;code>result&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a07b4d5a-4cfd-4755-99eb-5bac7f666ebc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="dd535856-6b1c-4ef3-a525-e7f938a696f4" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="b32c4dd3-88a2-4418-b414-e75ceb0bb432" name="Expression" visibility="public">
+      <ownedComment xmi:id="13346c64-d599-45fe-8d64-42d783d4dfca" annotatedElement="b32c4dd3-88a2-4418-b414-e75ceb0bb432">
+        <body>&lt;p>An Expression is a Step that is typed by a Function. An Expression that also has a Function as its &lt;code>featuringType&lt;/code> is a computational step within that Function. An Expression always has a single &lt;code>result&lt;/code> parameter, which redefines the &lt;code>result&lt;/code> parameter of its defining &lt;code>function&lt;/code>. This allows Expressions to be interconnected in tree structures, in which inputs to each Expression in the tree are determined as the results of other Expressions in the tree.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="807e7ff1-3254-44f3-a573-691a107617d3" general="b1a2875a-af89-47c5-ad2b-d5763c43aafd"/>
+      <ownedAttribute xmi:id="fa2d0459-19c1-4516-ae3f-4d6dceebe431" name="function" visibility="public" type="29b2aa40-d30d-41a0-9030-891c06fc9924" isDerived="true" redefinedProperty="1f2423e8-9b61-4497-af7c-8de89dbda20c" association="e145f3b1-d33b-4c34-ab7e-32762b46580c">
+        <ownedComment xmi:id="c84c2041-5a81-461b-b52e-70fb3339a85e" annotatedElement="fa2d0459-19c1-4516-ae3f-4d6dceebe431">
+          <body>&lt;p>The Function that types this Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="002f1fc4-5572-4c21-9e44-4cd5061e6ec1" annotatedElement="fa2d0459-19c1-4516-ae3f-4d6dceebe431">
+          <body>&lt;p>This is the Function that types the Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3a47e1ed-20f9-4a80-abec-010317356af0" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="db9619f0-2820-41a8-a6d4-d1d29354ed48" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="20def006-bff2-41d2-9bb5-caabe9d21b63" name="result" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 b458eea7-79b9-4c8f-a066-b9d0dbd03ec8" association="55a6ae65-1c2f-42a6-a5e5-14db4d20214d">
+        <ownedComment xmi:id="646a7771-8d60-43e6-b348-cd13e4e137dc" annotatedElement="20def006-bff2-41d2-9bb5-caabe9d21b63">
+          <body>&lt;p>&lt;p>The &lt;code>result&lt;/code> parameter of the Expression, derived as the single &lt;code>parameter&lt;/code> of the Expression with direction &lt;code>out&lt;/code>. The result of an Expression must either be inherited from its &lt;code>function&lt;/code> or (directly or indirectly) redefine the &lt;code>result&lt;/code> parameter of its &lt;code>function&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="50b35950-0ade-4245-bf8f-82daac4f69cd" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6decc775-62aa-4481-aabb-f79de29389fb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1ff1f309-2e70-4eeb-b54d-9ac8f92df6bd" name="isModelLevelEvaluable" visibility="public" isDerived="true">
+        <ownedComment xmi:id="0572a479-714f-40a8-a1d2-bdbf92588e37" annotatedElement="1ff1f309-2e70-4eeb-b54d-9ac8f92df6bd">
+          <body>&lt;p>Whether this Expression meets the constraints necessary to be evaluated at &lt;em>model level&lt;/em>, that is, using metadata within the model.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="af02a9a7-91b4-41e0-886f-eebf43805cd1" name="evaluate" visibility="public" precondition="bcb9ffd2-69ff-45c4-aafd-4311fc9203b8">
+        <ownedComment xmi:id="cb1f4ca8-0186-4c3b-955e-5728b3338008" annotatedElement="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+          <body>&lt;p>If this Expression &lt;code>isModelLevelEvaluable&lt;/code>, then evaluate it using the &lt;code>target&lt;/code> as the context Element for resolving Feature names and testing classification. The result is a collection of Elements, each of which must be a LiteralExpression or a Feature that is not an Expression.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="bcb9ffd2-69ff-45c4-aafd-4311fc9203b8" name="evaluatePre" visibility="public" constrainedElement="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="fa05759a-fe2e-48e0-9d23-9f8e229db9ee" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isModelLevelEvaluable</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="15316587-7cac-4026-85cc-f5af4700ed4d" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="3b6447a6-c836-4183-803f-2955bde33c87" name="result" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aa2e4324-1731-4dd7-927e-2df60574c0a7" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d52bf0d2-bd70-4ade-9c23-756ea7d5c23e" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8b8adea4-4ce5-4a09-98c6-2270c5180f8c" name="" visibility="public" memberEnd="bef5aa0b-9bbd-4c21-9de6-9c42092555aa 4a9a5440-ac87-435a-a97d-bd7e1730e0e6">
+      <ownedEnd xmi:id="4a9a5440-ac87-435a-a97d-bd7e1730e0e6" name="owningResultExpressionMembership" visibility="public" type="d5de2f0f-e6f0-457c-ae0d-90b2a89ce674" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="8b8adea4-4ce5-4a09-98c6-2270c5180f8c">
+        <ownedComment xmi:id="13db9114-611a-4a2e-b032-9b4089e6fe8a" annotatedElement="4a9a5440-ac87-435a-a97d-bd7e1730e0e6">
+          <body>&lt;p>The ResultExpressionMembership that owns the &lt;code>ownedResultExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f5730d3b-d7a4-465b-bb09-a5b4afc6aacc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="248f4a2d-5599-42ab-b2f5-7cc287a2e3bf" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="42eb906b-afc3-4e19-9cf1-3acb2b325108" name="" visibility="public" memberEnd="5e317aa3-fe01-4c0d-b580-4e798d36cb83 773d6c77-786f-4827-af6a-74ebec676cf1">
+      <ownedEnd xmi:id="773d6c77-786f-4827-af6a-74ebec676cf1" name="operatorExpression" visibility="public" type="3164fef9-064a-469f-9c1a-20e58415db72" association="42eb906b-afc3-4e19-9cf1-3acb2b325108">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="79a8cfef-ecd2-4ff5-ab13-60b7b6c0d580" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="86aab2c6-7b8e-4e9e-bbe6-a6861a84c23e" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4d002077-b074-453c-af31-7e11292a04bc" name="" visibility="public" memberEnd="099543ec-d7b6-4ccb-836e-af416ceb4ad9 1cc59a61-d8bd-4202-b505-53942a713622">
+      <ownedEnd xmi:id="1cc59a61-d8bd-4202-b505-53942a713622" name="chainExpression" visibility="public" type="7d9c676d-1416-49b1-b12a-f9440cd883c6" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="4d002077-b074-453c-af31-7e11292a04bc">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e790357c-dccd-46b5-98f8-e4d2f6853a55" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9b001e4a-4698-495e-b78b-52d2790965eb" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="a992e14b-0838-46e3-a486-3d4339717f13" name="FeatureReferenceExpression" visibility="public">
+      <ownedComment xmi:id="bdcc5a77-52be-40cd-a4f3-f4eedb462eee" annotatedElement="a992e14b-0838-46e3-a486-3d4339717f13">
+        <body>&lt;p>A FeatureReferenceExpression is an Expression whose &lt;code>result&lt;/code> is bound a &lt;code>referent&lt;/code> Feature. The only &lt;code>members&lt;/code> allowed for a FeatureReferenceExpression are the &lt;code>referent&lt;/code>, the &lt;code>result&lt;/code> and the BindingConnector between them.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="92d844f1-f1af-4926-9e4e-ba61fb537f12" name="featureReferenceExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="a992e14b-0838-46e3-a486-3d4339717f13">
+        <ownedComment xmi:id="d1eb2da3-07ce-4caa-b4b0-bf7bca6ef2ba" annotatedElement="92d844f1-f1af-4926-9e4e-ba61fb537f12">
+          <body>&lt;p>A FeatureReferenceExpression is always model-level evaluable (though it may produce no value on some targets).&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="3307d4a9-0d07-48d7-aca1-d385571aa9fd" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="61ffcbee-ba92-43e7-a36d-04b0abc3f642" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <ownedAttribute xmi:id="a42a34a1-0748-4b76-b3b6-a6770814f850" name="referent" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="688933df-72ee-4c19-bbdd-04b161fffa61">
+        <ownedComment xmi:id="df37cdce-8971-4764-ae40-8dd16dcc65ed" annotatedElement="a42a34a1-0748-4b76-b3b6-a6770814f850">
+          <body>&lt;p>The Feature that is referenced by this FeatureReferenceExpression, derived as its first &lt;code>member&lt;/code> Feature.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="09dd9a8e-74c8-4c8b-b486-fbf5f68a86e8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5883b29a-2169-4f11-8d5b-6c23edad7a4c" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="0b517eab-051c-493b-b0e1-2fc09485614d" name="evaluate" visibility="public" bodyCondition="c149c1f9-f2f0-4791-9cdd-14b49b72b7d1" redefinedOperation="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+        <ownedComment xmi:id="5f691571-36d9-4ede-83cf-49147d227401" annotatedElement="0b517eab-051c-493b-b0e1-2fc09485614d">
+          <body>&lt;p>If the &lt;code>target&lt;/code> Element is a Type that  has a &lt;code>feature&lt;/code> that redefines the &lt;code>referent&lt;/code>, then return the result of evaluating the Expression given by the FeatureValue of that &lt;code>feature&lt;/code>. Otherwise, if the &lt;code>referent&lt;/code> has no &lt;code>featuringTypes&lt;/code>, return the &lt;code>referent&lt;/code>. Otherwise return an empty sequence.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="c149c1f9-f2f0-4791-9cdd-14b49b72b7d1" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="b1cb17b0-1fbf-4c36-89dc-5846f499b519" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if not target.oclIsKindOf(Type) then Sequence{}
+else
+    let feature: Sequence(Feature) = 
+        target.oclAsType(Type).feature->select(f |
+            f.ownedRedefinition.redefinedFeature->
+                includes(referent)) in
+        if feature->notEmpty() then 
+            feature.valuation.value.evaluate(target)
+        else if referent.featuringType->isEmpty() 
+            then referent
+        else Sequence{} 
+        endif endif
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="de7c4747-befb-46aa-a992-c363ef195cf3" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="e34b80f1-cc0c-4f01-9a0f-3d8ee3ee9ed8" name="result" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="526c98e3-2998-47d4-b350-4ca250c2e513" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b1638a6-bada-4e44-b81d-a65842c38972" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="75dec4cf-666d-4957-9f0a-9747fffae584" name="LiteralInfinity" visibility="public">
+      <ownedComment xmi:id="bd74b62d-2e66-47ed-b360-313ac11947d3" annotatedElement="75dec4cf-666d-4957-9f0a-9747fffae584">
+        <body>&lt;p>A LiteralInfinity is a LiteralExpression that provides the positive infinity value (&amp;quot;*&amp;quot;). It must have an owned &lt;code>result&lt;/code> parameter whose type is &lt;em>Positive&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="9bc2fc76-cae4-4800-99b7-de209b82fc49" annotatedElement="75dec4cf-666d-4957-9f0a-9747fffae584">
+        <body>&lt;p>An Expression that provides a value without a given bound as a result.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="048e17fe-4e87-4e1a-87d7-49c3853b00e6" general="3030353e-d110-4b65-b200-e8d1c7308e36"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7195c02a-f102-4843-88a2-4f3a0217284f" name="InvocationExpression" visibility="public">
+      <ownedComment xmi:id="797c7cb1-e5f7-438b-b7c2-b825665b7df7" annotatedElement="7195c02a-f102-4843-88a2-4f3a0217284f">
+        <body>&lt;p>An InvocationExpression is an Expression each of whose input &lt;code>parameters&lt;/code> are bound to the &lt;code>result&lt;/code> of an owned &lt;code>argument&lt;/code> Expression. Each input &lt;code>parameter&lt;/code> may be bound to the &lt;code>result&lt;/code> of at most one &lt;code>argument&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="4e920fa7-c0c8-45e8-9dbe-ceefa92ef799" name="invocationExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="7195c02a-f102-4843-88a2-4f3a0217284f">
+        <ownedComment xmi:id="961ffcd1-d9e7-407a-b2b1-d70d25ae57c9" annotatedElement="4e920fa7-c0c8-45e8-9dbe-ceefa92ef799">
+          <body>&lt;p>An InvocationExpression is model-level evaluable if all its &lt;code>argument&lt;/code> Expressions are model-level evaluable and its &lt;code>function&lt;/code> is model-level evaluable.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="8dcd6485-fd4c-4613-b4c6-a3d03c7de6cb" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isModelLevelEvaluable = 
+    argument->forAll(isModelLevelEvaluable) and 
+    function.isModelLevelEvaluable</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="23b18af1-8b93-4b52-af89-77fb26a0657e" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <ownedAttribute xmi:id="8df13e80-6028-4c00-b26b-10d581ca6fce" name="argument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="7cce3305-d157-4e27-a770-74890174c028">
+        <ownedComment xmi:id="a4b35546-313b-425d-9bf2-080ccb61d17b" annotatedElement="8df13e80-6028-4c00-b26b-10d581ca6fce">
+          <body>&lt;p>The &lt;code>value&lt;/code> &lt;code>Expressions&lt;/code> of the &lt;code>FeatureValues&lt;/code> of the input &lt;code>parameters&lt;/code> of the &lt;code>InvocationExpression&lt;/code>.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="48bf03e3-b4ab-4146-89e9-d9dd61daf98a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="83b0d075-f631-44f8-87ed-b4ddb9a76e62" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="f8829988-1c1e-42ba-b95c-00e581e03aa4" name="evaluate" visibility="public" redefinedOperation="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+        <ownedComment xmi:id="402f9177-f258-4dfb-aee4-f3a5ea49be01" annotatedElement="f8829988-1c1e-42ba-b95c-00e581e03aa4">
+          <body>&lt;p>Apply the Function that is the &lt;code>type&lt;/code> of this InvocationExpression to the argument values resulting from evaluating each of the &lt;code>argument&lt;/code> Expressions on the given &lt;code>target&lt;/code>. If the application is not possible, then return an empty sequence.&lt;/p></body>
+        </ownedComment>
+        <ownedParameter xmi:id="ea8f8a35-d063-4012-9ed4-6c73b9b13f08" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="0ab07077-75aa-4182-a60f-40b12dc61a27" name="result" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="359babf7-1ad2-4273-a6af-863386f98171" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="914613d6-b987-47a2-8f21-ed69257d79fd" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="64bffd4e-a3a9-449a-a29b-f74212f94e46" name="CollectExpression" visibility="public">
+      <ownedComment xmi:id="6533ec24-9fe3-451d-9a8d-cb70d8ce5d08" annotatedElement="64bffd4e-a3a9-449a-a29b-f74212f94e46">
+        <body>&lt;p>A CollectExpression is an OperatorExpression whose operator is &lt;code>&quot;collect&quot;&lt;/code>, which resolves to the library Function &lt;em>&lt;code>ControlFunctions::collect&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="5f230689-1451-425a-bdef-818a2dab9319" general="3164fef9-064a-469f-9c1a-20e58415db72"/>
+      <ownedAttribute xmi:id="9a5f910a-21d0-4521-a075-9aae45e79406" name="operator" visibility="public" redefinedProperty="20570f1e-fe68-4660-8050-e8f8e05ce806">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <defaultValue xmi:type="uml:LiteralString" xmi:id="92d92329-292e-40f7-b26b-45c15f81d867" name="" visibility="public" value="collect"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7d9c676d-1416-49b1-b12a-f9440cd883c6" name="FeatureChainExpression" visibility="public">
+      <ownedComment xmi:id="505450f2-4ec0-4b8f-bc50-ab8f3c31b6be" annotatedElement="7d9c676d-1416-49b1-b12a-f9440cd883c6">
+        <body>&lt;p>A FeatureChainExpression is an OperatorExpression whose operator is &lt;code>&quot;.&quot;&lt;/code>, which resolves to the library Function &lt;em>&lt;code>ControlFunctions::'.'&lt;/code>&lt;/em>. It evaluates to the result of chaining the &lt;code>result&lt;/code> Feature of its single &lt;code>argument&lt;/code> Expression with its &lt;code>targetFeature&lt;/code>.&lt;/p>
+
+&lt;p>The first two &lt;code>members&lt;/code> of a FeatureChainExpression must be its single &lt;code>argument&lt;/code> Expression and its &lt;code>targetFeature&lt;/code>. Its only other &lt;code>members&lt;/code> shall be those necessary to complete it as an InvocationExpression.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="3a1c1849-3435-493a-a5b3-34ffa1c9d4f6" general="3164fef9-064a-469f-9c1a-20e58415db72"/>
+      <ownedAttribute xmi:id="396232d3-2bf0-4164-9440-9ecfc79359b5" name="operator" visibility="public" redefinedProperty="20570f1e-fe68-4660-8050-e8f8e05ce806">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <defaultValue xmi:type="uml:LiteralString" xmi:id="7ca3d76b-79ae-4e82-b0c1-a0120fc6c51f" name="" visibility="public" value="."/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="099543ec-d7b6-4ccb-836e-af416ceb4ad9" name="targetFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="4d002077-b074-453c-af31-7e11292a04bc">
+        <ownedComment xmi:id="92404f4a-97ff-4e8e-8af4-68d538161e12" annotatedElement="099543ec-d7b6-4ccb-836e-af416ceb4ad9">
+          <body>&lt;p>The Feature that is accessed by this FeatureChainExpression, derived as its second &lt;code>member&lt;/code> Feature (the first being its one &lt;code>argument&lt;/code> Expression). This Feature must redefine the &lt;em>&lt;code>target&lt;/code> Feature of the Function &lt;em>&lt;code>ControlFunctions::'.'&lt;/code>&lt;/em>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="366b02a6-d0ed-4a41-9ebf-e32ee1d65c5c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e858f565-12ed-4eb1-9db9-b23920187fc1" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3030353e-d110-4b65-b200-e8d1c7308e36" name="LiteralExpression" visibility="public">
+      <ownedComment xmi:id="2b42dea0-d92e-420d-87ec-692010ac656a" annotatedElement="3030353e-d110-4b65-b200-e8d1c7308e36">
+        <body>&lt;p>A&amp;nbsp;LiteralExpression is an Expression that provides a basic value as a result. It must directly or indirectly specialize the Function &lt;em>LiteralEvaluation&lt;/em> from the &lt;em>Base&lt;/em> model library, which has no parameters other than its result, which is a single &lt;em>DataValue&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="cae2e76f-9c40-43b9-86f3-2c364959508a" annotatedElement="3030353e-d110-4b65-b200-e8d1c7308e36">
+        <body>&lt;p>An Expression that provides a basic value as a result.&lt;/p>
+
+&lt;p>A LiteralExpression must be typed by a specialization of Evaluation with no input parameters and a single value as its result.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="f9f3c081-bec4-461a-910f-43f6c742260a" name="literalExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="3030353e-d110-4b65-b200-e8d1c7308e36">
+        <ownedComment xmi:id="dd9e0e24-8e89-407a-a00c-b9e319384943" annotatedElement="f9f3c081-bec4-461a-910f-43f6c742260a">
+          <body>&lt;p>A LiteralExpression is always model-level evaluable.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="9b99b334-df40-4c4c-8182-647d1dc18276" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isModelLevelEvaluable = true</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="0df6155e-f9bf-4fee-a4a3-139ac31e4814" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <ownedOperation xmi:id="38402a85-67e8-44a9-bb70-53a7e8add6bc" name="evaluate" visibility="public" bodyCondition="05bea1d0-d358-4fe3-b913-fa44f53d6c12" redefinedOperation="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+        <ownedComment xmi:id="00635a43-b2c7-4bf0-ae40-4c2f9b22750a" annotatedElement="38402a85-67e8-44a9-bb70-53a7e8add6bc">
+          <body>&lt;p>The model-level value of a LiteralExpression is itself.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="05bea1d0-d358-4fe3-b913-fa44f53d6c12" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="d9bcf9b0-d58f-4964-a10d-c8be91866f9d" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>Sequence{self}</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="1bfb1888-05e3-4938-92c3-07afcf860c97" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="9e1cb769-9ccd-4361-b7cf-4070750d9ed9" name="result" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="156e289b-e72e-4f46-96c0-1badc2835d8d" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="50810b06-67a5-4f71-8f1a-9696c18a5517" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="c8059061-a218-4e1a-974a-072b7659d8c7" name="NullExpression" visibility="public">
+      <ownedComment xmi:id="6ed65118-f0c9-4796-a4f8-abfd05686d54" annotatedElement="c8059061-a218-4e1a-974a-072b7659d8c7">
+        <body>&lt;p>A NullExpression is an&amp;nbsp;Expression that results in a null value. It must be typed by a &lt;em>NullEvaluation&lt;/em> that results in an empty value.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="9e9fa694-3f3c-434f-a6ee-48cc4117f386" annotatedElement="c8059061-a218-4e1a-974a-072b7659d8c7">
+        <body>&lt;p>An Expression that results in a null value.&lt;/p>
+
+&lt;p>A NullExpression must be typed by a NullEvaluation which results in an empty value.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="f116d955-7e2c-44f2-b407-4f860775a065" name="nullExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="c8059061-a218-4e1a-974a-072b7659d8c7">
+        <ownedComment xmi:id="cf68e90c-88dd-42e3-b276-f6440986ef3f" annotatedElement="f116d955-7e2c-44f2-b407-4f860775a065">
+          <body>&lt;p>A NullExpression is always model-level evaluable.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="6cc698d7-1a53-43b9-8a1d-7b057e7d08eb" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isModelLevelEvaluable = true</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="e0612e16-df7d-4e03-81c6-5f22629bface" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <ownedOperation xmi:id="d7479628-ed7c-4e1b-bcac-1749897a05e6" name="evaluate" visibility="public" bodyCondition="eb42b6aa-935f-40ef-8143-f24c99dc8b8a" redefinedOperation="af02a9a7-91b4-41e0-886f-eebf43805cd1">
+        <ownedComment xmi:id="80f0edb4-2c00-43e4-9ae9-fe7c374473e4" annotatedElement="d7479628-ed7c-4e1b-bcac-1749897a05e6">
+          <body>&lt;p>The model-level value of a NullExpression is an empty sequence.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="eb42b6aa-935f-40ef-8143-f24c99dc8b8a" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="d08eb2ef-fb38-45ff-ba0d-6b559b94316f" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>Sequence{}</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="56846e86-6945-4ba3-81bb-ecef03bdb9c1" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="df079e0e-70f7-4949-a4c4-aa398ee9a84a" name="result" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a1427460-9eac-4bf7-8e15-12ae63189436" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8663c16e-6cbd-45d5-8a1c-a3d94c18e7cb" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f5e64d05-9e84-4c67-9e46-3c95b351873b" name="LiteralString" visibility="public">
+      <ownedComment xmi:id="8be32c05-f85a-4b54-a708-16c571c468f6" annotatedElement="f5e64d05-9e84-4c67-9e46-3c95b351873b">
+        <body>&lt;p>A&amp;nbsp;LiteralString&amp;nbsp; is&amp;nbsp;a LiteralExpression that provides a String value as a result. It must have an owned &lt;code>result&lt;/code> parameter whose type is &lt;em>String&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="5aec4c75-f527-4f9d-a61e-a57a6808d3f3" annotatedElement="f5e64d05-9e84-4c67-9e46-3c95b351873b">
+        <body>&lt;p>An Expression that provides a String value as a result.&lt;/p>
+
+&lt;p>A LiteralString must be typed by a specialization of Evaluation with no input parameters and a single String value as its result.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="283fd5a0-0f6f-4300-9953-f690a8efe079" general="3030353e-d110-4b65-b200-e8d1c7308e36"/>
+      <ownedAttribute xmi:id="56e4ac2c-9d1c-4376-b0d5-b02e91174d96" name="value" visibility="public">
+        <ownedComment xmi:id="be519786-d7da-4988-8541-fe06f78a888b" annotatedElement="56e4ac2c-9d1c-4376-b0d5-b02e91174d96">
+          <body>&lt;p>The String value that is the result of evaluating this Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="d168197c-0bf7-42b0-a3ce-8f0b2b4d4c71" annotatedElement="56e4ac2c-9d1c-4376-b0d5-b02e91174d96">
+          <body>&lt;p>The String value that is the result of evaluating this Expression.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="688933df-72ee-4c19-bbdd-04b161fffa61" name="" visibility="public" memberEnd="a42a34a1-0748-4b76-b3b6-a6770814f850 f7b8fa23-31d7-4311-9742-5754a2260720">
+      <ownedEnd xmi:id="f7b8fa23-31d7-4311-9742-5754a2260720" name="referenceExpression" visibility="public" type="a992e14b-0838-46e3-a486-3d4339717f13" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="688933df-72ee-4c19-bbdd-04b161fffa61">
+        <ownedComment xmi:id="303bd1c3-ba10-40e8-ba48-fc35693348dc" annotatedElement="f7b8fa23-31d7-4311-9742-5754a2260720">
+          <body>&lt;p>A FeatureReferenceExpression that has a certain &lt;code>referent&lt;/code> Feature.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="be9e0adb-c5f5-4d42-a433-1f1df7a1b07d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a6d1a860-be48-43ee-afd7-2e5f2f70fe93" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="73f10b45-1295-456f-8e6e-8cbb90e1251e" name="SelectExpression" visibility="public">
+      <ownedComment xmi:id="3957c1c1-5639-4c65-afdf-e7536881b36a" annotatedElement="73f10b45-1295-456f-8e6e-8cbb90e1251e">
+        <body>&lt;p>A SelectExpression is an OperatorExpression whose operator is &lt;code>&quot;select&quot;&lt;/code>, which resolves to the library Function &lt;em>&lt;code>ControlFunctions::select&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="e95cd848-7a29-4db5-9a35-666e9a10b27c" general="3164fef9-064a-469f-9c1a-20e58415db72"/>
+      <ownedAttribute xmi:id="4a762481-445a-47fe-a410-43b40a607207" name="operator" visibility="public" redefinedProperty="20570f1e-fe68-4660-8050-e8f8e05ce806">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <defaultValue xmi:type="uml:LiteralString" xmi:id="95894c24-e4d2-48ef-9000-f145afa6593d" name="" visibility="public" value="select"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7cce3305-d157-4e27-a770-74890174c028" name="" visibility="public" memberEnd="8df13e80-6028-4c00-b26b-10d581ca6fce 75ef8b26-5b50-4603-bd82-f51a3f81843a">
+      <ownedEnd xmi:id="75ef8b26-5b50-4603-bd82-f51a3f81843a" name="invocation" visibility="public" type="7195c02a-f102-4843-88a2-4f3a0217284f" isDerived="true" subsettedProperty="9ff6b50f-f460-482b-87eb-ee1e2b945f99" association="7cce3305-d157-4e27-a770-74890174c028">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4ed2b3f9-05ac-4674-8435-0cba954fd169" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ed406a06-fa20-43a8-9716-1389c93715ed" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="b4fec5b2-6e4c-41da-b27b-6173fd2687ec" name="LiteralInteger" visibility="public">
+      <ownedComment xmi:id="2f96ff5e-d542-4a6e-8983-6f43bd84fd52" annotatedElement="b4fec5b2-6e4c-41da-b27b-6173fd2687ec">
+        <body>&lt;p>A LiteralInteger is a LiteralExpression that provides an Integer value as a result. It must have an owned &lt;code>result&lt;/code> parameter whose type is &lt;em>Integer&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="fd9e3ded-f067-4211-bf61-dc0907f62e30" annotatedElement="b4fec5b2-6e4c-41da-b27b-6173fd2687ec">
+        <body>&lt;p>An Expression that provides an Integer value as a result.&lt;/p>
+
+&lt;p>A LiteralInteger must be typed by a specialization of Evaluation with no input parameters and a single Integer value as its result.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="eb219c3c-c6f2-4386-a22b-a9506628146d" general="3030353e-d110-4b65-b200-e8d1c7308e36"/>
+      <ownedAttribute xmi:id="e831f116-b22a-4762-84ae-5e08040a6e37" name="value" visibility="public">
+        <ownedComment xmi:id="40a2bc35-38aa-4653-a8f4-452a5c54bb6c" annotatedElement="e831f116-b22a-4762-84ae-5e08040a6e37">
+          <body>&lt;p>The Integer value that is the result of evaluating this Expression.&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="449799cf-fc7f-4893-9e45-62bf146351c5" annotatedElement="e831f116-b22a-4762-84ae-5e08040a6e37">
+          <body>&lt;p>The Integer value that is the result of evaluating this Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e7a3ee42-43ac-4282-85cc-2a83e06885d7" name="LiteralRational" visibility="public">
+      <ownedComment xmi:id="a66b55de-e1dd-44f8-8a0c-b4caf427fb13" annotatedElement="e7a3ee42-43ac-4282-85cc-2a83e06885d7">
+        <body>&lt;p>A LiteralRational is a LiteralExpression that provides a Rational value as a result. It must have an owned &lt;code>result&lt;/code> parameter whose type is &lt;em>Rational&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="1aecad4c-78ad-4e31-a95d-9d98af245299" annotatedElement="e7a3ee42-43ac-4282-85cc-2a83e06885d7">
+        <body>&lt;p>An Expression that provides a Real value as a result.&lt;/p>
+
+&lt;p>A LiteralReal must be typed by a specialization of Evaluation with no input parameters and a single Real value as its result.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="82dc53af-d7c5-406f-bb4d-f6466889579c" general="3030353e-d110-4b65-b200-e8d1c7308e36"/>
+      <ownedAttribute xmi:id="7db21a79-717f-4f97-b646-7e6ab9106c43" name="value" visibility="public">
+        <ownedComment xmi:id="5cd0ae34-8d0e-4b48-ae7b-af1b889c6324" annotatedElement="7db21a79-717f-4f97-b646-7e6ab9106c43">
+          <body>&lt;p>The value whose rational approximation is the result of evaluating this Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="1a2957db-12f0-41ee-899c-fde650c7b39e" annotatedElement="7db21a79-717f-4f97-b646-7e6ab9106c43">
+          <body>&lt;p>The Real value that is the result of evaluating this Expression.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3164fef9-064a-469f-9c1a-20e58415db72" name="OperatorExpression" visibility="public">
+      <ownedComment xmi:id="3ecb209e-6a0d-46d1-9c50-effa5933626a" annotatedElement="3164fef9-064a-469f-9c1a-20e58415db72">
+        <body>&lt;p>An OperatorExpression is an InvocationExpression whose &lt;code>function&lt;/code> is determined by resolving its &lt;code>operator&lt;/code> in the context of one of the standard Function packages from the Kernel Model Library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="f4a32e1b-07b1-4ad4-835b-c0f9c29a71fd" general="7195c02a-f102-4843-88a2-4f3a0217284f"/>
+      <ownedAttribute xmi:id="20570f1e-fe68-4660-8050-e8f8e05ce806" name="operator" visibility="public">
+        <ownedComment xmi:id="529b3086-3897-4ec0-835f-8b4a9d324ac7" annotatedElement="20570f1e-fe68-4660-8050-e8f8e05ce806">
+          <body>&lt;p>An operator symbol that names a corresponding Function from one of the standard Function packages from the Kernel Model Library .&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5e317aa3-fe01-4c0d-b580-4e798d36cb83" name="operand" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" aggregation="composite" isDerived="true" association="42eb906b-afc3-4e19-9cf1-3acb2b325108">
+        <ownedComment xmi:id="322c9bb0-bcb0-4ff3-84af-e791916500cd" annotatedElement="5e317aa3-fe01-4c0d-b580-4e798d36cb83">
+          <body>&lt;strong>Implementation note.&lt;/strong> This property is currently just an implementation workaround and is not part of the normative abstract syntax.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fc6509ca-3420-4606-bf23-12c8693c0ca1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8b18ac6c-f136-487e-9a82-53b1263152a4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="39c6cc9f-5f24-454f-96f5-cc8bb6e4ee10" name="LiteralBoolean" visibility="public">
+      <ownedComment xmi:id="e161d083-4049-4507-a241-7f3bbba31a78" annotatedElement="39c6cc9f-5f24-454f-96f5-cc8bb6e4ee10">
+        <body>&lt;p>LiteralBoolean is a&amp;nbsp;LiteralExpression that provides a &lt;em>Boolean&lt;/em> value as a result. It must have an owned &lt;code>result&lt;/code> parameter whose type is &lt;em>Boolean&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="fbd722cf-7ca4-4c4e-9445-c98147801f8d" annotatedElement="39c6cc9f-5f24-454f-96f5-cc8bb6e4ee10">
+        <body>&lt;p>An Expression that provides a Boolean value as a result.&lt;/p>
+
+&lt;p>A LiteralBoolean must be typed by a specialization of Evaluation with no input parameters and a single Boolean value as its result.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="d06e8182-9948-48a1-88fa-c0c465b047cd" general="3030353e-d110-4b65-b200-e8d1c7308e36"/>
+      <ownedAttribute xmi:id="d82eeee4-6a5f-43b3-9438-fee88c62fffe" name="value" visibility="public">
+        <ownedComment xmi:id="ad5c4acc-7efb-4bea-93b7-5463f7682683" annotatedElement="d82eeee4-6a5f-43b3-9438-fee88c62fffe">
+          <body>&lt;p>The Boolean value that is the result of evaluating this Expression.&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="24d9aacc-ea73-405d-829c-7e02b36adcd8" annotatedElement="d82eeee4-6a5f-43b3-9438-fee88c62fffe">
+          <body>&lt;p>The Boolean value that is the result of evaluating this Expression.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="eabb05a5-3e97-41e1-9668-d9bf801193a6" name="Structure" visibility="public">
+      <ownedComment xmi:id="d53c4f1e-cd6e-45ce-90e2-97e215fed198" annotatedElement="eabb05a5-3e97-41e1-9668-d9bf801193a6">
+        <body>&lt;p>A Structure is a Class of objects in the modeled universe that are primarily structural in nature. While an Object is not itself behavioral, it may be involved in and acted on by Behaviors, and it may be the performer of some of them.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="d13948a2-9a28-48b2-8347-e8d4107dd876" name="structureClassifiesObject" visibility="public" constrainedElement="eabb05a5-3e97-41e1-9668-d9bf801193a6">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="3559cd16-e538-48f3-9f7e-5aac7c0de953" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::Object)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="b0ded548-5816-4678-9c85-523738e04502" general="19920a63-7648-49b9-9666-eb0dcfbde515"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="aa6e1f73-4e6a-4e69-8133-78e9b49858fb" name="" visibility="public" memberEnd="c559f3c7-96bd-45da-a2c7-1770af2759aa 25696705-71e7-4f65-aead-1d106b54640c">
+      <ownedEnd xmi:id="25696705-71e7-4f65-aead-1d106b54640c" name="featuringBehavior" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="aa6e1f73-4e6a-4e69-8133-78e9b49858fb">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b81f2b81-389a-46b9-b46a-ebc35e0a4b41" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="51b5158b-1c25-4a43-b068-486f73766094" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="b1a2875a-af89-47c5-ad2b-d5763c43aafd" name="Step" visibility="public">
+      <ownedComment xmi:id="5f04ecc7-d128-4a6e-a36c-7c118648a475" annotatedElement="b1a2875a-af89-47c5-ad2b-d5763c43aafd">
+        <body>&lt;p>A Step is a Feature that is typed by one or more Behaviors. Steps may be used by one Behavior to coordinate the performance of other Behaviors, supporting the steady refinement of behavioral descriptions. Steps can be ordered in time and can be connected using ItemFlows to specify things flowing between their parameters.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="7733652b-1a1b-4e57-b950-67c2adbf1b89" annotatedElement="b1a2875a-af89-47c5-ad2b-d5763c43aafd">
+        <body>&lt;p>Steps are Features for Behaviors and support the steady refinement of behavioral descriptions. Steps can be related in time and serve as sources and targets for object transfers.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="43aa4998-1707-4c6f-8f93-d6cb02924415" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+      <ownedAttribute xmi:id="1f2423e8-9b61-4497-af7c-8de89dbda20c" name="behavior" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isOrdered="true" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="0de6ef83-6deb-4ac1-86c9-acb9c9d83e33">
+        <ownedComment xmi:id="924cbe14-5a5d-4cf0-a129-2d89a31e87e5" annotatedElement="1f2423e8-9b61-4497-af7c-8de89dbda20c">
+          <body>&lt;p>The Behaviors that type this Step.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1923b0eb-fdc5-4f79-8200-072b4dc955b5" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b0e4bb92-bfd2-40c1-b1e2-05f31887a795" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ba7a9394-5d4f-4a40-be17-a628644b092e" name="parameter" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" redefinedProperty="ee47daa4-a81f-4204-b23b-bfc54283691f" association="42320e37-b5da-4932-a04b-6140c17bb5ed">
+        <ownedComment xmi:id="bc75fb8f-cd5b-4d40-b552-0d1c3828ca23" annotatedElement="ba7a9394-5d4f-4a40-be17-a628644b092e">
+          <body>&lt;p>The parameters of this Expression, which are all its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the Behavior.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="30bb9634-f183-40aa-8828-26d6bad4f76a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="900218ad-ae9e-4f70-bd49-fe6c0b08f8b8" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0de6ef83-6deb-4ac1-86c9-acb9c9d83e33" name="" visibility="public" memberEnd="1f2423e8-9b61-4497-af7c-8de89dbda20c f160608e-ca2e-4daa-9b89-f6dad7620456">
+      <ownedEnd xmi:id="f160608e-ca2e-4daa-9b89-f6dad7620456" name="typedStep" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" subsettedProperty="8627f6e3-1ebb-4b3a-b829-d9923e876aa4" association="0de6ef83-6deb-4ac1-86c9-acb9c9d83e33">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e6ff5087-0a95-4437-ad3c-3de1b12b6a1a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f3097368-4db8-4e81-a4e7-2b6980a5e521" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="16d55f7c-8349-4f30-8508-7d10aa3fa01d" name="" visibility="public" memberEnd="c0294af9-25fb-420c-ab74-c37076bb923c 34337938-9330-47ce-a97a-d5628dfadca7" navigableOwnedEnd="c0294af9-25fb-420c-ab74-c37076bb923c">
+      <ownedEnd xmi:id="34337938-9330-47ce-a97a-d5628dfadca7" name="" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" association="16d55f7c-8349-4f30-8508-7d10aa3fa01d"/>
+      <ownedEnd xmi:id="c0294af9-25fb-420c-ab74-c37076bb923c" name="involvesFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" association="16d55f7c-8349-4f30-8508-7d10aa3fa01d">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2ec70c7d-9536-49ce-8206-df019c4ea2f1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="40305387-f18a-43c3-9f3b-5e34c3512d38" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d135b5aa-dc0c-4d36-b3cc-192078dfe217" name="" visibility="public" memberEnd="0dbfb406-bae0-4d85-8c9c-66c3c336f800 9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a">
+      <ownedEnd xmi:id="9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a" name="parameteredBehavior" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="d135b5aa-dc0c-4d36-b3cc-192078dfe217">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="dfcb13b6-0be4-4e6c-9880-584c5522c781" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3e23f605-191b-4709-8297-07d4d94f2d81" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9605471a-0807-46e5-a8ba-d63b8ecf101a" name="" visibility="public" memberEnd="34d5222b-28dc-443a-bcaa-396d3b3ec6aa e7238cc7-e86f-4d19-a3e2-c52b238d9fb0">
+      <ownedEnd xmi:id="e7238cc7-e86f-4d19-a3e2-c52b238d9fb0" name="owningParameterMembership" visibility="public" type="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="9605471a-0807-46e5-a8ba-d63b8ecf101a">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9e65bc40-30e1-4cf7-89d5-b8c0c1dcac92" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a3a2e49d-2044-4111-9f7c-bae70ac075cb" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="42320e37-b5da-4932-a04b-6140c17bb5ed" name="" visibility="public" memberEnd="ba7a9394-5d4f-4a40-be17-a628644b092e 58f50343-0f2e-4d6c-891c-20350eaf6937">
+      <ownedEnd xmi:id="58f50343-0f2e-4d6c-891c-20350eaf6937" name="parameteredStep" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="42320e37-b5da-4932-a04b-6140c17bb5ed">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="88e486aa-557a-4cd7-9b89-85dc58e6a12d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d080009a-6ef0-4211-9502-195540468f5d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb" name="ParameterMembership" visibility="public">
+      <ownedComment xmi:id="d8bbba3e-f588-488c-831e-d0bec3846a43" annotatedElement="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb">
+        <body>&lt;p>A ParameterMembership is a FeatureMembership that identifies its &lt;code>memberFeature&lt;/code> as a parameter, which is always owned, and must have a &lt;code>direction&lt;/code>. A ParameterMembership must be owned by a Behavior or a Step.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c1728128-5a14-479d-978f-7951cff5374a" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="34d5222b-28dc-443a-bcaa-396d3b3ec6aa" name="ownedMemberParameter" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="9605471a-0807-46e5-a8ba-d63b8ecf101a">
+        <ownedComment xmi:id="57902603-4205-439f-8784-f3d32e8a616f" annotatedElement="34d5222b-28dc-443a-bcaa-396d3b3ec6aa">
+          <body>&lt;p>The Feature that is identified as a parameter by this ParameterMembership, which is always owned by the ParameterMembership.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0ef24539-5587-49fe-b19d-3b061c2f8839" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="33296c8d-2847-4ad7-b2ab-5b9c2692f6e5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" name="Behavior" visibility="public">
+      <ownedComment xmi:id="92f0c79e-efe4-40c8-91b5-419efebc4384" annotatedElement="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba">
+        <body>&lt;p>A Behavior coordinates occurrences of other Behaviors, as well as&amp;nbsp;changes in objects. Behaviors can be decomposed into Steps and be characterized by &lt;code>parameters&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="790a2929-2570-4cbe-8646-0001b4059296" annotatedElement="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba">
+        <body>&lt;p>Behaviors provide a place to describe changes in objects over time. Behaviors can be decomposed into steps and be characterized by parameters.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="88ff2e9b-b1bb-4038-b6f4-a2a90201c449" name="behaviorClassifiesPerformance" visibility="public" constrainedElement="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="5d578026-d8ad-4760-b9f4-cc0a6d60ffc8" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::Performance)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="40ba5486-bdb6-496b-a40a-da92bf03b42e" general="19920a63-7648-49b9-9666-eb0dcfbde515"/>
+      <ownedAttribute xmi:id="c559f3c7-96bd-45da-a2c7-1770af2759aa" name="step" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="aa6e1f73-4e6a-4e69-8133-78e9b49858fb">
+        <ownedComment xmi:id="61f92358-728c-4ad4-b9fd-6e8e2564b4d9" annotatedElement="c559f3c7-96bd-45da-a2c7-1770af2759aa">
+          <body>&lt;p>The Steps that make up this Behavior.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c306dbfc-77ae-4796-9e71-528709774235" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a6ce4494-879f-435d-a79b-e1df1a0eb141" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0dbfb406-bae0-4d85-8c9c-66c3c336f800" name="parameter" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" redefinedProperty="ee47daa4-a81f-4204-b23b-bfc54283691f" association="d135b5aa-dc0c-4d36-b3cc-192078dfe217">
+        <ownedComment xmi:id="36735fbd-10f6-47ec-b09a-906dd4887b5b" annotatedElement="0dbfb406-bae0-4d85-8c9c-66c3c336f800">
+          <body>&lt;p>The parameters of this Behavior, which are all its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the Behavior.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4ee3cb9e-e691-4c03-aa47-fb2ce16082be" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7a506cc6-e36d-4dc4-a233-a71de9883220" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="5900f3d7-6ef6-4e58-8446-348ebe932311" name="TargetEnd" visibility="public">
+      <generalization xmi:id="894f50f8-d552-4e66-81f9-e4a309bd4eae" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="90d1a2e1-bdfe-42ef-b409-198ac45d05e6" name="SourceEnd" visibility="public">
+      <generalization xmi:id="26854849-b63b-4745-a352-3e99ec0bc043" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e7803d16-98d9-40d2-9d79-13e1011b78d8" name="" visibility="public" memberEnd="26c234f6-e39b-44e8-bdfa-d449deaeef28 7dbeea16-feec-4238-8827-676ea750d8e1">
+      <ownedEnd xmi:id="7dbeea16-feec-4238-8827-676ea750d8e1" name="succession" visibility="public" type="fec12715-7238-4666-8f45-3e70ed179c7b" association="e7803d16-98d9-40d2-9d79-13e1011b78d8">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d22fe203-05e1-41a5-8dd7-c9ce06595c55" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c8c0aa43-57bf-4084-9811-45effcf176c8" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="714450ea-a8c2-4175-9fcc-8df756333746" name="" visibility="public" memberEnd="610b8f39-4aed-4ab9-b580-ee8d04ddf349 f181c61d-a684-4f14-b1d3-5febba06a8d3">
+      <ownedEnd xmi:id="f181c61d-a684-4f14-b1d3-5febba06a8d3" name="connector" visibility="public" type="f6ecf6da-3e35-489a-86f4-6c9eee938686" isDerived="true" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="714450ea-a8c2-4175-9fcc-8df756333746">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1fa03f28-5f88-4ed0-8aec-0f8610477e1e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b071c27b-3612-4c28-9b78-6264ed52776c" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="6f8dba76-c940-4351-9052-c7b90e0663d8" name="ReferenceSubsetting" visibility="public">
+      <ownedComment xmi:id="b5f0b323-bfe0-42f0-bfc0-3fdfe2d47ca1" annotatedElement="6f8dba76-c940-4351-9052-c7b90e0663d8">
+        <body>&lt;p>ReferenceSubsetting is a kind of Subsetting in which the &lt;code>referencedFeature&lt;/code> is syntactically distinguished from other Features subsetted by the &lt;code>referencingFeature&lt;/code>. ReferenceSubsetting has the same semantics as Subsetting, but the &lt;code>referenceFeature&lt;/code> may have a special purpose relative to the &lt;code>referencingFeature&lt;/code>. For instance, ReferenceSubsetting is used to identify the &lt;code>relatedFeatures&lt;/code> of a Connector.&lt;/p>
+
+&lt;p>ReferenceSubsetting is always an &lt;code>ownedRelationship&lt;/code> of its &lt;code>referencingFeature&lt;/code>. A Feature can have at most one &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="80da5138-6760-4221-91e7-d14772c6f883" general="d9dbfafc-fa14-4bd6-845e-ff8ce5511e56"/>
+      <ownedAttribute xmi:id="40c70f86-740f-4a86-afad-21e3146d66c6" name="referencedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="7537c16f-8968-42b7-bf42-d7e7ae6cfeee" association="b257db53-0e6f-45a8-a5f2-f67997e4e155">
+        <ownedComment xmi:id="d183dc8e-ff36-465f-be78-b65b48c5709e" annotatedElement="40c70f86-740f-4a86-afad-21e3146d66c6">
+          <body>&lt;p>The Feature that is referenced by the &lt;code>referencingFeature&lt;/code> of this ReferenceSubsetting.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8f226a7c-6d87-4774-a0ba-83458380e88c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="caec27a0-72c4-4a12-bb02-1fd4fc9de998" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="568bfd45-c088-4cf6-b582-fc7a9e714d1e" name="referencingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" redefinedProperty="cddd2eb1-4d1e-439c-bc90-88583bfeb153 4d938e84-5350-4b24-bdcd-6591091d85be" association="e792bd50-071f-4a2d-81d0-feeb333f183f">
+        <ownedComment xmi:id="84673b8d-07f0-47e4-9dfe-f9fd3f287103" annotatedElement="568bfd45-c088-4cf6-b582-fc7a9e714d1e">
+          <body>&lt;p>The Feature that owns this ReferenceSubsetting relationship, which is also its &lt;code>subsettingFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="43fe8e53-3f14-4b5d-bae9-ddd196a06bbd" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5e6193eb-9b57-4a1d-bfdf-2fc4faadd4a7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="bc672718-eb8c-478d-a15a-edbfa3fe64cd" name="" visibility="public" memberEnd="9b127f81-c214-41d5-86e0-06db4de245fb f6c0f8f2-de3d-43e3-a129-da215db27283">
+      <ownedEnd xmi:id="f6c0f8f2-de3d-43e3-a129-da215db27283" name="succession" visibility="public" type="fec12715-7238-4666-8f45-3e70ed179c7b" association="bc672718-eb8c-478d-a15a-edbfa3fe64cd">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b1760ef2-b986-4b39-af55-88ca2daadc69" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f08d36d3-fac1-4b30-a9c1-ce5201156937" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b257db53-0e6f-45a8-a5f2-f67997e4e155" name="" visibility="public" memberEnd="40c70f86-740f-4a86-afad-21e3146d66c6 ec1702ad-28aa-4165-bd2a-e85e980ed8de">
+      <ownedEnd xmi:id="ec1702ad-28aa-4165-bd2a-e85e980ed8de" name="referencing" visibility="public" type="6f8dba76-c940-4351-9052-c7b90e0663d8" subsettedProperty="10aa2871-4318-4d93-aa42-d81688d3cba3" association="b257db53-0e6f-45a8-a5f2-f67997e4e155">
+        <ownedComment xmi:id="1e782fe4-4250-4dad-8d41-f09bc8cd5010" annotatedElement="ec1702ad-28aa-4165-bd2a-e85e980ed8de">
+          <body>&lt;p>The ReferenceSubsettings with a certain Feature as the &lt;code>referencedFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="132ab84a-d9f9-4a03-8d76-f0f86e7dbf15" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1229f4ef-af1d-4578-9cc1-e33102432112" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="091a3501-21e5-4ed8-a4c3-f694e0a2761e" name="" visibility="public" memberEnd="b77fdca8-ca31-4cae-88c4-5eee9cd916cf 06118f89-7962-4660-90a5-157a8093778f">
+      <ownedEnd xmi:id="06118f89-7962-4660-90a5-157a8093778f" name="sourceConnector" visibility="public" type="f6ecf6da-3e35-489a-86f4-6c9eee938686" isDerived="true" subsettedProperty="f181c61d-a684-4f14-b1d3-5febba06a8d3 1807da4c-d8f2-454f-911f-8a98c3302238" association="091a3501-21e5-4ed8-a4c3-f694e0a2761e">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8d7f9083-d63b-4434-bd9f-f277ae7c11bc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="99f276ec-88a9-4166-8023-55623638fed6" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a0045b8d-1fb8-4331-b394-e3e53322ebb7" name="" visibility="public" memberEnd="5014930c-7127-4294-a2fe-4c69287023af 3b399653-8937-47cb-828a-74d049e1c19c">
+      <ownedEnd xmi:id="3b399653-8937-47cb-828a-74d049e1c19c" name="featuringConnector" visibility="public" type="f6ecf6da-3e35-489a-86f4-6c9eee938686" isDerived="true" subsettedProperty="d071e7ea-2566-41c5-9eff-acc7a2507370" association="a0045b8d-1fb8-4331-b394-e3e53322ebb7">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a33a62b6-f025-4fd2-8003-65f24365854c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fe6c6e14-049e-40bb-a54a-370b7dab73d6" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="06285a7a-37fa-4aed-bed7-6d4ac75394f4" name="" visibility="public" memberEnd="0a86361f-1a5a-4043-9934-862f4f73d182 f78c9269-a09c-4b80-9ec1-c2ca729438de">
+      <ownedEnd xmi:id="f78c9269-a09c-4b80-9ec1-c2ca729438de" name="succession" visibility="public" type="fec12715-7238-4666-8f45-3e70ed179c7b" association="06285a7a-37fa-4aed-bed7-6d4ac75394f4">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7de87164-a510-4055-a104-48862f9cb645" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cd0d056d-df00-4354-8631-956e1b01c6d8" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7913d6df-ed58-43ff-9f15-42d8ce2b979e" name="" visibility="public" memberEnd="6c83968c-1fff-42f7-9f8b-82272ab0e9cb 31be452c-98a2-4dc5-b5bd-faf5bf569b24" navigableOwnedEnd="6c83968c-1fff-42f7-9f8b-82272ab0e9cb">
+      <ownedEnd xmi:id="31be452c-98a2-4dc5-b5bd-faf5bf569b24" name="" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" association="7913d6df-ed58-43ff-9f15-42d8ce2b979e"/>
+      <ownedEnd xmi:id="6c83968c-1fff-42f7-9f8b-82272ab0e9cb" name="participantFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="7913d6df-ed58-43ff-9f15-42d8ce2b979e">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="78a74e35-7ade-4162-9f9d-236dab72097c" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="307207fa-e201-484e-85f2-d9d1bb9df674" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f6ecf6da-3e35-489a-86f4-6c9eee938686" name="Connector" visibility="public">
+      <ownedComment xmi:id="349833cc-e5de-4137-ad89-0985c35869a3" annotatedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <body>&lt;p>A Connector is a usage of Associations, with links restricted to instances of the Type in which it is used (domain of the Connector). Associations restrict what kinds of things might be linked. The Connector further restricts these links to between values of two Features on instances of its&amp;nbsp;domain.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="5dee0ade-7515-4086-99d5-6694af1caf79" name="connectorRelatedFeatures" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="3dbd3cbf-09b3-4352-96fb-92a08b1efb66" annotatedElement="5dee0ade-7515-4086-99d5-6694af1caf79">
+          <body>&lt;p>The &lt;code>relatedFeatures&lt;/code> of a Connector are the referenced Features of its &lt;code>connectorEnds&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4b335469-031e-49d3-a7b5-23dfd87d0c6d" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>relatedFeature = connectorEnd.ownedReferenceSubsetting.subsettedFeature</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="4dd5d45d-c821-448e-ae3a-8e064c774966" name="connectorFeaturingType" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="db7a72af-6e0b-4ebb-b7da-71c1b60f2a39" annotatedElement="4dd5d45d-c821-448e-ae3a-8e064c774966">
+          <body>&lt;p>Each &lt;code>relatedFeature&lt;/code> of a Connector must have some &lt;code>featuringType&lt;/code> of the Connector as a direct or indirect &lt;code>featuringType&lt;/code> (where a Feature with no &lt;code>featuringType&lt;/code> is treated as if the Classifier &lt;em>Base::Anything&lt;/em> was its &lt;code>featuringType&lt;/code>).&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="86baf5d7-6c5b-4f8f-ac72-344b98a5ab37" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>relatedFeature->forAll(f | 
+    if featuringType->isEmpty() then f.isFeaturedWithin(null)
+    else featuringType->exists(t | f.isFeaturedWithin(t))
+    endif)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="180ab6da-d2da-47d4-9275-4c74c01c040e" name="connectorSourceFeature" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="b3c26d36-5769-4ae5-9bb3-f82c9479d6f7" annotatedElement="180ab6da-d2da-47d4-9275-4c74c01c040e">
+          <body>&lt;p>If this is a binary Connector, then the &lt;code>sourceFeature&lt;/code> is the first &lt;code>relatedFeature&lt;/code>. If this Connector is not binary, then it has no &lt;code>sourceFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="a82a39de-8e16-4489-947e-5f6612890db6" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>sourceFeature = 
+    if relatedFeature->size() = 2 then relatedFeature->at(1) 
+    else null 
+    endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="d8581260-f663-42e7-a7e3-fba2d9e108f9" name="connectorTargetFeature" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="7806a7ce-9879-4a88-8572-a21853739cf1" annotatedElement="d8581260-f663-42e7-a7e3-fba2d9e108f9">
+          <body>&lt;p>The &lt;code>targetFeatures&lt;/code> of a Connector are the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="73dccebc-3f0c-4e69-881f-d2fabf13a282" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>targetFeature =
+    if sourceFeature = null then relatedFeature
+    else relatedFeature->excluding(sourceFeature)
+    endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="37809d24-1a99-49d5-b63e-fd6113987ea9" name="connectorConnectorEnd" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="ceaecc86-1296-4fc9-9104-37911da066ad" annotatedElement="37809d24-1a99-49d5-b63e-fd6113987ea9">
+          <body>&lt;p>The &lt;code>connectorEnds&lt;/code> of a Connector are its &lt;code>endFeatures&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="958f40bb-c018-4634-a509-d09c2acecc73" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>connectorEnd = feature->select(isEnd)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="a65c8842-2fd9-4669-9edd-3b2215319383" name="connectorEndRedefinition" visibility="public" constrainedElement="f6ecf6da-3e35-489a-86f4-6c9eee938686">
+        <ownedComment xmi:id="b3293163-703d-4d16-aa02-3e0484d2e4a2" annotatedElement="a65c8842-2fd9-4669-9edd-3b2215319383">
+          <body>&lt;p>For each &lt;code>association&lt;/code> of a Connector, each &lt;code>associationEnd&lt;/code> must be redefined by a different &lt;code>connectorEnd&lt;/code> of the Connector.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="df5a5a9e-cdb9-4677-ba0d-bb930710effa" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>association->forAll(a |
+    a.associationEnd->forAll(ae |
+        connectorEnd->one(ce | 
+            ce.ownedRedefinition.redefinedFeature->includes(ae))))
+</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="67a6c9bd-9a31-448a-995c-64fa8c61ab9f" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+      <generalization xmi:id="f34a1ef1-4ecd-40c8-becb-22fa68055c46" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="610b8f39-4aed-4ab9-b580-ee8d04ddf349" name="relatedFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isUnique="false" isDerived="true" redefinedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="714450ea-a8c2-4175-9fcc-8df756333746">
+        <ownedComment xmi:id="562ee1a4-2c46-4672-a660-3634fa13e117" annotatedElement="610b8f39-4aed-4ab9-b580-ee8d04ddf349">
+          <body>&lt;p>The Features that are related by this Connector considered as a Relationship, derived as the referenced Features of the &lt;code>connectorEnds&lt;/code> of the Connector.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f55f7f74-8ba9-4ffb-8a21-c37e64d6fb32" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4621be24-47c6-430d-b1b3-d8f36f772711" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="927f6cdf-59b8-4e3c-8c17-f626bfd38a38" name="association" visibility="public" type="86a283c4-fc00-49a6-af2c-f85043eadd9f" isOrdered="true" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="b0e24ddc-126c-4417-bc56-6d8b8612d10b">
+        <ownedComment xmi:id="51ab24a9-c79b-407a-b3c9-752c50068cda" annotatedElement="927f6cdf-59b8-4e3c-8c17-f626bfd38a38">
+          <body>&lt;p>The Associations that type the Connector.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="172cfdc7-2482-40da-be65-e3dce2a74951" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c51c03c4-0bdb-4d6b-8b51-5c3bf0e90cab" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="87a574a4-df49-43e7-99cd-e5129284fe52" name="isDirected" visibility="public">
+        <ownedComment xmi:id="669c6d48-1198-4500-84c1-55ddf7c67170" annotatedElement="87a574a4-df49-43e7-99cd-e5129284fe52">
+          <body>&lt;p>For a binary Connector, whether or not the Connector should be considered to have a direction from &lt;code>source&lt;/code> to &lt;code>target&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="06bd12d4-8ad1-43cf-9827-21a0d3fe050d" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5014930c-7127-4294-a2fe-4c69287023af" name="connectorEnd" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" redefinedProperty="a845e308-0fa7-49d9-9d90-152949ecf7e1" association="a0045b8d-1fb8-4331-b394-e3e53322ebb7">
+        <ownedComment xmi:id="31e8a13d-4187-4573-b337-bcd66e4add52" annotatedElement="5014930c-7127-4294-a2fe-4c69287023af">
+          <body>&lt;p>The &lt;code>endFeatures&lt;/code> of a Connector, which redefine the &lt;code>endFeatures&lt;code> of the &lt;code>associations&lt;/code> of the Connector. The &lt;code>connectorEnds&lt;/code> determine via ReferenceSubsetting Relationships which Features are related by the Connector.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b59c509f-bea3-4003-900c-3c92a3139769" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="08ef8e4a-6693-4094-a08d-ee6e2bcf01ae" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b77fdca8-ca31-4cae-88c4-5eee9cd916cf" name="sourceFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="610b8f39-4aed-4ab9-b580-ee8d04ddf349" association="091a3501-21e5-4ed8-a4c3-f694e0a2761e">
+        <ownedComment xmi:id="2c4b413c-2f5d-4adf-9fba-877c96305701" annotatedElement="b77fdca8-ca31-4cae-88c4-5eee9cd916cf">
+          <body>&lt;p>The source &lt;code>relatedFeature&lt;/code> for this Connector. If this is a binary Connector, then the &lt;code>sourceFeature&lt;/code> is the first &lt;code>relatedFeature&lt;/code>, and the first end Feature of the Connector must redefine the &lt;em>&lt;code>source&lt;/code>&lt;/em> Feature of the Connector &lt;em>&lt;code>binaryLinks&lt;/code>&lt;/em> from the Kernel Semantic Library. If the Connector is not binary, then it has no &lt;code>sourceFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="58a6c49f-d6d8-4f70-ae6b-7275f732d0e5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e561eb9d-fb6e-4fa9-8404-30cfc735ec46" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d3c3ab40-5dc9-4630-a66f-057723bc8e39" name="targetFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isDerived="true" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" subsettedProperty="610b8f39-4aed-4ab9-b580-ee8d04ddf349" association="1b7f37a1-4554-43c0-98b3-79a9be0800f9">
+        <ownedComment xmi:id="d4893db2-0707-4b65-9677-5209603a4279" annotatedElement="d3c3ab40-5dc9-4630-a66f-057723bc8e39">
+          <body>&lt;p>The target &lt;code>relatedFeatures&lt;/code> for this Connector. This includes all the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>. If this is a binary Connector, then the end Feature corresponding to the &lt;code>targetFeature&lt;/code> must redefine the &lt;em>&lt;code>target&lt;/code>&lt;/em> Feature of the Connector &lt;em>&lt;code>binaryLinks&lt;/code>&lt;/em> from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="54bab64c-6470-48c4-9527-c77f736453e7" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8ed8b44f-7739-4d91-bab5-c3527f81e5b2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fec12715-7238-4666-8f45-3e70ed179c7b" name="Succession" visibility="public">
+      <ownedComment xmi:id="490380f2-ff95-484a-8738-8afb5c2ae5ed" annotatedElement="fec12715-7238-4666-8f45-3e70ed179c7b">
+        <body>&lt;p>A Succession is a binary&amp;nbsp;Connector that requires its &lt;code>relatedFeatures&lt;/code> to happen separately in time. A Succession must be typed by the Association &lt;em>HappensBefore&lt;/em> from the Kernel Model Library (or a specialization of it).&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="0d7931c5-9e72-422d-8c41-3af50038b93f" general="f6ecf6da-3e35-489a-86f4-6c9eee938686"/>
+      <ownedAttribute xmi:id="fcadde3e-eb7f-4a6f-b369-df7c2c0cc0bf" name="transitionStep" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="f07bfab6-e256-4ab3-b9b7-3fe3a5379bed">
+        <ownedComment xmi:id="d6e235ee-f1c1-4f6f-8f9b-935aa719a294" annotatedElement="fcadde3e-eb7f-4a6f-b369-df7c2c0cc0bf">
+          <body>&lt;p>A Step that is typed by the Behavior &lt;em>TransitionPerformance&lt;/em> (from the Model Library) that has this Succession as its &lt;em>&lt;code>transitionLink&lt;/code>&lt;/em>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="adee5e9f-bd02-40e2-865b-7e5886bd81b9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d0702b68-97f9-4859-8d6a-c969ffb4d8cd" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0a86361f-1a5a-4043-9934-862f4f73d182" name="triggerStep" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" association="06285a7a-37fa-4aed-bed7-6d4ac75394f4">
+        <ownedComment xmi:id="7f2fd05c-1a32-4058-aa9a-1ca1b41cd85e" annotatedElement="0a86361f-1a5a-4043-9934-862f4f73d182">
+          <body>&lt;p>Steps that map incoming events to the timing of occurrences of the &lt;code>transitionStep&lt;/code>. The values of &lt;code>triggerStep&lt;/code> subset the list of acceptable events to be received by a Behavior or the object that performs it.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e293c99b-a2d2-45af-bac5-e1abd3de0840" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="af0bfe18-2d74-4ddf-9371-fad45e08ade7" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9b127f81-c214-41d5-86e0-06db4de245fb" name="effectStep" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" isDerived="true" association="bc672718-eb8c-478d-a15a-edbfa3fe64cd">
+        <ownedComment xmi:id="bb76f34e-9c01-4334-b41d-ba4ff8b8272d" annotatedElement="9b127f81-c214-41d5-86e0-06db4de245fb">
+          <body>&lt;p>Steps that represent occurrences that are side effects of the &lt;code>transitionStep&lt;/code> occurring.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="071eafc2-558b-4692-8021-6093ec3e5e69" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9eff577a-55d4-4acb-a830-1929dfd7ab79" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="26c234f6-e39b-44e8-bdfa-d449deaeef28" name="guardExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="e7803d16-98d9-40d2-9d79-13e1011b78d8">
+        <ownedComment xmi:id="a3909728-f3b7-4615-9eb7-4fbaa3805759" annotatedElement="26c234f6-e39b-44e8-bdfa-d449deaeef28">
+          <body>&lt;p>Expressions that must evaluate to true before the &lt;code>transitionStep&lt;/code> can occur.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a89fd09c-eecb-47c2-b891-37316a131581" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4fd012b6-ab26-4cd4-954b-0543703aca02" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b0e24ddc-126c-4417-bc56-6d8b8612d10b" name="" visibility="public" memberEnd="927f6cdf-59b8-4e3c-8c17-f626bfd38a38 68475b4b-be4c-4323-812c-5020bb7be7e4">
+      <ownedEnd xmi:id="68475b4b-be4c-4323-812c-5020bb7be7e4" name="typedConnector" visibility="public" type="f6ecf6da-3e35-489a-86f4-6c9eee938686" isDerived="true" subsettedProperty="8627f6e3-1ebb-4b3a-b829-d9923e876aa4" association="b0e24ddc-126c-4417-bc56-6d8b8612d10b">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d3c0328d-a3f2-4ab5-8448-1e3b4279636f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="49950466-274a-44fe-ad89-db6c04db0220" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1b7f37a1-4554-43c0-98b3-79a9be0800f9" name="" visibility="public" memberEnd="d3c3ab40-5dc9-4630-a66f-057723bc8e39 71e173af-8df5-47a5-93ed-234d61d5e5af">
+      <ownedEnd xmi:id="71e173af-8df5-47a5-93ed-234d61d5e5af" name="targetConnector" visibility="public" type="f6ecf6da-3e35-489a-86f4-6c9eee938686" isDerived="true" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc f181c61d-a684-4f14-b1d3-5febba06a8d3" association="1b7f37a1-4554-43c0-98b3-79a9be0800f9">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bb71a3e1-132f-44d6-bcf9-eb5386217b4a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="06cb73df-e8d4-4e96-a562-ae1befbff202" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f07bfab6-e256-4ab3-b9b7-3fe3a5379bed" name="" visibility="public" memberEnd="fcadde3e-eb7f-4a6f-b369-df7c2c0cc0bf dd15fe15-1698-48f0-9536-6ad14df1dc27">
+      <ownedEnd xmi:id="dd15fe15-1698-48f0-9536-6ad14df1dc27" name="succession" visibility="public" type="fec12715-7238-4666-8f45-3e70ed179c7b" association="f07bfab6-e256-4ab3-b9b7-3fe3a5379bed">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f3fed45b-6783-4e25-a33f-a705b7ea661b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2c987e72-a3f8-442d-843b-eb5f36f2f242" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="95e1ddab-8a9b-412b-935c-67f12e35ac12" name="BindingConnector" visibility="public">
+      <ownedComment xmi:id="fdbf815e-0a0b-4b16-acbf-ef43dd3285ef" annotatedElement="95e1ddab-8a9b-412b-935c-67f12e35ac12">
+        <body>&lt;p>A Binding Connector is a binary Connector that requires its &lt;code>relatedFeatures&lt;/code> to identify the same things (have the same values). 
+
+&lt;p> A BindingConnector must be directly or indirectly typed by the &lt;em>&lt;code>SelfLink&lt;/code>&lt;/em> Association from the &lt;em>&lt;code>Links&lt;/code&lt;/em> library model. Both end multiplicities must be 1..1 when the &lt;code>relatedFeatures&lt;/code> have unique values.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="06e1d291-9013-4796-9528-35e0f7e2c970" general="f6ecf6da-3e35-489a-86f4-6c9eee938686"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="763cb753-fe4d-496a-a46f-1fe9f5e63a66" name="" visibility="public" memberEnd="6507856f-a68c-4c3c-b4b5-f6a17faac658 52cd36c4-3937-4c59-a74e-ebbc2fb3c1bf">
+      <ownedEnd xmi:id="52cd36c4-3937-4c59-a74e-ebbc2fb3c1bf" name="valuation" visibility="public" type="dbb63699-e461-4532-aa45-7e1a10f1f2c5" isDerived="true" subsettedProperty="ec58580f-851c-4202-a5c6-27b2ec9ac376" association="763cb753-fe4d-496a-a46f-1fe9f5e63a66">
+        <ownedComment xmi:id="37d42f85-c845-49ab-a995-e7a36ce05bdf" annotatedElement="52cd36c4-3937-4c59-a74e-ebbc2fb3c1bf">
+          <body>&lt;p>The (at most one) &lt;code>ownedMembership&lt;/code> of this Feature that is the FeatureValue that provides the value of the Feature.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cc91fca3-6150-4042-91a9-a377bd314728" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d6dc2659-e83b-4b83-87e0-e3bf2cff8205" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b3cc51bf-cf4c-4f4f-b389-7ebcfc5a2cd0" name="" visibility="public" memberEnd="40c71826-483c-4bc7-b060-fcd8869d2722 092370dd-cb4a-4697-b894-3a45b3764fcc">
+      <ownedEnd xmi:id="092370dd-cb4a-4697-b894-3a45b3764fcc" name="expressedValuation" visibility="public" type="dbb63699-e461-4532-aa45-7e1a10f1f2c5" isDerived="true" subsettedProperty="4e9a7462-c2c0-42cd-a715-dc21395cc779" association="b3cc51bf-cf4c-4f4f-b389-7ebcfc5a2cd0">
+        <ownedComment xmi:id="e953e589-2d02-4074-be56-27f44862b5cf" annotatedElement="092370dd-cb4a-4697-b894-3a45b3764fcc">
+          <body>&lt;p>The FeatureValue that owns the &lt;code>value&lt;/code> Expression.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="85487433-df61-4510-a9a8-3993380890b4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="669353f3-cf89-4f9f-b75f-ee86c74f5f83" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="dbb63699-e461-4532-aa45-7e1a10f1f2c5" name="FeatureValue" visibility="public">
+      <ownedComment xmi:id="827a532a-22e9-4ae6-9102-b1ceb484755c" annotatedElement="dbb63699-e461-4532-aa45-7e1a10f1f2c5">
+        <body>&lt;p>A FeatureValue is a Membership that identifies a particular member Expression that provides the value of the Feature that owns the FeatureValue. The value is specified as either a bound value or an initial value, and as either a concrete or default value. A Feature can have at most one FeatureValue.&lt;/p>
+
+&lt;p>If &lt;code>isInitial = false&lt;/code>, then the result of the &lt;code>value&lt;/code> expression is bound to the &lt;code>featureWithValue&lt;/code> using a BindingConnector. Otherwise, the &lt;code>featureWithValue&lt;/code> is initialized using a FeatureWritePeformance.&lt;/p>
+
+&lt;p>If &lt;code>isDefault = false&lt;/code>, then the above semantics of the FeatureValue are realized for the given &lt;code>featureWithValue&lt;/code>. Otherwise, the semantics are realized for any individual of the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>, unless another value is explicitly given for the &lt;code>featureWithValue&lt;/code> for that individual.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="4d974370-41f3-4cb7-a454-135d05d098ff" name="featureValueExpressionDomain" visibility="public" constrainedElement="dbb63699-e461-4532-aa45-7e1a10f1f2c5">
+        <ownedComment xmi:id="0641cb70-c99d-4891-8be7-ca622426eed0" annotatedElement="4d974370-41f3-4cb7-a454-135d05d098ff">
+          <body>&lt;p>The &lt;code>value&lt;/code> Expression must have the same &lt;code>featuringTypes&lt;/code> as the &lt;code>featureWithValue&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="9b97d50a-3d54-4f00-9f4e-4df8dcdc3ea9" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>value.featuringType = featureWithValue.featuringType</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="bcf130b1-fffd-469f-84cf-cab6bf2c3743" name="featureValueBindingConnector" visibility="public" constrainedElement="dbb63699-e461-4532-aa45-7e1a10f1f2c5">
+        <ownedComment xmi:id="eb3cc9b8-9ce3-4ce0-817a-16a81e8dc3c7" annotatedElement="bcf130b1-fffd-469f-84cf-cab6bf2c3743">
+          <body>&lt;p>The &lt;code>valueConnector&lt;/code> must be an &lt;code>ownedMember&lt;/code> of the &lt;code>featureWithValue&lt;/code> whose &lt;code>relatedElements&lt;/code> are the &lt;code>featureWithValue&lt;/code> and the &lt;code>result&lt;/code> of the &lt;code>value&lt;/code> Expression and whose &lt;code>featuringTypes&lt;/code> are the same as those of the &lt;code>featureWithValue&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ed507ed0-a850-4acd-9cb6-4e36d05f9f3c" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>valueConnector.owningNamespace = featureWithValue and
+valueConnector.relatedFeature->includes(featureWithValue) and
+valueConnector.relatedFeature->includes(value.result) and
+valueConnector.featuringType = featureWithValue.featuringType</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="0e977c83-fb3e-4f9a-a38b-b846cb2c8446" general="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d"/>
+      <ownedAttribute xmi:id="6507856f-a68c-4c3c-b4b5-f6a17faac658" name="featureWithValue" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="cfd14843-bce5-4ee1-8fb3-a2fdd0237258" association="763cb753-fe4d-496a-a46f-1fe9f5e63a66">
+        <ownedComment xmi:id="ed42fb2f-6cb0-4b99-9cea-d5b532c49a38" annotatedElement="6507856f-a68c-4c3c-b4b5-f6a17faac658">
+          <body>&lt;p>The Feature to be provided a value.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="eca6759e-aad9-4c1f-96df-6f6537377495" annotatedElement="6507856f-a68c-4c3c-b4b5-f6a17faac658">
+          <body>&lt;p>The Feature to be provided a value.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="30337ba9-c0ff-493e-9e5f-24bfc78aef4e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9ac6482d-f4a1-45ac-87f4-5355fcd2f91b" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="40c71826-483c-4bc7-b060-fcd8869d2722" name="value" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" aggregation="composite" isDerived="true" redefinedProperty="50d115dd-9fe9-4a0c-8d67-bcca24186f18" association="b3cc51bf-cf4c-4f4f-b389-7ebcfc5a2cd0">
+        <ownedComment xmi:id="df533cad-bb3b-4ec3-8e0b-3bca2e42be1f" annotatedElement="40c71826-483c-4bc7-b060-fcd8869d2722">
+          <body>&lt;p>The Expression that provides the value of the &lt;code>featureWithValue&lt;/code> as its &lt;code>result&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="999d1162-c0bf-49aa-975b-7124e145bffe" annotatedElement="40c71826-483c-4bc7-b060-fcd8869d2722">
+          <body>&lt;p>The Expression that provides the value as a result.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="65525c9c-31a3-49a6-a423-f94e5bdad453" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cd9e1c7f-176e-41fc-8763-53d6c00fdecc" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="96b06642-c410-438a-9269-9b1f775709fe" name="isInitial" visibility="public">
+        <ownedComment xmi:id="aa0b3f3c-c005-44ac-8317-d1b1031e6892" annotatedElement="96b06642-c410-438a-9269-9b1f775709fe">
+          <body>&lt;p>Whether this FeatureValue specifies a bound value or an initial value for the &lt;code>featureWithValue&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="3ab755f7-b110-4e73-a933-fd27dcd6e2fa" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b9991a2a-a7d3-450b-8820-0a8308048d4d" name="isDefault" visibility="public">
+        <ownedComment xmi:id="fcbb9625-4fbe-44ed-b592-c94494050110" annotatedElement="b9991a2a-a7d3-450b-8820-0a8308048d4d">
+          <body>&lt;p>Whether this FeatureValue is a concrete specification of the bound of initial value of the &lt;code>featureWithValue&lt;/code>, or just a default value that may be overridden.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="d1fd9ccc-6018-4ae6-9e85-b88466b6d00d" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9b64be93-8d9c-429d-9b36-956c57241e8f" name="" visibility="public" memberEnd="0b629a34-f791-46f7-ab12-3befdba2f4d4 0714ede9-ab57-4a83-a639-57a2681c931a">
+      <ownedEnd xmi:id="0714ede9-ab57-4a83-a639-57a2681c931a" name="multiplicity" visibility="public" type="3f431538-13b8-4b12-aab0-1fad3d7fff4d" isDerived="true" subsettedProperty="952875f0-3ee1-4651-ad7b-31868a29c4f3" association="9b64be93-8d9c-429d-9b36-956c57241e8f">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1d7b130c-2e73-410d-8925-0d066f4d3cf6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="862d3e51-713f-43f3-b21f-5fce8bc14075" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3f431538-13b8-4b12-aab0-1fad3d7fff4d" name="MultiplicityRange" visibility="public">
+      <ownedComment xmi:id="f00f827f-ddf0-4335-8246-ce6532f9e522" annotatedElement="3f431538-13b8-4b12-aab0-1fad3d7fff4d">
+        <body>&lt;p>A MultiplicityRange is a Multiplicity whose value is defined to be the (inclusive) range of natural numbers given by the result of a &lt;code>lowerBound&lt;/code> Expression and the result of an &lt;code>upperBound&lt;/code> Expression. The result of the &lt;code>lowerBound&lt;/code> Expression shall be of type &lt;em>Natural&lt;/em>, while the result of the &lt;code>upperBound&lt;/code> Expression shall be of type &lt;em>UnlimitedNatural&lt;/em>. If the result of the &lt;code>upperBound&lt;/code> Expression is the unbounded value &lt;code>*&lt;/code>, then the specified range includes all natural numbers greater than or equal to the &lt;code>lowerBound&lt;/code> value.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="23322a50-8ed3-4106-8da2-2b63b411e614" name="multiplicityRangeExpressionDomain" visibility="public" constrainedElement="3f431538-13b8-4b12-aab0-1fad3d7fff4d">
+        <ownedComment xmi:id="fbbe9f5d-86f3-4098-a091-ebca69526ba2" annotatedElement="23322a50-8ed3-4106-8da2-2b63b411e614">
+          <body>&lt;p>The &lt;code>bounds&lt;/code> of a MultiplicityRange shall have the same &lt;code>featuringTypes&lt;/code> as the MultiplicityRange.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="0742f7a8-5a2d-4943-b25f-f5e013931cfe" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>bound->forAll(b | b.featuringType = self.featuringType)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="3ce5e0de-3bba-4675-8c83-96ab9cd306e0" general="50f20a49-7ff4-48b1-aac0-8f6ee31b322f"/>
+      <ownedAttribute xmi:id="0b629a34-f791-46f7-ab12-3befdba2f4d4" name="lowerBound" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="b4a24f70-4ada-4cbb-8db1-28c8ae0c0427" association="9b64be93-8d9c-429d-9b36-956c57241e8f">
+        <ownedComment xmi:id="5ed81234-c17a-43ec-97b8-694a8ecf875a" annotatedElement="0b629a34-f791-46f7-ab12-3befdba2f4d4">
+          <body>&lt;p>The Expression whose result provides the lower bound of MultiplicityRange. If no &lt;code>lowerBound&lt;/code> Expression is given, then the lower bound shall have the same value as the upper bound, unless the upper bound is unbounded (&lt;code>*&lt;/code>), in which case the lower bound shall be 0.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="be99ed0a-ba42-40a9-8bd7-b51f060a77a8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0ac61d22-2c4f-4faf-aba7-dd9a3726ab35" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8799ce07-5a78-45d7-ae15-d91132262efc" name="upperBound" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="b4a24f70-4ada-4cbb-8db1-28c8ae0c0427" association="43be9aa3-f50f-4b4c-ae69-c43ddc717a8b">
+        <ownedComment xmi:id="caf75cd4-f9d1-4a8b-bea4-61ea9475f759" annotatedElement="8799ce07-5a78-45d7-ae15-d91132262efc">
+          <body>The Expression whose result is the upper bound of the MultiplicityRange.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e03a2601-f121-4849-849c-c24f63da8685" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0466faa8-4933-44ba-8e63-e3df416c0191" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b4a24f70-4ada-4cbb-8db1-28c8ae0c0427" name="bound" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" isDerived="true" isDerivedUnion="true" redefinedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="790bb85b-f979-4b62-9d96-f3ae63a161ad">
+        <ownedComment xmi:id="a4e474fa-b810-4557-8ef3-fc6d5e901b05" annotatedElement="b4a24f70-4ada-4cbb-8db1-28c8ae0c0427">
+          <body>&lt;p>The bound Expressions of the MultiplicityRange. These shall be the only &lt;code>ownedMembers&lt;/code> of the MultiplicityRange.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2d3c7731-804b-41bd-a26f-bd9cef9872eb" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="76e35ca6-4fd4-4fef-9e00-3c72b556ccf2" name="" visibility="public" value="2"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="43be9aa3-f50f-4b4c-ae69-c43ddc717a8b" name="" visibility="public" memberEnd="8799ce07-5a78-45d7-ae15-d91132262efc d002b927-b8bf-468f-99d4-02ae48ae93f8">
+      <ownedEnd xmi:id="d002b927-b8bf-468f-99d4-02ae48ae93f8" name="multiplicity" visibility="public" type="3f431538-13b8-4b12-aab0-1fad3d7fff4d" isDerived="true" subsettedProperty="952875f0-3ee1-4651-ad7b-31868a29c4f3" association="43be9aa3-f50f-4b4c-ae69-c43ddc717a8b">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="09183928-91fa-406f-aae7-45a103aa32d3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e30c4638-e0fe-4faa-89e7-1193e5486450" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="790bb85b-f979-4b62-9d96-f3ae63a161ad" name="" visibility="public" memberEnd="b4a24f70-4ada-4cbb-8db1-28c8ae0c0427 952875f0-3ee1-4651-ad7b-31868a29c4f3">
+      <ownedEnd xmi:id="952875f0-3ee1-4651-ad7b-31868a29c4f3" name="multiplicity" visibility="public" type="3f431538-13b8-4b12-aab0-1fad3d7fff4d" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="790bb85b-f979-4b62-9d96-f3ae63a161ad">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="04c42ed7-96f4-4c0a-9d7a-65c355da3082" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="542b007d-4065-49af-9230-7e8bf65a232d" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e86830ef-5236-4271-8427-c567436efdcf" name="" visibility="public" memberEnd="9f743946-04e1-48ce-9097-b65525c16ac4 591eb622-a431-49b0-9c31-8fd191b9278e">
+      <ownedEnd xmi:id="591eb622-a431-49b0-9c31-8fd191b9278e" name="typedMetadata" visibility="public" type="2b4eb448-4bfe-4fb4-9509-33764e4f1fc3" isDerived="true" subsettedProperty="8627f6e3-1ebb-4b3a-b829-d9923e876aa4" association="e86830ef-5236-4271-8427-c567436efdcf">
+        <ownedComment xmi:id="0060d222-3ffa-4008-afa2-06117000478b" annotatedElement="591eb622-a431-49b0-9c31-8fd191b9278e">
+          <body>&lt;p>The MetadataFeatures whose &lt;code>type&lt;/code> is a certain Metaclass.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c098cfae-5e84-4bae-aa32-7c2749447aab" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0d58da92-2dff-49d6-aadb-6b9260873835" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="2b4eb448-4bfe-4fb4-9509-33764e4f1fc3" name="MetadataFeature" visibility="public">
+      <ownedComment xmi:id="fb0191c1-bf88-479f-979b-0a3bd07927da" annotatedElement="2b4eb448-4bfe-4fb4-9509-33764e4f1fc3">
+        <body>&lt;p>A MetadataFeature is a Feature that is an AnnotatingElement used to annotate another Element with metadata. It is typed by a Metaclass. All its &lt;code>ownedFeatures&lt;/code> must redefine &lt;code>features&lt;/code> of its &lt;code>metaclass&lt;/code> and any feature bindings must be model-level evaluable.&lt;/p>
+
+&lt;p>A MetadataFeature must subset, directly or indirectly, the base MetadataFeature &lt;em>&lt;code>metadata&lt;/code>&lt;/em> from the Kernel Library.&lt;/p>
+
+</body>
+      </ownedComment>
+      <generalization xmi:id="17209545-c4f1-42d1-844b-197f5920536d" general="64ba1c53-870d-4e8f-bae0-3656f588ffd3"/>
+      <generalization xmi:id="14ea299c-6605-4ef9-ae89-ca2338a1ad43" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+      <ownedAttribute xmi:id="9f743946-04e1-48ce-9097-b65525c16ac4" name="metaclass" visibility="public" type="39dba466-47bd-4a57-aab6-e6a0524cb57e" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="e86830ef-5236-4271-8427-c567436efdcf">
+        <ownedComment xmi:id="14769e0a-45a6-4360-aad5-ce06bebaae14" annotatedElement="9f743946-04e1-48ce-9097-b65525c16ac4">
+          <body>&lt;p>The &lt;code>type&lt;/code> of this AnnotatingFeature, which must be a DataType.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ab96be1d-136c-4d67-bc15-88b56d2468c9" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5db81c30-0247-411b-b90e-dc73ac7e9442" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="39dba466-47bd-4a57-aab6-e6a0524cb57e" name="Metaclass" visibility="public">
+      <ownedComment xmi:id="2b75617c-91b2-4b56-a435-12a353802617" annotatedElement="39dba466-47bd-4a57-aab6-e6a0524cb57e">
+        <body>&lt;p>A Metaclass is a Structure used to type MetadataFeatures. It must subclassify, directly or indirectly, the base type &lt;em>&lt;code>Metadata&lt;/code>&lt;/em> from the Kernel Library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="6c03439a-5d2e-4aa9-9e0f-71b0905e89ae" general="eabb05a5-3e97-41e1-9668-d9bf801193a6"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="00658dfa-2ca1-42d3-ad0b-5659f78a9f2c" name="ItemFlowEnd" visibility="public">
+      <generalization xmi:id="5f52a09c-7441-46ce-9d54-0fab42ccfbd3" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7149393d-c66f-49d5-bcfb-646ada5f96be" name="ItemFeature" visibility="public">
+      <generalization xmi:id="9e33bf29-2741-4ccc-9359-f0191cece77a" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="47145ccb-fc3b-4af9-af2a-e2508b914012" name="ItemFlowFeature" visibility="public">
+      <generalization xmi:id="ba5a8f24-f0f4-468f-80f5-5092e86e96fb" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fd27dfa3-9e11-465f-8981-00bc57981023" name="ItemFlow" visibility="public">
+      <ownedComment xmi:id="60fc344c-c729-4624-92bd-9697611f50d3" annotatedElement="fd27dfa3-9e11-465f-8981-00bc57981023">
+        <body>&lt;p>An ItemFlow is a Step that represents the transfer of objects or values from one Feature to another. ItemFlows can take non-zero time to complete.&lt;/p>
+
+&lt;p>An ItemFlow must be typed by the Interaction &lt;em>&lt;code>Transfer&lt;/code>&lt;/em> from the Kernel Semantic Library, or a specialization of it.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="dfba447a-4014-4d80-a49d-034a4213c18a" general="f6ecf6da-3e35-489a-86f4-6c9eee938686"/>
+      <generalization xmi:id="d6fdb47d-99f2-4d3f-9c7d-437581a2dcc0" general="b1a2875a-af89-47c5-ad2b-d5763c43aafd"/>
+      <ownedAttribute xmi:id="905d8cfc-b7d5-4afa-b7d6-2433fa7db64c" name="itemType" visibility="public" type="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" isOrdered="true" isUnique="false" isDerived="true" association="fb150ddc-d0ec-454c-91eb-97d6312eee81">
+        <ownedComment xmi:id="a89932e2-ae34-4a52-8af1-04730056f944" annotatedElement="905d8cfc-b7d5-4afa-b7d6-2433fa7db64c">
+          <body>&lt;p>The type of the item transferred, derived as the &lt;code>type&lt;/code> of the &lt;code>feature&lt;/code> of the ItemFlow that directly or indirectly redefines &lt;em>&lt;code>Transfer::item&lt;/code>&lt;/em>.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="297953f6-276a-4c90-9de2-53c7c837ddff" annotatedElement="905d8cfc-b7d5-4afa-b7d6-2433fa7db64c">
+          <body>&lt;p>This is the Type of the item transferred.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="30695fcb-d1a6-4876-a35c-9ad810dda577" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="530f28d9-3668-4677-a684-8708f508b979" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c65d69ad-37d1-4a50-96f9-e1081c43ceff" name="targetInputFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isUnique="false" isDerived="true" association="55b3702f-0b9e-47c6-a564-20932f3278a6">
+        <ownedComment xmi:id="491ea383-8ffb-41a2-8631-5ff5c8a55f8b" annotatedElement="c65d69ad-37d1-4a50-96f9-e1081c43ceff">
+          <body>&lt;p>The Feature that receives the ItemFlow. It must be an owned &lt;code>output&lt;/code> of the target participant of the ItemFlow. If there is no such Feature, then the ItemFlow must be abstract.&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="74eee1b9-c7b6-458f-8647-8fdeea4a55bd" annotatedElement="c65d69ad-37d1-4a50-96f9-e1081c43ceff">
+          <body>&lt;p>The Feature that receives the ItemFlow.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7b61e919-b8c5-4729-8910-b91b88d8fa20" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="93eecf55-45a8-4fc6-9a1c-01ddc800eca2" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c2420f01-822c-4a39-9651-f1d23c363f62" name="sourceOutputFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isOrdered="true" isUnique="false" isDerived="true" association="939343d3-0c79-4f7b-8a3b-b4a0e8b5bf8c">
+        <ownedComment xmi:id="f3cca6de-71ee-462b-8425-d916f8db1b3f" annotatedElement="c2420f01-822c-4a39-9651-f1d23c363f62">
+          <body>&lt;p>The Feature that originates the ItemFlow. It must be an owned &lt;code>output&lt;/code> of the &lt;code>source&lt;/code>  of the ItemFlow. If there is no such Feature, then the ItemFlow must be abstract.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="dfa286fa-efc7-4f02-87ce-410d721a47fd" annotatedElement="c2420f01-822c-4a39-9651-f1d23c363f62">
+          <body>&lt;p>The Feature that originates the ItemFlow.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="77d3587e-1539-4171-a424-3e7b14d8aa27" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5d43cf90-8477-4846-86d9-4f455109f553" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="632623d1-5176-48d7-9c82-37eb17dd6adc" name="itemFlowEnd" visibility="public" type="00658dfa-2ca1-42d3-ad0b-5659f78a9f2c" isDerived="true" redefinedProperty="5014930c-7127-4294-a2fe-4c69287023af" association="7ca7a973-ecd9-456b-9dee-f5d05bfeedc2">
+        <ownedComment xmi:id="810fec8e-8f5d-485a-a564-8424514056ba" annotatedElement="632623d1-5176-48d7-9c82-37eb17dd6adc">
+          <body>&lt;p>A &lt;code>connectorEnd&lt;/code> of this ItemFlow. (IMPL)&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="0b46af51-bebb-445a-b0f8-1ca95c50609f" annotatedElement="632623d1-5176-48d7-9c82-37eb17dd6adc">
+          <body>&lt;p>TBD. Uses a class from the Interactions IMPL package.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="eba4e5c0-20cf-4568-b7c6-90a9d284ebc4" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="32832b31-eb2f-40fe-93ec-ce5827e7f536" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d3a73396-d17d-4e95-8d4b-7cfc099b093c" name="itemFeature" visibility="public" type="7149393d-c66f-49d5-bcfb-646ada5f96be" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="3c4ccec5-675e-4a04-bfe5-2956d64b9255">
+        <ownedComment xmi:id="0e4b0b2a-d88b-4790-8fb2-ba2f1294025c" annotatedElement="d3a73396-d17d-4e95-8d4b-7cfc099b093c">
+          <body>&lt;p>The Feature representing the Item in transit between the source and the target during the transfer. (IMPL)&lt;/p>
+</body>
+        </ownedComment>
+        <ownedComment xmi:id="b5ebda54-6021-4a76-808d-3292d84e8820" annotatedElement="d3a73396-d17d-4e95-8d4b-7cfc099b093c">
+          <body>&lt;p>This Feature represents the Item in transit between the source and the target during the transfer.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d13a36c8-2676-4380-b59a-3d2f260a98e2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f7681196-972c-4438-a8e1-e2773374bc41" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="bdb89a06-8136-493b-872d-4100bf65ed4f" name="itemFlowFeature" visibility="public" type="47145ccb-fc3b-4af9-af2a-e2508b914012" isDerived="true" association="3a0783d2-2853-4099-9e72-33118c210eab">
+        <ownedComment xmi:id="4c2474d7-c731-4124-a7e9-baec2047c42e" annotatedElement="bdb89a06-8136-493b-872d-4100bf65ed4f">
+          <body>&lt;p>The &lt;code>sourceOutputFeatures&lt;/code> and &lt;code>targetInputFeatures&lt;/code> of this ItemFlow. (IMPL).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a33293b9-0f16-4ba1-a8cb-5cc8148ba387" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bab821a6-ab59-4574-9899-599280a39e70" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ad39eccc-e849-4f84-a77a-d890d8c26433" name="interaction" visibility="public" type="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af" isOrdered="true" isDerived="true" redefinedProperty="927f6cdf-59b8-4e3c-8c17-f626bfd38a38 1f2423e8-9b61-4497-af7c-8de89dbda20c" association="6869132f-ec84-4af6-a737-e7f0bc22b2b3">
+        <ownedComment xmi:id="d758956d-169f-4129-bb4d-aab87b82d6a8" annotatedElement="ad39eccc-e849-4f84-a77a-d890d8c26433">
+          <body>&lt;p>The Interactions that type this ItemFlow. Interactions are both Associations (which type Connectors) and Behaviors (which type Steps).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0cd9e27f-5e72-4fe4-9523-7c177fba8f01" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e15bd73e-08ce-4b02-bbe4-0f9c316723a1" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="939343d3-0c79-4f7b-8a3b-b4a0e8b5bf8c" name="" visibility="public" memberEnd="c2420f01-822c-4a39-9651-f1d23c363f62 de51428e-d67e-4b7e-8aa1-fbb0508ed883">
+      <ownedEnd xmi:id="de51428e-d67e-4b7e-8aa1-fbb0508ed883" name="itemFlowFromOutput" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" isDerived="true" association="939343d3-0c79-4f7b-8a3b-b4a0e8b5bf8c">
+        <ownedComment xmi:id="6eec36e5-d0be-4f2f-af28-ca3ca18424ec" annotatedElement="de51428e-d67e-4b7e-8aa1-fbb0508ed883">
+          <body>&lt;p>The ItemFlow that has a certain &lt;code>sourceOutputFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="138c3ecd-a020-4365-b299-daa5d0339c5f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="eeee9d23-3c35-43f0-93cd-1941cce76cde" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3c4ccec5-675e-4a04-bfe5-2956d64b9255" name="" visibility="public" memberEnd="d3a73396-d17d-4e95-8d4b-7cfc099b093c c1ec6f87-bb72-40d6-a2bc-e1955bb838ea">
+      <ownedEnd xmi:id="c1ec6f87-bb72-40d6-a2bc-e1955bb838ea" name="" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" association="3c4ccec5-675e-4a04-bfe5-2956d64b9255"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af" name="Interaction" visibility="public">
+      <ownedComment xmi:id="cc03eff9-5b68-4a02-a457-3bffed9a7e35" annotatedElement="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af">
+        <body>&lt;p>An Interaction is a Behavior that is also an Association, providing a context for multiple objects that have behaviors that impact one another.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="951a9732-6182-4532-b66d-413bdee936ff" annotatedElement="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af">
+        <body>&lt;p>Interactions are Behaviors that also provide context for multiple objects that have behaviors that impact one another.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c111bc04-7963-416e-b029-8a9f2f086d84" general="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba"/>
+      <generalization xmi:id="a3dff1b1-94aa-418c-a60e-57911f3fabdd" general="86a283c4-fc00-49a6-af2c-f85043eadd9f"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="55b3702f-0b9e-47c6-a564-20932f3278a6" name="" visibility="public" memberEnd="c65d69ad-37d1-4a50-96f9-e1081c43ceff 339931e2-3d38-4721-a6c3-3b821d4f0635">
+      <ownedEnd xmi:id="339931e2-3d38-4721-a6c3-3b821d4f0635" name="itemFlowToInput" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" isDerived="true" association="55b3702f-0b9e-47c6-a564-20932f3278a6">
+        <ownedComment xmi:id="d38ad028-0be7-4f88-8a3d-0faab19fa313" annotatedElement="339931e2-3d38-4721-a6c3-3b821d4f0635">
+          <body>&lt;p>The ItemFlow that has a certain &lt;code>targetInputFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="54296d03-4ebb-4c58-ac47-7169313528d8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d0899c48-cbd8-43e9-97f8-d104cc6bb565" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3a0783d2-2853-4099-9e72-33118c210eab" name="" visibility="public" memberEnd="bdb89a06-8136-493b-872d-4100bf65ed4f b9b67c3b-3aae-48ad-96dc-e0333c515e84">
+      <ownedEnd xmi:id="b9b67c3b-3aae-48ad-96dc-e0333c515e84" name="" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" association="3a0783d2-2853-4099-9e72-33118c210eab"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6869132f-ec84-4af6-a737-e7f0bc22b2b3" name="" visibility="public" memberEnd="ad39eccc-e849-4f84-a77a-d890d8c26433 5974346c-3338-4ee4-a27d-e6eade3a7f48">
+      <ownedEnd xmi:id="5974346c-3338-4ee4-a27d-e6eade3a7f48" name="" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" association="6869132f-ec84-4af6-a737-e7f0bc22b2b3"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="fb150ddc-d0ec-454c-91eb-97d6312eee81" name="" visibility="public" memberEnd="905d8cfc-b7d5-4afa-b7d6-2433fa7db64c 7ea8e6cc-ca54-4d22-ad41-daf7e116ad08">
+      <ownedComment xmi:id="ef548f5c-7310-428c-b34a-eae0c875c266" annotatedElement="fb150ddc-d0ec-454c-91eb-97d6312eee81">
+        <body>&lt;p>The ItemFlow that has a certain &lt;code>itemType&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <ownedEnd xmi:id="7ea8e6cc-ca54-4d22-ad41-daf7e116ad08" name="itemFlowForType" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" isDerived="true" association="fb150ddc-d0ec-454c-91eb-97d6312eee81">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e3d9429e-a75f-432b-afbd-de504e8e0d5a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1fcd8049-8b6e-4b64-b745-20e3911290da" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8b917de1-c346-4747-ae2f-13ea396ac789" name="" visibility="public" memberEnd="d5ad9849-bd99-47ac-aaa9-02b858533c21 5eb6cbf8-2072-47f1-bc7b-12d4b23cc639" navigableOwnedEnd="d5ad9849-bd99-47ac-aaa9-02b858533c21">
+      <generalization xmi:id="a5f229bd-7bcf-4b94-ab16-886a18a48fa1" general="7913d6df-ed58-43ff-9f15-42d8ce2b979e"/>
+      <ownedEnd xmi:id="5eb6cbf8-2072-47f1-bc7b-12d4b23cc639" name="" visibility="public" type="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af" association="8b917de1-c346-4747-ae2f-13ea396ac789"/>
+      <ownedEnd xmi:id="d5ad9849-bd99-47ac-aaa9-02b858533c21" name="participantFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" redefinedProperty="6c83968c-1fff-42f7-9f8b-82272ab0e9cb" subsettedProperty="c0294af9-25fb-420c-ab74-c37076bb923c" association="8b917de1-c346-4747-ae2f-13ea396ac789">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="74344d70-d79f-49dc-9931-ede444e4d596" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="dc649b8c-5b6a-400f-b164-91c754c11f45" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="23ba3ee9-5e71-4e14-ae22-71d1775ec2c8" name="SuccessionItemFlow" visibility="public">
+      <ownedComment xmi:id="c3e7ade8-3d7f-4c40-b749-c7ecfb1b2f80" annotatedElement="23ba3ee9-5e71-4e14-ae22-71d1775ec2c8">
+        <body>&lt;p>A SuccessionItemFlow is an ItemFlow that also provides temporal ordering. It classifies &lt;em>Transfers&lt;/em> that cannot start until the source &lt;em>Occurrence&lt;/em> has completed and that must complete before the target &lt;em>Occurrence&lt;/em> can start.&lt;/p>
+
+&lt;p>A SuccessionItemFlow must be typed by the Interaction &lt;em>TransferBefore&lt;/em> from the Kernel Library, or a specialization of it.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="3a89ccfe-831d-4113-87eb-4a4378747d93" annotatedElement="23ba3ee9-5e71-4e14-ae22-71d1775ec2c8">
+        <body>&lt;p>SuccessionItemFlows are ItemFlows that also provide temporal ordering. They classify Transfers that must complete before the target behavior can start.&lt;/p>
+
+&lt;p>Must be typed by M1 TransferBefore or one of its specializations.&lt;br />
+association-&amp;gt;is=OrSpecializationOf(TransferBefore) }&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="cb31f92e-6be7-405b-b48c-fd37a3b5c58e" general="fec12715-7238-4666-8f45-3e70ed179c7b"/>
+      <generalization xmi:id="5f9daa73-a573-426f-9a3f-47b5f39a3abc" general="fd27dfa3-9e11-465f-8981-00bc57981023"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7ca7a973-ecd9-456b-9dee-f5d05bfeedc2" name="" visibility="public" memberEnd="632623d1-5176-48d7-9c82-37eb17dd6adc b54159ee-9336-4793-aa44-fdd57270cb4e">
+      <ownedEnd xmi:id="b54159ee-9336-4793-aa44-fdd57270cb4e" name="" visibility="public" type="fd27dfa3-9e11-465f-8981-00bc57981023" association="7ca7a973-ecd9-456b-9dee-f5d05bfeedc2"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="8fb1addf-512a-4250-97a3-5fb06485a999" name="DataType" visibility="public">
+      <ownedComment xmi:id="46b4fa94-9d64-44b2-8d2c-9d9c3ad9e9f0" annotatedElement="8fb1addf-512a-4250-97a3-5fb06485a999">
+        <body>&lt;p>A DataType is a Classifier of things (in the universe) that can only be distinguished by how they are related to other things (via Features). This means multiple things classified by the same DataType&lt;/p>
+
+&lt;ul>
+	&lt;li>Cannot be distinguished when they are related to other things in exactly the same way, even when they are intended to be about different things.&lt;/li>
+	&lt;li>Can be distinguished when they are related to other things in different ways, even when they are intended to be about the same thing.&lt;/li>
+&lt;/ul>
+</body>
+      </ownedComment>
+      <ownedComment xmi:id="924b1072-f21e-419c-a761-bf7a9f03e1fa" annotatedElement="8fb1addf-512a-4250-97a3-5fb06485a999">
+        <body>&lt;p>DataTypes serve to subdivide Classifiers into two kinds of objects: those that have some definition beyond their property values and those that are defined entirely by their values. DataTypes are the second kind. If two objects classified by DataType have identical property values, they are understood to be in fact the same object. DataTypes are intended to represent data or mathematical objects which is where the equivalence based on matched values is appropriate.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="2dacbe30-b5c2-4155-84a1-c45c05f0d551" name="datatypeClassifiesDataValue" visibility="public" constrainedElement="8fb1addf-512a-4250-97a3-5fb06485a999">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="6804f08a-1bce-4e2f-9652-c0d9af5333d6" name="" visibility="public">
+          <language>English</language>
+          <body>allSupertypes()->includes(Kernel Library::DataValue)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="1bd0ebd3-13f0-4dc5-bdda-fbadb332a7cf" name="datatypeValidSpecialization" visibility="public" constrainedElement="8fb1addf-512a-4250-97a3-5fb06485a999">
+        <ownedComment xmi:id="56121ec6-5284-4018-9c47-5615e66c2065" annotatedElement="1bd0ebd3-13f0-4dc5-bdda-fbadb332a7cf">
+          <body>&lt;p>A &lt;code>DataType&lt;/code> must not specialize a &lt;code>Class&lt;/code> or an &lt;code>Association&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="912c6bd2-f502-4ddf-83c3-2b9aaea5d324" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="0cedcfa8-180b-4219-9f0c-83ee35e52d41" general="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da"/>
+    </packagedElement>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_B3mdEEQmEe22v6M5Q5J7KQ" name="Root">
+    <packagedElement xmi:type="uml:Association" xmi:id="977bcdf7-41e4-447a-bee7-041451134d1e" name="" visibility="public" memberEnd="9cb24139-400c-4446-9029-caa031ce7380 88831956-f19e-4ad6-b59c-160e8cb854c6">
+      <ownedEnd xmi:id="88831956-f19e-4ad6-b59c-160e8cb854c6" name="annotation" visibility="public" type="28c8d0fe-6d47-4359-89c2-c8cdf10600f1" isOrdered="true" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="977bcdf7-41e4-447a-bee7-041451134d1e">
+        <ownedComment xmi:id="7ec836c9-3f0d-4d43-8358-0c492faed668" annotatedElement="88831956-f19e-4ad6-b59c-160e8cb854c6">
+          <body>&lt;p>The Annotations associated with a certain &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ae5f0c85-75e2-4307-9280-57dd53936b0c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f9d6b7ae-73e1-4692-9105-a3534fbbc1b5" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="64ba1c53-870d-4e8f-bae0-3656f588ffd3" name="AnnotatingElement" visibility="public">
+      <ownedComment xmi:id="34500499-e31b-4d83-a2db-a542a7c059e0" annotatedElement="64ba1c53-870d-4e8f-bae0-3656f588ffd3">
+        <body>&lt;p>An AnnotatingElement is an Element that provides additional description of or metadata on some other Element. An AnnotatingElement is attached to its &lt;code>annotatedElement&lt;/code> by an Annotation Relationship.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="674c227a-fcee-4581-b400-5490ca0b5538" name="annotatingElementAnnotatedElement" visibility="public" constrainedElement="64ba1c53-870d-4e8f-bae0-3656f588ffd3">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="69be3978-8ae5-4f0d-b3f5-c055b7aee5c7" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>annotatedElement = 
+ if annotation->notEmpty() then annotation.annotatedElement
+ else owningNamespace endif</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="38d8d2f8-2bf0-4165-a661-8a92d9c7c3ba" general="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+      <ownedAttribute xmi:id="f28fb435-e3bc-4cbf-818d-f2d6a08a6846" name="annotation" visibility="public" type="28c8d0fe-6d47-4359-89c2-c8cdf10600f1" isOrdered="true" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="6e39ff9b-bd6f-4011-b855-a0223a225b58">
+        <ownedComment xmi:id="6d7fc844-370f-443e-82de-a0ae6f361e5c" annotatedElement="f28fb435-e3bc-4cbf-818d-f2d6a08a6846">
+          <body>&lt;p>The Annotations that relate this AnnotatingElement to its &lt;code>annotatedElements&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0a52ba60-af05-42c2-932b-4abc2cff2b68" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c1267357-09ac-425b-9d05-9f6c9457e5ac" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b751b60a-19dd-4d98-8640-63506920779b" name="annotatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isDerived="true" association="af3b6326-c882-4c5c-a31f-45437c2ea9ee">
+        <ownedComment xmi:id="336446db-1444-48c2-b5d1-6037c606bec0" annotatedElement="b751b60a-19dd-4d98-8640-63506920779b">
+          <body>&lt;p>The Elements that are annotated by this AnnotatingElement. If &lt;code>annotation&lt;/code&lt;> is not empty, this is derived as the &lt;code>annotatedElements&lt;/code> of the &lt;code>annotations&lt;/code>. If &lt;code>annotation&lt;/code>, then it is derived as the &lt;code>owningNamespace&lt;/code> of the AnnotatingElement.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1a9f44be-949b-4c6f-bb57-89dd7b7804d6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4322d6ca-644e-497c-a050-534a18aab4f3" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="28c8d0fe-6d47-4359-89c2-c8cdf10600f1" name="Annotation" visibility="public">
+      <ownedComment xmi:id="3775a989-f213-4119-9461-1d23697bcf12" annotatedElement="28c8d0fe-6d47-4359-89c2-c8cdf10600f1">
+        <body>&lt;p>An Annotation is a Relationship between an AnnotatingElement and the Element that is annotated by that AnnotatingElement.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="2a51162d-c584-4e46-be55-4bf5fb5737d0" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="cc997d4c-b6c9-47bd-985f-115ebc369f4d" name="annotatingElement" visibility="public" type="64ba1c53-870d-4e8f-bae0-3656f588ffd3" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="6e39ff9b-bd6f-4011-b855-a0223a225b58">
+        <ownedComment xmi:id="6f2ba812-c3d5-4967-880b-5f62201f028f" annotatedElement="cc997d4c-b6c9-47bd-985f-115ebc369f4d">
+          <body>&lt;p>The AnnotatingElement that annotates the &lt;code>annotatedElement&lt;/code> of this Annotation.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d7cb9c8b-7233-467e-815a-c949080d4023" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1e2c524b-9a14-47ee-87e4-08f142612b38" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9cb24139-400c-4446-9029-caa031ce7380" name="annotatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="977bcdf7-41e4-447a-bee7-041451134d1e">
+        <ownedComment xmi:id="8d260da7-8e30-48f0-be96-f50a62b9d39a" annotatedElement="9cb24139-400c-4446-9029-caa031ce7380">
+          <body>&lt;p>The Element that is annotated by the &lt;code>annotatingElement&lt;/code> of this Annotation.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f1ff28c1-5ef9-4468-a040-5a5e698247c6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1a7b2906-a046-494a-a23d-3ac8cbfeaf48" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="2388a6c0-e1b5-4a97-ac6a-1aafd4f32147" name="owningAnnotatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isDerived="true" subsettedProperty="9cb24139-400c-4446-9029-caa031ce7380 53d1b371-a5c5-4812-87a8-a61e672f7314" association="3e23c631-5451-41e4-a047-5d4795c11d60">
+        <ownedComment xmi:id="7d02d6fe-9ab0-4728-9f03-eeca59d93ffb" annotatedElement="2388a6c0-e1b5-4a97-ac6a-1aafd4f32147">
+          <body>&lt;p>The &lt;code>annotatedElement&lt;/code> of this Annotation, when it is also its &lt;code>owningRelatedElement&lt;/code>.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4ef3695e-8914-488b-985c-c967d4133d1b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ed03dbaf-a7ca-4b4b-bcca-b821d2d76746" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="40a5660e-4260-4601-ac14-6da99c5449cf" name="Comment" visibility="public">
+      <ownedComment xmi:id="c8f4bab2-ea1a-44f2-9bbd-aa7b2edc526b" annotatedElement="40a5660e-4260-4601-ac14-6da99c5449cf">
+        <body>&lt;p>A Comment is an AnnotatingElement whose &lt;code>body&lt;/code> in some way describes its &lt;code>annotatedElements&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="a8176bb2-b5d8-4568-8ba5-3519f89ecd79" general="64ba1c53-870d-4e8f-bae0-3656f588ffd3"/>
+      <ownedAttribute xmi:id="f91249d4-845a-4828-a72a-7ae640575b59" name="locale" visibility="public">
+        <ownedComment xmi:id="3b7011f2-7dd0-4ddb-b4c1-18e8354a4226" annotatedElement="f91249d4-845a-4828-a72a-7ae640575b59">
+          <body>&lt;p>Identification of the language of the &lt;code>body&lt;/code> text and, optionally, the region and/or encoding. The format shall be a POSIX locale conformant to ISO/IEC 15897, with the format &lt;code>[language[_territory][.codeset][@modifier]]&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="85e59f00-c618-481b-a02b-d0079a9f577d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="de95fbe1-8ad5-4ef9-a525-2d176e21e47a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="6bcd878c-36a7-4172-8809-8e79bceefd6f" name="body" visibility="public">
+        <ownedComment xmi:id="44825b71-55d0-41b7-a276-80a7cb005a43" annotatedElement="6bcd878c-36a7-4172-8809-8e79bceefd6f">
+          <body>&lt;p>The annotation text for the Comment.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8a45f9de-024b-4bcd-bafb-d3ce99682fa0" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7a61168a-f505-48cc-ae16-f029147f50a9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="af3b6326-c882-4c5c-a31f-45437c2ea9ee" name="" visibility="public" memberEnd="b751b60a-19dd-4d98-8640-63506920779b 92f188bb-f6e4-4cbf-86f8-da0462d4f1e0">
+      <ownedEnd xmi:id="92f188bb-f6e4-4cbf-86f8-da0462d4f1e0" name="annotatingElement" visibility="public" type="64ba1c53-870d-4e8f-bae0-3656f588ffd3" isOrdered="true" isDerived="true" association="af3b6326-c882-4c5c-a31f-45437c2ea9ee">
+        <ownedComment xmi:id="513e0b3e-dba6-44f3-b8ba-8860a08a9a80" annotatedElement="92f188bb-f6e4-4cbf-86f8-da0462d4f1e0">
+          <body>&lt;p>The AnnotatingElements that have a certain Element as their &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4a2de1dd-4a37-4334-984b-3c00b8b85bd2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7b538a38-b299-4c36-82c8-7db465c8d9ef" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cd0c0e14-e1a3-4235-baa4-102302dfc168" name="Documentation" visibility="public">
+      <ownedComment xmi:id="8f7286f9-7384-423b-b84e-40d0f6a70a66" annotatedElement="cd0c0e14-e1a3-4235-baa4-102302dfc168">
+        <body>&lt;p>Documentation is a Comment that specifically documents a &lt;code>documentedElement&lt;/code>, which must be its &lt;code>owner&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="45b9df34-36c4-4986-9789-0bffe8fecbce" general="40a5660e-4260-4601-ac14-6da99c5449cf"/>
+      <ownedAttribute xmi:id="6a7858b5-3913-48b8-82a4-919ce5daabd0" name="documentedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isDerived="true" redefinedProperty="b751b60a-19dd-4d98-8640-63506920779b" subsettedProperty="5b67d4ab-f48e-41ba-af2d-16d57429f489" association="ce0e0672-de3c-4d80-98e0-025c1927223c">
+        <ownedComment xmi:id="980880cd-0829-419c-874d-02b30602a227" annotatedElement="6a7858b5-3913-48b8-82a4-919ce5daabd0">
+          <body>&lt;p>The Element that is documented by this Documentation.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="251410b0-47b7-4f5d-bf7c-bd87bdab23f6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="57519c13-1198-4fae-983f-04327da2c2b5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="20035586-007c-4491-bebb-4954fd6b1b46" name="TextualRepresentation" visibility="public">
+      <ownedComment xmi:id="65007f2c-c489-4952-8758-fe47862a6b0c" annotatedElement="20035586-007c-4491-bebb-4954fd6b1b46">
+        <body>&lt;p>A TextualRepresentation is an AnnotatingElement whose &lt;code>body&lt;/code> represents the &lt;code>representedElement&lt;/code> in a given &lt;code>language&lt;/code>. The &lt;code>representedElement&lt;/code> must be the &lt;code>owner&lt;/code> of the TextualRepresentation. The named &lt;code>language&lt;/code> can be a natural language, in which case the &lt;code>body&lt;/code> is an informal representation, or an artifical language, in which case the &lt;code>body&lt;/code> is expected to be a formal, machine-parsable representation.&lt;/p>
+
+&lt;p>If the named &lt;code>language&lt;/code> of a TextualRepresentation is machine-parsable, then the &lt;code>body&lt;/code> text should be legal input text as defined for that &lt;code>language&lt;/code>. The interpretation of the named language string shall be case insensitive. The following &lt;code>language&lt;/code> names are defined to correspond to the given standard languages:&lt;/p>
+
+&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; width=&quot;498&quot;>
+	&lt;thead>
+	&lt;/thead>
+	&lt;tbody>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>kerml&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Kernel Modeling Language&lt;/td>
+		&lt;/tr>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>ocl&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Object Constraint Language&lt;/td>
+		&lt;/tr>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>alf&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Action Language for fUML&lt;/td>
+		&lt;/tr>
+	&lt;/tbody>
+&lt;/table>
+
+&lt;p>Other specifications may define specific &lt;code>language&lt;/code> strings, other than those shown in&amp;nbsp;&lt;mms-view-link mms-doc-id=&quot;_19_0_4_12e503d9_1655498859928_646482_53332&quot; mms-element-id=&quot;MMS_1656305537944_6a3ca48e-424a-4a4d-8ce2-56df128ebabe&quot; mms-pe-id=&quot;_hidden_MMS_1656305558930_8d3925ff-003f-4024-a594-14317550f480_pei&quot;>[cf:Standard Language Names.vlink]&lt;/mms-view-link>, to be used to indicate the use of languages from those specifications in KerML TextualRepresentations.&lt;/p>
+
+&lt;p>If the &lt;code>language&lt;/code> of a TextualRepresentation is &amp;quot;&lt;code>kerml&lt;/code>&amp;quot;, then the &lt;code>body&lt;/code> text shall be a legal representation of the &lt;code>representedElement&lt;/code> in the KerML textual concrete syntax. A conforming tool can use such a TextualRepresentation Annotation to record the original KerML concrete syntax text from which an Element was parsed. In this case, it is a tool responsibility to ensure that the &lt;code>body&lt;/code> of the TextualRepresentation remains correct (or the Annotation is removed) if the annotated Element changes other than by re-parsing the &lt;code>body&lt;/code> text.&lt;/p>
+
+&lt;p>An Element with a TextualRepresentation in a language other than KerML is essentially a semantically &amp;quot;opaque&amp;quot; Element specified in the other language. However, a conforming KerML tool may interpret such an element consistently with the specification of the named language.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="de146be5-136a-408e-ae55-ebbca34eef76" general="64ba1c53-870d-4e8f-bae0-3656f588ffd3"/>
+      <ownedAttribute xmi:id="81d79ae2-1046-4057-a1e5-c9b2ccc0b26d" name="language" visibility="public">
+        <ownedComment xmi:id="85e1900e-518b-492c-8d68-2bbcd720ea15" annotatedElement="81d79ae2-1046-4057-a1e5-c9b2ccc0b26d">
+          <body>&lt;p>The natural or artifical language in which the &lt;code>body&lt;/code> text is written.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3f0f01c7-f9bb-4cef-befe-82fea8ccd5e0" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="99316932-431e-4a72-a011-2c41099d2126" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="302f9fde-2bfd-4cd6-bb3d-c7ae8691ddc4" name="representedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isDerived="true" redefinedProperty="b751b60a-19dd-4d98-8640-63506920779b" subsettedProperty="5b67d4ab-f48e-41ba-af2d-16d57429f489" association="43ff234f-2149-4231-a1cd-e926d4a00b2e">
+        <ownedComment xmi:id="2e9b1914-2aa7-4074-a0ff-8ee98e839447" annotatedElement="302f9fde-2bfd-4cd6-bb3d-c7ae8691ddc4">
+          <body>&lt;p>The Element that is represented by this TextualRepresentation.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="55e05d16-96b2-4ecd-9819-08b7c8631161" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="64a3fde3-a2ad-46a8-87cd-8be026c8a1c9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7571a300-5744-4f62-ac90-7e073cc00fb1" name="body" visibility="public">
+        <ownedComment xmi:id="0e58c616-404d-49f4-9d9c-c46d0d663aa8" annotatedElement="7571a300-5744-4f62-ac90-7e073cc00fb1">
+          <body>&lt;p>The textual representation of the &lt;code>representedElement&lt;/code> in the given &lt;code>language&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aad0aad5-13a3-46eb-ada4-d554eb2cb8f8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a746781f-159d-47c8-8d85-929068f80e89" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6e39ff9b-bd6f-4011-b855-a0223a225b58" name="" visibility="public" memberEnd="f28fb435-e3bc-4cbf-818d-f2d6a08a6846 cc997d4c-b6c9-47bd-985f-115ebc369f4d"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="4b79fb44-57d3-446f-a4cc-4fd50fbc2bfb" name="" visibility="public" memberEnd="3d9def15-9cea-4500-9f8e-6255b8653611 7f952a01-37c9-4a58-b3f4-24261885c2b4"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="1602dda7-1550-4f0e-9963-da6a7d52732a" name="" visibility="public" memberEnd="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634 a30aa520-08d8-4370-937a-bfdf0d24795f">
+      <ownedEnd xmi:id="a30aa520-08d8-4370-937a-bfdf0d24795f" name="membershipNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" isDerivedUnion="true" association="1602dda7-1550-4f0e-9963-da6a7d52732a">
+        <ownedComment xmi:id="39799432-8ad6-4a7f-9070-d1bec490981e" annotatedElement="a30aa520-08d8-4370-937a-bfdf0d24795f">
+          <body>&lt;p>The Namespace that has a certain &lt;code>membership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f69449f5-8153-4eb8-a8d2-8a9297c21ed3" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6d3ba120-2cf6-49eb-8b86-7b33512eafeb" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="796fe363-bffa-4627-835b-596597fa363f" name="VisibilityKind" visibility="public">
+      <ownedComment xmi:id="01178ace-ae76-418a-9365-4fed5a72f843" annotatedElement="796fe363-bffa-4627-835b-596597fa363f">
+        <body>&lt;p>VisibilityKind is an enumeration whose literals specify the visibility of a Membership of an Element in a Namespace outside of that Namespace. Note that &amp;quot;visibility&amp;quot; specifically restricts whether an Element in a Namespace may be referenced by name from outside the Namespace and only otherwise restricts access to an Element as provided by specific constraints in the abstract syntax (e.g., preventing the import or inheritance of private Elements).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedLiteral xmi:id="deaca133-d914-4fd1-9766-25cd981409c8" name="private" visibility="public">
+        <ownedComment xmi:id="3a6d8c03-a545-41b8-a883-94d21eaa9ac9" annotatedElement="deaca133-d914-4fd1-9766-25cd981409c8">
+          <body>&lt;p>Indicates a Membership is not visible outside its owning Namespace.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="bde46c0f-cfc8-4a98-a3fd-132cb09871be" name="protected" visibility="public">
+        <ownedComment xmi:id="95bcd87f-fa21-4378-a25f-9c7e43d91b3a" annotatedElement="bde46c0f-cfc8-4a98-a3fd-132cb09871be">
+          <body>&lt;p>An intermediate level of visibility between &lt;code>public&lt;/code> and &lt;code>private&lt;/code>. By default, it is equivalent to &lt;code>private&lt;/code> for the purposes of normal access to and import of Elements from a Namespace. However, other Relationships may be specified to include Memberships with &lt;code>protected&lt;/code> visibility in the list of &lt;code>memberships&lt;/code> for a Namespace (e.g., Generalization).&lt;/p>
+</body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="630895bf-2288-4a06-819b-db66abaf2d2d" name="public" visibility="public">
+        <ownedComment xmi:id="7bfac7b5-5a9a-478f-bd5f-f9aa23be12f4" annotatedElement="630895bf-2288-4a06-819b-db66abaf2d2d">
+          <body>&lt;p>Indicates that a Membership is publicly visible outside its owning Namespace.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="02dd1761-99f0-425d-89b2-db5e59446922" name="" visibility="public" memberEnd="f214bf22-c5eb-4468-9610-e8c47f940ac5 8a78149d-9cec-4086-b8f5-55013c10635a">
+      <ownedEnd xmi:id="8a78149d-9cec-4086-b8f5-55013c10635a" name="namespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" association="02dd1761-99f0-425d-89b2-db5e59446922">
+        <ownedComment xmi:id="c67a8b9a-b51f-4a72-9973-d3e220cf41c4" annotatedElement="8a78149d-9cec-4086-b8f5-55013c10635a">
+          <body>&lt;p>The Namespace the has a certain Element as a &lt;code>member&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ea80f3d9-fdcc-40ec-bb81-c23c7562346c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d06ae531-a701-4fe8-aa71-5622ec7a00ec" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9d51dc54-0933-4524-b056-580592e50a33" name="" visibility="public" memberEnd="31a6f5d4-5255-4f30-b241-b6ded539a56d 924fd44a-214d-4a76-8491-969b9c74555d">
+      <ownedEnd xmi:id="924fd44a-214d-4a76-8491-969b9c74555d" name="importingNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" subsettedProperty="a30aa520-08d8-4370-937a-bfdf0d24795f" association="9d51dc54-0933-4524-b056-580592e50a33">
+        <ownedComment xmi:id="e82cd5b4-b1c9-4df5-9f00-f83c191c518e" annotatedElement="924fd44a-214d-4a76-8491-969b9c74555d">
+          <body>&lt;p>The Namespace with a certain &lt;code>importedMembership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="624ea26e-563e-45a8-9437-23a2f7d648fe" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a9f3b2b8-2c0f-47b4-a7fa-56440077e525" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7eaea69d-33cc-4ebf-bf81-534192877604" name="" visibility="public" memberEnd="ec58580f-851c-4202-a5c6-27b2ec9ac376 cfd14843-bce5-4ee1-8fb3-a2fdd0237258"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="7a17743e-8792-43e8-bdd4-b0013908623c" name="" visibility="public" memberEnd="c7119062-781b-4d3c-8b28-5d5466ffc105 ab3b057a-1552-43d2-aca6-9598c8b704b3">
+      <ownedEnd xmi:id="ab3b057a-1552-43d2-aca6-9598c8b704b3" name="membership" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="7a17743e-8792-43e8-bdd4-b0013908623c">
+        <ownedComment xmi:id="d0d8ab5f-23d5-4034-9948-4351092cab83" annotatedElement="ab3b057a-1552-43d2-aca6-9598c8b704b3">
+          <body>&lt;p>The Membership with a certain Element as its &lt;code>memberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aa7d2b81-d596-46ea-95c6-503c0fb15cec" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="86774a43-0ab5-455f-9f26-b6dbc15fa9ef" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a0fab899-a06e-4564-9388-8d9e5d44ec52" name="" visibility="public" memberEnd="50d115dd-9fe9-4a0c-8d67-bcca24186f18 4e9a7462-c2c0-42cd-a715-dc21395cc779"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="894f7139-5012-425b-8828-c525833a91b3" name="Import" visibility="public">
+      <ownedComment xmi:id="cf2fdc6c-34a8-41bd-b181-fa38d04e6a50" annotatedElement="894f7139-5012-425b-8828-c525833a91b3">
+        <body>&lt;p>An Import is a Relationship between an &lt;code>importOwningNamespace&lt;/code> in which one or more of the visible Memberships of the &lt;code>importedNamespace&lt;/code> become &lt;code>importedMemberships&lt;/code> of the &lt;code>&lt;code>importOwningNamespace&lt;/code>&lt;/code>. If &lt;code>&lt;code>isImportAll = false&lt;/code>&lt;/code> (the default), then only public Memberships are considered &amp;quot;visible&amp;quot;. If &lt;code>isImportAll = true&lt;/code>, then all Memberships are considered &amp;quot;visible&amp;quot;, regardless of their declared &lt;code>visibility&lt;/code>.&lt;/p>
+
+&lt;p>If no &lt;code>importedMemberName&lt;/code> is given, then all visible Memberships are imported from the &lt;code>importedNamespace&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, then visible Memberships are also recursively imported from all visible &lt;code>ownedMembers&lt;/code> of the Namespace that are also Namespaces.&lt;/p>
+
+&lt;p>If an &lt;code>&lt;code> importedMemberName&lt;/code>&lt;/code> is given, then the Membership whose &lt;code>&lt;code>effectiveMemberName&lt;/code> &lt;/code>is that name is imported from the &lt;code>&lt;code>importedNamespace&lt;/code>&lt;/code>, if it is visible. If &lt;code>&lt;code>isRecursive = true&lt;/code>&lt;/code> and the imported &lt;code>&lt;code>memberElement&lt;/code>&lt;/code> is a Namespace, then visible Memberships are also recursively imported from that Namespace and its owned sub-Namespaces.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="f79b2745-38df-42d4-b2ac-bec4c7e10cbf" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="be610b50-ba2d-4404-a0fc-8515b8e5f629" name="importedNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="7de5a7c3-a541-456a-9aa8-f45d2d8128ae">
+        <ownedComment xmi:id="440444a6-83be-4534-bddb-fdc2223b7862" annotatedElement="be610b50-ba2d-4404-a0fc-8515b8e5f629">
+          <body>&lt;p>The Namespace whose visible &lt;code>members&lt;/code> are imported by this Import.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2b8df830-6df4-4050-8ed2-aa76776f69ec" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="56643ee2-818e-4306-a9a1-32f418fb62cf" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7f952a01-37c9-4a58-b3f4-24261885c2b4" name="importOwningNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="53d1b371-a5c5-4812-87a8-a61e672f7314" association="4b79fb44-57d3-446f-a4cc-4fd50fbc2bfb">
+        <ownedComment xmi:id="6ef1c4f6-303f-42fd-84f8-f2710c4433dc" annotatedElement="7f952a01-37c9-4a58-b3f4-24261885c2b4">
+          <body>&lt;p>The Namespace into which &lt;code>members&lt;/code> are imported by this Import, which must be the &lt;code>owningRelatedElement&lt;/code> of the Import.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c5b570ba-7584-41d2-92ba-050d3aa441df" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a9e51875-2e14-4188-972d-421570b807a6" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="865c5c9e-d019-4607-a2aa-4e4982843e4e" name="visibility" visibility="public" type="796fe363-bffa-4627-835b-596597fa363f">
+        <ownedComment xmi:id="0ee2b633-cbc7-4167-aef7-ef23bbd830dc" annotatedElement="865c5c9e-d019-4607-a2aa-4e4982843e4e">
+          <body>&lt;p>The visibility level of the imported &lt;code>members&lt;/code> from this Import relative to the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <defaultValue xmi:type="uml:InstanceValue" xmi:id="fe8d8f04-1cb8-427e-aede-3847eb1ee53a" name="" visibility="public" instance="630895bf-2288-4a06-819b-db66abaf2d2d"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c4161c37-589a-4127-b144-d022be9b022b" name="importedMemberName" visibility="public">
+        <ownedComment xmi:id="a26c2b1c-2fec-4e30-b1c7-0021b745854a" annotatedElement="c4161c37-589a-4127-b144-d022be9b022b">
+          <body>&lt;p>The &lt;code>effectiveMemberName&lt;/code> of the Membership of the &lt;code>importedNamspace&lt;/code> to be imported. If not given, all public Memberships of the &lt;code>importedNamespace&lt;/code> are imported.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6de9415e-b760-4710-af10-1a88943a1bd7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b783f3c2-37a9-4e60-b278-3fb63ca5412d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e0d1d991-4faf-4b19-bd88-0a7b9068c9cb" name="isRecursive" visibility="public">
+        <ownedComment xmi:id="9c1a9962-2c7f-4f51-9e28-9edac07bb052" annotatedElement="e0d1d991-4faf-4b19-bd88-0a7b9068c9cb">
+          <body>&lt;p>Whether to recursively import Memberships from visible, owned sub-namespaces.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="d72b9b34-1ac7-49da-8b51-e4c47240ce0d" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f2def83b-f635-495b-a701-6c20493f3db1" name="isImportAll" visibility="public">
+        <ownedComment xmi:id="117a33cf-7deb-4132-b600-b8fe63cca827" annotatedElement="f2def83b-f635-495b-a701-6c20493f3db1">
+          <body>&lt;p>Whether to import memberships without regard to declared visibility.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="9981e3ee-aae7-4c76-be4e-d91f1758de76" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="68b7f828-1f54-4bbd-81ad-99523b0c3b44" name="importedMembership" visibility="public" bodyCondition="5efb0f0b-8d0c-42f8-87a4-d75b17e43123">
+        <ownedComment xmi:id="470c882f-8baa-4687-94c7-cf4db61efb2d" annotatedElement="68b7f828-1f54-4bbd-81ad-99523b0c3b44">
+          <body>&lt;p>Returns the Memberships of the &lt;code>importedNamespace&lt;/code> whose &lt;code>memberElements&lt;/code> are to become imported &lt;code>members&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. By default, this is the set of publicly visible Memberships of the &lt;code>importedNamespace&lt;/code>, but this may be overridden in specializations of Import. (The &lt;code>excluded&lt;/code> parameter is used to handle the possibility of circular Import Relationships.)&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="5efb0f0b-8d0c-42f8-87a4-d75b17e43123" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="deaa9799-0bff-45bf-a253-1759a1270666" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let exclusions : Set(Namespace) = 
+    excluded->including(importOwningNamspace) in
+let visibleMemberships : Sequence(Membership) = 
+    importedNamespace.visibleMemberships(exclusions, false, isImportAll) in
+let memberships : Sequence(Membership) =
+    if importedMemberName = null then visibleMemberships
+    else visibleMemberships->select(effectiveMemberName = importedMemberName)
+    endif in
+if not isRecursive then memberships
+else memberships->union(
+        memberships.ownedMember->selectAsKind(Namespace).
+        visibleMemberships(exclusions, true, isImportAll))
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="874f99d0-b00f-4edf-a932-779e23562861" name="excluded" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fdce9eb6-db45-4113-8746-e4fcae3a10b4" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3d97d4c9-6a39-4346-a0d0-b8fdbb27358e" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="f0503105-f3e9-4e26-adee-d0ebad661d6f" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c030f75d-1f40-40dc-aef1-96693df96d8a" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1b25305f-d168-41f3-8647-9b943caa217b" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7de5a7c3-a541-456a-9aa8-f45d2d8128ae" name="" visibility="public" memberEnd="be610b50-ba2d-4404-a0fc-8515b8e5f629 62ec963c-fe39-49f0-9e5c-6680e135e3ec">
+      <ownedEnd xmi:id="62ec963c-fe39-49f0-9e5c-6680e135e3ec" name="import" visibility="public" type="894f7139-5012-425b-8828-c525833a91b3" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="7de5a7c3-a541-456a-9aa8-f45d2d8128ae">
+        <ownedComment xmi:id="c83fdd99-5ce2-479f-8975-6e08b1cf650a" annotatedElement="62ec963c-fe39-49f0-9e5c-6680e135e3ec">
+          <body>&lt;p>The Import that has a certain &lt;code>importedNamespace&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3823e058-e39c-4cd7-98c1-6e891da7a043" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="378d00f8-4264-4de9-8fdd-2773aa057145" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="80df4982-4fcb-4c30-853c-0f2415033759" name="Membership" visibility="public">
+      <ownedComment xmi:id="23dfcd6c-e0a0-4cd7-9b76-67010c51652c" annotatedElement="80df4982-4fcb-4c30-853c-0f2415033759">
+        <body>&lt;p>Membership is a Relationship between a Namespace and an Element that indicates the Element is a &lt;code>member&lt;/code> of (i.e., is contained in) the Namespace. Any &lt;code>memberNames&lt;/code> specify how the &lt;code>memberElement&lt;/code> is identified in the Namespace and the &lt;code>visibility&lt;/code> specifies whether or not the &lt;code>memberElement&lt;/code> is publicly visible from outside the Namespace.&lt;/p>
+
+&lt;p>If a Membership is an OwningMembership, then it owns its &lt;code>memberElement&lt;/code>, which becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>. Otherwise, the &lt;code>memberNames&lt;/code> of a Membership are effectively aliases within the &lt;code>membershipOwningNamespace&lt;/code> for an Element with a separate OwningMembership in the same or a different Namespace.&lt;p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="84817c4c-aa81-4611-97f6-72b42035ff85" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="df3deff1-7319-47dd-ac97-981ce9ab9788" name="memberElementId" visibility="public" isDerived="true">
+        <ownedComment xmi:id="ee59115c-9e56-4e65-9026-7b1667765fd6" annotatedElement="df3deff1-7319-47dd-ac97-981ce9ab9788">
+          <body>&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>memberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cfd14843-bce5-4ee1-8fb3-a2fdd0237258" name="membershipOwningNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" subsettedProperty="a30aa520-08d8-4370-937a-bfdf0d24795f 53d1b371-a5c5-4812-87a8-a61e672f7314" association="7eaea69d-33cc-4ebf-bf81-534192877604">
+        <ownedComment xmi:id="d944ae30-b4e0-4aa8-9596-b61970cd06d0" annotatedElement="cfd14843-bce5-4ee1-8fb3-a2fdd0237258">
+          <body>&lt;p>The Namespace of which the &lt;code>memberElement&lt;/code> becomes a &lt;cpde>member&lt;/code> due to this Membership.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bdf5e53e-cf60-4e7e-a98e-88e2bf1e0b1e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c4640766-b2a1-4af8-9953-6e0ea6d2ff43" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c651fdea-ea67-47d3-865a-9a09eeb14153" name="memberShortName" visibility="public">
+        <ownedComment xmi:id="bd4fb9b8-650a-4b5d-85d0-a014a0ed1478" annotatedElement="c651fdea-ea67-47d3-865a-9a09eeb14153">
+          <body>&lt;p>The short name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0e7cf4b8-5c30-4526-ab7e-776f0e0f02a4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f39b6016-6a46-4ef2-b6bd-5c3a9503e9ac" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c7119062-781b-4d3c-8b28-5d5466ffc105" name="memberElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="7a17743e-8792-43e8-bdd4-b0013908623c">
+        <ownedComment xmi:id="4fe281e6-222d-4333-a4f6-f40beede2abc" annotatedElement="c7119062-781b-4d3c-8b28-5d5466ffc105">
+          <body>&lt;p>The Element that becomes a &lt;code>member&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this Membership.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="148c41db-a9a1-4271-9709-0fbfdd0453f8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d5ee9f1f-78d3-447e-a5ad-e5149817a789" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="6bb70491-4908-4463-bc95-d3cc23f13d93" name="memberName" visibility="public">
+        <ownedComment xmi:id="8731e3a6-cbb1-4b69-9307-4e179b6defc5" annotatedElement="6bb70491-4908-4463-bc95-d3cc23f13d93">
+          <body>&lt;p>The name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bd570bbc-09f9-4d64-bc58-03bd614d8e88" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="94f726be-1b78-4a4f-ac5b-764100f86002" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="211c02df-2c75-4b9d-a645-61eb4172f039" name="visibility" visibility="public" type="796fe363-bffa-4627-835b-596597fa363f">
+        <ownedComment xmi:id="69aca9df-4620-4ef7-bd2c-fd1e32d730a5" annotatedElement="211c02df-2c75-4b9d-a645-61eb4172f039">
+          <body>&lt;p>Whether or not the Membership of the &lt;code>memberElement&lt;/code> in the &lt;code>membershipOwningNamespace&lt;/code> is publicly visible outside that Namespace.&lt;/p>
+</body>
+        </ownedComment>
+        <defaultValue xmi:type="uml:InstanceValue" xmi:id="4e919db1-2a26-41de-b907-1c65a5d2289d" name="" visibility="public" instance="630895bf-2288-4a06-819b-db66abaf2d2d"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="8724d289-7918-4859-96c3-553af15af713" name="isDistinguishableFrom" visibility="public" bodyCondition="761001d9-95af-45a3-91b6-dcbd7a8ae927">
+        <ownedComment xmi:id="a486c57f-e58d-4e11-8bf1-09f5e868211e" annotatedElement="8724d289-7918-4859-96c3-553af15af713">
+          <body>&lt;p>Whether this Membership is distinguishable from a given &lt;code>other&lt;/code> Membership. By default, this is true if this Membership has no &lt;code>memberShortName&lt;/code> or &lt;code>memberName&lt;/code>; or each of the &lt;code>memberShortName&lt;/code> and &lt;code>memberName&lt;/code> are different than both of those of the &lt;code>other&lt;/code> Membership; or neither of the metaclasses of the &lt;code>memberElement&lt;/code> of this Membership and the &lt;code>memberElement&lt;/code> of the &lt;code>other&lt;/code> Membership conform to the other. But this may be overridden in specializations of Membership.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="761001d9-95af-45a3-91b6-dcbd7a8ae927" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="0b55eb1a-c21a-4c9c-ae14-adc0c679d609" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not (memberElement.oclKindOf(other.memberElement.oclType()) or
+     other.memberElement.oclKindOf(memberElement.oclType())) or
+(shortMemberName = null or
+    (shortMemberName &lt;> other.shortMemberName and
+     shortMemberName &lt;> other.memberName)) and
+(memberName = null or
+    (memberName &lt;> other.shortMemberName and
+     memberName &lt;> other.memberName)))
+</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="c7c1d7eb-fd9b-4fec-8b95-2168b3d4cfe8" name="other" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759"/>
+        <ownedParameter xmi:id="b4b60496-6a69-4142-91e9-173515d02d16" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d" name="OwningMembership" visibility="public">
+      <ownedComment xmi:id="58a5885d-3604-417e-bfb6-9a789221fc83" annotatedElement="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d">
+        <body>&lt;p>An OwningMembership is a Membership that owns its &lt;code>memberElement&lt;/code> as a &lt;code>ownedRelatedElement&lt;/code>. The &lt;code>ownedMemberElementM&lt;/code> becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>.</body>
+      </ownedComment>
+      <ownedRule xmi:id="da04337d-1409-411c-916c-a1e585087c6f" name="owningMembershipOwnedMemberName" visibility="public" constrainedElement="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d">
+        <ownedComment xmi:id="e03b9c66-8169-430b-b5e5-d9dcf27c6a40" annotatedElement="da04337d-1409-411c-916c-a1e585087c6f">
+          <body>&lt;p>The &lt;code>ownedMemberName&lt;/code> of an OwningMembership is the &lt;code>effectiveName&lt;/code> of its &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4bab1fca-00c6-4d75-ba59-1ffbdfd0fc1b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMemberName = ownedMemberElement.effectiveName</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="1d3cbf69-a595-489d-8ec2-f90854dddffb" name="owningMembershipOwnedMemberShortName" visibility="public">
+        <ownedComment xmi:id="9226a5de-8bf5-4f80-a989-4c429e2034a3" annotatedElement="1d3cbf69-a595-489d-8ec2-f90854dddffb">
+          <body>&lt;p>The &lt;code>ownedMemberName&lt;/code> of an OwningMembership is the &lt;code>effectiveName&lt;/code> of its &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c2a8f9be-43c7-4d61-8a2f-b15fd751ae1b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMemberShortName = ownedMemberElement.shortName</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="60f7307e-7418-47ae-91fb-5e7977beb90c" general="80df4982-4fcb-4c30-853c-0f2415033759"/>
+      <ownedAttribute xmi:id="50d115dd-9fe9-4a0c-8d67-bcca24186f18" name="ownedMemberElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" aggregation="composite" isDerived="true" redefinedProperty="c7119062-781b-4d3c-8b28-5d5466ffc105" subsettedProperty="5ff40f8f-8e18-4298-8a4e-5e6c47254836" association="a0fab899-a06e-4564-9388-8d9e5d44ec52">
+        <ownedComment xmi:id="cbb6ec8a-a031-4af9-9d6f-b65dbe40c5b0" annotatedElement="50d115dd-9fe9-4a0c-8d67-bcca24186f18">
+          <body>&lt;p>The Element that becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this OwningMembership. Derived as the first &lt;code>ownedRelatedElement&lt;/code> of the OwningRelationship.&lt;/p>
+
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="60a31cfb-c26c-4084-a5df-f3201d6fb862" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="25cabca0-25c2-40a4-920d-ab8a5f0d6efc" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="edc8b341-6f27-4dc0-aa29-a36a5df8a1e0" name="ownedMemberElementId" visibility="public" isDerived="true" redefinedProperty="df3deff1-7319-47dd-ac97-981ce9ab9788">
+        <ownedComment xmi:id="b0de10f1-965e-40ec-993e-3d4854c47e32" annotatedElement="edc8b341-6f27-4dc0-aa29-a36a5df8a1e0">
+          <body>&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="55731f4a-53be-4087-8148-d13ad8917da1" name="ownedMemberShortName" visibility="public" isDerived="true" redefinedProperty="c651fdea-ea67-47d3-865a-9a09eeb14153">
+        <ownedComment xmi:id="88494215-9982-4b0b-abee-752237d531e9" annotatedElement="55731f4a-53be-4087-8148-d13ad8917da1">
+          <body>&lt;p>The &lt;code>shortName&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="efc58d58-29dd-434b-a913-10093a9844dc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6d34155c-3cf8-41b4-bc12-0dc4b1cc8d54" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4cdef144-4717-40b4-84e1-dbe74bcff646" name="ownedMemberName" visibility="public" isDerived="true" redefinedProperty="6bb70491-4908-4463-bc95-d3cc23f13d93">
+        <ownedComment xmi:id="962a0659-0044-4a78-99db-2a7f093a75de" annotatedElement="4cdef144-4717-40b4-84e1-dbe74bcff646">
+          <body>&lt;p>The &lt;code>effectiveName&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1a6b8ddc-9cd9-42cb-b080-b84524f1d9bf" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5bca054e-7a3a-42c3-839e-423f079496fc" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2839a315-3b0c-415e-9ac3-6e1ab52f299b" name="" visibility="public" memberEnd="d69940fb-b910-4da2-a95d-9eb8d7caf86e c1a0b88f-cde6-41fb-b4cb-ab881827eef7"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="732bd40e-fb64-42e2-8663-8fcee1dac982" name="Namespace" visibility="public">
+      <ownedComment xmi:id="3678af91-02a2-4e73-8b6a-1f5110408c95" annotatedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <body>&lt;p>A Namespace is an Element that contains other Elements, known as its &lt;code>members&lt;/code>, via Membership Relationships with those Elements. The &lt;code>members&lt;/code> of a Namespace may be owned by the Namespace, aliased in the Namespace, or imported into the Namespace via Import Relationships with other Namespaces.&lt;/p>
+
+&lt;p>A Namespace can provide names for its &lt;code>members&lt;/code> via the &lt;code>memberNames&lt;/code> specified by the Memberships in the Namespace. If a Membership specifies a &lt;code>memberName&lt;/code>, then that is the name of the corresponding &lt;code>memberElement&lt;/code> relative to the Namespace. Note that the same Element may be the &lt;code>memberElement&lt;/code> of multiple Memberships in a Namespace (though it may be owned at most once), each of which may define a separate alias for the Element relative to the Namespace.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="32268883-6b2f-41ec-b090-7c27cc25a62c" name="namespaceDistinguishibility" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="e5aa8081-45b6-4699-bac4-8c948d3db0c9" annotatedElement="32268883-6b2f-41ec-b090-7c27cc25a62c">
+          <body>&lt;p>All &lt;code>memberships&lt;/code> of a Namespace must be distinguishable from each other.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="85bd82ea-c49a-4eb6-9fba-ee41d4a4c73d" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>membership->forAll(m1 | membership->forAll(m2 | m1 &lt;> m2 implies m1.isDistinguishableFrom(m2)))</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="20e27939-5c75-4bcc-b15c-c4f7523778cc" name="namespaceMembers" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="97690d72-1037-422a-8acc-26648992f775" annotatedElement="20e27939-5c75-4bcc-b15c-c4f7523778cc">
+          <body>&lt;p>The &lt;code>members&lt;/code> of a Namespace are the &lt;code>memberElements&lt;/code> of all its &lt;code>memberships&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="e6efe84a-1d19-444b-9287-5907f777a678" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>member = membership.memberElement</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="2f28c493-1ca4-4e87-8f06-50a6413a9960" name="namespaceOwnedMember" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="50b8231b-1a01-40fe-a41b-dc9fa54f4d1d" annotatedElement="2f28c493-1ca4-4e87-8f06-50a6413a9960">
+          <body>&lt;p>The &lt;code>ownedMembers&lt;/code> of a Namespace are the &lt;code>ownedMemberElements&lt;/code> of all its &lt;code>ownedMemberships&lt;/code> that are OwningMemberships.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="048cda48-8fee-4354-bf12-f79c2841f982" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMember = ownedMembership->selectByKind(OwningMembership).ownedMemberElement</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="bad66075-63a7-4040-8d0a-8001a09b452f" name="namespaceImportedMembership" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="630a1c23-fb32-42cd-85ad-1385543ffffc" annotatedElement="bad66075-63a7-4040-8d0a-8001a09b452f">
+          <body>&lt;p>The &lt;code>importedMemberships&lt;/code> of a Namespace are derived using the &lt;code>importedMemberships()&lt;/code> operation,with no initially &lt;code>excluded&lt;/code> Namespaces.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="73cfb218-a5e9-4680-8f11-9fda05ae82b9" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>importedMembership = importedMemberships(Set{})</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="315fecfa-8c2c-4398-a584-5474ccacf758" name="namespaceOwnedImport" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="ad5f2abc-9adb-462d-84d1-4906e47ce38b" annotatedElement="315fecfa-8c2c-4398-a584-5474ccacf758">
+          <body>&lt;p>The &lt;code>ownedImports&lt;/code> of a Namespace are all its &lt;code>ownedRelationships&lt;/code> that are Imports.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ea2ba6de-1074-4dcd-b094-023ba2c831e0" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedImport = ownedRelationship->selectByKind(Import)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="06f3a823-c471-419f-9cd8-a16a3a05d67a" name="namespaceOwnedMembership" visibility="public" constrainedElement="732bd40e-fb64-42e2-8663-8fcee1dac982">
+        <ownedComment xmi:id="0fd0d530-451f-4033-8391-6bf3b22387f2" annotatedElement="06f3a823-c471-419f-9cd8-a16a3a05d67a">
+          <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of a Namespace are all its &lt;code>ownedRelationships&lt;/code> that are Memberships.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4fdb0a19-3521-4a5a-b241-951367531d51" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedMembership = ownedRelationship->selectByKind(Membership)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="201f43d5-5297-4be4-8ce4-cd5add210938" general="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+      <ownedAttribute xmi:id="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634" name="membership" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" isDerived="true" isDerivedUnion="true" association="1602dda7-1550-4f0e-9963-da6a7d52732a">
+        <ownedComment xmi:id="c8fdbb0b-18e7-4226-9c57-7c0674297e71" annotatedElement="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634">
+          <body>&lt;p>All Memberships in this Namespace, including (at least) the union of &lt;code>ownedMemberships&lt;/code> and &lt;code>importedMemberships&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c7755a18-2dcb-4852-809d-70790da3f9ad" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="74a8d9d3-d290-47df-a4b9-2a353bb0d29e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="3d9def15-9cea-4500-9f8e-6255b8653611" name="ownedImport" visibility="public" type="894f7139-5012-425b-8828-c525833a91b3" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="4b79fb44-57d3-446f-a4cc-4fd50fbc2bfb">
+        <ownedComment xmi:id="9f1b0bce-23b2-46dd-93ed-5bb1046b2c3d" annotatedElement="3d9def15-9cea-4500-9f8e-6255b8653611">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Namespace that are Imports, for which the Namespace is the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="46a85f0b-a5fa-4f7a-91c5-310bb95d58ca" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1bd750f2-1074-47dc-8ccc-0745c6361e24" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f214bf22-c5eb-4468-9610-e8c47f940ac5" name="member" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isDerived="true" association="02dd1761-99f0-425d-89b2-db5e59446922">
+        <ownedComment xmi:id="c638cc56-de9e-499d-ac4d-fe6f3ceea04e" annotatedElement="f214bf22-c5eb-4468-9610-e8c47f940ac5">
+          <body>&lt;p>The set of all member Elements of this Namespace, derived as the &lt;code>memberElements&lt;/code> of all &lt;code>memberships&lt;/code> of the Namespace.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="60eaa426-29ac-4baa-a285-b60a55ce8829" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="09131b72-cad3-4c46-ac45-4d803d2e076a" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d69940fb-b910-4da2-a95d-9eb8d7caf86e" name="ownedMember" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="2839a315-3b0c-415e-9ac3-6e1ab52f299b">
+        <ownedComment xmi:id="f0631d4d-9e00-412c-95c3-7dd5aafcfa25" annotatedElement="d69940fb-b910-4da2-a95d-9eb8d7caf86e">
+          <body>&lt;p>The owned &lt;code>members&lt;/code> of this Namespace, derived as the &lt;cpde>ownedMemberElements&lt;/code> of the &lt;code>ownedMemberships&lt;/code> of the Namespace.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bae04f18-e33d-42fa-890d-caa2e2a6f595" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8b80590c-5b24-4d56-91c2-143d7428bdcd" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ec58580f-851c-4202-a5c6-27b2ec9ac376" name="ownedMembership" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634 1807da4c-d8f2-454f-911f-8a98c3302238 aef5233e-d4ea-47ae-8b8e-47a2dde39024" association="7eaea69d-33cc-4ebf-bf81-534192877604">
+        <ownedComment xmi:id="92a008b6-7664-479f-ad32-bc2617a4ead8" annotatedElement="ec58580f-851c-4202-a5c6-27b2ec9ac376">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Namespace that are Memberships, for which the Namespace is the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="962d8deb-45cf-4fe7-bc42-e4af0f238f09" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a64f3e5b-d5e0-4ea7-9e86-f445bb8f4076" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="31a6f5d4-5255-4f30-b241-b6ded539a56d" name="importedMembership" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" isDerived="true" subsettedProperty="f2d14e39-8a2b-4bf1-8722-5c2a7da5f634" association="9d51dc54-0933-4524-b056-580592e50a33">
+        <ownedComment xmi:id="07504591-4e9a-4264-b491-cf1ad3c0b5d1" annotatedElement="31a6f5d4-5255-4f30-b241-b6ded539a56d">
+          <body>&lt;p>The Memberships in this Namespace that result from Import Relationships between the Namespace and other Namespaces.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0d1576c2-68c4-4647-880b-208497d149d6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3b430f68-499c-4481-b8be-6f1d33aed129" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="d694ce61-405d-42b8-9895-8b880aa2118c" name="namesOf" visibility="public" bodyCondition="a8a538a8-2583-47b8-adc5-7ddc3e69c1b9">
+        <ownedComment xmi:id="211ebf5c-fbd8-4b65-8913-4ca2e1155bf4" annotatedElement="d694ce61-405d-42b8-9895-8b880aa2118c">
+          <body>&lt;p>Return the names of the given &lt;code>element&lt;/code> as it is known in this Namespace.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="a8a538a8-2583-47b8-adc5-7ddc3e69c1b9" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="bf0539cc-3d00-4903-932d-33d6806a1db9" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let elementMemberships : Sequence(Membership) = 
+    memberships->select(memberElement = element) 
+in
+    memberships.memberShortName->
+        union(memberships.memberName)->
+        asSet()</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="9f4f9682-70a1-4587-b1e0-d5fcf3a2809b" name="element" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+        <ownedParameter xmi:id="f3cc32c1-8140-4a9d-96db-2dcdf31dec1d" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="075c7f2c-b157-4f75-ba33-184d016488f7" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="70437bff-77d8-41d6-a629-cdb431af6bff" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="e115a0ea-8c90-4abc-9f7d-ae392da0e773" name="visibilityOf" visibility="public" bodyCondition="33027892-e42e-46f7-9aa2-862c164f3b7f">
+        <ownedComment xmi:id="16b89156-4204-417d-8cce-86aa5db1600b" annotatedElement="e115a0ea-8c90-4abc-9f7d-ae392da0e773">
+          <body>&lt;p>Returns this visibility of &lt;code>mem&lt;/code> relative to this Namespace. If &lt;code>mem&lt;/code> is an &lt;code>importedMembership&lt;/code>, this is the &lt;code>visibility&lt;/code> of its Import. Otherwise it is the &lt;code>visibility&lt;/code> of the Membership itself.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="33027892-e42e-46f7-9aa2-862c164f3b7f" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="2b3a591b-f8f8-4a3e-88f8-89d03394b978" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if importedMembership->includes(mem) then
+    ownedImport->any(importedMembership(Set{})->includes(mem)).visibility
+else if memberships->includes(mem) then
+    mem.visibility
+else
+    VisibilityKind::private
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="98055f55-4ca1-42fe-8f5e-b75502a51c4a" name="mem" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759"/>
+        <ownedParameter xmi:id="908b563a-03ed-4018-8f1e-ccace66e7880" name="" visibility="public" type="796fe363-bffa-4627-835b-596597fa363f" direction="return"/>
+      </ownedOperation>
+      <ownedOperation xmi:id="f4285a30-2753-41d1-a00b-79fbc140cff0" name="visibleMemberships" visibility="public" bodyCondition="b8c7f7a4-5e1a-4c42-b73f-fd94059135a2">
+        <ownedComment xmi:id="883c7ecc-872e-4019-ab2f-a7de08b8ac1d" annotatedElement="f4285a30-2753-41d1-a00b-79fbc140cff0">
+          <body>&lt;p>If &lt;code>includeAll = true&lt;/code>, then return all the Memberships of this Namespace. Otherwise, return
+only the publicly visible Memberships of this Namespace (which includes those &lt;code>ownedMemberships&lt;/code> that have a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code> and those &lt;code>importedMemberships&lt;/code> imported with a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code>). If &lt;code>isRecursive = true&lt;/code>, also recursively include all visible Memberships of any visible owned Namespaces.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="b8c7f7a4-5e1a-4c42-b73f-fd94059135a2" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="a2914e8e-f7e7-4a9c-b7c7-90c6d3b1f676" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let publicMemberships : Sequence(Membership) =
+    ownedMembership->
+        select(visibility = VisibilityKind::public)->
+        union(ownedImport->
+            select(visibility = VisibilityKind::public).
+            importedMembership(excluded)) in
+if not isRecursive then publicMemberships
+else publicMemberships->union(publicMemberships->
+        selectAsKind(Namespace).
+        publicMembership(excluded->including(this), true))
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="f7635c9a-f2fd-48fe-b695-4088b553adb1" name="excluded" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ab3374d3-d6e4-481e-b3f4-fff028d57f5b" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="377cd0a2-54b2-4937-ac86-b64ecee46f85" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="984168bb-77c5-49a8-b37a-e6e6219788a8" name="isRecursive" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="96e03488-7447-4079-af1b-0c71e9c223ed" name="includeAll" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="2a3e050a-b71f-4057-8cd0-79ee1996052c" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="febbe3f2-3a52-4444-bbf2-20a4eab7688f" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c0084b44-bb3b-4a20-855f-c5e437405fa9" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="65d39ffc-24e5-4d71-a8c3-ec34112bf2c6" name="importedMemberships" visibility="public" bodyCondition="0719683a-9a94-4ad2-964f-3ae7e727273d">
+        <ownedComment xmi:id="468f7620-8ab8-4979-85a7-1b518514859e" annotatedElement="65d39ffc-24e5-4d71-a8c3-ec34112bf2c6">
+          <body>&lt;p>Derive the imported Memberships of this Namespace as the &lt;code>importedMembership&lt;/code> of all &lt;code>ownedImports&lt;/code>, excluding those Imports whose &lt;code>importOwningNamespace&lt;/code> is in the &lt;code>excluded&lt;/code> set, and excluding Memberships that have distinguisibility collisions with each other or with any &lt;code>ownedMembership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="0719683a-9a94-4ad2-964f-3ae7e727273d" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="c629e531-3fe1-4975-ad3f-41d4610b0cf2" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedImport->
+    excluding(excluded->contains(importOwningNamespace)).
+    importedMembership(excluded)</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="bf82d254-7bf5-4a8f-b31c-38da53638afa" name="excluded" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ddee94d7-4e2a-4bca-bd12-b4ff387c07e3" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="45c97931-eafe-4e2f-bd96-493a35ffb9e0" name="" visibility="public" value="*"/>
+        </ownedParameter>
+        <ownedParameter xmi:id="fff9d4bd-a6cf-4db8-b763-582185a8dfa4" name="" visibility="public" type="80df4982-4fcb-4c30-853c-0f2415033759" isOrdered="true" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="79cf46a9-6d7a-4719-a059-b4ecf2641b0a" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fa093773-cb45-4075-baa6-c261dff5fab8" name="" visibility="public" value="*"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2b4710c1-9a53-4d4d-90f2-356575bdf43d" name="" visibility="public" memberEnd="aef5233e-d4ea-47ae-8b8e-47a2dde39024 53d1b371-a5c5-4812-87a8-a61e672f7314"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="6a8a7dfd-eda2-44de-8585-b1ab21fb91fc" name="" visibility="public" memberEnd="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc">
+      <ownedEnd xmi:id="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" name="targetRelationship" visibility="public" type="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="6a8a7dfd-eda2-44de-8585-b1ab21fb91fc">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e0950237-3eb6-4305-a4c8-438ef448e732" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1f4a5af4-722b-4c05-a729-317bd08de204" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b892d830-8731-45d6-8649-a853573bd24e" name="" visibility="public" memberEnd="5ff40f8f-8e18-4298-8a4e-5e6c47254836 efc396e8-bcd6-4a21-a0d8-6588161444eb"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="5b17eab0-1751-4bcb-bde8-c4b1e73a90ad" name="" visibility="public" memberEnd="5b67d4ab-f48e-41ba-af2d-16d57429f489 41eb0599-95cb-4d4d-9387-c097bf0a6736"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="3e23c631-5451-41e4-a047-5d4795c11d60" name="" visibility="public" memberEnd="cabbe0a7-2254-4e73-96eb-c7635134d2dc 2388a6c0-e1b5-4a97-ac6a-1aafd4f32147"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" name="Relationship" visibility="public">
+      <ownedComment xmi:id="8e323d10-c95e-4eec-bdcb-7006a9464ee9" annotatedElement="d00373f6-e7de-4c9f-9b9a-35937ead2cb2">
+        <body>&lt;p>A Relationship is an Element that relates two or more other Elements. Some of its &lt;code>relatedElements&lt;/code> may be owned, in which case those &lt;code>ownedRelatedElements&lt;/code> will be deleted from a model if their &lt;code>owningRelationship&lt;/code> is. A Relationship may also be owned by another Element, in which case the &lt;code>ownedRelatedElements&lt;/code> of the Relationship are also considered to be transitively owned by the &lt;code>owningRelatedElement&lt;/code> of the Relationship.&lt;/p>
+
+&lt;p>The &lt;code>relatedElements&lt;/code> of a Relationship are divided into &lt;code>source&lt;/code> and &lt;code>target&lt;/code> Elements. The Relationship is considered to be directed from the &lt;code>source&lt;/code> to the &lt;code>target&lt;/code> Elements. An undirected Relationship may have either all &lt;code>source&lt;/code> or all &lt;code>target&lt;/code> Elements.&lt;/p>
+
+&lt;p>A &amp;quot;relationship Element&amp;quot; in the kernel abstract syntax is generically any Element that is an instance of either Relationship or a direct or indirect specialization of Relationship. Any other kind of Element is a &amp;quot;non-relationship Element&amp;quot;. It is a convention of the kernel abstract syntax that non-relationship Elements are &lt;em>only&lt;/em> related via reified relationship Elements. Any meta-associations directly between non-relationship Elements must be derived from underlying reified Relationships.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="eb07f7ec-75f7-4d66-9cc1-2a9c727974e6" name="relationshipRelatedElement" visibility="public" constrainedElement="d00373f6-e7de-4c9f-9b9a-35937ead2cb2">
+        <ownedComment xmi:id="cf8d739d-2cbb-4959-832c-424b6d21332a" annotatedElement="eb07f7ec-75f7-4d66-9cc1-2a9c727974e6">
+          <body>&lt;p>The &lt;code>relatedElements&lt;/code> of a Relationship consist of all of its &lt;code>source&lt;/code> Elements followed by all of its &lt;code>target&lt;/code> Elements.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="fd2e52fa-c431-4318-9fcd-f216ea99cf0d" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>relatedElement = source->union(target)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="499b05eb-c4f9-4ba9-8b94-2e549a478f22" general="fff854cf-ff36-41d3-94f6-fb13f8063186"/>
+      <ownedAttribute xmi:id="e81d47df-5f0a-4544-bfe7-9955c8a986fc" name="relatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isUnique="false" isDerived="true" association="855879d3-305e-463c-9bc2-73edc52e6d37">
+        <ownedComment xmi:id="bdc92a46-d10b-4bbd-906c-8d87e9282586" annotatedElement="e81d47df-5f0a-4544-bfe7-9955c8a986fc">
+          <body>&lt;p>The Elements that are related by this Relationship, derived as the union of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code> Elements of the Relationship. Every Relationship must have at least two &lt;code>relatedElements&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ccd67895-5057-42f8-92ba-8dcb16c29ab1" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="770861c8-1589-411f-9223-de494b379e4f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" name="target" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="6a8a7dfd-eda2-44de-8585-b1ab21fb91fc">
+        <ownedComment xmi:id="d9874318-16d0-49fa-9c6e-b4fff536e853" annotatedElement="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f">
+          <body>&lt;p>The &lt;code>relatedElements&lt;/code> to which this Relationship is considered to be directed.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5ceed6a5-406b-4e3a-9e1c-10193c741fa2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="38da49ae-47f8-41b3-a9db-5b52c5c6c507" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7aa626dc-3421-4c50-845b-0e7252b338a3" name="source" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="d73e5617-89af-4dd0-bdc2-90f1e9257c35">
+        <ownedComment xmi:id="2cd24a64-b819-42b7-aeb2-3f7ac6cdfe01" annotatedElement="7aa626dc-3421-4c50-845b-0e7252b338a3">
+          <body>&lt;p>The &lt;code>relatedElements&lt;/c ode> from which this Relationship is considered to be directed.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="293c14bd-c226-485c-b0f4-d8f965d7f4e4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f1f90e0c-d3fc-417c-82b7-f343c79eef5b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="53d1b371-a5c5-4812-87a8-a61e672f7314" name="owningRelatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="2b4710c1-9a53-4d4d-90f2-356575bdf43d">
+        <ownedComment xmi:id="90e9be6c-e8d7-4b6e-b440-7bcbd7d9d982" annotatedElement="53d1b371-a5c5-4812-87a8-a61e672f7314">
+          <body>&lt;p>The &lt;tt>relatedElement&lt;/tt> of this Relationship that owns the Relationship, if any.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4f911926-416a-4b71-b313-328305af4154" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="585a3919-bc7a-4270-ab87-909a4314fdb9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5ff40f8f-8e18-4298-8a4e-5e6c47254836" name="ownedRelatedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" aggregation="composite" subsettedProperty="e81d47df-5f0a-4544-bfe7-9955c8a986fc" association="b892d830-8731-45d6-8649-a853573bd24e">
+        <ownedComment xmi:id="63063dc6-8425-4573-8dca-194bec2feced" annotatedElement="5ff40f8f-8e18-4298-8a4e-5e6c47254836">
+          <body>&lt;p>The &lt;tt>relatedElements&lt;/tt> of this Relationship that are owned by the Relationship.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="601f17b0-7daf-4779-ad09-402bc0925c38" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="af4573c6-1972-4935-9e52-5d0039ffe087" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f633235c-5085-4e76-8c89-848fc146f55e" name="isImplied" visibility="public">
+        <ownedComment xmi:id="789695a1-102d-403c-a4e0-ed5b22094570" annotatedElement="f633235c-5085-4e76-8c89-848fc146f55e">
+          <body>&lt;p>Whether this Relationship was generated by tooling to meet semantic rules, rather than being directly created by a modeler.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="30bbc206-2436-4bff-975b-736aaa102a19" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="855879d3-305e-463c-9bc2-73edc52e6d37" name="" visibility="public" memberEnd="e81d47df-5f0a-4544-bfe7-9955c8a986fc 1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d">
+      <ownedEnd xmi:id="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" name="relationship" visibility="public" type="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" isUnique="false" isDerived="true" isDerivedUnion="true" association="855879d3-305e-463c-9bc2-73edc52e6d37">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9f9a0003-3f37-4ebc-a022-415d5334dbe7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f85d606c-ad74-4de4-81f6-fc41ae5dc482" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="43ff234f-2149-4231-a1cd-e926d4a00b2e" name="" visibility="public" memberEnd="0e646eed-d670-4de4-b471-9fd6f0ef8bcc 302f9fde-2bfd-4cd6-bb3d-c7ae8691ddc4"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="d73e5617-89af-4dd0-bdc2-90f1e9257c35" name="" visibility="public" memberEnd="7aa626dc-3421-4c50-845b-0e7252b338a3 1807da4c-d8f2-454f-911f-8a98c3302238">
+      <ownedEnd xmi:id="1807da4c-d8f2-454f-911f-8a98c3302238" name="sourceRelationship" visibility="public" type="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="d73e5617-89af-4dd0-bdc2-90f1e9257c35">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9c23b268-0b28-4835-a869-7742e7aa59bb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="19f4887d-7fac-466a-bc52-4c8d7184063f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fff854cf-ff36-41d3-94f6-fb13f8063186" name="Element" visibility="public">
+      <ownedComment xmi:id="30178944-a07a-4d13-8195-4c09736cc7c5" annotatedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <body>&lt;p>An Element is a constituent of a model that is uniquely identified relative to all other Elements. It can have Relationships with other Elements. Some of these Relationships might imply ownership of other Elements, which means that if an Element is deleted from a model, then so are all the Elements that it owns.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="f5b8d411-c3ce-42bc-8d06-68b58108b284" name="elementOwnedElements" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="9e375392-da96-417a-a4e3-c114079edc50" annotatedElement="f5b8d411-c3ce-42bc-8d06-68b58108b284">
+          <body>&lt;p>The &lt;code>ownedElements&lt;/code> of an Element are the &lt;code>ownedRelatedElements&lt;/code> of its &lt;code>ownedRelationships&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="90ac5da8-0bea-4129-ae6e-89312359d7d0" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedElement = ownedRelationship.ownedRelatedElement</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="dbca9d93-a9f7-4035-a121-5b8b4a4dbab4" name="elementOwner" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="05b5b47d-fc5b-43bd-80f3-d6c29ecd3a16" annotatedElement="dbca9d93-a9f7-4035-a121-5b8b4a4dbab4">
+          <body>&lt;p>The &lt;code>owneder&lt;/code> of an Element is the &lt;code>owningRelatedElement&lt;/code> of its &lt;code>owningRelationship&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="3d83e3a8-192e-4c77-86eb-9a1562a3d695" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>owner = owningRelationship.owningRelatedElement</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="8d7d56e9-46e8-4b87-8592-7f30a61a0726" name="elementQualifiedName" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="675ff284-b7e8-42ea-8907-f0f36b68034a" annotatedElement="8d7d56e9-46e8-4b87-8592-7f30a61a0726">
+          <body>&lt;p>If this Element does not have an &lt;code>owningNamespace&lt;/code>, then its &lt;code>qualifiedName&lt;/code> is empty. If the &lt;code>owningNamespace&lt;/code> of this Element is a root Namespace, then the &lt;code>qualifiedName&lt;/code> of the Element is the escaped name of the Element (if any). If the &lt;code>owningNamespace&lt;/code> is non-empty but not a root Namespace, then the &lt;code>qualifiedName&lt;/code> of this Element is constructed from the &lt;code>qualifiedName&lt;/code> of the &lt;code>owningNamespace&lt;/code> and the escaped name of the Element, unless the &lt;code>qualifiedName&lt;/code> of the &lt;code>owningNamespace&lt;/code> is empty, in which case the &lt;code>qualifiedName&lt;/code> of this Element is also empty.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="62de5b85-411b-467c-889d-163807ff4f2b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>qualifiedName =
+    if owningNamespace = null then null
+    else if owningNamespace.owner = null then escapedName()
+    else if owningNamespace.qualifiedName = null then null
+    else owningNamespace.qualifiedName + '::' + escapedName()
+    endif endif endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="a57fe6f2-9f61-4b2b-affb-cd31cb0ec4b0" name="elementDocumentation" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="72922c45-c9df-4ce2-9d72-85f788b1d91e" annotatedElement="a57fe6f2-9f61-4b2b-affb-cd31cb0ec4b0">
+          <body>&lt;p>The &lt;code>documentation&lt;/code> of an Element are its &lt;code>ownedElements&lt;/code> that are Documentation.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="0a74c217-173d-4f2b-8872-2182261a648b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>documentation = ownedElement->selectByKind(Documentation)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="b293317b-a48d-433d-962f-48170e8c4d4b" name="elementOwnedAnnotation" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="e3d0fdb7-823a-4779-a372-8b2613900e99" annotatedElement="b293317b-a48d-433d-962f-48170e8c4d4b">
+          <body>&lt;p>The &lt;code>ownedAnnotations&lt;/code> of an Element are its &lt;code>ownedRelationships&lt;/code> that are Annotations.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="067fb120-88e9-4234-a47c-55c3821ce63d" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedAnnotation = ownedRelationship->selectByKind(Annotation)->
+    select(a | a.annotatedElement = self)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="9b16748d-7037-4a54-af4a-67255d34731e" name="elementEffectiveName" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="4b429d64-0641-4a44-be11-13fd15d9e124" annotatedElement="9b16748d-7037-4a54-af4a-67255d34731e">
+          <body>&lt;p>The &lt;code>effectiveName&lt;/code> of an Element is given by the result of the &lt;code>effectiveName()&lt;/code> operation.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="d1dc8cd0-9afb-44d2-9614-79e8037592f9" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>effectiveName()</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="8861a820-d0f4-417f-be2f-1f9518080766" name="elementVerifyIsImpliedIncluded" visibility="public" constrainedElement="fff854cf-ff36-41d3-94f6-fb13f8063186">
+        <ownedComment xmi:id="1f03e7cf-2a09-40c2-9239-a47de396ebbc" annotatedElement="8861a820-d0f4-417f-be2f-1f9518080766">
+          <body></body>
+        </ownedComment>
+        <ownedComment xmi:id="88950696-8514-4092-ab21-a15c9d6a605f" annotatedElement="8861a820-d0f4-417f-be2f-1f9518080766">
+          <body>&lt;p>If an Element has any &lt;code>ownedRelationships&lt;/code> that are implied, then &lt;code>ownedRelationships&lt;/code> must include all required implied relationships.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="eb57240d-6dca-400c-bcf1-e9e2595edd75" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedRelationship->exists(isImplied) implies isImpliedIncluded</body>
+        </specification>
+      </ownedRule>
+      <ownedAttribute xmi:id="4e9a7462-c2c0-42cd-a715-dc21395cc779" name="owningMembership" visibility="public" type="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d" isDerived="true" subsettedProperty="efc396e8-bcd6-4a21-a0d8-6588161444eb ab3b057a-1552-43d2-aca6-9598c8b704b3" association="a0fab899-a06e-4564-9388-8d9e5d44ec52">
+        <ownedComment xmi:id="345985ac-00e7-45af-844b-78139ac3561f" annotatedElement="4e9a7462-c2c0-42cd-a715-dc21395cc779">
+          <body>&lt;p>The &lt;code>owningRelationship&lt;/code> of this Element, if that Relationship is a Membership.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="019003cf-e8a3-43e9-b0c6-4ed9e373703a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="03e94ce8-3eae-4972-94e9-bcbdc403d4f9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="efc396e8-bcd6-4a21-a0d8-6588161444eb" name="owningRelationship" visibility="public" type="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="b892d830-8731-45d6-8649-a853573bd24e">
+        <ownedComment xmi:id="2811ff05-ffed-4be6-89f4-425046c97639" annotatedElement="efc396e8-bcd6-4a21-a0d8-6588161444eb">
+          <body>&lt;p>The Relationship for which this Element is an &lt;tt>ownedRelatedElement&lt;/tt>, if any.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b3f1cd3e-1add-40a1-9267-e853247e0b02" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8821817a-2653-4552-b76e-6d57e1d2ea8e" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" name="owningNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="2839a315-3b0c-415e-9ac3-6e1ab52f299b">
+        <ownedComment xmi:id="9ecfd38f-96e3-440c-aa11-ebf77fcbe209" annotatedElement="c1a0b88f-cde6-41fb-b4cb-ab881827eef7">
+          <body>&lt;p>The Namespace that owns this Element, derived as the &lt;code>membershipOwningNamespace&lt;/code> of the &lt;code>owningMembership&lt;/code> of this Element, if any.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="28791b64-e690-47b8-92ae-ca03bed8a0f8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0fd1c383-af62-44b0-910d-2b6ebb1a26fb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="db22c1a5-89f4-4152-86af-096e787680c0" name="elementId" visibility="public" isID="true">
+        <ownedComment xmi:id="4dfe1692-3fb1-4efc-846a-e5c3555edb0c" annotatedElement="db22c1a5-89f4-4152-86af-096e787680c0">
+          <body>&lt;p>The globally unique identifier for this Element. This is intended to be set by tooling, and it must not change during the lifetime of the Element.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="aef5233e-d4ea-47ae-8b8e-47a2dde39024" name="ownedRelationship" visibility="public" type="d00373f6-e7de-4c9f-9b9a-35937ead2cb2" isOrdered="true" aggregation="composite" subsettedProperty="1dbbd5f2-1d61-4ed5-89c9-395ca3cfa81d" association="2b4710c1-9a53-4d4d-90f2-356575bdf43d">
+        <ownedComment xmi:id="102c06bf-1429-46ae-99fe-7ddcf8c77fda" annotatedElement="aef5233e-d4ea-47ae-8b8e-47a2dde39024">
+          <body>&lt;p>The Relationships for which this Element is the &lt;tt>owningRelatedElement&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f054aa36-2e0e-4305-8f20-929fa105236c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e749c7f6-8e6c-4782-9e19-1f60e3505774" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5b67d4ab-f48e-41ba-af2d-16d57429f489" name="owner" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isDerived="true" association="5b17eab0-1751-4bcb-bde8-c4b1e73a90ad">
+        <ownedComment xmi:id="cc6907f2-da3a-4970-b612-9ea61e3180f3" annotatedElement="5b67d4ab-f48e-41ba-af2d-16d57429f489">
+          <body>&lt;p>The owner of this Element, derived as the &lt;tt>owningRelatedElement&lt;/tt> of the &lt;tt>owningRelationship&lt;/tt> of this Element, if any.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8aee23b7-80aa-4c87-9eb5-eb823d4eae4c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8b9715a0-dc7d-41f2-8831-6d00d7b80aa7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="41eb0599-95cb-4d4d-9387-c097bf0a6736" name="ownedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isDerived="true" association="5b17eab0-1751-4bcb-bde8-c4b1e73a90ad">
+        <ownedComment xmi:id="bb7f5bc3-c36d-4ec4-b792-dc2d37f9c860" annotatedElement="41eb0599-95cb-4d4d-9387-c097bf0a6736">
+          <body>&lt;p>The Elements owned by this Element, derived as the &lt;tt>ownedRelatedElements&lt;/tt> of the &lt;tt>ownedRelationships&lt;/tt> of this Element.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0347d732-9a3c-4f20-bfdd-a9b87c8237cb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cfd60420-da74-485c-9193-ffa504e7df02" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="48e57473-ad4e-4356-bdd0-a6517135396f" name="documentation" visibility="public" type="cd0c0e14-e1a3-4235-baa4-102302dfc168" isOrdered="true" isDerived="true" subsettedProperty="41eb0599-95cb-4d4d-9387-c097bf0a6736 92f188bb-f6e4-4cbf-86f8-da0462d4f1e0" association="ce0e0672-de3c-4d80-98e0-025c1927223c">
+        <ownedComment xmi:id="442fea6b-c41b-4e96-b5a7-4901040fc168" annotatedElement="48e57473-ad4e-4356-bdd0-a6517135396f">
+          <body>&lt;p>The Documentation owned by this Element.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1d006947-3994-44ac-848d-fa775057f9b3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7b80d843-2032-49b6-8282-1a52d12233a9" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cabbe0a7-2254-4e73-96eb-c7635134d2dc" name="ownedAnnotation" visibility="public" type="28c8d0fe-6d47-4359-89c2-c8cdf10600f1" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="aef5233e-d4ea-47ae-8b8e-47a2dde39024 88831956-f19e-4ad6-b59c-160e8cb854c6" association="3e23c631-5451-41e4-a047-5d4795c11d60">
+        <ownedComment xmi:id="48dae0e9-8974-463a-9cc0-3ec3ffd16dd8" annotatedElement="cabbe0a7-2254-4e73-96eb-c7635134d2dc">
+          <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this Element that are Annotations, for which this Element is the &lt;code>annotatedElement&lt;/code>.&lt;/code></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="05c203ac-b48d-4840-9919-703896a9b174" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="92a6f746-c5f7-4723-9b73-c5fe974ce5f9" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0e646eed-d670-4de4-b471-9fd6f0ef8bcc" name="textualRepresentation" visibility="public" type="20035586-007c-4491-bebb-4954fd6b1b46" isOrdered="true" isDerived="true" subsettedProperty="41eb0599-95cb-4d4d-9387-c097bf0a6736 92f188bb-f6e4-4cbf-86f8-da0462d4f1e0" association="43ff234f-2149-4231-a1cd-e926d4a00b2e">
+        <ownedComment xmi:id="d8bf210e-f3cb-485d-95c8-d01f42ff1cf0" annotatedElement="0e646eed-d670-4de4-b471-9fd6f0ef8bcc">
+          <body>&lt;p>The &lt;code>textualRepresentations&lt;/code> that annotate this Element.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="049136c8-8b1d-4272-9132-54493ca1c3d1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e3c136d6-018c-4aee-9c06-106308d9babb" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fa55c035-b014-401c-bd49-764abc1417c6" name="aliasIds" visibility="public" isOrdered="true">
+        <ownedComment xmi:id="9c4b5386-cabe-40f7-b1bb-ce8400ac814f" annotatedElement="fa55c035-b014-401c-bd49-764abc1417c6">
+          <body>&lt;p>Various alternative identifiers for this Element. Generally, these will be set by tools.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="880e6ac3-324b-40a6-b574-424f168d8819" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1ad93e4d-10b9-4edf-8610-f6cceac1a2a3" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a3a60717-82ce-452b-ba0e-bade66ef3b72" name="shortName" visibility="public">
+        <ownedComment xmi:id="27dbcb7d-1561-4d29-a2e4-68d7866bbe36" annotatedElement="a3a60717-82ce-452b-ba0e-bade66ef3b72">
+          <body>&lt;p>An optional alternative name for the Element that is intended to be shorter or in some way more succinct than its primary &lt;code>name&lt;/code>. It may act as a modeler-specified identifier for the Element, though it is then the responsibility of the modeler to maintain the uniqueness of this identifier within a model or relative to some other context.&lt;/p> 
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="54b94dce-c8d2-43af-abf3-1ee0a3dbb5ea" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="90780bdb-b044-4663-b776-f34e9973fd7e" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fc8c2a2b-d9d0-4b04-a4c9-cdf46459a6a4" name="name" visibility="public">
+        <ownedComment xmi:id="c3d0516d-c7ed-4e29-a264-33edcda9d8ad" annotatedElement="fc8c2a2b-d9d0-4b04-a4c9-cdf46459a6a4">
+          <body>&lt;p>The primary name of this Element.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="41296bdf-91ef-4b25-9f81-61f1ba6be9a3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="02989b7f-c44e-41e4-974c-22aa636245f6" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="681c1806-08ec-460e-864d-9f8dd5fcf186" name="effectiveName" visibility="public" isDerived="true">
+        <ownedComment xmi:id="6dba3abf-c7bc-41ee-9f71-2ec0a5564bdf" annotatedElement="681c1806-08ec-460e-864d-9f8dd5fcf186">
+          <body>&lt;p>The effective name to be used for this Element during name resolution within its &lt;code>owningNamespace&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="85c3aa71-5ed9-4b38-9a3d-ff14ac57cfe4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3a5dbb25-32d0-4eab-b332-c316293bbc98" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1551665d-9584-41b2-9113-95a22ed50b03" name="qualifiedName" visibility="public" isDerived="true">
+        <ownedComment xmi:id="eee779b2-e816-432c-a9c6-7ed51e088cd8" annotatedElement="1551665d-9584-41b2-9113-95a22ed50b03">
+          <body>&lt;p>The full ownership-qualified name of this Element, represented in a form that is valid according to the KerML textual concrete syntax for qualified names (including use of unrestricted name notation and escaped characters, as necessary). The &lt;code>qualifiedName&lt;/code> is null if this Element has no &lt;code>owningNamespace&lt;/code> or if there is not a complete ownership chain of named Namespaces from a root Namespace to this Element.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e7ec6e86-254b-4bf8-ac53-1970895d1914" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b1b3f9c6-a21d-4163-87c2-6d6682ec4004" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9bac1ddf-891c-4aaf-9426-158b32d39d77" name="isImpliedIncluded" visibility="public">
+        <ownedComment xmi:id="e47fa3ac-47f4-4576-b238-720a811b6af9" annotatedElement="9bac1ddf-891c-4aaf-9426-158b32d39d77">
+          <body>&lt;p>Whether all necessary implied Relationships have been included in the &lt;code>ownedRelationships&lt;/code> of this Element. This property may be true, even if there are not actually any &lt;code>ownedRelationships&lt;/code> with &lt;code>isImplied = true&lt;/code>, meaning that no such Relationships are actually implied for this Element. However, if it is false, then &lt;code>ownedRelationships&lt;/code> may &lt;em>not&lt;/em> contain any implied Relationships. That is, either &lt;em>all&lt;/em> required implied Relationships must be included, or none of them.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="4693263f-9f64-4a3c-996d-489afe02916a" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="3cea1955-b770-4ff9-bdaa-eb5dc237f876" name="escapedName" visibility="public">
+        <ownedComment xmi:id="f1c63be3-fe12-40e1-a19e-1e35ed6c96b1" annotatedElement="3cea1955-b770-4ff9-bdaa-eb5dc237f876">
+          <body>&lt;p>Return &lt;code>effectiveName&lt;/code>, if that is not null, otherwise &lt;code>shortName&lt;/code>, if that is not null, otherwise null. If the returned name is non-null, it is returned as-is if it has the form of a basic name, or, otherwise, represented as a restricted name according to the lexical structure of the KerML textual notation (i.e., surrounded by single quote characters and with special characters escaped).&lt;/p></body>
+        </ownedComment>
+        <ownedParameter xmi:id="02716a16-0339-4577-8f35-4b9245be8a81" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6b23d57e-c4ad-47b7-b01d-08e61f9e3e24" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b725bc27-75a8-438d-b0c7-d113fd769865" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+      <ownedOperation xmi:id="a047ae2c-0109-4d52-9cef-b13139830170" name="effectiveName" visibility="public" bodyCondition="20aa7ab9-0de1-4750-b920-f2924516bc11">
+        <ownedComment xmi:id="cf79b036-ed5c-4393-a3ec-48cbadfaff55" annotatedElement="a047ae2c-0109-4d52-9cef-b13139830170">
+          <body>&lt;p>Return the effective name for this Element. By default this is the same as its &lt;code>name&lt;/code>, but, for certain kinds of Elements, this may be overridden if the Element &lt;code>name&lt;/code> is empty (e.g., for redefining Features).&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="20aa7ab9-0de1-4750-b920-f2924516bc11" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="d3eb19c2-fcf0-4b3b-8043-6eda266a0ba5" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>name</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="f4a6ea4c-5c99-4fc5-871a-2d7a9fae1acc" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5b2ee055-cfc1-4210-895e-c14995379757" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="75a6d8d8-95fc-4ee6-87c7-4d9f8650131c" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ce0e0672-de3c-4d80-98e0-025c1927223c" name="" visibility="public" memberEnd="48e57473-ad4e-4356-bdd0-a6517135396f 6a7858b5-3913-48b8-82a4-919ce5daabd0"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_B3mdEUQmEe22v6M5Q5J7KQ" name="Systems">
+    <packagedElement xmi:type="uml:Association" xmi:id="9fc8be5f-ff19-4235-8fc8-5c8ce942365a" name="" visibility="public" memberEnd="a3004bd7-fef2-4b93-b764-fad91aea3e39 2bf1269b-708f-4c9d-926f-9d14ae847928">
+      <ownedEnd xmi:id="2bf1269b-708f-4c9d-926f-9d14ae847928" name="featuringCalculationDefinition" visibility="public" type="1b48a93b-7518-41c0-89cc-27a5b62dd441" isDerived="true" subsettedProperty="cb023d69-80e9-4e0f-9a9d-7420ac84da10 938b7976-b666-4fc3-95f6-ce5646e2ea54" association="9fc8be5f-ff19-4235-8fc8-5c8ce942365a">
+        <ownedComment xmi:id="4c958ca1-604e-4c70-9c46-22cc174558f3" annotatedElement="2bf1269b-708f-4c9d-926f-9d14ae847928">
+          <body>&lt;p>The CalculationDefinitions that feature a certain CalculationUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fcc05dff-1471-42dd-849d-b0de9e2a21a9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1edc9296-314c-48cd-afdb-dc2350fea178" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="1b48a93b-7518-41c0-89cc-27a5b62dd441" name="CalculationDefinition" visibility="public">
+      <ownedComment xmi:id="975f5ea6-87ea-4d50-afb4-7f37cf3f1338" annotatedElement="1b48a93b-7518-41c0-89cc-27a5b62dd441">
+        <body>&lt;p>A CalculationDefinition is an ActionDefinition that also defines a Function producing a &lt;code>result&lt;/code>.&lt;/p>
+
+&lt;p>A CalculationDefinition must subclass, directly or indirectly, the base CalculationDefinition Calculation from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="8efc7190-75db-4396-8e3f-dc5ebae96996" general="29b2aa40-d30d-41a0-9030-891c06fc9924"/>
+      <generalization xmi:id="0bdb84b1-570e-4116-8f06-c9e3f75db30b" general="724913be-4700-496b-accb-f45750955b14"/>
+      <ownedAttribute xmi:id="a3004bd7-fef2-4b93-b764-fad91aea3e39" name="calculation" visibility="public" type="92887cda-1376-415e-86ad-315e1dcd7de8" isOrdered="true" isDerived="true" subsettedProperty="58a4f97e-ec9b-405a-a512-c223a347970e 7413c86e-1cfb-4727-b275-a5fafde797fa" association="9fc8be5f-ff19-4235-8fc8-5c8ce942365a">
+        <ownedComment xmi:id="4494fb19-9fe4-4adb-91e4-d86dc1ccbec2" annotatedElement="a3004bd7-fef2-4b93-b764-fad91aea3e39">
+          <body>&lt;p>The CalculationUsages that are &lt;code>actions&lt;/code> in this CalculationDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d283bc32-2761-4007-a2b0-a09e8d3fafce" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="98282c40-0ef2-4010-a6b4-1b73d72dad8b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8e0dab31-22d4-4818-a29b-20c004c237df" name="" visibility="public" memberEnd="adbfc462-f15f-455b-8702-bf3de4f6f466 f4108bb5-9250-480a-8c21-4f85269bc6b1">
+      <ownedEnd xmi:id="f4108bb5-9250-480a-8c21-4f85269bc6b1" name="definedCalculation" visibility="public" type="92887cda-1376-415e-86ad-315e1dcd7de8" isDerived="true" subsettedProperty="8dd7c22c-b05f-4eae-b36f-15870a385730 fb464d93-e7f2-4d5d-9e9c-aaf2c4fdd16c" association="8e0dab31-22d4-4818-a29b-20c004c237df">
+        <ownedComment xmi:id="673e3a7a-5581-415e-bb93-d659aee71adb" annotatedElement="f4108bb5-9250-480a-8c21-4f85269bc6b1">
+          <body>&lt;p>The CalculationUsage being typed by a certain Function.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="900cd71a-1318-42d3-96bf-ba0c45ddd024" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ae882fd2-7788-4e88-8515-089fcc19800d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="92887cda-1376-415e-86ad-315e1dcd7de8" name="CalculationUsage" visibility="public">
+      <ownedComment xmi:id="6b194107-33ea-4810-9930-01a3081c2aa1" annotatedElement="92887cda-1376-415e-86ad-315e1dcd7de8">
+        <body>&lt;p>A CalculationUsage is an ActionUsage that is also an Expression, and, so, is typed by a Function. Nominally, if the type is a CalculationDefinition, a CalculationUsage is a Usage of that CalculationDefinition within a system. However, other kinds of kernel Functions are also allowed, to permit use of Functions from the Kernel Library.&lt;/p>
+
+&lt;p>A CalculationUsage must subset, directly or indirectly, either the base CalculationUsage &lt;code>calculations&lt;/code> from the Systems model library, if it is not a composite feature, or the CalculationUsage &lt;code>subcalculations&lt;/code> inherited from its owner, if it is a composite feature.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="5ffd7e1f-c546-42d8-83f5-f674af4eb6a6" general="b32c4dd3-88a2-4418-b414-e75ceb0bb432"/>
+      <generalization xmi:id="5e4ebf1d-a7e2-40f8-a169-2ed7150311f6" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="adbfc462-f15f-455b-8702-bf3de4f6f466" name="calculationDefinition" visibility="public" type="29b2aa40-d30d-41a0-9030-891c06fc9924" isOrdered="true" isDerived="true" redefinedProperty="fa2d0459-19c1-4516-ae3f-4d6dceebe431 5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b" association="8e0dab31-22d4-4818-a29b-20c004c237df">
+        <ownedComment xmi:id="1c1e60e6-50ef-4312-87d7-3aae6808533d" annotatedElement="adbfc462-f15f-455b-8702-bf3de4f6f466">
+          <body>&lt;p>The Function that is the type of this CalculationUsage. Nominally, this would be a CalculationDefinition, but a kernel Function is also allowed, to permit use of Functions from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cf870d06-c3c2-4594-8628-7cf124c79c58" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="281f2cdb-2a6a-488b-89ac-8307fdc609d1" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="209d05bb-038e-4a1c-8ff2-127fc0fdedce" name="" visibility="public" memberEnd="72d981f9-d23c-4ef7-a2a8-636c221553aa 16ae6b07-d65d-446e-80d9-cb171d471566">
+      <ownedEnd xmi:id="72d981f9-d23c-4ef7-a2a8-636c221553aa" name="calculationOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="1b7b5463-e55a-4c54-a0bb-5130c627562a" association="209d05bb-038e-4a1c-8ff2-127fc0fdedce">
+        <ownedComment xmi:id="794f3c09-266f-4ca7-a0b4-83cba98d41fc" annotatedElement="72d981f9-d23c-4ef7-a2a8-636c221553aa">
+          <body>&lt;p>The Usage in which the &lt;code>nestedCalculation&lt;code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="17c779f3-ad89-4605-a210-308e8336c136" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8d631895-4f67-43d0-8b48-bf21f7efa3f2" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8552ebd4-bc13-4cf4-89d2-0ed28eb014fa" name="" visibility="public" memberEnd="4abca074-c488-4d21-989e-33cb9f542328 39599fde-2f5c-41f1-8b5a-08e27a774f5a">
+      <ownedEnd xmi:id="4abca074-c488-4d21-989e-33cb9f542328" name="calculationOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="187ce9bc-8499-4f74-a487-3bc7b8666616" association="8552ebd4-bc13-4cf4-89d2-0ed28eb014fa">
+        <ownedComment xmi:id="8252d7d2-6401-4d07-8a03-9f0c523779d2" annotatedElement="4abca074-c488-4d21-989e-33cb9f542328">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedCalculation&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ecfb6fb9-1075-4864-af99-f35cf3674109" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8c740052-7745-4bab-8961-687fbf9bc8ae" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9358a6ec-830f-4b6b-8f4a-ff481b52fe55" name="" visibility="public" memberEnd="0e5e08ee-b091-4594-bce0-e3cf0d351488 4c0295f7-0b08-44ab-b5ab-22d823fae8e4">
+      <ownedEnd xmi:id="4c0295f7-0b08-44ab-b5ab-22d823fae8e4" name="definedAttribute" visibility="public" type="23e8be75-009b-43b9-8e7a-f88c061ac220" isDerived="true" subsettedProperty="96ec9372-1879-4d45-a114-b4276d6a9bdf" association="9358a6ec-830f-4b6b-8f4a-ff481b52fe55">
+        <ownedComment xmi:id="c534ee5e-d0b1-42e1-97d9-9a8da368ad45" annotatedElement="4c0295f7-0b08-44ab-b5ab-22d823fae8e4">
+          <body>&lt;p>The AttributeUsages that are typed by a certain DataType.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ccbcaa89-39ba-45df-8073-edd7bcc4c8de" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f56541f1-e2ef-4a0c-909e-489c9f1886b8" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fb0b0e03-353a-4661-aaad-e229afb2f5e8" name="AttributeDefinition" visibility="public">
+      <ownedComment xmi:id="dff3ff60-bbfc-4cd8-8761-a86d5dffe8f2" annotatedElement="fb0b0e03-353a-4661-aaad-e229afb2f5e8">
+        <body>&lt;p>An AttributeDefinition is a Definition and a DataType of information about a quality or characteristic of a system or part of a system that has no independent identity other than its value. All &lt;code>features&lt;/code> of an AttributeDefinition must have &lt;code>isComposite&lt;/code> = &lt;code>false&lt;/code>.&lt;/p>
+
+&lt;p>An AttributeDefinition must subclass, directly or indirectly, the base AttributeDefinition AttributeValue from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="2102015c-1f00-4793-a616-1a7b83e66fb7" general="8fb1addf-512a-4250-97a3-5fb06485a999"/>
+      <generalization xmi:id="0c50c85c-38ad-4752-a80e-cdf7ba636d1f" general="bbec763b-2ef0-415f-9e22-c531739690bb"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="23e8be75-009b-43b9-8e7a-f88c061ac220" name="AttributeUsage" visibility="public">
+      <ownedComment xmi:id="3aa74000-fcea-46d3-981b-0344ad20e44d" annotatedElement="23e8be75-009b-43b9-8e7a-f88c061ac220">
+        <body>&lt;p>An AttributeUsage is a Usage whose type is a DataType. Nominally, if the type is an AttributeDefinition, an AttributeUsage is a usage of a AttributeDefinition to represent the value of some system quality or characteristic. However, other kinds of kernel DataTypes are also allowed, to permit use of DataTypes from the Kernel Library. An AttributeUsage itself as well as all its nested &lt;code>features&lt;/code> must have &lt;code>isComposite&lt;/code> = &lt;code>false&lt;/code>.&lt;/p>
+
+&lt;p>An AttributeUsage must subset, directly or indirectly, the base AttributeUsage &lt;code>attributeValues&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="b8aca072-99c0-40f8-a375-a93a71933c33" general="46068009-84f1-4001-a9bb-fc03fd6a381c"/>
+      <ownedAttribute xmi:id="0e5e08ee-b091-4594-bce0-e3cf0d351488" name="attributeDefinition" visibility="public" type="8fb1addf-512a-4250-97a3-5fb06485a999" isOrdered="true" isDerived="true" redefinedProperty="201738a1-0499-47ef-8c07-ab15564d86c0" association="9358a6ec-830f-4b6b-8f4a-ff481b52fe55">
+        <ownedComment xmi:id="7ec935e2-04df-4e7c-8406-158cf6695da3" annotatedElement="0e5e08ee-b091-4594-bce0-e3cf0d351488">
+          <body>&lt;p>The DataTypes that are the types of this AttributeUsage. Nominally, these are AttributeDefinitions, but other kinds of kernel DataTypes are also allowed, to permit use of DataTypes from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6d7e9d6f-5d16-4578-ab06-ad3c50d56df8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9a35c115-e873-4b1c-b785-d9a58ad56e1d" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="115acdd9-b2ae-4074-822a-8c440b36a8b8" name="isReference" visibility="public" redefinedProperty="4b97024d-0fb2-4e8d-8d39-3132a89b44bc">
+        <ownedComment xmi:id="421b146b-a59f-4175-9ddb-cb9a17188552" annotatedElement="115acdd9-b2ae-4074-822a-8c440b36a8b8">
+          <body>&lt;p>Always true for an AttributeUsage.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="e49f0906-edcc-4315-9f6c-15b6db5d66c8" name="" visibility="public" value="true"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f7811485-83ca-4a1c-aee2-785cbd6572ea" name="VerificationCaseDefinition" visibility="public">
+      <ownedComment xmi:id="77607ec2-263d-4e3b-88cb-8d72ae877ab8" annotatedElement="f7811485-83ca-4a1c-aee2-785cbd6572ea">
+        <body>&lt;p>A VerificationCaseDefinition is a CaseDefinition for the purpose of verification of the subect of the case against its requirements.&lt;/p>
+
+&lt;p>A VerificationCaseDefinition must subclass, directly or indirectly, the base VerificationCaseDefinition VerificationCase from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="fa4744e1-5093-4acc-8e9b-d643a8592e32" general="20e23891-303c-400f-909a-032f49ef946d"/>
+      <ownedAttribute xmi:id="61d18663-1667-476e-adc4-776b9302a88b" name="verifiedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" association="e822bc37-08dc-42dc-aded-a0d156e1a6c3">
+        <ownedComment xmi:id="576d94ae-c059-42bd-873f-4966fa277292" annotatedElement="61d18663-1667-476e-adc4-776b9302a88b">
+          <body>&lt;p>The RequirementUsages verified by this VerificationCaseDefinition, derived as the &lt;code>verifiedRequirements&lt;/code> of all RequirementVerificationMemberships of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4339220a-32ad-4924-b383-72643265458f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5e43f1a8-658c-4a07-af71-eb1a81210b50" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="11e641b7-f5c7-4058-9c0d-f8fd8044e7fe" name="" visibility="public" memberEnd="7c5e2996-0d35-4cbf-9720-ac6afa99b2b9 4c8d544c-ab04-4b0b-9c9c-629356318b23">
+      <ownedEnd xmi:id="4c8d544c-ab04-4b0b-9c9c-629356318b23" name="verifyingCase" visibility="public" type="e7e9b658-76e1-4155-96e8-426f06ad1824" isDerived="true" association="11e641b7-f5c7-4058-9c0d-f8fd8044e7fe">
+        <ownedComment xmi:id="85cf0ad7-3046-4ee0-8321-3199c90b203a" annotatedElement="4c8d544c-ab04-4b0b-9c9c-629356318b23">
+          <body>&lt;p>The VerificationCaseUsages that verify a certain &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e56e2bd2-fa73-4a8c-8597-b84e57512c1d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="be45dddd-eb4e-4163-b91e-4c6ee922b4dd" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c31b5140-fafc-43a3-b2bc-5a566d66a9e9" name="" visibility="public" memberEnd="98c4e874-50a2-4a67-8e4a-4d5683d1aafb b07a5864-c228-43a0-935d-9e5995871137">
+      <ownedEnd xmi:id="b07a5864-c228-43a0-935d-9e5995871137" name="requirementVerification" visibility="public" type="bbe6f298-3ad5-4b8d-86a7-0c500ad29d37" isDerived="true" subsettedProperty="5a616d70-18a6-4a4e-931b-9170604a6f2e" association="c31b5140-fafc-43a3-b2bc-5a566d66a9e9">
+        <ownedComment xmi:id="c4e13e86-de26-4d36-a195-392dee635c22" annotatedElement="b07a5864-c228-43a0-935d-9e5995871137">
+          <body>&lt;p>The RequirementVerificationMembership that has a certain RequirementUsage as its &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="06de2c2d-c3a5-450e-a2de-ae66cc0d4098" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0151f422-bfaa-4c73-99dc-2f344d1a4c02" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="cf3ccab6-9aa3-41cb-b2ed-ee532cffd464" name="" visibility="public" memberEnd="27e17f81-4b9e-4522-9a8b-8062540fb5e9 d9478b2d-e17b-4e01-a19b-4c4796a5242d">
+      <ownedEnd xmi:id="d9478b2d-e17b-4e01-a19b-4c4796a5242d" name="definedVerificationCase" visibility="public" type="e7e9b658-76e1-4155-96e8-426f06ad1824" isDerived="true" subsettedProperty="68ef8977-70e3-45c6-b3d6-88ce8e43d10a" association="cf3ccab6-9aa3-41cb-b2ed-ee532cffd464">
+        <ownedComment xmi:id="872959fa-9b1b-43d2-a498-bafe3dbe7fc0" annotatedElement="d9478b2d-e17b-4e01-a19b-4c4796a5242d">
+          <body>&lt;p>The VerificationUsages that are defined by a certain &lt;code>verificationCaseDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="32fe2985-e8f7-4dfe-9655-419276263318" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a85f322d-50b8-4fd0-90bc-23ab5362ec8b" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e7e9b658-76e1-4155-96e8-426f06ad1824" name="VerificationCaseUsage" visibility="public">
+      <ownedComment xmi:id="f46857ce-fc6c-4470-a793-d78f70c6f9db" annotatedElement="e7e9b658-76e1-4155-96e8-426f06ad1824">
+        <body>&lt;p>A VerificationCaseUsage is a Usage of a VerificationCaseDefinition.&lt;/p>
+
+&lt;p>A VerificationCaseUsage must subset, directly or indirectly, either the base VerificationCaseUsage &lt;code>verificationCases&lt;/code> from the Systems model library, if it is not owned by a VerificationCaseDefinition or VerificationCaseUsage, or the VerificationCaseUsage &lt;code>subVerificationCases&lt;/code> inherited from its owner, otherwise.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="6b21f2c1-e037-4171-9d88-82e9a43081fe" general="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9"/>
+      <ownedAttribute xmi:id="27e17f81-4b9e-4522-9a8b-8062540fb5e9" name="verificationCaseDefinition" visibility="public" type="f7811485-83ca-4a1c-aee2-785cbd6572ea" isDerived="true" subsettedProperty="71c31818-03f0-478b-b70c-b2b99a975562" association="cf3ccab6-9aa3-41cb-b2ed-ee532cffd464">
+        <ownedComment xmi:id="9a796c22-6364-4926-a41e-fd2e3663e4aa" annotatedElement="27e17f81-4b9e-4522-9a8b-8062540fb5e9">
+          <body>&lt;p>The VerificationCase that defines this VerificationCaseUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a4ec8262-9e70-4f1f-8c6a-4f5ba18dac5a" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f6d1103d-3f67-4800-8a11-718756f426cf" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7c5e2996-0d35-4cbf-9720-ac6afa99b2b9" name="verifiedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" association="11e641b7-f5c7-4058-9c0d-f8fd8044e7fe">
+        <ownedComment xmi:id="bab49998-bf46-4d1c-bbff-602352b1b1be" annotatedElement="7c5e2996-0d35-4cbf-9720-ac6afa99b2b9">
+          <body>&lt;p>The RequirementUsages verified by this VerificationCaseUsage, derived as the &lt;code>verifiedRequirements&lt;/code> of all RequirementVerificationMemberships of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e5b07ba6-3548-440d-81f4-187c126cb003" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5da5c58c-269b-4837-b01c-ae5894241217" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1f9ea36b-a13e-4603-886a-22d6e724ef52" name="" visibility="public" memberEnd="d66e399b-91ac-4c34-90fe-5495eefabac9 b15bdf9d-8606-48a7-ac11-c73732554579">
+      <ownedEnd xmi:id="b15bdf9d-8606-48a7-ac11-c73732554579" name="requirementVerificationMembership" visibility="public" type="bbe6f298-3ad5-4b8d-86a7-0c500ad29d37" isDerived="true" subsettedProperty="9fe75d22-5564-40f4-ae65-6e87f3b51e3e" association="1f9ea36b-a13e-4603-886a-22d6e724ef52">
+        <ownedComment xmi:id="9bc05bb2-cd57-4332-9bf8-0b692da41e26" annotatedElement="b15bdf9d-8606-48a7-ac11-c73732554579">
+          <body>&lt;p>The RequirementVerificationMembership that owns a certain RequirementUsage as its &lt;code>ownedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1edb08fb-9965-4b41-b50e-705a649aed60" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f3b88dc0-bb4f-4eea-a979-e93a8e2d2bdd" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="bbe6f298-3ad5-4b8d-86a7-0c500ad29d37" name="RequirementVerificationMembership" visibility="public">
+      <ownedComment xmi:id="29e0ddf7-7d34-4a9c-932d-583fa0a92cae" annotatedElement="bbe6f298-3ad5-4b8d-86a7-0c500ad29d37">
+        <body>&lt;p>A RequirementVerificationMembership is a RequirementConstraintMembership used in the objective of a VerificationCase to identify a Requirement that is verified by the VerificationCase.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="ef7180c1-d9a0-4e46-92a5-bb8c79fc26b7" general="8859d359-18f4-4d1f-a21f-99e07609793e"/>
+      <ownedAttribute xmi:id="d66e399b-91ac-4c34-90fe-5495eefabac9" name="ownedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" aggregation="composite" isDerived="true" redefinedProperty="8d8ad8e5-05f6-4913-94ce-c865031fc5f6" association="1f9ea36b-a13e-4603-886a-22d6e724ef52">
+        <ownedComment xmi:id="7abf2830-99e0-4c50-9600-582e7c07313c" annotatedElement="d66e399b-91ac-4c34-90fe-5495eefabac9">
+          <body>&lt;p>The owned Requirement that acts as the &lt;code>constraint&lt;/code> for this RequirementVerificationMembership. This will either be the &lt;code>verifiedRequirement&lt;/code>, or it will subset the &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c00e7ea8-f935-4ac5-a442-97e3a501592c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b096d98e-18d0-4cd5-8e23-d15cc46703ee" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c9c61647-259a-4f77-acf8-e0e9e0ebab25" name="kind" visibility="public" type="6d72d7bc-e8f0-4f8a-863f-58eec2c12068" redefinedProperty="4103afed-d240-48d3-b873-06eb1fda77d9">
+        <ownedComment xmi:id="094c96fc-dcef-466f-9760-1e6067956953" annotatedElement="c9c61647-259a-4f77-acf8-e0e9e0ebab25">
+          <body>&lt;p>The &lt;code>kind&lt;/code> of a RequirementVerificationMembership must be &lt;code>requirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <defaultValue xmi:type="uml:InstanceValue" xmi:id="affbf2a1-7afb-4243-860e-3e95c14df810" name="" visibility="public" instance="88d51804-a25f-454f-abff-d7cec0f3ae1a"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="98c4e874-50a2-4a67-8e4a-4d5683d1aafb" name="verifiedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" redefinedProperty="97b5bde3-a770-48b5-814d-f6023a915f73" association="c31b5140-fafc-43a3-b2bc-5a566d66a9e9">
+        <ownedComment xmi:id="e24aa330-f453-4798-b239-1024fd74f51b" annotatedElement="98c4e874-50a2-4a67-8e4a-4d5683d1aafb">
+          <body>&lt;p> The RequirementUsage that is identified as being verified. It is the &lt;code>referencedConstraint&lt;/code> of the RequirementVerificationMembership considered as a RequirementConstraintMembership, which must be a RequirementUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2979b370-b3df-4584-823e-fcf3add4f0a6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ab870cb7-7400-4227-8f4b-60302f942460" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e822bc37-08dc-42dc-aded-a0d156e1a6c3" name="" visibility="public" memberEnd="61d18663-1667-476e-adc4-776b9302a88b ff76ba55-9855-48cb-8c09-165fa54e3c10">
+      <ownedEnd xmi:id="ff76ba55-9855-48cb-8c09-165fa54e3c10" name="verifyingCaseDefinition" visibility="public" type="f7811485-83ca-4a1c-aee2-785cbd6572ea" association="e822bc37-08dc-42dc-aded-a0d156e1a6c3">
+        <ownedComment xmi:id="1847790f-1869-4335-8c85-717d08c3b0bc" annotatedElement="ff76ba55-9855-48cb-8c09-165fa54e3c10">
+          <body>&lt;p>The VerificationCaseDefinitions that verify a certain &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="05c0289a-6c69-452b-8d8a-ea7eb4e1ace6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c49068e9-0e41-4aa3-bff8-5020344eb1bd" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="adefe816-3a50-420d-ba86-8dd170c461eb" name="" visibility="public" memberEnd="4edaea8c-a8cd-49fe-a4e8-1bfc0d32ca97 8f893a19-4e19-4a18-a3ef-f09ae9f0f334">
+      <ownedEnd xmi:id="8f893a19-4e19-4a18-a3ef-f09ae9f0f334" name="typingByConjugatedPort" visibility="public" type="a9dc1867-c177-49df-936d-664bef67b699" isDerived="true" subsettedProperty="3fa62c18-c9b0-4087-b8cf-da609129f725" association="adefe816-3a50-420d-ba86-8dd170c461eb">
+        <ownedComment xmi:id="31a016cd-5b52-433b-8a87-9728cce84bd5" annotatedElement="8f893a19-4e19-4a18-a3ef-f09ae9f0f334">
+          <body>&lt;p>The ConjugatedPortTypings whose effective &lt;tt>type&lt;/tt> is given by a certain ConjugatedPortDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="447fce3f-b67e-4d96-8294-3b87fa673705" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0435d1df-b0d0-458d-bc58-fe0bf9e36ec7" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="4cb0317d-1900-48b9-85d3-5c63991b39bf" name="ConjugatedPortDefinition" visibility="public">
+      <ownedComment xmi:id="d1cd1890-1ad2-4f38-84d5-8e98fe878f01" annotatedElement="4cb0317d-1900-48b9-85d3-5c63991b39bf">
+        <body>&lt;p>A ConjugatedPortDefinition is a PortDefinition that is a PortConjugation of its original PortDefinition. That is, a ConjugatedPortDefinition inherits all the &lt;code>features&lt;/code> of the original PortDefinition, but input &lt;code>flows&lt;/code> of the original PortDefinition become outputs on the ConjugatedPortDefinition and output &lt;code>flows&lt;/code> of the original PortDefinition become inputs on the ConjugatedPortDefinition. Every PortDefinition (that is not itself a ConjugatedPortDefinition) has exactly one corresponding ConjugatedPortDefinition, whose effective name is the name of the &lt;code>originalPortDefinition&lt;/code>, with the character &lt;code>~&lt;/code> prepended.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="abd009f0-c31c-4ada-883b-f00b4215ba39" name="conjugatedPortDefinitionOriginalPortDefinition" visibility="public" constrainedElement="4cb0317d-1900-48b9-85d3-5c63991b39bf">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="34431254-f708-4f2b-bd95-047e015966db" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>originalPortDefinition = ownedPortConjugator.originalPortDefinition</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="b770b093-1b60-4be5-8649-8534a90209f9" name="conjugatedPortDefinitionConjugatedPortDefinitionIsEmpty" visibility="public" constrainedElement="4cb0317d-1900-48b9-85d3-5c63991b39bf">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="d95af05d-afbb-473f-bcac-39006a9613a8" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>conjugatedPortDefinition = null</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="f231be15-cd2d-420f-8477-d3f9389dffb5" general="33b8dad8-751d-4025-b226-108cc30128ef"/>
+      <ownedAttribute xmi:id="d17cc865-ac12-4eaa-ba72-f81bb1afb604" name="originalPortDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" isDerived="true" redefinedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="c26fb938-b50c-45fb-a011-b3541b630374">
+        <ownedComment xmi:id="07d2b227-b607-4694-bff8-5488a475fdca" annotatedElement="d17cc865-ac12-4eaa-ba72-f81bb1afb604">
+          <body>&lt;p>The original PortDefinition for this ConjugatedPortDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="790c6a0e-6feb-415b-a0a6-140ee33ff176" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2d844d83-eae0-47f8-a2db-eb8cd2a665f5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1ca95f7f-4990-4388-8404-47ed14e2cb3c" name="ownedPortConjugator" visibility="public" type="23c0ddbc-c60a-484a-9802-a8d33c7b41cb" isDerived="true" redefinedProperty="a41e0e5b-2f38-490c-ba49-036643b528f4" association="e9b21012-ef16-4680-9d45-4c23a000896e">
+        <ownedComment xmi:id="a443d36e-ed35-43f5-842e-ec10bd4f43bf" annotatedElement="1ca95f7f-4990-4388-8404-47ed14e2cb3c">
+          <body>&lt;p>The PortConjugation that is the &lt;code>ownedConjugator&lt;/code> of this ConjugatedPortDefinition, linking it its &lt;code>originalPortDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="291534f4-c145-4125-8982-c5fd78ac0b27" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="beb16e2c-57be-4d84-8334-b72aed2bea76" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="90f8c2bb-3c83-4940-ab04-10294727c4a3" name="effectiveName" visibility="public" bodyCondition="d34d57fb-28d6-460d-a1b4-3f83f6fc9235" redefinedOperation="a047ae2c-0109-4d52-9cef-b13139830170">
+        <ownedComment xmi:id="13c2f6a1-3aa0-4fd3-b409-0af9ac000c40" annotatedElement="90f8c2bb-3c83-4940-ab04-10294727c4a3">
+          <body>&lt;p>If the name of the &lt;code>originalPortDefinition&lt;/code> is non-empty, then return that with the character &lt;code>~&lt;/code> prepended.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="d34d57fb-28d6-460d-a1b4-3f83f6fc9235" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="0945c0d7-da7e-4434-9664-dbabc3179a1f" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let originalName : String = originalPortDefinition.name in
+if originalName.isEmpty() then null
+else '~' + originalName
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="fa716232-98f1-4791-94be-57c3160aea50" name="" visibility="public" direction="return">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ce30fe07-59c6-401d-a9ef-daa9707da879" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c48d4040-5f62-497d-b1f8-df4a949e9c5a" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e9b21012-ef16-4680-9d45-4c23a000896e" name="" visibility="public" memberEnd="9988fa5c-c797-47a8-876e-9bc4a1e61e6f 1ca95f7f-4990-4388-8404-47ed14e2cb3c"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="51b81dab-aa27-42d6-b69d-41282702d8da" name="" visibility="public" memberEnd="7f81e158-10c4-4198-8cfa-546ae4d8387b d8fc5453-dad7-4fe4-934c-8bd5c2574039">
+      <ownedEnd xmi:id="d8fc5453-dad7-4fe4-934c-8bd5c2574039" name="portConjugation" visibility="public" type="23c0ddbc-c60a-484a-9802-a8d33c7b41cb" subsettedProperty="1e635a71-0f38-409d-854d-73411323bde4" association="51b81dab-aa27-42d6-b69d-41282702d8da">
+        <ownedComment xmi:id="cb0b7c8c-6d38-4ca6-be0c-e9e9e3e9a641" annotatedElement="d8fc5453-dad7-4fe4-934c-8bd5c2574039">
+          <body>&lt;p>The PortConjugation that relates a certain PortDefinition to its ConjugatedPortDefinition (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2c7feeba-0d0b-4de4-a70c-a0b3b7c92348" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6e34b2eb-372d-4868-b5bd-fa391937c509" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="23c0ddbc-c60a-484a-9802-a8d33c7b41cb" name="PortConjugation" visibility="public">
+      <ownedComment xmi:id="9354a011-4d56-4ab1-acad-57ea7f23d481" annotatedElement="23c0ddbc-c60a-484a-9802-a8d33c7b41cb">
+        <body>&lt;p>A PortConjugation is a Conjugation Relationship between a PortDefinition and its corresponding ConjugatedPortDefinition. As a result of this Relationship, the ConjugatedPortDefinition inherits all the &lt;code>features&lt;/code> of the original PortDefinition, but input &lt;code>flows&lt;/code> of the original PortDefinition become outputs on the ConjugatedPortDefinition and output &lt;code>flows&lt;/code> of the original PortDefinition become inputs on the ConjugatedPortDefinition.&lt;/code>&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="bdbc9db1-0562-4a00-9074-cb7ca3648094" general="0700b3ef-921a-4677-a325-db5e475a9240"/>
+      <ownedAttribute xmi:id="7f81e158-10c4-4198-8cfa-546ae4d8387b" name="originalPortDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" redefinedProperty="1a94208b-8320-4353-a599-b68806aed393" association="51b81dab-aa27-42d6-b69d-41282702d8da">
+        <ownedComment xmi:id="5e0484f2-e6c0-40d9-90d2-d7b7111a1ef7" annotatedElement="7f81e158-10c4-4198-8cfa-546ae4d8387b">
+          <body>&lt;p>The PortDefinition being conjugated.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9b3f5505-23dc-49af-ac23-afc88a3795f8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c9c6b116-f131-419c-a2fb-f56aa28dc178" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9988fa5c-c797-47a8-876e-9bc4a1e61e6f" name="conjugatedPortDefinition" visibility="public" type="4cb0317d-1900-48b9-85d3-5c63991b39bf" isDerived="true" redefinedProperty="9ff6b50f-f460-482b-87eb-ee1e2b945f99" association="e9b21012-ef16-4680-9d45-4c23a000896e">
+        <ownedComment xmi:id="e95ab63c-a56c-440a-96e3-9e4a79f61ed9" annotatedElement="9988fa5c-c797-47a8-876e-9bc4a1e61e6f">
+          <body>&lt;p>The ConjugatedPortDefinition that is conjugate to the &lt;tt>originalPortDefinition&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5162e771-8761-49d2-ab47-11852d39ed5e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6d0ecbbf-1fc7-4db8-a794-df8e95669760" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c26fb938-b50c-45fb-a011-b3541b630374" name="" visibility="public" memberEnd="492559af-5dd2-48d2-9760-fd21ead5c176 d17cc865-ac12-4eaa-ba72-f81bb1afb604"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="33b8dad8-751d-4025-b226-108cc30128ef" name="PortDefinition" visibility="public">
+      <ownedComment xmi:id="5a2a575f-41ee-4e06-8836-f4a5a547e0b9" annotatedElement="33b8dad8-751d-4025-b226-108cc30128ef">
+        <body>&lt;p>A PortDefinition defines a point at which external entities can connect to and interact with a system or part of a system. Any &lt;code>ownedUsages&lt;/code> of a PortDefinition, other than PortUsages, must not be composite.&lt;/p>
+
+&lt;p>A PortDefinition must subclass, directly or indirectly, the base Class &lt;em>Port&lt;/em> from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="e2afd711-8578-4089-8437-5322146926af" name="portDefinitionConjugatedPortDefinition" visibility="public" constrainedElement="33b8dad8-751d-4025-b226-108cc30128ef">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="73da06f3-ed4f-4684-8727-c87c62a3d321" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>conjugatedPortDefinition = ownedMember->select(oclIsKindOf(ConjugatedPortDefinition))</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="c0ea694d-2ada-4063-bf5e-0a66663798c5" name="portDefinitionOwnedUsagesNotComposite" visibility="public" constrainedElement="33b8dad8-751d-4025-b226-108cc30128ef">
+        <ownedComment xmi:id="dff9795e-5797-40be-b554-b67bf2b8d314" annotatedElement="c0ea694d-2ada-4063-bf5e-0a66663798c5">
+          <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of a PortUsage that are not PortUsages must not be composite.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ef344e0a-5c6a-46f2-8a19-e48aa06dafc3" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedUsage->
+    select(not oclIsKindOf(PortUsage))->
+    forAll(not isComposite)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="ec58ab66-54ff-4e49-ab8c-8295fdbb6a4a" general="01787c81-d827-4988-80ba-3f358b159b5c"/>
+      <generalization xmi:id="6fcd5cf0-9d95-44b7-b40b-726f1b0e5fca" general="eabb05a5-3e97-41e1-9668-d9bf801193a6"/>
+      <ownedAttribute xmi:id="492559af-5dd2-48d2-9760-fd21ead5c176" name="conjugatedPortDefinition" visibility="public" type="4cb0317d-1900-48b9-85d3-5c63991b39bf" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="c26fb938-b50c-45fb-a011-b3541b630374">
+        <ownedComment xmi:id="f71241fa-126e-473f-95e1-4d038a16f00b" annotatedElement="492559af-5dd2-48d2-9760-fd21ead5c176">
+          <body>&lt;p>The ConjugatedPortDefinition that is conjugate to this PortDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b5e84dcf-0766-4eb9-9e57-6ebdde2e8db0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1ff94a46-e12c-43d8-b1c8-04e0b2c5728d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="a9dc1867-c177-49df-936d-664bef67b699" name="ConjugatedPortTyping" visibility="public">
+      <ownedComment xmi:id="b7617f82-684c-48f3-8b7e-abaf71784b74" annotatedElement="a9dc1867-c177-49df-936d-664bef67b699">
+        <body>&lt;p>A ConjugatedPortTyping is a FeatureTyping in which the &lt;code>type&lt;/code> is derived as the &lt;code>conjugatedPortDefinition&lt;/code> of a given PortDefinition. A ConjugatedPortTyping allows a PortUsage to by related directly to a PortDefinition, but to be effectively typed by the conjugation of the referenced PortDefinition.&lt;/p>
+
+&lt;p>Note that ConjugatedPortTyping is a &lt;em>ternary&lt;/em> Relationship, with &lt;code>portDefinition&lt;/code> being a third &lt;code>relatedElement&lt;/code>, in addition to &lt;code>type&lt;/code> and &lt;code>typedFeature&lt;/code> from FeatureTyping.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="b0d2bbd4-6acc-496a-95a4-4abd90594061" name="conjugatedPortTypingConjugatedPortDefinition" visibility="public" constrainedElement="a9dc1867-c177-49df-936d-664bef67b699">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c8e52849-cbee-422d-be85-cda60ec2a572" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>conjugatedPortDefinition = portDefinition.conjugatedPortDefinition</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="38c3785c-550a-4ec8-89b4-a0204da17896" general="38d72c05-06ba-4112-bd58-c4519c98d654"/>
+      <ownedAttribute xmi:id="d2e516cd-abc7-4c2c-af97-0ce19099bbe0" name="portDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" subsettedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="257e131e-f069-44bf-a5a4-a94b34914b11">
+        <ownedComment xmi:id="cc323b5b-2fc2-4fe7-b51e-b3df203d75e4" annotatedElement="d2e516cd-abc7-4c2c-af97-0ce19099bbe0">
+          <body>&lt;p>The PortDefinition whose &lt;tt>conjugatedPortDefinition&lt;/tt> is to be the derived &lt;tt>type&lt;/tt> of this ConjugatedPortTyping.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="328bcbca-b85b-4516-859d-dec37dd2aae8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="46bfb2f1-8e27-468c-8338-7833eb4e04f3" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4edaea8c-a8cd-49fe-a4e8-1bfc0d32ca97" name="conjugatedPortDefinition" visibility="public" type="4cb0317d-1900-48b9-85d3-5c63991b39bf" isDerived="true" redefinedProperty="d536c4ac-f8ed-475e-9750-bc30806712a4" association="adefe816-3a50-420d-ba86-8dd170c461eb">
+        <ownedComment xmi:id="072c877c-37f7-463f-a732-9396442bc3d2" annotatedElement="4edaea8c-a8cd-49fe-a4e8-1bfc0d32ca97">
+          <body>&lt;p>The &lt;tt>conjugatedPortDefinition&lt;/tt> of the &lt;tt>portDefinition&lt;/tt> of this ConjugatedPortTyping, which is the derived &lt;tt>type&lt;/tt> of the ConjugatedPortTyping considered as a FeatureTyping.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="396cdf6d-440d-4ad2-97d7-592bcf911b30" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="97c14358-1a4e-43bf-b6e0-a81bb6d81abb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="257e131e-f069-44bf-a5a4-a94b34914b11" name="" visibility="public" memberEnd="d2e516cd-abc7-4c2c-af97-0ce19099bbe0 1d31af2e-df8f-4fdf-b73d-fac90f92c8e5">
+      <ownedEnd xmi:id="1d31af2e-df8f-4fdf-b73d-fac90f92c8e5" name="conjugatedPortTyping" visibility="public" type="a9dc1867-c177-49df-936d-664bef67b699" isDerived="true" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="257e131e-f069-44bf-a5a4-a94b34914b11">
+        <ownedComment xmi:id="4b9f26f4-e452-4ed1-b017-d81803be62f1" annotatedElement="1d31af2e-df8f-4fdf-b73d-fac90f92c8e5">
+          <body>&lt;p>The ConjugatedPortTypings based on a certain PortDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="52d716e4-1810-411f-bfab-218cc3317079" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="dd3f88ce-12ac-4351-a246-4cd388bd6c35" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="29e9a6bd-3e49-43d3-b43f-395beda16adc" name="PortUsage" visibility="public">
+      <ownedComment xmi:id="b9c42759-1dc8-4f54-868e-c34851de57c1" annotatedElement="29e9a6bd-3e49-43d3-b43f-395beda16adc">
+        <body>&lt;p>A PortUsage is a usage of a PortDefinition. A PortUsage must be owned by a PartDefinition, a PortDefinition, a PartUsage or another PortUsage.  Any &lt;code>nestedUsages&lt;/code> of a PortUsage, other than nested PortUsages, must not be composite.&lt;/p>
+
+&lt;p>A PortUsage must subset, directly or indirectly, the PortUsage &lt;code>ports&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="798ef294-33ba-4059-a24e-15eae16046b7" name="portUsageNestedUsagesNotComposite" visibility="public" constrainedElement="29e9a6bd-3e49-43d3-b43f-395beda16adc">
+        <ownedComment xmi:id="1739bb36-6d38-400e-a47b-9517c7fa40e2" annotatedElement="798ef294-33ba-4059-a24e-15eae16046b7">
+          <body>&lt;p>The &lt;code>nestedUsages&lt;/code> of a PortUsage that are not themselves PortUsages must not be composite.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="71a94e02-b861-4e58-88ad-9ebb4f7ce4e1" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>nestedUsage->
+    select(not oclIsKindOf(PortUsage))->
+    forAll(not isComposite)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="ec4ad4e0-e51b-4489-884d-f81dc9af4856" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
+      <ownedAttribute xmi:id="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e" name="portDefinition" visibility="public" type="33b8dad8-751d-4025-b226-108cc30128ef" isOrdered="true" isDerived="true" redefinedProperty="48d91227-fa8b-4b65-a4f8-d27701f010c0" association="69486941-f79d-4a72-b385-244a7bb06b8d">
+        <ownedComment xmi:id="b102bcc2-b61d-4490-9735-be10e3d280b5" annotatedElement="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e">
+          <body>&lt;p>The &lt;code>types&lt;/code> of this PortUsage, which must all be PortDefinitions.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a8f22f27-0e83-459a-829f-f19e3542ee07" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="689e99f5-9f1a-4a8b-8136-06428a046098" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="69486941-f79d-4a72-b385-244a7bb06b8d" name="" visibility="public" memberEnd="6ffbdc03-bffe-4fe8-841d-7ff7cbc5ed6e 90fbd870-65ef-48ad-accd-14ede51e79df">
+      <ownedEnd xmi:id="90fbd870-65ef-48ad-accd-14ede51e79df" name="definedPort" visibility="public" type="29e9a6bd-3e49-43d3-b43f-395beda16adc" isDerived="true" subsettedProperty="b3f1997a-fa47-4624-b4f8-5163772191d3" association="69486941-f79d-4a72-b385-244a7bb06b8d">
+        <ownedComment xmi:id="4e7708a7-0123-40b8-a2c8-5725e5fb81ef" annotatedElement="90fbd870-65ef-48ad-accd-14ede51e79df">
+          <body>&lt;p>The PortUsages that are typed by a certain PortDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="95e96241-0573-4449-a90e-0057a812dd96" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1b6e6ab0-d82d-486e-815a-a5919a89bd82" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="20e23891-303c-400f-909a-032f49ef946d" name="CaseDefinition" visibility="public">
+      <ownedComment xmi:id="52f21e0e-6594-4ecc-9fa4-3a6213833528" annotatedElement="20e23891-303c-400f-909a-032f49ef946d">
+        <body>&lt;p>A CaseDefinition is a CalculationDefinition for a process, often involving collecting evidence or data, relative to a subject, possibly involving the collaboration of one or more other actors, producing a result that meets an objective.&lt;/p>
+
+&lt;p>A CaseDefinition must subclass, directly or indirectly, the base CaseDefinition &lt;em>Case&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="4fa29c50-5d0e-4492-98cb-914b7eca1f16" general="1b48a93b-7518-41c0-89cc-27a5b62dd441"/>
+      <ownedAttribute xmi:id="d302abff-06e1-4c25-a819-e69213d975fd" name="objectiveRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" subsettedProperty="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8" association="c22d48cd-d31e-41b6-89ae-49d140eb9f93">
+        <ownedComment xmi:id="37432e0a-7c56-4d1c-bbc6-cdc17db90f0c" annotatedElement="d302abff-06e1-4c25-a819-e69213d975fd">
+          <body>&lt;p>The &lt;code>ownedFeature&lt;/code> of this CaseDefinition that is owned via an ObjectiveMembership, and that must redefine, directly or indirectly, the &lt;code>objective&lt;/code> RequirementUsage of the base CaseDefinition Case from the Systems model library.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e02549e-1301-4349-bcd7-2c0b88ac36ff" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="721e577c-9d37-4ad1-baa1-cb27471fd620" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="220aa10a-54f5-41d3-8b5b-b8ec49668261" name="subjectParameter" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 ab0dbb87-5e95-4819-9217-2128904f4064" association="27da402d-ddc9-470f-a6cf-864bdd7540e6">
+        <ownedComment xmi:id="25c5e3d0-06e0-42ff-8cad-fc2924dbbd8f" annotatedElement="220aa10a-54f5-41d3-8b5b-b8ec49668261">
+          <body>&lt;p>The &lt;code>parameter&lt;/code> of this CaseDefinition that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base CaseDefinition Case from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bcd67b87-7f46-44f9-8a59-4e60881f26aa" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ef39ecec-8497-4214-a061-ccc3c8d6087a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="79019838-97b9-4d31-8e54-fd8ad4db6dd1" name="actorParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 8e3f1de2-c767-4cdd-af33-aacf5abe7d73" association="d4e058f8-6405-47b1-8715-cd0ea2ff5e8f">
+        <ownedComment xmi:id="306b4d5e-37d1-4ff0-92ee-93342927f4dc" annotatedElement="79019838-97b9-4d31-8e54-fd8ad4db6dd1">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this CaseDefinition that are owned via ActorMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base CaseDefinition &lt;em>Case&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c716ee14-6e90-49e2-95e1-e772ecfd794d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bcdb9652-d179-44df-89a9-d907d16b0355" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="997c7363-92e6-4eca-b1ee-633babfc076f" name="" visibility="public" memberEnd="ad0ec492-b924-4601-9167-1c2b93596ef8 79d197dc-5e54-4a94-85f8-b0a74e342228">
+      <ownedEnd xmi:id="79d197dc-5e54-4a94-85f8-b0a74e342228" name="owningObjectiveMembership" visibility="public" type="7d019768-1210-4d07-87ad-8b33e9a139a2" isDerived="true" subsettedProperty="e7238cc7-e86f-4d19-a3e2-c52b238d9fb0" association="997c7363-92e6-4eca-b1ee-633babfc076f">
+        <ownedComment xmi:id="ef8c0b50-152f-4855-8d19-ec805d727768" annotatedElement="79d197dc-5e54-4a94-85f8-b0a74e342228">
+          <body>&lt;p>The ObjectMembership that owns a particular RequirementUsage as its &lt;code>ownedObjectiveRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="531b597d-ef31-4d3e-8397-b8ff928247c4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3caa0c1f-ce4d-4e2b-a319-dc7d8730f03e" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="afd97c4d-bb88-476d-9333-425c74f49e19" name="" visibility="public" memberEnd="9bc76574-5dd5-415b-b578-4f8b34ca7e48 af8526f8-1df3-474f-a9ea-e3d869a61b8d">
+      <ownedEnd xmi:id="9bc76574-5dd5-415b-b578-4f8b34ca7e48" name="caseOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="72d981f9-d23c-4ef7-a2a8-636c221553aa" association="afd97c4d-bb88-476d-9333-425c74f49e19">
+        <ownedComment xmi:id="e9634de1-9fa7-43b3-897e-9a3a24520761" annotatedElement="9bc76574-5dd5-415b-b578-4f8b34ca7e48">
+          <body>&lt;p>The Usage in which the &lt;code>nestedCase&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="58b6ca9c-5168-44ab-b923-4e7695afccc5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="877343fa-6178-40cf-b719-8d4155b21c58" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d4e058f8-6405-47b1-8715-cd0ea2ff5e8f" name="" visibility="public" memberEnd="79019838-97b9-4d31-8e54-fd8ad4db6dd1 06204383-585f-41d6-b9d5-d70e622ab7ba">
+      <ownedEnd xmi:id="06204383-585f-41d6-b9d5-d70e622ab7ba" name="actorOwningCaseDefinition" visibility="public" type="20e23891-303c-400f-909a-032f49ef946d" subsettedProperty="ac78893b-0ca0-443c-9f14-131910814067 9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a" association="d4e058f8-6405-47b1-8715-cd0ea2ff5e8f">
+        <ownedComment xmi:id="7da0ecbe-7fda-49b1-b2b6-5b080b548e55" annotatedElement="06204383-585f-41d6-b9d5-d70e622ab7ba">
+          <body>&lt;p>The CaseDefinitions that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="19b264d4-3164-42e7-9770-8507936608b1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="60cb9a04-35ef-41df-8092-15d398baad3a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" name="CaseUsage" visibility="public">
+      <ownedComment xmi:id="f07b877b-ffb6-41d0-9fba-887cd56293ba" annotatedElement="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9">
+        <body>&lt;p>A CaseUsage is a Usage of a CaseDefinition.&lt;/p>
+
+&lt;p>A CaseUsage must subset, directly or indirectly, either the base CaseUsage &lt;em>&lt;code>cases&lt;/code>&lt;/em> from the Systems model library. If it is owned by a CaseDefinition or CaseUsage, it must subset the CaseUsage &lt;em>&lt;code>Cases::subcases&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="0453500c-0e56-42d4-9a5c-05036df7a225" general="92887cda-1376-415e-86ad-315e1dcd7de8"/>
+      <ownedAttribute xmi:id="91c4ae9b-cc0d-432b-8d66-341cf5dc10a3" name="objectiveRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" subsettedProperty="5d453801-4f2d-4df0-bc76-a99e5ce278a6" association="05a9bd79-91d4-4915-9aad-cf67bd8a4136">
+        <ownedComment xmi:id="6aba78f4-0358-4e8c-8886-29062ea472f3" annotatedElement="91c4ae9b-cc0d-432b-8d66-341cf5dc10a3">
+          <body>&lt;p>The &lt;code>ownedFeature&lt;/code> of this CaseUsage that is owned via an ObjectiveMembership, and that must redefine, directly or indirectly, the &lt;code>objective&lt;/code> RequirementUsage of the base CaseDefinition Case from the Systems model library.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="95fc5c4f-fb74-44a3-b8aa-b3fe68d4e816" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="aec3d5a6-ef90-4397-83c9-28c4dad922eb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="71c31818-03f0-478b-b70c-b2b99a975562" name="caseDefinition" visibility="public" type="20e23891-303c-400f-909a-032f49ef946d" isDerived="true" redefinedProperty="adbfc462-f15f-455b-8702-bf3de4f6f466" association="d21384b8-ca58-4e2d-81c1-260b883d39d0">
+        <ownedComment xmi:id="ab48b89e-1e71-496b-a327-343cb055f0dc" annotatedElement="71c31818-03f0-478b-b70c-b2b99a975562">
+          <body>&lt;p>The CaseDefinition that is the type of this CaseUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="27f31044-9edf-4de0-a3fe-4c0389cbd49e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="62310248-9e62-48a3-a05f-e40a650d6366" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="25396519-db44-4a2d-8cb4-78c34227c0b3" name="subjectParameter" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 3aeed792-7c5b-4145-ad3c-981f4de83751" association="0bf990e6-3d5a-4125-9a66-6e94a169d60d">
+        <ownedComment xmi:id="ed9f8667-b81f-4b7e-8a28-fb20745ab2af" annotatedElement="25396519-db44-4a2d-8cb4-78c34227c0b3">
+          <body>&lt;p>The &lt;code>parameter&lt;/code> of this CaseUsage that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base CaseDefinition Case from the Systems model library.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6a4be8f6-80be-4694-a7ad-52618eba4734" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d75f3dd8-127c-4b75-886e-e97f1eb92c1a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d462c343-5ea7-4fa3-afe5-09d368edf369" name="actorParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857 ba7a9394-5d4f-4a40-be17-a628644b092e" association="56ec35c9-0990-4d48-a83f-67922d677510">
+        <ownedComment xmi:id="cd210371-a22e-437d-a66d-731dfe989347" annotatedElement="d462c343-5ea7-4fa3-afe5-09d368edf369">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this CaseUsage that are owned via ActorMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base CaseDefinition &lt;em>Case&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="06133ac8-7c3d-4177-b501-f0f7ede34183" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fe6b562d-ef2c-494c-9e60-a608d9eab299" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="27da402d-ddc9-470f-a6cf-864bdd7540e6" name="" visibility="public" memberEnd="220aa10a-54f5-41d3-8b5b-b8ec49668261 aba4ea2a-3d3b-4e28-a3f4-3d86057b53fa">
+      <ownedEnd xmi:id="aba4ea2a-3d3b-4e28-a3f4-3d86057b53fa" name="subjectOwningCaseDefinition" visibility="public" type="20e23891-303c-400f-909a-032f49ef946d" isDerived="true" subsettedProperty="9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a 750ac38e-ae6c-4718-856d-a704775bdd8b" association="27da402d-ddc9-470f-a6cf-864bdd7540e6">
+        <ownedComment xmi:id="ce370c0a-c6ff-4610-a44c-4b26eef2da3c" annotatedElement="aba4ea2a-3d3b-4e28-a3f4-3d86057b53fa">
+          <body>&lt;p>The CaseDefinitions that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3fc660ce-b1b4-479d-bd1f-1467e1ded889" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3aa58bbb-a097-4fc4-987e-744668709227" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d21384b8-ca58-4e2d-81c1-260b883d39d0" name="" visibility="public" memberEnd="68ef8977-70e3-45c6-b3d6-88ce8e43d10a 71c31818-03f0-478b-b70c-b2b99a975562">
+      <ownedEnd xmi:id="68ef8977-70e3-45c6-b3d6-88ce8e43d10a" name="definedCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" isDerived="true" subsettedProperty="f4108bb5-9250-480a-8c21-4f85269bc6b1" association="d21384b8-ca58-4e2d-81c1-260b883d39d0">
+        <ownedComment xmi:id="9b6c176d-66bf-41b6-93fb-972810c884ca" annotatedElement="68ef8977-70e3-45c6-b3d6-88ce8e43d10a">
+          <body>&lt;p>The CaseUsages being typed by a certain CaseDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="329833fb-fb19-42bc-a00e-8b51ca63dc81" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="31284246-990d-4d99-a638-3a69696f8dfd" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="56ec35c9-0990-4d48-a83f-67922d677510" name="" visibility="public" memberEnd="d462c343-5ea7-4fa3-afe5-09d368edf369 c1cdd110-2845-4181-bc55-77e09c1d7c4a">
+      <ownedEnd xmi:id="c1cdd110-2845-4181-bc55-77e09c1d7c4a" name="actorOwningCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" isDerived="true" subsettedProperty="58f50343-0f2e-4d6c-891c-20350eaf6937 e02ee31c-b895-45b1-a5bb-a0a465f786e0" association="56ec35c9-0990-4d48-a83f-67922d677510">
+        <ownedComment xmi:id="eddda97b-4784-49e5-8e8a-4d2b6cc24c1a" annotatedElement="c1cdd110-2845-4181-bc55-77e09c1d7c4a">
+          <body>&lt;p>The CaseUsages that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fde2d511-b770-42b6-8d50-9f5798fcdbbb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cbae9cdd-61f8-4cba-92b0-c64074ffa9bb" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c22d48cd-d31e-41b6-89ae-49d140eb9f93" name="" visibility="public" memberEnd="d302abff-06e1-4c25-a819-e69213d975fd 255986da-d167-4b7c-8307-df44d31986eb">
+      <ownedEnd xmi:id="255986da-d167-4b7c-8307-df44d31986eb" name="objectiveOwningCaseDefinition" visibility="public" type="20e23891-303c-400f-909a-032f49ef946d" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="c22d48cd-d31e-41b6-89ae-49d140eb9f93">
+        <ownedComment xmi:id="473cf937-897b-481d-af22-b7956be4d5c1" annotatedElement="255986da-d167-4b7c-8307-df44d31986eb">
+          <body>&lt;p>The CaseDefinitions that have a certain RequirementUsage as their &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7722bbbd-7a69-46a8-805f-902dfb082d03" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fc263801-fc17-47bd-a8a6-91af8c6d2561" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0bf990e6-3d5a-4125-9a66-6e94a169d60d" name="" visibility="public" memberEnd="25396519-db44-4a2d-8cb4-78c34227c0b3 66013676-95f7-4264-8979-095f3d2e9a1e">
+      <ownedEnd xmi:id="66013676-95f7-4264-8979-095f3d2e9a1e" name="subjectOwningCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" subsettedProperty="58f50343-0f2e-4d6c-891c-20350eaf6937 e3db423d-543e-47fa-864c-573abd896990" association="0bf990e6-3d5a-4125-9a66-6e94a169d60d">
+        <ownedComment xmi:id="f3401474-f8b6-4ec5-b253-69106a2c2de6" annotatedElement="66013676-95f7-4264-8979-095f3d2e9a1e">
+          <body>&lt;p>The CaseUsages that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6e3bd951-b994-4dff-99c1-c134e7962037" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="789e9c34-005d-48f0-903d-e2178c89539a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="05a9bd79-91d4-4915-9aad-cf67bd8a4136" name="" visibility="public" memberEnd="91c4ae9b-cc0d-432b-8d66-341cf5dc10a3 39faf145-2721-409f-9d75-992bd1501ef8">
+      <ownedEnd xmi:id="39faf145-2721-409f-9d75-992bd1501ef8" name="objectiveOwningCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" isDerived="true" subsettedProperty="3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a" association="05a9bd79-91d4-4915-9aad-cf67bd8a4136">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="01649d9c-cafa-45a7-96bf-2908ff9deaa2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="658f526d-3b00-429f-b12a-c775d4706a81" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7d019768-1210-4d07-87ad-8b33e9a139a2" name="ObjectiveMembership" visibility="public">
+      <ownedComment xmi:id="fe63e594-2702-4e6b-af0a-33d4d158e102" annotatedElement="7d019768-1210-4d07-87ad-8b33e9a139a2">
+        <body>&lt;p>An ObjectiveMembership is a FeatureMembership that indicates that its &lt;code>ownedObjectiveRequirement&lt;/code> is the objective RequirementUsage for its &lt;code>owningType&lt;/code>. The &lt;code>owningType&lt;/code> of an ObjectiveMembership must be a CaseDefinition or CaseUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="21ca038b-1023-4660-bf2c-9ca02c6f613b" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="ad0ec492-b924-4601-9167-1c2b93596ef8" name="ownedObjectiveRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="997c7363-92e6-4eca-b1ee-633babfc076f">
+        <ownedComment xmi:id="c5b62098-247f-4ea8-bd73-8105b3bc544f" annotatedElement="ad0ec492-b924-4601-9167-1c2b93596ef8">
+          <body>&lt;p>The RequirementUsage that is the &lt;code>ownedMemberFeature&lt;/code> of this RequirementUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8e184090-f016-459f-b184-da9a671469d8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4f1db2a3-ed1a-4f6d-adcc-78dd51483345" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="12567f90-5e15-4581-8048-1aeccf197848" name="" visibility="public" memberEnd="24570db9-c8a5-4b6c-ad4b-e2992bf0b976 e4c45446-bda9-4831-a917-7ef839b4ff80">
+      <ownedEnd xmi:id="e4c45446-bda9-4831-a917-7ef839b4ff80" name="stakholderOwningRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="e02ee31c-b895-45b1-a5bb-a0a465f786e0 58f50343-0f2e-4d6c-891c-20350eaf6937" association="12567f90-5e15-4581-8048-1aeccf197848">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="59f4a499-c1e3-4933-885a-7f49ecc7cb6c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9e711f9e-f211-4683-b096-7603e0ec4055" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="239221a4-785b-4526-b45d-0a747816cd1b" name="ConcernUsage" visibility="public">
+      <ownedComment xmi:id="0803999e-d110-4aa3-87c4-13716f70a615" annotatedElement="239221a4-785b-4526-b45d-0a747816cd1b">
+        <body>&lt;p>A ConcernUsage is a Usage of a ConcernDefinition.&lt;/p>
+
+&lt;p>A ConcernUsage must subset, directly or indirectly, the base ConcernUsage &lt;em>&lt;code>concernChecks&lt;/code>&lt;/em> from the Systems model library. The &lt;code>ownedStakeholder&lt;/code> features of the ConcernUsage shall all subset the &lt;em>&lt;code>ConcernCheck::concernedStakeholders&lt;/code> &lt;/em>feature. If the ConcernUsage is an &lt;code>ownedFeature&lt;/code> of a StakeholderDefinition or StakeholderUsage, then the ConcernUsage shall have an &lt;code>ownedStakeholder&lt;/code> feature that is bound to the &lt;em>&lt;code>self&lt;/code>&lt;/em> feature of its owner.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="2c8d3433-c06f-4bac-887b-1da31fecbc15" general="7248aae3-2934-47cd-bf16-f9aca7f25ad7"/>
+      <ownedAttribute xmi:id="9df9c9cb-3b04-47d9-b3a2-4ec90ca54893" name="concernDefinition" visibility="public" type="8942fcc8-9f59-4781-a650-51d50b4b9589" isDerived="true" redefinedProperty="ee688400-5d8a-4c4d-9fa5-a21e6047ebf2" association="50919f0a-4162-49c7-89c0-f6206b56bd35">
+        <ownedComment xmi:id="94421156-c463-4e6d-a74d-c6ad3e9d453d" annotatedElement="9df9c9cb-3b04-47d9-b3a2-4ec90ca54893">
+          <body>&lt;p>The ConcernDefinition that is the single type of this ConcernUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="84c1e6d7-e47d-4fa5-b3be-cfc89ac78707" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7147c1b1-a342-4172-963b-400124cff5d9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="27cb391b-653c-40e3-8ef1-454e095836b7" name="" visibility="public" memberEnd="ee688400-5d8a-4c4d-9fa5-a21e6047ebf2 af52c6b6-b2e3-49ec-9e90-ef120c251f2b">
+      <ownedEnd xmi:id="af52c6b6-b2e3-49ec-9e90-ef120c251f2b" name="definedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="160253ec-6160-4a89-bea8-927d47d13bd3" association="27cb391b-653c-40e3-8ef1-454e095836b7">
+        <ownedComment xmi:id="0efff3a7-0ca7-44ee-b8fa-8b131f89512e" annotatedElement="af52c6b6-b2e3-49ec-9e90-ef120c251f2b">
+          <body>&lt;p>The RequirementUsages typed by a certain RequirementDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e96910d4-f743-4081-8362-7dc098d0f6e3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3895c9e4-a5a9-42ec-b769-12816b71e90a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f69bfec2-1553-42db-9c1a-edc051087e18" name="" visibility="public" memberEnd="1cfd3353-ec12-48ee-a8e6-e4db271172d0 a75f920a-d38e-4c86-9dd3-b68f6f21aa66">
+      <ownedEnd xmi:id="a75f920a-d38e-4c86-9dd3-b68f6f21aa66" name="owningStakeholderMembership" visibility="public" type="84e89d15-607d-415a-bb54-78f4e4e064cd" isDerived="true" subsettedProperty="e7238cc7-e86f-4d19-a3e2-c52b238d9fb0" association="f69bfec2-1553-42db-9c1a-edc051087e18">
+        <ownedComment xmi:id="9b53d046-90a0-40eb-861e-8fbba89c4c37" annotatedElement="a75f920a-d38e-4c86-9dd3-b68f6f21aa66">
+          <body>&lt;p>TheStakehplderMembership that has a certain PartUsage as its &lt;code>ownedStakeholderParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="84d7c685-631d-481b-bd3f-f7cc2bd49098" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c7ddd648-7466-4a18-880c-ef2d3cbd9068" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="cb4ea770-7f7f-44d4-ab99-bf6c66a16b24" name="" visibility="public" memberEnd="054b56fc-b021-4a87-a055-b1858e22e237 aca5d6a8-2637-492a-a193-2638138cac84">
+      <ownedEnd xmi:id="aca5d6a8-2637-492a-a193-2638138cac84" name="requiringRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="cb4ea770-7f7f-44d4-ab99-bf6c66a16b24">
+        <ownedComment xmi:id="08ac2306-0987-4319-9148-15c313e7023b" annotatedElement="aca5d6a8-2637-492a-a193-2638138cac84">
+          <body>&lt;p>The RequirementDefinition that has a certain ConstraintUsage as a &lt;code>requiredConstraint&lt;/code> (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f94bbb9e-432f-4bb4-aa3d-5385c1a675dc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f7670fda-c9a2-4be2-9b62-cd1eba289f84" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="86d0dc31-9098-4568-b211-a2bc55d82614" name="" visibility="public" memberEnd="e1c33cda-a7c3-41b7-a2d1-342a58e9eed7 607be847-ad97-4bc4-b7a2-7987091899ef">
+      <ownedEnd xmi:id="607be847-ad97-4bc4-b7a2-7987091899ef" name="framingRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="1697da46-03b0-45de-90db-3f1dd60634c1" association="86d0dc31-9098-4568-b211-a2bc55d82614">
+        <ownedComment xmi:id="d78a69a5-b21d-4c29-8b68-8617ade9ff82" annotatedElement="607be847-ad97-4bc4-b7a2-7987091899ef">
+          <body>&lt;p>The RequirementDefinition that addresses a certain &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6deb3dc6-e32a-492a-86d1-6cbc13a89cb3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d583136e-fb58-4f41-b2c9-9671c42f97d0" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="0166e229-2eaf-4190-a88e-5cf9393b79ec" name="SatisfyRequirementUsage" visibility="public">
+      <ownedComment xmi:id="04fd28b7-0a38-40b4-868f-c98693dec406" annotatedElement="0166e229-2eaf-4190-a88e-5cf9393b79ec">
+        <body>&lt;p>A SatisfyRequirementUsage is an AssertConstraintUsage that asserts, by default, that a satisfied RequirementUsage is true for a specific &lt;code>satisfyingSubject&lt;/code>, or, if &lt;code>isNegated = true&lt;/code>, that the RequirementUsage is false. The satisfied RequirementUsage is related to the SatisfyRequirementUsage by a Subsetting relationship.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="ea5b8a11-f658-4d5b-a8fa-e44e655bf497" general="7248aae3-2934-47cd-bf16-f9aca7f25ad7"/>
+      <generalization xmi:id="247b03fc-570c-4dd5-b661-004532daa6a7" general="d044b5f7-f450-41c8-9ed0-7935ba775263"/>
+      <ownedAttribute xmi:id="32b9d807-bbe1-4e96-96e1-3cc93af08531" name="satisfiedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" redefinedProperty="f5f2add9-297d-4679-98cf-c380ac18fd59" association="abd9798f-2785-41f5-8591-fbec0b727021">
+        <ownedComment xmi:id="b606a013-c237-42f2-a6d7-c04fa3c2c719" annotatedElement="32b9d807-bbe1-4e96-96e1-3cc93af08531">
+          <body>&lt;p>The RequirementUsage that is satisfied by the &lt;code>satisfyingSubject&lt;/code> of this SatisfyRequirementUsage. It is the &lt;code>assertedConstraint&lt;/code> of the SatisfyRequirementUsage considered as an AssertConstraintUsage, which must be a RequirementUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="55969888-acbe-46ba-88dc-b41d0b18138f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d9b35dfc-ef22-4bfc-8242-8874d7aa7b0b" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1291278e-da63-45e7-a37e-0ecb876ab538" name="satisfyingFeature" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" association="3a8ae61d-bc9d-42c8-b73f-4e26989467b9">
+        <ownedComment xmi:id="c6f56503-7e83-48a7-bdbe-4bbfae60b7be" annotatedElement="1291278e-da63-45e7-a37e-0ecb876ab538">
+          <body>&lt;p>The Feature that represents the actual subject that is asserted to satisfy the &lt;tt>satisfiedRequirement&lt;/tt>. The &lt;tt>satisfyingFeature&lt;/tt> must be the target of a BindingConnector from the &lt;tt>subjectParameter&lt;/tt> of the &lt;tt>satisfiedRequirement&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0ebb975d-60a6-4bc2-908c-359b329cb662" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="859a08ef-b379-4a35-92b5-cc9651fd3798" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b3672bb4-9088-46e0-8c3f-311574544564" name="" visibility="public" memberEnd="acf36ad0-69c3-41a4-b4aa-6f1f175d3fde debabb10-265e-4090-8316-2de16d5f94ad">
+      <ownedEnd xmi:id="debabb10-265e-4090-8316-2de16d5f94ad" name="actorOwningRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="ac78893b-0ca0-443c-9f14-131910814067 9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a" association="b3672bb4-9088-46e0-8c3f-311574544564">
+        <ownedComment xmi:id="7b42846d-6b71-435b-93b2-eb153abd4b01" annotatedElement="debabb10-265e-4090-8316-2de16d5f94ad">
+          <body>&lt;p>The RequirementDefinitions that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="75ae614e-1350-46cc-94ec-3d0638245e45" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="150ab690-4170-410c-8058-d3c09aa2c1ab" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="8942fcc8-9f59-4781-a650-51d50b4b9589" name="ConcernDefinition" visibility="public">
+      <ownedComment xmi:id="ef4552cf-315b-40cd-aee1-d40e2a873293" annotatedElement="8942fcc8-9f59-4781-a650-51d50b4b9589">
+        <body>&lt;p>A ConcernDefinition is a RequirementDefinition that one or more stakeholders may be interested in having addressed. These stakeholders are identified by the &lt;code>ownedStakeholders&lt;/code>of the ConcernDefinition.&lt;/p>
+
+&lt;p>A ConcernDefinition must subclass, directly or indirectly, the base ConcernDefinition &lt;em>ConcernCheck&lt;/em> from the Systems model library. The &lt;code>ownedStakeholder&lt;/code> features of a ConcernDefinition shall all subset the &lt;em>&lt;code>ConcernCheck::concernedStakeholders&lt;/code>&lt;/em> feature.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="63ae3146-553b-4e5e-be48-64b8ce3eaeac" general="3f439339-e30b-454e-9a33-9a90c3c37bc9"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4d14f93a-1f2f-4c1e-a1c2-b47529e1534f" name="" visibility="public" memberEnd="94d209a9-5c5f-4117-9165-727aa5a35240 8b942f9b-fdac-48e6-855c-0d776320efd3">
+      <ownedEnd xmi:id="8b942f9b-fdac-48e6-855c-0d776320efd3" name="owningSubjectMembership" visibility="public" type="9957b1cd-e700-4654-88c8-5205b48393dc" isDerived="true" subsettedProperty="e7238cc7-e86f-4d19-a3e2-c52b238d9fb0" association="4d14f93a-1f2f-4c1e-a1c2-b47529e1534f">
+        <ownedComment xmi:id="03bf67ac-cde4-4461-8dd9-9e1b91afb0b4" annotatedElement="8b942f9b-fdac-48e6-855c-0d776320efd3">
+          <body>&lt;p>The SubjectMembership that owns a particular Parameter as its &lt;code>ownedSubjectParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8dd75faa-80ec-4192-bd8f-6965a5956535" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="db9f9690-5585-4bc0-993f-0ef434a1b2c3" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0b00f5d5-15c2-4efa-a42e-f6bc50bb4b0f" name="" visibility="public" memberEnd="a5b20671-3b1d-4fd0-9447-ed52627e53a5 ddd47c7b-fc05-4e33-8f1c-689c51fe8554">
+      <ownedEnd xmi:id="ddd47c7b-fc05-4e33-8f1c-689c51fe8554" name="framingRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="0e72d6af-0830-4859-9181-ea55a5c07e9e" association="0b00f5d5-15c2-4efa-a42e-f6bc50bb4b0f">
+        <ownedComment xmi:id="830c21b0-ced2-43de-a27f-77c37470d161" annotatedElement="ddd47c7b-fc05-4e33-8f1c-689c51fe8554">
+          <body>&lt;p>The RequirementUsage that addresses a certain &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8d380c5d-e3a1-4a09-9580-772bea9b8af5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="166c5968-add8-4004-803e-c91e1d2f5c6a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="5432b3d2-9c70-46c0-8b58-717dce024f89" name="FramedConcernMembership" visibility="public">
+      <ownedComment xmi:id="7bb3de84-07a6-414d-8349-2d832c90735a" annotatedElement="5432b3d2-9c70-46c0-8b58-717dce024f89">
+        <body>&lt;p>A FramedConcernMembership is a RequirementConstraintMembership for a framed ConcernUsage of a RequirementDefinition or RequirementUsage. The &lt;code>ownedConstraint&lt;/code> of a FramedConcernMembership must be a ConcernUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="0bc7e0b8-8da0-4289-9705-b01d5ccbd392" general="8859d359-18f4-4d1f-a21f-99e07609793e"/>
+      <ownedAttribute xmi:id="de6687e9-efe9-4fb7-88cc-56c4d760442f" name="kind" visibility="public" type="6d72d7bc-e8f0-4f8a-863f-58eec2c12068" redefinedProperty="4103afed-d240-48d3-b873-06eb1fda77d9">
+        <ownedComment xmi:id="c29d3a6b-0704-4615-9d69-ae4d9bb8ec9a" annotatedElement="de6687e9-efe9-4fb7-88cc-56c4d760442f">
+          <body>&lt;p>The &lt;code>kind&lt;/code> of an AddressedConcernMembership must be &lt;code>requirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <defaultValue xmi:type="uml:InstanceValue" xmi:id="13299538-2b57-4aed-8519-d9af9ed10158" name="" visibility="public" instance="88d51804-a25f-454f-abff-d7cec0f3ae1a"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ea1ba2f4-1ee5-4cf1-9ff8-2966213d116f" name="ownedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" aggregation="composite" isDerived="true" redefinedProperty="8d8ad8e5-05f6-4913-94ce-c865031fc5f6" association="d717b823-6820-4d94-ad3b-6b0ec3d9b378">
+        <ownedComment xmi:id="d38cb3c7-ef4a-446a-807f-0add602f979d" annotatedElement="ea1ba2f4-1ee5-4cf1-9ff8-2966213d116f">
+          <body>&lt;p>The ConcernUsage that is the &lt;code>ownedConstraint&lt;/code> of this AddressedConcernMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6e2c3a90-648b-4191-ba0b-2b3a76b465d3" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d75074a6-efdc-4b10-a95b-9e9065b3273a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="14774214-8b77-47af-8fed-1ebf4e7e2f0c" name="referencedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isDerived="true" redefinedProperty="97b5bde3-a770-48b5-814d-f6023a915f73" association="ce53703c-704a-4db6-8440-97c7e3620e33">
+        <ownedComment xmi:id="312525a4-bb5f-4def-a5b0-5567e49f1aaa" annotatedElement="14774214-8b77-47af-8fed-1ebf4e7e2f0c">
+          <body>&lt;p> The ConcernUsage that is referenced through this AddressedConcernMembership. It is the &lt;code>referencedConstraint&lt;/code> of the FramedConcernMembership considered as a RequirementConstraintMembership, which must be a ConcernUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a99534ea-d882-44d3-a6d8-0c497d08eaf9" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ba8db576-0f00-4fc0-81d3-043be4d04b9f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3f439339-e30b-454e-9a33-9a90c3c37bc9" name="RequirementDefinition" visibility="public">
+      <ownedComment xmi:id="4ed44a2c-1311-4171-8cee-2c9f332e9953" annotatedElement="3f439339-e30b-454e-9a33-9a90c3c37bc9">
+        <body>&lt;p>A RequirementDefinition is a ConstraintDefinition that defines a requirement as a constraint that is used in the context of a specification of a that a valid solution must satisfy. The specification is relative to a specified subject, possibly in collaboration with one or more external actors.&lt;/p>
+
+&lt;p>A RequirementDefinition must subclass, directly or indirectly, the base RequirementDefinition &lt;em>&lt;code>RequirementCheck&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="4c0bd113-75b9-40fb-9417-6349c4531c5a" general="ace0f696-55e9-4501-b2f7-8ce04daf34bd"/>
+      <ownedAttribute xmi:id="36ca9283-380a-4978-9f20-81f15830cb8a" name="reqId" visibility="public" redefinedProperty="a3a60717-82ce-452b-ba0e-bade66ef3b72">
+        <ownedComment xmi:id="0fa9a5a1-c2aa-471b-9140-45f818593b82" annotatedElement="36ca9283-380a-4978-9f20-81f15830cb8a">
+          <body>&lt;p>An optional modeler-specified identifier for this RequirementDefinition (used, e.g., to link it to an original requirement text in some source document), derived as the &lt;code>modeledId&lt;/code> for the RequirementDefinition.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0cd325a2-a0c5-45b0-ac0a-21d2e8256b80" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="90efcd4b-c0e9-4d2e-b399-727d98f0543d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4186afa5-f997-4ca0-a6c1-531d9b3b3fcf" name="text" visibility="public" isDerived="true">
+        <ownedComment xmi:id="d2850e6b-74a8-4c49-b90e-108113dbd1f0" annotatedElement="4186afa5-f997-4ca0-a6c1-531d9b3b3fcf">
+          <body>&lt;p>An optional textual statement of the requirement represented by this RequirementDefinition, derived as the &lt;code>bodies&lt;/code> of the &lt;code>documentaryComments&lt;/code> of the RequirementDefinition.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1d91d848-3f84-4186-abad-4378ae2ef975" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="15db878a-33ee-47af-9d5d-90b88556d87b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="25506cfc-64aa-4c62-8a3f-14b4ec3820be" name="assumedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="df528bd3-41d1-47cf-9fbe-cfc120babf4d">
+        <ownedComment xmi:id="a6aedbd4-de16-4f11-a0c6-f41e9c7d7922" annotatedElement="25506cfc-64aa-4c62-8a3f-14b4ec3820be">
+          <body>&lt;p>The owned ConstraintUsages that represent assumptions of this RequirementDefinition, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the RequirementDefinition with &lt;code>kind&lt;/code> = &lt;code>assumption&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="14699886-b0da-4ef5-9d01-0f9ecebcdb4a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c59bcc0f-92a3-43d9-8eb7-debc5247bfcb" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="054b56fc-b021-4a87-a055-b1858e22e237" name="requiredConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="cb4ea770-7f7f-44d4-ab99-bf6c66a16b24">
+        <ownedComment xmi:id="c4305813-f082-4a59-84c9-4b0e246ce723" annotatedElement="054b56fc-b021-4a87-a055-b1858e22e237">
+          <body>&lt;p>The owned ConstraintUsages that represent requirements of this RequirementDefinition, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the RequirementDefinition with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4fa05eed-28e2-445c-b403-ad61acf43640" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b9054bd6-b4a7-4f9d-9290-edcec1db49e4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5730e999-f0bc-460f-8079-cec1f24b01af" name="subjectParameter" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 ab0dbb87-5e95-4819-9217-2128904f4064" association="017cb3cb-f3fa-4822-ab8a-f7be4da48a64">
+        <ownedComment xmi:id="a6131dd7-9752-4ff8-a537-cd1cd276d02c" annotatedElement="5730e999-f0bc-460f-8079-cec1f24b01af">
+          <body>&lt;p>The &lt;code>parameter&lt;/code> of this RequirementDefinition that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base RequirementDefinition RequirementCheck from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="878b0467-fea8-4ccd-8f32-5f204d3b6ca2" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2c15e2b8-7d69-4987-a51d-7c5a92fa77d2" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e1c33cda-a7c3-41b7-a2d1-342a58e9eed7" name="framedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isOrdered="true" isDerived="true" subsettedProperty="054b56fc-b021-4a87-a055-b1858e22e237" association="86d0dc31-9098-4568-b211-a2bc55d82614">
+        <ownedComment xmi:id="e11bc5b4-c3cb-4b5a-b965-08d91c00e06c" annotatedElement="e1c33cda-a7c3-41b7-a2d1-342a58e9eed7">
+          <body>&lt;p>The Concerns framed by this RequirementDefinition, derived as the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the RequirementDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="36caafed-1a82-421c-827b-5d4cf847a2a4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="41fadabf-b6a1-4dfd-9ca5-2d1b18bc556b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="acf36ad0-69c3-41a4-b4aa-6f1f175d3fde" name="actorParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="8e3f1de2-c767-4cdd-af33-aacf5abe7d73 0dbfb406-bae0-4d85-8c9c-66c3c336f800" association="b3672bb4-9088-46e0-8c3f-311574544564">
+        <ownedComment xmi:id="391bfa4f-afc4-400a-8d01-56e0c9ed863a" annotatedElement="acf36ad0-69c3-41a4-b4aa-6f1f175d3fde">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this RequirementDefinition that are owned via ActorMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base RequirementDefinition &lt;em>RequirementCheck&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ae59ff0c-cc68-49d2-9790-0bf6ed0850a1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="efc492d6-529b-469d-bd9b-ade74a33a5c2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fb2a2d8c-8f1b-408c-b34e-42ce154d231b" name="stakeholderParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="8e3f1de2-c767-4cdd-af33-aacf5abe7d73 0dbfb406-bae0-4d85-8c9c-66c3c336f800" association="2900aecf-e770-44d4-a71a-d0c4890138fa">
+        <ownedComment xmi:id="ff8e5f39-9723-439f-beba-3a5a6f68dce9" annotatedElement="fb2a2d8c-8f1b-408c-b34e-42ce154d231b">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this RequirementDefinition that are owned via StakeholderMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>stakeholders&lt;/code>&lt;/em> of the base RequirementDefinition &lt;em>RequirementCheck&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4fc71b14-2f7a-4f03-ae4b-66bdcfeba164" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8f3dfa78-f9ac-456d-a1fd-6944bef6125c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="8859d359-18f4-4d1f-a21f-99e07609793e" name="RequirementConstraintMembership" visibility="public">
+      <ownedComment xmi:id="231e02b0-6018-401a-8d73-9321777d59a2" annotatedElement="8859d359-18f4-4d1f-a21f-99e07609793e">
+        <body>&lt;p>A RequirementConstraintMembership is a FeatureMembership for an assumed or required ConstraintUsage of a RequirementDefinition or RequirementUsage. The &lt;code>ownedMemberFeature&lt;/code> of a RequirementConstraintMembership must be a ConstraintUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="d16778af-f924-4f62-8137-774f8181fac2" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="4103afed-d240-48d3-b873-06eb1fda77d9" name="kind" visibility="public" type="6d72d7bc-e8f0-4f8a-863f-58eec2c12068">
+        <ownedComment xmi:id="5132947a-90c3-46af-a358-50da1d6ad9b8" annotatedElement="4103afed-d240-48d3-b873-06eb1fda77d9">
+          <body>&lt;p>Whether the RequirementConstraintMembership is for an assumed or required ConstraintUsage.&lt;/p></body>
+        </ownedComment>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8d8ad8e5-05f6-4913-94ce-c865031fc5f6" name="ownedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="e70037ca-e86b-4c49-9a68-1914b4285828">
+        <ownedComment xmi:id="01f7fce7-f1b8-4e17-8cd2-f847eaea32b5" annotatedElement="8d8ad8e5-05f6-4913-94ce-c865031fc5f6">
+          <body>&lt;p>The ConstraintUsage that is the &lt;code>ownedMemberFeature&lt;/code> of this RequirementConstraintMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8381424a-0f64-4105-b038-98d2a15e6ad9" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2277bb3d-3c0a-489c-a690-3405253ff6c7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="97b5bde3-a770-48b5-814d-f6023a915f73" name="referencedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isDerived="true" association="57fb129e-522a-416f-a9f7-5cb2470f5cfa">
+        <ownedComment xmi:id="060c76d1-300e-406e-87df-7195bb6f9bac" annotatedElement="97b5bde3-a770-48b5-814d-f6023a915f73">
+          <body>&lt;p> The ConstraintUsage that is referenced through this RequirementConstraintMembership. This is derived as &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> of the &lt;code>ownedConstraint&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedConstraint&lt;/code> itself.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ebbe3b6e-e890-4362-ac52-a6fb6e963e55" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="171cdb6a-1a43-4f9b-b244-a69d7e2d7a9d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e70037ca-e86b-4c49-9a68-1914b4285828" name="" visibility="public" memberEnd="8d8ad8e5-05f6-4913-94ce-c865031fc5f6 9fe75d22-5564-40f4-ae65-6e87f3b51e3e">
+      <ownedEnd xmi:id="9fe75d22-5564-40f4-ae65-6e87f3b51e3e" name="requirementConstraintMembership" visibility="public" type="8859d359-18f4-4d1f-a21f-99e07609793e" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="e70037ca-e86b-4c49-9a68-1914b4285828">
+        <ownedComment xmi:id="5810adae-6d3e-43ae-a80c-cef5e75478fd" annotatedElement="9fe75d22-5564-40f4-ae65-6e87f3b51e3e">
+          <body>&lt;p>The RequirementConstraintMembership that owns a certain ConstraintUsage as its &lt;code>ownedConstraint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b1e2ad1c-75d6-4b0a-a096-6ba92145095e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b1478f38-2526-4aef-95a1-3063a22d8e8b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="9957b1cd-e700-4654-88c8-5205b48393dc" name="SubjectMembership" visibility="public">
+      <ownedComment xmi:id="7c4aef4f-85ec-4e2c-8a60-c9eea24f026b" annotatedElement="9957b1cd-e700-4654-88c8-5205b48393dc">
+        <body>&lt;p>A SubjectMembership is a ParameterMembership that indicates that its &lt;code>ownedSubjectParameter&lt;/code> is the subject Parameter for its &lt;code>owningType&lt;/code>. The &lt;code>owningType&lt;/code> of a SubjectMembership must be a CaseDefinition, CaseUsage, RequirementDefinition or RequirementUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="522230de-046a-4746-a367-06b9bbf4f49d" general="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb"/>
+      <ownedAttribute xmi:id="94d209a9-5c5f-4117-9165-727aa5a35240" name="ownedSubjectParameter" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" aggregation="composite" isDerived="true" redefinedProperty="34d5222b-28dc-443a-bcaa-396d3b3ec6aa" association="4d14f93a-1f2f-4c1e-a1c2-b47529e1534f">
+        <ownedComment xmi:id="85ae5b8c-b67a-497a-85e1-82154ab81d86" annotatedElement="94d209a9-5c5f-4117-9165-727aa5a35240">
+          <body>&lt;p>The Usage that is the &lt;code>ownedMemberParameter&lt;/code> of this SubjectMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="34d3b7bf-06c5-498b-9b8b-0bfc8a14fcaa" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a499e7ca-074d-4e74-b20e-d5b79820d3fc" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="84e89d15-607d-415a-bb54-78f4e4e064cd" name="StakeholderMembership" visibility="public">
+      <ownedComment xmi:id="045ed81e-f8fc-46a3-9b31-400952d2c07e" annotatedElement="84e89d15-607d-415a-bb54-78f4e4e064cd">
+        <body>&lt;p>A StakeholderMembership is a ParameterMembership that identifies a PartUsage as a stakeholder parameter, which specifies a role played by an entity with Concerns framed by the parametered requirement.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="1c87ed36-bc7f-4a7b-b78d-4ff6bc60b07c" general="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb"/>
+      <ownedAttribute xmi:id="1cfd3353-ec12-48ee-a8e6-e4db271172d0" name="ownedStakeholderParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" aggregation="composite" isDerived="true" redefinedProperty="34d5222b-28dc-443a-bcaa-396d3b3ec6aa" association="f69bfec2-1553-42db-9c1a-edc051087e18">
+        <ownedComment xmi:id="34454b4c-8491-4eb8-baaa-b28ee366daf7" annotatedElement="1cfd3353-ec12-48ee-a8e6-e4db271172d0">
+          <body>&lt;p>The PartUsage specifying the stakeholder.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ac5eb5f8-129d-4342-8621-af44e163cdb1" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d6d9957e-de44-4a1f-8e0a-234b816d5b9b" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3a8ae61d-bc9d-42c8-b73f-4e26989467b9" name="" visibility="public" memberEnd="1291278e-da63-45e7-a37e-0ecb876ab538 ebcbc526-ee27-4339-9e4c-b6c4af1f4ff7">
+      <ownedEnd xmi:id="ebcbc526-ee27-4339-9e4c-b6c4af1f4ff7" name="satisfiedRequirement" visibility="public" type="0166e229-2eaf-4190-a88e-5cf9393b79ec" isDerived="true" association="3a8ae61d-bc9d-42c8-b73f-4e26989467b9">
+        <ownedComment xmi:id="fa0533a4-98d7-4df9-981e-3388db501ace" annotatedElement="ebcbc526-ee27-4339-9e4c-b6c4af1f4ff7">
+          <body>&lt;p>The SatisfyRequirementUsages that have a certain Feature as their &lt;tt>satisfyingFeature&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7f5d7292-b09f-4c0c-b056-7d7b2a078cbd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a7608369-7d21-402b-8dd8-4b97044de0de" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e2510ba5-0d2a-4338-9f13-67a440a36a93" name="" visibility="public" memberEnd="0319a346-894f-438a-8573-3da7580073ce 80a79040-95ec-4036-8e65-a24a8c4543be">
+      <ownedEnd xmi:id="80a79040-95ec-4036-8e65-a24a8c4543be" name="assumingRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="e2510ba5-0d2a-4338-9f13-67a440a36a93">
+        <ownedComment xmi:id="06d152ca-f052-467f-b196-be0895e94efb" annotatedElement="80a79040-95ec-4036-8e65-a24a8c4543be">
+          <body>&lt;p>The RequirementUsage that has a certain ConstraintUsage as an &lt;cod>assumedConstraint&lt;/code> (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="68c5984b-d0af-4cce-b79c-c69a88376b70" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4c6071cd-ac64-4a4b-aa8a-70da14e71380" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ce53703c-704a-4db6-8440-97c7e3620e33" name="" visibility="public" memberEnd="14774214-8b77-47af-8fed-1ebf4e7e2f0c b0f26584-a001-4726-8680-939994ce62a6">
+      <ownedEnd xmi:id="b0f26584-a001-4726-8680-939994ce62a6" name="referencingConcernMembership" visibility="public" type="5432b3d2-9c70-46c0-8b58-717dce024f89" isDerived="true" subsettedProperty="5a616d70-18a6-4a4e-931b-9170604a6f2e" association="ce53703c-704a-4db6-8440-97c7e3620e33">
+        <ownedComment xmi:id="7ebf2c10-29e3-4be7-8d0e-84eb7022ef68" annotatedElement="b0f26584-a001-4726-8680-939994ce62a6">
+          <body>&lt;p>The AddressedConcernMembership that has a certain ConcernUsage as its &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f6e6132e-5338-454f-8baf-dd08c17b67fd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="711cf119-077b-46d1-b78a-0a12b8a9f71f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="6d72d7bc-e8f0-4f8a-863f-58eec2c12068" name="RequirementConstraintKind" visibility="public">
+      <ownedComment xmi:id="71bc07d2-647a-459d-b201-a3d35edce4a8" annotatedElement="6d72d7bc-e8f0-4f8a-863f-58eec2c12068">
+        <body>&lt;p>A RequirementConstraintKind indicates whether a ConstraintUsage is an assumption or a requirement in a RequirementDefinition or RequirementUsage.&lt;/p></body>
+      </ownedComment>
+      <ownedLiteral xmi:id="64d0a782-e124-4915-84ca-8cffef896cd5" name="assumption" visibility="public">
+        <ownedComment xmi:id="901fdbd5-9b00-40de-baae-70c1a27a4e93" annotatedElement="64d0a782-e124-4915-84ca-8cffef896cd5">
+          <body>&lt;p>Indicates that a member ConstraintUsage of a RequirementDefinition or RequirementUsage represents an assumption.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="88d51804-a25f-454f-abff-d7cec0f3ae1a" name="requirement" visibility="public">
+        <ownedComment xmi:id="4106c1b8-5fd3-4ff6-aa6d-570e59cc1af3" annotatedElement="88d51804-a25f-454f-abff-d7cec0f3ae1a">
+          <body>&lt;p>Indicates that a member ConstraintUsage of a RequirementDefinition or RequirementUsage represents an requirement.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="017cb3cb-f3fa-4822-ab8a-f7be4da48a64" name="" visibility="public" memberEnd="5730e999-f0bc-460f-8079-cec1f24b01af b7641e78-71fd-454f-89f0-2c33f9b9ff2c">
+      <ownedEnd xmi:id="b7641e78-71fd-454f-89f0-2c33f9b9ff2c" name="subjectOwningRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="9df0cf94-7d5b-4d14-b3f2-d656f0c9a85a 750ac38e-ae6c-4718-856d-a704775bdd8b" association="017cb3cb-f3fa-4822-ab8a-f7be4da48a64">
+        <ownedComment xmi:id="06be484c-cc2c-4831-b9a3-076c26888845" annotatedElement="b7641e78-71fd-454f-89f0-2c33f9b9ff2c">
+          <body>&lt;p>The RequirementDefinitions that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f03f4fda-2fcc-44c4-aa86-dd98c3d9e23c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9b80250a-639a-4143-bde8-b806a0ccfd38" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2900aecf-e770-44d4-a71a-d0c4890138fa" name="" visibility="public" memberEnd="fb2a2d8c-8f1b-408c-b34e-42ce154d231b af25ad08-35f1-4f2c-b9c7-c238dfb2cb5d">
+      <ownedEnd xmi:id="af25ad08-35f1-4f2c-b9c7-c238dfb2cb5d" name="stakholderOwiningRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="e02ee31c-b895-45b1-a5bb-a0a465f786e0 58f50343-0f2e-4d6c-891c-20350eaf6937" association="2900aecf-e770-44d4-a71a-d0c4890138fa">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="05e95da8-bb9a-4a24-b1d0-5177c0de176b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="26db2ef8-f92f-4b51-b782-7bc0bcbdf1d5" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="abd9798f-2785-41f5-8591-fbec0b727021" name="" visibility="public" memberEnd="32b9d807-bbe1-4e96-96e1-3cc93af08531 42e3a357-dd4c-4d63-af07-c007a3dbd593">
+      <ownedEnd xmi:id="42e3a357-dd4c-4d63-af07-c007a3dbd593" name="requirementSatisfaction" visibility="public" type="0166e229-2eaf-4190-a88e-5cf9393b79ec" isDerived="true" subsettedProperty="f822ceae-c8b6-4082-a0a3-b0ebb3b216e7" association="abd9798f-2785-41f5-8591-fbec0b727021">
+        <ownedComment xmi:id="cd8aeb3a-e127-43b8-87c9-b5755203e23a" annotatedElement="42e3a357-dd4c-4d63-af07-c007a3dbd593">
+          <body>&lt;p>The SatifyRequirementUsages that have a certain RequirementUsage as their &lt;tt>satisfiedRequirement&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a0b48809-917d-4f5d-a604-4b0dcb9860dd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1f5ae871-702d-43e9-9347-c038ab7ad434" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="df528bd3-41d1-47cf-9fbe-cfc120babf4d" name="" visibility="public" memberEnd="25506cfc-64aa-4c62-8a3f-14b4ec3820be 1697da46-03b0-45de-90db-3f1dd60634c1">
+      <ownedEnd xmi:id="1697da46-03b0-45de-90db-3f1dd60634c1" name="assumingRequirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="df528bd3-41d1-47cf-9fbe-cfc120babf4d">
+        <ownedComment xmi:id="5dc0c36b-bff0-4548-9e9e-4e1573dd2f9b" annotatedElement="1697da46-03b0-45de-90db-3f1dd60634c1">
+          <body>&lt;p>The RequirementDefinition that has a certain ConstraintUsage as an &lt;code>assumedConstraint&lt;/code> (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2fdf8b99-c205-4ca8-9111-da000b045ff4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bbe9cf0b-6aae-4ca7-a383-e97d21a959df" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7bb432b6-6716-414d-b4b2-1e20cb7693d8" name="" visibility="public" memberEnd="7e086ebc-f6e2-4614-9bf7-e01520e64f72 62d0afb6-8951-4001-bc5a-64eb89958f4e">
+      <ownedEnd xmi:id="62d0afb6-8951-4001-bc5a-64eb89958f4e" name="subjectOwningRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="58f50343-0f2e-4d6c-891c-20350eaf6937 e3db423d-543e-47fa-864c-573abd896990" association="7bb432b6-6716-414d-b4b2-1e20cb7693d8">
+        <ownedComment xmi:id="b3cec784-5007-43d0-9984-42f70e15e8ec" annotatedElement="62d0afb6-8951-4001-bc5a-64eb89958f4e">
+          <body>&lt;p>The RequirementUsages that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bb7d1287-eeee-492d-b629-ed7672aac0a8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ef1ea6e5-d2f0-41a6-83da-127c031563aa" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d717b823-6820-4d94-ad3b-6b0ec3d9b378" name="" visibility="public" memberEnd="ea1ba2f4-1ee5-4cf1-9ff8-2966213d116f 56921403-0dfc-4384-b348-ced2540f5595">
+      <ownedEnd xmi:id="56921403-0dfc-4384-b348-ced2540f5595" name="framedConstraintMembership" visibility="public" type="5432b3d2-9c70-46c0-8b58-717dce024f89" isDerived="true" subsettedProperty="9fe75d22-5564-40f4-ae65-6e87f3b51e3e" association="d717b823-6820-4d94-ad3b-6b0ec3d9b378">
+        <ownedComment xmi:id="71469bf4-27c6-47a2-a995-bdadd9a36036" annotatedElement="56921403-0dfc-4384-b348-ced2540f5595">
+          <body>&lt;p>The AddressedConcernMembership that owns a certain ConcernUsage as its &lt;code>ownedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="62d6a78e-d82a-4592-84ee-a9cf7a87dc90" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f40024a3-d971-42b6-9685-f9ca2059c5b9" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9a42c1b8-38d4-47a5-9b88-0ede4c5c1713" name="" visibility="public" memberEnd="91a1c248-6c2d-49be-8de8-30ac709a91ff 0e72d6af-0830-4859-9181-ea55a5c07e9e">
+      <ownedEnd xmi:id="0e72d6af-0830-4859-9181-ea55a5c07e9e" name="requiringRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="9a42c1b8-38d4-47a5-9b88-0ede4c5c1713">
+        <ownedComment xmi:id="78a71bba-417d-40f3-829f-e8088a2feb0b" annotatedElement="0e72d6af-0830-4859-9181-ea55a5c07e9e">
+          <body>&lt;p>The RequirementUsage that has a certain ConstraintUsage as a &lt;code>requiredConstraint&lt;/code> (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d14fdfcc-6d26-4f84-9647-937c05ec049d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f2e51c9a-be51-410f-b187-fe8dfb8d3119" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="64c73808-9a98-4790-bd3e-c47422a7efed" name="" visibility="public" memberEnd="0b366375-d15a-463c-876c-04f6def506b1 16d87bbc-2312-4502-af32-6ddd38c0d4ca">
+      <ownedEnd xmi:id="16d87bbc-2312-4502-af32-6ddd38c0d4ca" name="actorOwningRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" subsettedProperty="58f50343-0f2e-4d6c-891c-20350eaf6937 e02ee31c-b895-45b1-a5bb-a0a465f786e0" association="64c73808-9a98-4790-bd3e-c47422a7efed">
+        <ownedComment xmi:id="3e483fce-78ec-405a-a7f6-bc18ecca1b0d" annotatedElement="16d87bbc-2312-4502-af32-6ddd38c0d4ca">
+          <body>&lt;p>The RequirementUsages that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="88a37ccf-ff97-4d47-86b3-f5bc7888cc90" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="91160fb6-b461-4295-8eb7-d12173015049" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7248aae3-2934-47cd-bf16-f9aca7f25ad7" name="RequirementUsage" visibility="public">
+      <ownedComment xmi:id="61e35374-18c9-4a87-af33-beffcffb2827" annotatedElement="7248aae3-2934-47cd-bf16-f9aca7f25ad7">
+        <body>&lt;p>A RequirementUsage is a Usage of a RequirementDefinition.&lt;/p>
+
+&lt;p>A RequirementUsage must subset, directly or indirectly, the base RequirementUsage &lt;em>&lt;code>requirementChecks&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="f61379e5-4f28-465f-8f2b-84cf65458786" general="9ee628bb-c896-4aab-b7c8-7548359ff376"/>
+      <ownedAttribute xmi:id="ee688400-5d8a-4c4d-9fa5-a21e6047ebf2" name="requirementDefinition" visibility="public" type="3f439339-e30b-454e-9a33-9a90c3c37bc9" isDerived="true" redefinedProperty="74340ca0-8044-4c8a-9cfc-fb2a6719b08a" association="27cb391b-653c-40e3-8ef1-454e095836b7">
+        <ownedComment xmi:id="4a7d9bcd-d33c-418a-9ec0-c7b8050d420a" annotatedElement="ee688400-5d8a-4c4d-9fa5-a21e6047ebf2">
+          <body>&lt;p>The RequirementDefinition that is the single type of this RequirementUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="010140ad-00eb-4fce-beb3-f8761f22ee81" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9db2cc8d-4ffb-4b61-bdcb-affefb4b10f6" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a148cd2c-ac0d-485c-a1ab-193d50522808" name="reqId" visibility="public" redefinedProperty="a3a60717-82ce-452b-ba0e-bade66ef3b72">
+        <ownedComment xmi:id="70160fc9-db4e-47b3-9037-a1280911a094" annotatedElement="a148cd2c-ac0d-485c-a1ab-193d50522808">
+          <body>&lt;p>An optional modeler-specified identifier for this RequirementUsage (used, e.g., to link it to an original requirement text in some source document), derived as the &lt;code>modeledId&lt;/code> for the RequirementUsage.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9700cf40-3647-4ca5-86f0-fd98b424c033" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="40f58aa7-d8c1-495d-8cd1-debdea873ace" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f4d8c50f-a3fc-4535-b822-40c48bff5f2d" name="text" visibility="public" isDerived="true">
+        <ownedComment xmi:id="721d66b9-45e3-406a-bc95-991790a91bbb" annotatedElement="f4d8c50f-a3fc-4535-b822-40c48bff5f2d">
+          <body>&lt;p>An optional textual statement of the requirement represented by this RequirementUsage, derived as the &lt;code>bodies&lt;code> of the &lt;code>documentaryComments&lt;/code> of the RequirementDefinition.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f7d55ac1-e0d3-47b6-8330-5b774586a32e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5c0cd62e-232a-421f-ae34-15ded159b17d" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="91a1c248-6c2d-49be-8de8-30ac709a91ff" name="requiredConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="9a42c1b8-38d4-47a5-9b88-0ede4c5c1713">
+        <ownedComment xmi:id="5b4aad5d-5c00-43d7-bde6-d77e0e096ab7" annotatedElement="91a1c248-6c2d-49be-8de8-30ac709a91ff">
+          <body>&lt;p>The owned ConstraintUsages that represent requirements of this RequirementUsage, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the RequirementUsage with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="dcef04b7-703b-400b-9e3f-c2e3779ca18a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3312340a-c055-4a82-a74e-ea5715418405" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0319a346-894f-438a-8573-3da7580073ce" name="assumedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="e2510ba5-0d2a-4338-9f13-67a440a36a93">
+        <ownedComment xmi:id="61d25420-e2f1-47b7-a6d1-f4d75a24f897" annotatedElement="0319a346-894f-438a-8573-3da7580073ce">
+          <body>&lt;p>The owned ConstraintUsages that represent assumptions of this RequirementUsage, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the RequirementUsage with &lt;code>kind&lt;/code> = &lt;code>assumption&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8deda891-2b19-457d-b050-473b0d54fe6c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="210a6fbf-608b-4a66-881f-c20c11567519" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7e086ebc-f6e2-4614-9bf7-e01520e64f72" name="subjectParameter" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="0dbfb406-bae0-4d85-8c9c-66c3c336f800 3aeed792-7c5b-4145-ad3c-981f4de83751" association="7bb432b6-6716-414d-b4b2-1e20cb7693d8">
+        <ownedComment xmi:id="ecce8d2f-d029-44b3-bdfe-dd9b0b829a64" annotatedElement="7e086ebc-f6e2-4614-9bf7-e01520e64f72">
+          <body>&lt;p>The &lt;code>parameter&lt;/code> of this RequirementUsage that is owned via a SubjectMembership, which must redefine, directly or indirectly, the &lt;code>subject&lt;/code> parameter of the base RequirementDefinition RequirementCheck from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c97eb50d-4360-4ce1-9e8f-21e5b3cb10f6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="908bf357-0866-4bf0-9395-8c71416a0230" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a5b20671-3b1d-4fd0-9447-ed52627e53a5" name="framedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isOrdered="true" isDerived="true" subsettedProperty="91a1c248-6c2d-49be-8de8-30ac709a91ff" association="0b00f5d5-15c2-4efa-a42e-f6bc50bb4b0f">
+        <ownedComment xmi:id="e6251a1d-7e28-4dbd-80fb-9f21c488cc1c" annotatedElement="a5b20671-3b1d-4fd0-9447-ed52627e53a5">
+          <body>&lt;p>The Concerns framed by this RequirementUsage, derived as the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the RequirementUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a1430cc6-71c3-4b50-baed-4a09e1e3d824" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1211aa4a-bc57-4e89-ba52-860d90b85b62" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0b366375-d15a-463c-876c-04f6def506b1" name="actorParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857 ba7a9394-5d4f-4a40-be17-a628644b092e" association="64c73808-9a98-4790-bd3e-c47422a7efed">
+        <ownedComment xmi:id="581c5cc0-9a30-46ca-a095-c94bc1d69f23" annotatedElement="0b366375-d15a-463c-876c-04f6def506b1">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this RequirementUsage that are owned via ActorMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>actors&lt;/code>&lt;/em> of the base RequirementDefinition &lt;em>RequirementCheck&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fec8fe04-7458-4ce3-948b-3a1ea9d66330" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="15f65d4c-d198-4888-91a4-ae820937a640" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="24570db9-c8a5-4b6c-ad4b-e2992bf0b976" name="stakeholderParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857 ba7a9394-5d4f-4a40-be17-a628644b092e" association="12567f90-5e15-4581-8048-1aeccf197848">
+        <ownedComment xmi:id="9df4af48-1d10-4600-b410-5469f963c0d4" annotatedElement="24570db9-c8a5-4b6c-ad4b-e2992bf0b976">
+          <body>&lt;p>The &lt;code>parameters&lt;/code> of this RequirementUsage that are owned via StakeholderMemberships, which must subset, directly or indirectly, the PartUsage &lt;em>&lt;code>stakeholders&lt;/code>&lt;/em> of the base RequirementDefinition &lt;em>RequirementCheck&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="057195fe-9ea7-471f-b226-32a48f332a26" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="346ca2ed-09b6-4ff9-a30b-b9d14e6e2227" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="0f1e3224-e721-4400-9844-a51c115827fb" name="ActorMembership" visibility="public">
+      <ownedComment xmi:id="c4fc1656-39c0-409d-b8a0-c97c4d8c13f3" annotatedElement="0f1e3224-e721-4400-9844-a51c115827fb">
+        <body>&lt;p>An ActorMembership is a ParameterMembership that identifies a PartUsage as an actor parameter, which specifies a role played by an entity external in interaction with the parametered element.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="6d45bf68-5efb-4764-9101-35fb54d5d08d" general="fa0fe3ef-c7be-41f2-a235-78f97a4e35cb"/>
+      <ownedAttribute xmi:id="62d46815-fe0e-426c-932d-c2f3eca8139b" name="ownedActorParameter" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" aggregation="composite" isDerived="true" redefinedProperty="34d5222b-28dc-443a-bcaa-396d3b3ec6aa" association="2873cbcc-9edc-4bdf-86b0-7098283e2c45">
+        <ownedComment xmi:id="3d8e3f63-8bc5-48d4-ba56-9fbddbac31d1" annotatedElement="62d46815-fe0e-426c-932d-c2f3eca8139b">
+          <body>&lt;p>The PartUsage specifying the actor.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f0c9a95d-0936-4c4f-a44c-9f6c9095a681" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a8c0de2f-7024-4d9d-887b-0b071458df4a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2873cbcc-9edc-4bdf-86b0-7098283e2c45" name="" visibility="public" memberEnd="62d46815-fe0e-426c-932d-c2f3eca8139b 53a1a61d-8e37-4fc3-a888-a800873e10b2">
+      <ownedEnd xmi:id="53a1a61d-8e37-4fc3-a888-a800873e10b2" name="owningActorMembership" visibility="public" type="0f1e3224-e721-4400-9844-a51c115827fb" isDerived="true" subsettedProperty="e7238cc7-e86f-4d19-a3e2-c52b238d9fb0" association="2873cbcc-9edc-4bdf-86b0-7098283e2c45">
+        <ownedComment xmi:id="92d0aaed-f342-4449-9172-a0da23907819" annotatedElement="53a1a61d-8e37-4fc3-a888-a800873e10b2">
+          <body>&lt;p>The ActorMembership that has a certain PartUsage as its &lt;code>ownedActorParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1a95d819-5e11-467b-9183-1670398d538d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c5aac1ea-44d5-41bf-be80-70f44e8e48ce" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="50919f0a-4162-49c7-89c0-f6206b56bd35" name="" visibility="public" memberEnd="9df9c9cb-3b04-47d9-b3a2-4ec90ca54893 b6094fbc-20f6-41be-9400-67e7c0818c26">
+      <ownedEnd xmi:id="b6094fbc-20f6-41be-9400-67e7c0818c26" name="definedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isDerived="true" subsettedProperty="af52c6b6-b2e3-49ec-9e90-ef120c251f2b" association="50919f0a-4162-49c7-89c0-f6206b56bd35">
+        <ownedComment xmi:id="88649481-7508-467c-9b8e-7636c1b0f28e" annotatedElement="b6094fbc-20f6-41be-9400-67e7c0818c26">
+          <body>&lt;p>The ConcernUsages that are typed by a certain &lt;code>concernDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="730f5bf1-bb47-4846-b824-c74137de19e3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8aca3a60-7c6d-4868-bf88-7113b24a0af8" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="57fb129e-522a-416f-a9f7-5cb2470f5cfa" name="" visibility="public" memberEnd="97b5bde3-a770-48b5-814d-f6023a915f73 5a616d70-18a6-4a4e-931b-9170604a6f2e">
+      <ownedEnd xmi:id="5a616d70-18a6-4a4e-931b-9170604a6f2e" name="referencingConstraintMembership" visibility="public" type="8859d359-18f4-4d1f-a21f-99e07609793e" isDerived="true" association="57fb129e-522a-416f-a9f7-5cb2470f5cfa">
+        <ownedComment xmi:id="bdc0c2cd-ec25-4f5e-acc7-9bb0a267a1b6" annotatedElement="5a616d70-18a6-4a4e-931b-9170604a6f2e">
+          <body>&lt;p>The RequirementConstraintMembership that has a certain ConstraintUsage as its &lt;code>referencedConstraint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cbd1f92d-b1a3-4677-9463-4572b89f9582" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9f4db982-cb43-467e-824d-932c3c13659a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="03fd6246-7836-482c-b412-c13d4f2bf5b8" name="" visibility="public" memberEnd="74340ca0-8044-4c8a-9cfc-fb2a6719b08a 160253ec-6160-4a89-bea8-927d47d13bd3">
+      <ownedEnd xmi:id="160253ec-6160-4a89-bea8-927d47d13bd3" name="definedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isDerived="true" subsettedProperty="81024738-6b78-42ed-99d6-5133b0f840e1" association="03fd6246-7836-482c-b412-c13d4f2bf5b8">
+        <ownedComment xmi:id="51576f79-8fa7-4ea7-9ad1-4b4af9c60f5a" annotatedElement="160253ec-6160-4a89-bea8-927d47d13bd3">
+          <body>&lt;p>The ConstraintUsages typed by a certain Predicate.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1047a85d-6648-4a33-9bf9-5a06d80b236c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="99550646-ae87-41da-8cbb-e2afca4d7547" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d044b5f7-f450-41c8-9ed0-7935ba775263" name="AssertConstraintUsage" visibility="public">
+      <ownedComment xmi:id="e180a928-2cac-4c42-a20c-91cc1a617785" annotatedElement="d044b5f7-f450-41c8-9ed0-7935ba775263">
+        <body>&lt;p>An AssertConstraintUsage is a ConstraintUsage that is also an Invariant and, so, is asserted to be true (by default). Unless it is the AssertConstraintUsage itself, the asserted ConstraintUsage is related to the AssertConstraintUsage by a ReferenceSubsetting relationship.&lt;/p>
+
+&lt;p>If the AssertConstraintUsage is owned by a PartDefinition or PartUsage, then it also subsets the &lt;em>&lt;code>assertedConstraints&lt;/code>&lt;/em> feature of the PartDefinition &lt;em>&lt;code>Part&lt;/code>&lt;/em> from the System Library model &lt;em>&lt;code>Parts&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="da4cd5f6-ad95-4d74-8c8b-b4d468e97ab0" name="assertConstraintUsageAssertedConstraint" visibility="public" constrainedElement="d044b5f7-f450-41c8-9ed0-7935ba775263">
+        <ownedComment xmi:id="94adbe26-f58e-43b0-b6a3-6aa8df3fbb14" annotatedElement="da4cd5f6-ad95-4d74-8c8b-b4d468e97ab0">
+          <body>&lt;p>If an AssertConstraintUsage has no &lt;code>ownedReferenceSubsetting&lt;/code>, then its &lt;code>assertedConstraint&lt;/code> is the AssertConstraintUsage itself. Otherwise, the &lt;code>assertedConstraint&lt;/code> is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code>, which must be a ConstraintUsage.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4399a033-7e24-4d28-8708-fd79973e18f7" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>assertedConstraint =
+    if ownedReferenceSubsetting = null then self
+    else ownedReferenceSubsetting.referencedFeature.oclAsType(ConstraintUsage)
+    endif</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="583c611b-1e7b-481a-aea6-80cd092425ef" general="9ee628bb-c896-4aab-b7c8-7548359ff376"/>
+      <generalization xmi:id="6ccd341e-947b-49b5-9d50-97109b5e9ff6" general="e8a20af6-2a0f-49f9-9cae-ba3760a7f13e"/>
+      <ownedAttribute xmi:id="f5f2add9-297d-4679-98cf-c380ac18fd59" name="assertedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isDerived="true" association="eb4cd73a-1969-4765-becb-d5d655bfb4ed">
+        <ownedComment xmi:id="f1c7232e-695c-42ea-9cbe-b13830b865f3" annotatedElement="f5f2add9-297d-4679-98cf-c380ac18fd59">
+          <body>&lt;p>The ConstraintUsage to be performed by the AssertConstraintUsage. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the AssertConstraintUsage, if there is one, and, otherwise, the AssertConstraintUsage itself.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="07a74965-bfe1-4139-802c-5822510bb229" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9f8e4dc8-9cb2-487e-9c37-743eafe60cda" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="eb4cd73a-1969-4765-becb-d5d655bfb4ed" name="" visibility="public" memberEnd="f5f2add9-297d-4679-98cf-c380ac18fd59 f822ceae-c8b6-4082-a0a3-b0ebb3b216e7">
+      <ownedEnd xmi:id="f822ceae-c8b6-4082-a0a3-b0ebb3b216e7" name="constraintAssertion" visibility="public" type="d044b5f7-f450-41c8-9ed0-7935ba775263" isDerived="true" association="eb4cd73a-1969-4765-becb-d5d655bfb4ed">
+        <ownedComment xmi:id="3316a51e-79ff-4775-8473-139d78602230" annotatedElement="f822ceae-c8b6-4082-a0a3-b0ebb3b216e7">
+          <body>&lt;p>The AssertConstraintUsages that have a certain ConstraintUsage as their &lt;tt>assertedConstraint&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6d19e884-564d-4453-9b3d-73627db0a4a2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b72bf058-3876-435a-ba87-14888bbd3c70" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="9ee628bb-c896-4aab-b7c8-7548359ff376" name="ConstraintUsage" visibility="public">
+      <ownedComment xmi:id="90132314-9a70-4314-88fb-7e619314621c" annotatedElement="9ee628bb-c896-4aab-b7c8-7548359ff376">
+        <body>&lt;p>A ConstraintUsage is a OccurrenceUsage that is also a BooleanExpression, and, so, is typed by a Predicate. Nominally, if the type is a ConstraintDefinition, a ConstraintUsage is a Usage of that ConstraintDefinition. However, other kinds of kernel Predicates are also allowed, to permit use of Predicates from the Kernel Library.&lt;/p>
+
+&lt;p>A ConstraintUsage (other than an AssertConstraintUsage owned by a Part) must subset, directly or indirectly, the base ConstraintUsage &lt;code>constraintChecks&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="a2310e2c-0114-4039-aaca-0bf879ae991a" general="293a8084-6bbb-46f9-86b2-30c8a7166a4a"/>
+      <generalization xmi:id="9db4a732-9ed8-4854-8e60-fa9be7b91abc" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
+      <ownedAttribute xmi:id="74340ca0-8044-4c8a-9cfc-fb2a6719b08a" name="constraintDefinition" visibility="public" type="dda34dab-e901-4ff2-b8d1-0800b55c803c" isDerived="true" redefinedProperty="db1dde5e-5547-4d92-939b-d44296f28e1e" association="03fd6246-7836-482c-b412-c13d4f2bf5b8">
+        <ownedComment xmi:id="f594b84b-fb1c-4aae-a9c7-073a0b681bf9" annotatedElement="74340ca0-8044-4c8a-9cfc-fb2a6719b08a">
+          <body>&lt;p>The (single) Predicate the is the type of this Constraint Usage. Nominally, this will be ConstraintDefinition, but non-ConstraintDefinition Predicates are also allowed, to permit use of Predicates from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="63272703-46f3-4432-8f4b-ffe1ea2025b0" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d38f8273-751c-4f83-9966-a10a9ff929f2" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="f0d6b7bb-c38a-4c1f-9ba1-c41f8b066954" name="namingFeature" visibility="public" redefinedOperation="a72f751c-5ed8-482a-8c58-0a536b396eac">
+        <ownedComment xmi:id="0d47db5c-9604-4e2d-80cc-8e1edd0352e9" annotatedElement="f0d6b7bb-c38a-4c1f-9ba1-c41f8b066954">
+          <body>&lt;p>If this ConstraintUsage is an &lt;code>assumedConstraint&lt;/code> or &lt;code>requiredConstraint&lt;/code> of a RequirementUsage, then its naming Feature is the first subsetted Feature that is not a default subsetting from the model library, if any.&lt;/code></body>
+        </ownedComment>
+        <ownedParameter xmi:id="6b3fa1f7-f03c-46cb-923f-6c766acf3ae8" name="" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2ceb10cb-7afd-4587-83bf-e1a4167170ac" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8878ae4a-ca63-4460-b8e8-cfa9df70ccb7" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="ace0f696-55e9-4501-b2f7-8ce04daf34bd" name="ConstraintDefinition" visibility="public">
+      <ownedComment xmi:id="ee856a89-8309-4d9b-9c08-795faae8557c" annotatedElement="ace0f696-55e9-4501-b2f7-8ce04daf34bd">
+        <body>&lt;p>A ConstraintDefinition is an OccurrenceDefinition that is also a Predicate that defines a constraint that may be asserted to hold on a system or part of a system.&lt;/p>
+
+&lt;p>A ConstraintDefinition must subclass, directly or indirectly, the base ConstraintDefinition ConstraintCheck from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="175f388a-97b9-4119-a34a-fdd4102a9696" general="01787c81-d827-4988-80ba-3f358b159b5c"/>
+      <generalization xmi:id="f4392958-7cf9-4f09-ace9-e8243efaa960" general="dda34dab-e901-4ff2-b8d1-0800b55c803c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" name="AnalysisCaseUsage" visibility="public">
+      <ownedComment xmi:id="574c72c8-5ed2-4c6d-88dc-e2dc1aa3a2b1" annotatedElement="42bd5675-21d5-40ad-ae7b-f1d50708d8bf">
+        <body>&lt;p>An AnalysisCaseUsage is a Usage of an AnalysisCaseDefinition.&lt;/p>
+
+&lt;p>An AnalysisCaseUsage must subset, directly or indirectly, either the base AnalysisCaseUsage &lt;code>analysisCases&lt;/code> from the Systems model library, if it is not owned by an AnalysisCaseDefinition or AnalysisCaseUsage, or the AnalysisCaseUsage &lt;code>subAnalysisCases&lt;/code> inherited from its owner, otherwise.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="4a78c44b-383f-49a2-bb6d-4caed1b07b79" general="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9"/>
+      <ownedAttribute xmi:id="e63d93a2-ea55-414a-bc3f-3effb86f5202" name="analysisAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="d1329cd2-4af6-44a1-83c1-397eeea5561b">
+        <ownedComment xmi:id="22580af9-3581-492b-9053-72799ef1a46c" annotatedElement="e63d93a2-ea55-414a-bc3f-3effb86f5202">
+          <body>&lt;p>The &lt;code>features&lt;/code> of the AnalysisCaseUsage that are typed as AnalysisActions. Each &lt;code>analysisAction&lt;/code> ActionUsage must subset the &lt;code>analysisSteps&lt;/code> ActionUsage of the base AnalysisCaseDefinition AnalysisCase from the Systems model library.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a5999396-99c6-4a3a-b4d5-2875454a9907" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9d7c29a0-f9f3-4d7f-8a9d-713c55b4d2e0" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="57979960-ae93-4521-86ff-d4ac1d35a408" name="analysisCaseDefinition" visibility="public" type="484519a3-41e8-4cf5-b937-9a91b1e101e7" isDerived="true" redefinedProperty="71c31818-03f0-478b-b70c-b2b99a975562" association="d8375738-d2d4-4467-86d1-7b2a0444167b">
+        <ownedComment xmi:id="4959a613-a594-4ef4-b219-c9321c1f2e89" annotatedElement="57979960-ae93-4521-86ff-d4ac1d35a408">
+          <body>&lt;p>The AnalysisCaseDefinition that is the type of this AnalysisCaseUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f91c58f6-e4b4-4749-8324-230bed675e79" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="59a4cc5a-009a-48fb-8677-b229d2c154a0" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="33a47bf8-b624-4217-9dbc-773ccd356e82" name="resultExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="c106aa40-14f2-42b5-8590-272b3f537280">
+        <ownedComment xmi:id="30d457f2-8a9b-4320-97fa-767190443b94" annotatedElement="33a47bf8-b624-4217-9dbc-773ccd356e82">
+          <body>&lt;p>The Expression used to compute the &lt;code>result&lt;/code> of the AnalysisCaseUsage, derived as the Expression owned via a ResultExpressionMembership. The &lt;code>resultExpression&lt;/code> must redefine directly or indirectly, the &lt;code>resultEvaluation&lt;/code> Expression of the base AnalysisCaseDefinition AnalysisCase from the Systems model library.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="16a4dba0-50e9-4893-b267-7761ca8209db" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="90b311a8-71cd-4947-81e1-3510e4d7377a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="484519a3-41e8-4cf5-b937-9a91b1e101e7" name="AnalysisCaseDefinition" visibility="public">
+      <ownedComment xmi:id="9f5fe444-e743-4576-99dd-e72af3951b43" annotatedElement="484519a3-41e8-4cf5-b937-9a91b1e101e7">
+        <body>&lt;p>An AnalysisCaseDefinition is a CaseDefinition for the case of carrying out an analysis.&lt;/p>
+
+&lt;p>An AnalysisCaseDefinition must subclass, directly or indirectly, the base AnalysisCaseDefinition AnalysisCase from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="8733b3ae-d645-4e25-801c-4feb801bf7e2" general="20e23891-303c-400f-909a-032f49ef946d"/>
+      <ownedAttribute xmi:id="d20711a2-c253-4dad-bf8d-a3e40c60c4dc" name="analysisAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isOrdered="true" isDerived="true" subsettedProperty="58a4f97e-ec9b-405a-a512-c223a347970e" association="9d0a067a-d801-4af9-8508-168ad74f48d3">
+        <ownedComment xmi:id="7e17aea4-02a5-4e61-a4ea-77667f0ae7d3" annotatedElement="d20711a2-c253-4dad-bf8d-a3e40c60c4dc">
+          <body>&lt;p>The &lt;code>actions&lt;/code> of the AnalysisCaseDefinitions that are typed as AnalysisActions. Each &lt;code>analysisAction&lt;/code> ActionUsage must subset the &lt;code&lt;>analysisSteps&lt;/code> ActionUsage of the base AnalysisCaseDefinition AnalysisCase from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b4111ec5-010b-462c-ae28-bfa2146d9512" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b198f9db-5f3e-4889-9b0b-cde4ef89b8cd" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="b70625ea-4c7c-4f1a-b41b-857c9d558a55" name="resultExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="7413c86e-1cfb-4727-b275-a5fafde797fa ea59f6ae-8a27-4163-a651-91da11bbfa67" association="eb816b6d-c1fe-4e24-a4c6-6533bafe2371">
+        <ownedComment xmi:id="2afb2cdd-3d5b-428a-9bb7-aeeed18fa31c" annotatedElement="b70625ea-4c7c-4f1a-b41b-857c9d558a55">
+          <body>&lt;p>The Expression used to compute the &lt;code>result&lt;/code> of the AnalysisCaseDefinition, derived as the Expression own via a ResultExpressionMembership. The &lt;code>resultExpression&lt;/code> must redefine directly or indirectly, the &lt;code>resultEvaluation&lt;/code> Expression of the base AnalysisCaseDefinition AnalysisCase from the Systems model library.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f9f9c7d9-2779-41b4-94c0-cac459b068f4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2f65cce5-bafc-4f63-907f-32bf2613c0ec" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9d0a067a-d801-4af9-8508-168ad74f48d3" name="" visibility="public" memberEnd="d20711a2-c253-4dad-bf8d-a3e40c60c4dc 59b86ecd-41e7-4acd-bcee-873436807d59">
+      <ownedEnd xmi:id="59b86ecd-41e7-4acd-bcee-873436807d59" name="featuringAnalysisCaseDefinition" visibility="public" type="484519a3-41e8-4cf5-b937-9a91b1e101e7" isDerived="true" subsettedProperty="cb023d69-80e9-4e0f-9a9d-7420ac84da10" association="9d0a067a-d801-4af9-8508-168ad74f48d3">
+        <ownedComment xmi:id="5a2b10b1-84e9-4961-a005-069694e6e5de" annotatedElement="59b86ecd-41e7-4acd-bcee-873436807d59">
+          <body>&lt;p>The AnalysisCaseDefinitions that have a certain ActionUsage as an &lt;code>analysisAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2a466f92-9e1b-4024-915c-7a63230c9dc9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8be0e20d-d940-4b48-a864-b4cc8edc6872" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="eb816b6d-c1fe-4e24-a4c6-6533bafe2371" name="" visibility="public" memberEnd="b70625ea-4c7c-4f1a-b41b-857c9d558a55 b5edf032-16e1-42dc-9658-8f0a70b5d42a">
+      <ownedEnd xmi:id="b5edf032-16e1-42dc-9658-8f0a70b5d42a" name="analysisCaseDefintion" visibility="public" type="484519a3-41e8-4cf5-b937-9a91b1e101e7" isDerived="true" subsettedProperty="521c8366-388f-410c-a57b-5256934269b5 938b7976-b666-4fc3-95f6-ce5646e2ea54" association="eb816b6d-c1fe-4e24-a4c6-6533bafe2371">
+        <ownedComment xmi:id="89e4ebb6-71a7-4bb1-a6ef-2e7703002b42" annotatedElement="b5edf032-16e1-42dc-9658-8f0a70b5d42a">
+          <body>&lt;p>The AnalysisCaseDefinitions that have a certain Expression as their &lt;code>resultExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0986d031-7602-4313-b361-3178d9d47e35" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="90bffc23-809c-4f96-9cc7-eae862d36a2b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d1329cd2-4af6-44a1-83c1-397eeea5561b" name="" visibility="public" memberEnd="e63d93a2-ea55-414a-bc3f-3effb86f5202 3b0d63f7-0bc9-4a8e-923b-7c3e26332f34">
+      <ownedEnd xmi:id="3b0d63f7-0bc9-4a8e-923b-7c3e26332f34" name="featuringAnalysisCase" visibility="public" type="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="d1329cd2-4af6-44a1-83c1-397eeea5561b">
+        <ownedComment xmi:id="eaf5f340-da33-454a-8098-eba232f58535" annotatedElement="3b0d63f7-0bc9-4a8e-923b-7c3e26332f34">
+          <body>&lt;p>The AnalysisCaseUsages that have a certain ActionUsage as an &lt;code>analysisAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9b8cf65a-014f-4517-aaeb-bb5af97b306c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="247c8e95-fb03-41ad-b344-e851027d406d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c106aa40-14f2-42b5-8590-272b3f537280" name="" visibility="public" memberEnd="33a47bf8-b624-4217-9dbc-773ccd356e82 04564c0e-0d18-4559-9185-6797658b2508">
+      <ownedEnd xmi:id="04564c0e-0d18-4559-9185-6797658b2508" name="analysisCase" visibility="public" type="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="c106aa40-14f2-42b5-8590-272b3f537280">
+        <ownedComment xmi:id="98a249dd-9070-4c1b-9601-8f3195f0b6c8" annotatedElement="04564c0e-0d18-4559-9185-6797658b2508">
+          <body>&lt;p>The AnalysisCaseUsages that have a certain Expression as their &lt;code>resultExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f5290876-5a95-490b-8df0-ec4867d2ece5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="eca67c89-0246-4ab9-b514-333faa9fec1f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d8375738-d2d4-4467-86d1-7b2a0444167b" name="" visibility="public" memberEnd="57979960-ae93-4521-86ff-d4ac1d35a408 d195b829-dd12-4baa-873b-98b26396a603">
+      <ownedEnd xmi:id="d195b829-dd12-4baa-873b-98b26396a603" name="definedAnalysisCase" visibility="public" type="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" isOrdered="true" isDerived="true" redefinedProperty="68ef8977-70e3-45c6-b3d6-88ce8e43d10a" association="d8375738-d2d4-4467-86d1-7b2a0444167b">
+        <ownedComment xmi:id="e9528819-5e9a-48f1-a5d3-bb9647b0b56d" annotatedElement="d195b829-dd12-4baa-873b-98b26396a603">
+          <body>&lt;p>The AnalysisCaseUsages being typed by a certain AnalysisCaseDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b7b97b9b-b160-4ecf-b817-d12dbe800657" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="25bcf596-667a-459a-9294-3f0d5e04e890" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5d810c6e-cf26-412c-b4d0-6d75d24777a4" name="" visibility="public" memberEnd="4ea5565c-d0ad-4761-b815-03bf0edd58a9 89569b8f-057c-495e-aa72-02fff1c005f9">
+      <ownedEnd xmi:id="89569b8f-057c-495e-aa72-02fff1c005f9" name="definedInterface" visibility="public" type="0e56c152-1b1c-4343-932c-0a979a2943ad" isDerived="true" subsettedProperty="11596646-ba5d-40a3-9bee-3c4a418cd55a" association="5d810c6e-cf26-412c-b4d0-6d75d24777a4">
+        <ownedComment xmi:id="a147d195-149e-442c-bf8c-5058be04b127" annotatedElement="89569b8f-057c-495e-aa72-02fff1c005f9">
+          <body>&lt;p>The InterfaceUsages typed by a certain InterfaceDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9fc9a37b-de46-4678-b0e9-93989132be22" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6c0131af-ed6b-4bff-9e46-135aa66c290d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7dedd46e-2ffd-46bf-8dca-d8c894902dca" name="InterfaceDefinition" visibility="public">
+      <ownedComment xmi:id="288ae1b2-aaed-417a-89ae-1ae28a2b9534" annotatedElement="7dedd46e-2ffd-46bf-8dca-d8c894902dca">
+        <body>&lt;p>An InterfaceDefinition is a ConnectionDefinition all of whose ends are PortUsages, defining an interface between elements that interact through such ports.&lt;/p>
+
+&lt;p>An InterfaceDefinition must subclass, directly or indirectly, the base InterfaceDefinition Interface from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="66590765-91c7-41fe-a8c3-ad902c36458f" general="0850c978-a960-479b-b462-53abc686273e"/>
+      <ownedAttribute xmi:id="cfc17545-6027-4616-815c-5a85490f125b" name="interfaceEnd" visibility="public" type="29e9a6bd-3e49-43d3-b43f-395beda16adc" isOrdered="true" isDerived="true" redefinedProperty="e445f08c-7fb5-4b4e-ba2a-7693cad822cc" association="364008d5-f570-468d-bccf-5508849f5c74">
+        <ownedComment xmi:id="124c1bf0-5f0d-4d5c-8988-fca21b51bbdb" annotatedElement="cfc17545-6027-4616-815c-5a85490f125b">
+          <body>&lt;p>The PortUsages that are the &lt;code>associationEnds&lt;/code> of this InterfaceDefinition.
+
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9ab782f9-da15-4d0a-b49d-93f574033a7a" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6e90271f-34e1-4546-98bd-9905e338ec99" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="0e56c152-1b1c-4343-932c-0a979a2943ad" name="InterfaceUsage" visibility="public">
+      <ownedComment xmi:id="c65e715c-e593-4b56-918a-1d09eddd7436" annotatedElement="0e56c152-1b1c-4343-932c-0a979a2943ad">
+        <body>&lt;p>An InterfaceUsage is a Usage of an InterfaceDefinition to represent an interface connecting parts of a system through specific ports.&lt;/p>
+
+&lt;p>An InterfaceUsage must subset, directly or indirectly, the base InterfaceUsage &lt;code>interfaces&lt;/code> from the Systems model libary.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="d09e0590-3d44-4490-a256-a1bf57f3f97d" general="bff72e7d-0f85-41e0-8138-4436ded8369d"/>
+      <ownedAttribute xmi:id="4ea5565c-d0ad-4761-b815-03bf0edd58a9" name="interfaceDefinition" visibility="public" type="7dedd46e-2ffd-46bf-8dca-d8c894902dca" isDerived="true" redefinedProperty="d2602be5-531e-4b57-bf07-1c6ba1f6f114" association="5d810c6e-cf26-412c-b4d0-6d75d24777a4">
+        <ownedComment xmi:id="eb2eb21c-a3d2-4c94-8209-a5891526945c" annotatedElement="4ea5565c-d0ad-4761-b815-03bf0edd58a9">
+          <body>&lt;p>The InterfaceDefinitions that type this InterfaceUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="416a3172-9665-44b6-8d7d-13736daa911a" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="22d36040-14da-4f65-ac4d-fdf5e2c70ee5" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="364008d5-f570-468d-bccf-5508849f5c74" name="" visibility="public" memberEnd="cfc17545-6027-4616-815c-5a85490f125b e7a66175-cde1-4a22-b8b1-6fc7de113eaa">
+      <ownedEnd xmi:id="e7a66175-cde1-4a22-b8b1-6fc7de113eaa" name="interfaceDefinitionWithEnd" visibility="public" type="7dedd46e-2ffd-46bf-8dca-d8c894902dca" isDerived="true" subsettedProperty="edd7db3a-1528-4f63-8014-e5455750fe0e" association="364008d5-f570-468d-bccf-5508849f5c74">
+        <ownedComment xmi:id="28915784-1458-42c5-98e6-bdc4b6cd4d45" annotatedElement="e7a66175-cde1-4a22-b8b1-6fc7de113eaa">
+          <body>&lt;p>The InterfaceDefinitions that have a certain PortUsage as an &lt;code>interfaceEnd&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3106fd9a-96c4-4563-aa6f-2977a8a3b30e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1526c5f4-aa03-48fa-86d7-ea6c28d19c97" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="57984062-3b27-4504-9a42-9828ff35bb43" name="" visibility="public" memberEnd="81650ec5-0051-4c1b-8a20-4e196bf4e2dd e5032f5f-c140-4ec4-956c-8ba776f6f221">
+      <ownedEnd xmi:id="e5032f5f-c140-4ec4-956c-8ba776f6f221" name="activeState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isDerived="true" association="57984062-3b27-4504-9a42-9828ff35bb43">
+        <ownedComment xmi:id="33049c05-e5d3-4ec1-80bf-64782f46124c" annotatedElement="e5032f5f-c140-4ec4-956c-8ba776f6f221">
+          <body>&lt;p>The StateUsages with a certain &lt;tt>doAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c9176d88-17c7-42bf-b561-02f684d48253" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="717d3d5d-a3d9-4a0f-9e16-4cc36ffc6190" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" name="StateUsage" visibility="public">
+      <ownedComment xmi:id="5890584b-aae6-4bd6-92b8-574a5d1cf22e" annotatedElement="6eefbf37-3bc7-4a0f-be57-5bd6b2344717">
+        <body>&lt;p>A StateUsage is an ActionUsage that is nominally the Usage of a StateDefinition. However, other kinds of kernel Behaviors are also allowed as types, to permit use of Behaviors from the Kernel Library.&lt;/p>
+
+&lt;p>A StateUsage (other than an ExhibitStateUsage owned by a PartDefinition or PartUsage) must subset, directly or indirectly, either the base StateUsage &lt;em>&lt;code>stateActions&lt;/code>&lt;/em> from the Systems model library, if it is not a composite feature, or the StateUsage &lt;em>&lt;code>substates&lt;/code>&lt;/em> inherited from its owner, if it is a composite feature.&lt;/p>
+
+&lt;p>A &lt;code>StateUsage&lt;/code> may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by StateBehaviorMembership Relationships, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the StateUsage.&lt;/code>&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="831b30a7-b514-4363-ab5a-0ff8fe1018d6" name="stateUsagesParallelGeneralization" visibility="public">
+        <ownedComment xmi:id="80a03b0d-2ddc-4f86-a3f9-b85701276853" annotatedElement="831b30a7-b514-4363-ab5a-0ff8fe1018d6">
+          <body>&lt;p>Every generalization of a StateUsage that is also a StateDefinition or a StateUsage must have the same value for &lt;code>isParallel&lt;/code> as this StateUsage.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="904a5378-c663-48ad-a40d-edfaf58d4d57" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>let general : Sequence(Type) = ownedGeneralization.general in
+general ->
+    selectByKind(StateDefinition).isParallel->
+    forAll(p | p = isParallel) and
+general ->
+    selectByKind(StateUsage).isParallel->
+    forAll(p | p = isParallel)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="4e892f3f-f416-4249-a2cf-49da9cd9991d" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="4c3c66de-b2c3-40e1-9037-18bfb5a18c19" name="stateDefinition" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isOrdered="true" isDerived="true" redefinedProperty="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b" association="546ddf66-c707-46a0-8983-112e7fb3f760">
+        <ownedComment xmi:id="f919b2f1-0e5c-4a7b-9110-95e1e5d02c13" annotatedElement="4c3c66de-b2c3-40e1-9037-18bfb5a18c19">
+          <body>&lt;p>The Behaviors that are the types of this StateUsage. Nominally, these would be StateDefinitions, but non-Activity Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4028b54e-df0e-44df-b542-5585f2d01897" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="081f7318-4b84-4926-a3c0-58e0982a90af" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5abcc3b4-e695-4aae-affd-d1be51ecfc1c" name="entryAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="07089ecd-f8f5-4d03-a9b9-76ef46580d6b">
+        <ownedComment xmi:id="389a8a1a-e50b-4b09-aea0-51bfce775512" annotatedElement="5abcc3b4-e695-4aae-affd-d1be51ecfc1c">
+          <body>&lt;p>The ActionUsage of this StateUsage to be performed on entry to the state specified by the StateUsage. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>entry&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1838d0ed-04a9-4a4f-94f8-915fca3490da" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8539ef93-245c-4ffe-9666-934a26d9b0b5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="81650ec5-0051-4c1b-8a20-4e196bf4e2dd" name="doAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="57984062-3b27-4504-9a42-9828ff35bb43">
+        <ownedComment xmi:id="f6e175b5-6e04-4c95-967a-082e6c641a2d" annotatedElement="81650ec5-0051-4c1b-8a20-4e196bf4e2dd">
+          <body>&lt;p>The ActionUsage of this StateUsage to be performed while in the state specified by the StateUsage. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>do&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0d8bddab-5584-43ee-a287-822138744764" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="dd79652b-d6d7-4b52-a2bd-4d2e0f861c31" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e708f648-e26a-4a3f-a960-2b156b0e4443" name="exitAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="dfa9ff9a-703e-4ba6-99bc-b7d9926216b6">
+        <ownedComment xmi:id="951b9c21-da49-44ba-a335-0c306cdc3362" annotatedElement="e708f648-e26a-4a3f-a960-2b156b0e4443">
+          <body>&lt;p>The ActionUsage of this StateUsage to be performed on exit from the state specified by the StateUsage. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>exit&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="252730ed-23c5-4c23-a77c-39c961a6abca" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7159e318-62cf-40a1-8cca-9dd5410acdca" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5ca55b14-5de2-4a4e-b0c7-2c3b4b959078" name="isParallel" visibility="public">
+        <ownedComment xmi:id="a6028ed2-982a-4fea-ae32-d9754574151b" annotatedElement="5ca55b14-5de2-4a4e-b0c7-2c3b4b959078">
+          <body>&lt;p>Whether the &lt;code>nestedStates&lt;/code> of this StateDefinition are to all be performed in parallel. If true, none of the &lt;code>nestedStates&lt;/code> may have any incoming or outgoing &lt;code>&lt;code>transitions. &lt;/code>&lt;/code>If false, only one &lt;code>nestedState&lt;/code> may be performed at a time.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="f3236878-f5c1-45d9-9045-af83ff633cd6" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f0f99605-685c-4d82-9bbe-a63db3c567fc" name="StateDefinition" visibility="public">
+      <ownedComment xmi:id="7931e784-bf2b-4f87-ba04-a0f18c9528eb" annotatedElement="f0f99605-685c-4d82-9bbe-a63db3c567fc">
+        <body>&lt;p>A StateDefinition is the Definition of the Behavior of a system or part of a system in a certain state condition.&lt;/p>
+
+&lt;p>A State Definition must subclass, directly or indirectly, the base StateDefinition &lt;em>StateAction&lt;/em> from the Systems model library.&lt;/p>
+
+&lt;p>A StateDefinition may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by StateBehaviorMembership Relationships, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the StateDefinition.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="de47a2fc-ca01-4655-9272-0826ae501d24" name="stateDefinitionIsParallelGeneralization" visibility="public">
+        <ownedComment xmi:id="121d0202-41b1-4389-943e-b5d4a05cf3b5" annotatedElement="de47a2fc-ca01-4655-9272-0826ae501d24">
+          <body>&lt;p>Every generalization of a StateDefinition that is also a StateDefinition must have the same value for &lt;code>isParallel&lt;/code> as this StateDefinition.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="83dd2ee5-6f8a-43e0-8fc2-89d53f83ee8f" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>ownedGeneralization.general->
+    selectByKind(StateDefinition).isParallel->
+    forAll(p | p = isParallel)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="ffda3ba0-8713-4904-aa25-11298b76ab94" general="724913be-4700-496b-accb-f45750955b14"/>
+      <ownedAttribute xmi:id="033d75dc-2ecc-415f-a55d-ca9a7437d0fb" name="state" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isOrdered="true" isDerived="true" subsettedProperty="c559f3c7-96bd-45da-a2c7-1770af2759aa" association="615effa3-df36-4ea6-af27-6a3fad5e10b8">
+        <ownedComment xmi:id="5aacec16-b75d-43de-9f7a-d31d6557b1d8" annotatedElement="033d75dc-2ecc-415f-a55d-ca9a7437d0fb">
+          <body>&lt;p>The StateUsages that are the &lt;tt>steps&lt;/tt> of the StateDefinition, which specify the discrete states in the Behavior defined by the StateDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="996f962e-c3c1-4037-9f29-1271a7abd1fc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fa4c5841-47d0-4144-ab22-3bbb4051e271" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5de082ff-e768-4e91-a42c-901ad8cdfddc" name="entryAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="94740f76-9d0d-4701-abb3-f4b7dcc76948">
+        <ownedComment xmi:id="0034ac1d-2190-4d19-a57d-8cb4fa8f6954" annotatedElement="5de082ff-e768-4e91-a42c-901ad8cdfddc">
+          <body>&lt;p>The ActionUsage of this StateDefinition to be performed on entry to the state defined by the StateDefinition. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>entry&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1b715cb5-7986-495e-861b-b1b7fdaefedd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0e8c0cfe-f4ec-4bce-a64d-212f4b816416" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f675b4dc-80e9-47df-85cf-b375a2c8d3de" name="doAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="f3d26d64-58c1-407e-9e52-7c05cbae4598">
+        <ownedComment xmi:id="babe63d2-d550-4b16-b64a-d35a6548b0ec" annotatedElement="f675b4dc-80e9-47df-85cf-b375a2c8d3de">
+          <body>&lt;p>The ActionUsage of this StateDefinition to be performed while in the state defined by the StateDefinition. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>do&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="935ef707-f4b7-4439-bf5f-6d7a49d6ec54" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="65780229-503a-4374-9b05-9a9104645b3c" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f307fece-6233-47c4-9673-67624c207097" name="exitAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="a2e39b5f-eda3-4f14-9d87-4dde3a2fd868">
+        <ownedComment xmi:id="8dca339f-d677-4d22-bcc7-176d45db95a2" annotatedElement="f307fece-6233-47c4-9673-67624c207097">
+          <body>&lt;p>The ActionUsage of this StateDefinition to be performed on exit from the state defined by the StateDefinition. This is derived as the owned ActionUsage related to the StateDefinition by a StateSubactionMembership  with &lt;tt>kind&lt;/tt> = &lt;tt>exit&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a5f8614c-4d7b-450c-a914-0129a22ef906" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b089046c-399f-46c9-8a8a-f0e205640de9" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fe7bddcc-519a-4799-b54a-0d81891ad1d5" name="isParallel" visibility="public">
+        <ownedComment xmi:id="a6a635fc-2fd0-4bce-9c96-19ddbc965f7e" annotatedElement="fe7bddcc-519a-4799-b54a-0d81891ad1d5">
+          <body>&lt;p>Whether the &lt;code>ownedStates&lt;/code> of this StateDefinition are to all be performed in parallel. If true, none of the &lt;code>ownedStates&lt;/code> may have any incoming or outgoing &lt;code>&lt;code>transitions. &lt;/code>&lt;/code>If false, only one &lt;code>ownedState&lt;/code> may be performed at a time.&lt;/p>
+</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="91423519-470c-4900-8716-dc3165b803e0" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="546ddf66-c707-46a0-8983-112e7fb3f760" name="" visibility="public" memberEnd="4c3c66de-b2c3-40e1-9037-18bfb5a18c19 bef1013a-3895-4cb4-beab-61fbadb0b829">
+      <ownedEnd xmi:id="bef1013a-3895-4cb4-beab-61fbadb0b829" name="definedState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isDerived="true" subsettedProperty="fb464d93-e7f2-4d5d-9e9c-aaf2c4fdd16c" association="546ddf66-c707-46a0-8983-112e7fb3f760">
+        <ownedComment xmi:id="55da3205-5e07-4a18-8ac4-87e3c04685e8" annotatedElement="bef1013a-3895-4cb4-beab-61fbadb0b829">
+          <body>&lt;p>The Behaviors that are the types of this StateUsage. Nominally, these would be StateDefinition, but non-StateDefinition Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c8de09a6-d705-43c5-b465-abf215007396" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="60ed9fb6-b065-4dc5-b567-7c90dcdb8880" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f3d26d64-58c1-407e-9e52-7c05cbae4598" name="" visibility="public" memberEnd="f675b4dc-80e9-47df-85cf-b375a2c8d3de ce52c19a-5028-4420-a7f6-0b7d0eb4caaa">
+      <ownedEnd xmi:id="ce52c19a-5028-4420-a7f6-0b7d0eb4caaa" name="activeStateDefintion" visibility="public" type="f0f99605-685c-4d82-9bbe-a63db3c567fc" isDerived="true" association="f3d26d64-58c1-407e-9e52-7c05cbae4598">
+        <ownedComment xmi:id="394617eb-b633-4af3-9777-8f151a7314d2" annotatedElement="ce52c19a-5028-4420-a7f6-0b7d0eb4caaa">
+          <body>&lt;p>The StateDefinitions with a certain &lt;tt>doAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="32e436f3-96bf-483d-8b0d-d19bb560ac36" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2960da66-4f8e-456d-8187-7de9f0d486fa" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d6076ef0-f964-4b74-95ce-74d8c95c3539" name="TransitionUsage" visibility="public">
+      <ownedComment xmi:id="0eb14c6a-fa39-4410-92ee-fcc2078ed38e" annotatedElement="d6076ef0-f964-4b74-95ce-74d8c95c3539">
+        <body>&lt;p>A TransitionUsage is an ActionUsage that is a behavioral Step representing a transition between ActionUsages or StateUsages.&lt;/p>
+
+&lt;p>A TransitionUsage must subset, directly or indirectly, the base TransitionUsage &lt;code>transitionActions&lt;/code>, if it is not a composite feature, or the TransitionUsage &lt;code>subtransitions&lt;/code> inherited from its owner, if it is a composite feature.&lt;/p>
+
+&lt;p>A TransitionUsage may by related to some of its &lt;code>ownedFeatures&lt;/code> using TransitionFeatureMembership Relationships, corresponding to the triggers, guards and effects of the TransitionUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="8dd5ca84-bcbe-4ca7-94a9-9d5bc05fe43c" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="2e2ac422-6617-4268-8761-134e646ad347" name="source" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="fbcd1131-f07f-4963-a5da-33d4087b9e11">
+        <ownedComment xmi:id="5dd78c40-728b-4a53-89c2-a3e601f95aed" annotatedElement="2e2ac422-6617-4268-8761-134e646ad347">
+          <body>&lt;p>The source ActionUsage of this TransitionUsage, derived as the &lt;tt>source&lt;/tt> of the &lt;tt>succession&lt;/tt> for the TransitionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="02c6bae0-169c-4940-9b32-fe28474d2814" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ee30a5ee-5460-4ba2-aaba-2400b5b87363" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a652ed66-e325-4038-8768-216e067a6207" name="target" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="254ca0fc-a6a3-426e-8aef-fd1a0878a371">
+        <ownedComment xmi:id="89eb8898-4278-4e15-a4a2-e22102d313df" annotatedElement="a652ed66-e325-4038-8768-216e067a6207">
+          <body>&lt;p>The target ActionUsage of this TransitionUsage, derived as the &lt;tt>target&lt;/tt> of the &lt;tt>succession&lt;/tt> for the TransitionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="68099ebc-dae5-4497-8626-3ce8f3a5b749" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bb1d313c-fbe6-4353-a00a-fa6dbafd835c" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="178eae3e-8ada-4dc4-af8b-2e27af326a78" name="triggerAction" visibility="public" type="27109495-ccfe-41d5-acb1-a77ceef57800" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="6f589fed-cb13-4e73-a34a-489ab8591d5b">
+        <ownedComment xmi:id="bb6b58a7-55b0-4089-8161-60384963e573" annotatedElement="178eae3e-8ada-4dc4-af8b-2e27af326a78">
+          <body>&lt;p>The AcceptActionUsages that define the triggers of this TransitionUsage, derived as the &lt;code>ownedFeatures&lt;/code> of this TransitionUsage related to it by a TransitionFeatureMembership with &lt;code>kind&lt;/code> = &lt;code>trigger&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="440e4463-a2b8-43e8-a250-d498ae8db0d2" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="169595fe-bd25-430b-8d05-056ddb7716ff" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="45afc642-b76b-4cb9-9e5c-dea8f15ffe41" name="guardExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="b90750f5-e0a2-4cad-8f03-3f1353fde024">
+        <ownedComment xmi:id="c465a22d-ff8a-456b-9fa2-3d0fe6d310c6" annotatedElement="45afc642-b76b-4cb9-9e5c-dea8f15ffe41">
+          <body>&lt;p>The Expressions that define the guards of this TransitionUsage, derived as the &lt;code>ownedFeatures&lt;/code> of this TransitionUsage related to it by a TransitionFeatureMembership with &lt;code>kind&lt;/code> = &lt;code>guard&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2a520b03-ef17-4896-a0c0-0326cebb46cb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="243928a1-f46b-4791-8a04-a8b4d52a341e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="01730311-16da-48b5-8b5c-a432780457d1" name="effectAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="2359c63a-6c3c-4811-84d6-5225d028303b">
+        <ownedComment xmi:id="2e15b9b1-76f6-4fc5-8c1c-86c29ca31c9d" annotatedElement="01730311-16da-48b5-8b5c-a432780457d1">
+          <body>&lt;p>The ActionUsages that define the effects of this TransitionUsage, derived as the &lt;tt>ownedFeatures&lt;/tt> of this TransitionUsage related to it by a TransitionFeatureMembership with &lt;tt>kind&lt;/tt> = &lt;tt>effect&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="95fe0821-3106-4f6c-964d-fed80f8c13e3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2f422558-f0f6-4cdd-ab0e-f99a49e8a8a7" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fe5a7b03-8db7-4c33-8f32-29ce19eab694" name="succession" visibility="public" type="fec12715-7238-4666-8f45-3e70ed179c7b" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="3620cf93-860b-40c7-b850-118220b332c8">
+        <ownedComment xmi:id="73aabbbb-b77e-47e0-8352-da14048551ae" annotatedElement="fe5a7b03-8db7-4c33-8f32-29ce19eab694">
+          <body>&lt;p>The Succession that is the &lt;code>ownedFeature&lt;/code> of this TransitionUsage that redefines &lt;code>TransitionPerformance::transitionLink&lt;/code>.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5c3b2e9a-8546-4e33-a1da-7a6d8c98c708" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="49b28ead-ff68-4a26-8df9-d0cded9b6a6f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a2e39b5f-eda3-4f14-9d87-4dde3a2fd868" name="" visibility="public" memberEnd="f307fece-6233-47c4-9673-67624c207097 501c98a6-d201-4111-8e2e-c936dc6e937e">
+      <ownedEnd xmi:id="501c98a6-d201-4111-8e2e-c936dc6e937e" name="exitedStateDefinition" visibility="public" type="f0f99605-685c-4d82-9bbe-a63db3c567fc" isDerived="true" association="a2e39b5f-eda3-4f14-9d87-4dde3a2fd868">
+        <ownedComment xmi:id="de09125f-1001-4914-a4ac-cc26bb1fd5e1" annotatedElement="501c98a6-d201-4111-8e2e-c936dc6e937e">
+          <body>&lt;p>The StateDefinitions with a certain &lt;tt>exitAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="896aea99-2960-431f-9d34-6f6f1f6d041f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="59b20ca8-52d1-42b2-9e6c-a3049e891908" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="07089ecd-f8f5-4d03-a9b9-76ef46580d6b" name="" visibility="public" memberEnd="5abcc3b4-e695-4aae-affd-d1be51ecfc1c bc45335d-4376-4f0d-aa56-16c4020b817f">
+      <ownedEnd xmi:id="bc45335d-4376-4f0d-aa56-16c4020b817f" name="enteredState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isDerived="true" association="07089ecd-f8f5-4d03-a9b9-76ef46580d6b">
+        <ownedComment xmi:id="af81bcdf-6de6-44d7-a131-a507f0d8f988" annotatedElement="bc45335d-4376-4f0d-aa56-16c4020b817f">
+          <body>&lt;p>The StateUsages with a certain &lt;tt>entryAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f436b2c4-f756-4a6f-9329-64cce40acdc9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2fa727fa-54af-4542-8086-97fd3486c55d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3e18b934-129e-4e3d-8872-21433eb0b1f9" name="TransitionFeatureMembership" visibility="public">
+      <ownedComment xmi:id="7e6d5eed-9b77-4ea5-bf93-132a96bbf7b9" annotatedElement="3e18b934-129e-4e3d-8872-21433eb0b1f9">
+        <body>&lt;p>A TransitionFeatureMembership is a FeatureMembership for a trigger, guard or effect of a TransitionUsage. The &lt;code>ownedMemberFeature&lt;/code> must be a Step. For a trigger, the &lt;code>ownedMemberFeature&lt;/code> must more specifically be a Transfer, while for a guard it must be an Expression with a result type of Boolean.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="d090c4bb-3195-4214-bd36-ec57014a6b7d" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="b3ab5578-e197-4e0f-850d-c1cccb3d9a3e" name="kind" visibility="public" type="c720dc71-ad6c-45f8-93a6-25154c68d1bd">
+        <ownedComment xmi:id="6c9a8ea7-0a00-4b80-b3d5-b6b05d5009f9" annotatedElement="b3ab5578-e197-4e0f-850d-c1cccb3d9a3e">
+          <body>&lt;p>Whether this TransitionFeatureMembership is for a trigger, guard or effect.&lt;/p></body>
+        </ownedComment>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8f28bf96-9be1-4b7d-8f3e-24d9a7fc3878" name="transitionFeature" visibility="public" type="b1a2875a-af89-47c5-ad2b-d5763c43aafd" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="dba27ce7-da1a-443f-a684-b6a885852bc3">
+        <ownedComment xmi:id="350da506-68f8-4c68-a6fa-839c3c0284e4" annotatedElement="8f28bf96-9be1-4b7d-8f3e-24d9a7fc3878">
+          <body>&lt;p>The Step that is the &lt;tt>ownedMemberFeature&lt;/tt> of this TransitionFeatureMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="597be5a8-5d5b-4771-871f-8e930962c70d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f043fc62-f1ee-4a85-8558-37828e1b1ef7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d7f092e1-1350-4d38-acdb-5cc55bc9c4cb" name="" visibility="public" memberEnd="f30a978a-5471-47c6-a279-1e41e7cb51bb 87c5016e-2ad0-485e-832a-d8ce30cc68c9">
+      <ownedEnd xmi:id="87c5016e-2ad0-485e-832a-d8ce30cc68c9" name="exhibitingState" visibility="public" type="31dbd7e6-18fc-4974-83d4-2b7731f86a98" isDerived="true" subsettedProperty="64bfffb5-01e9-4a92-af43-0f13349797b1" association="d7f092e1-1350-4d38-acdb-5cc55bc9c4cb">
+        <ownedComment xmi:id="51d11c76-35f0-4a88-85d8-19149db8a2dd" annotatedElement="87c5016e-2ad0-485e-832a-d8ce30cc68c9">
+          <body>&lt;p>The ExhibitStateUsages that have a certain StateUsage as their &lt;tt>exhibitedState&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d5869a3b-07f6-4044-957c-76d77be68a59" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3421c3ef-369d-453a-8dd9-e5401decb67e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3620cf93-860b-40c7-b850-118220b332c8" name="" visibility="public" memberEnd="fe5a7b03-8db7-4c33-8f32-29ce19eab694 34eeceaa-d09d-463a-b059-35b77e23f768">
+      <ownedEnd xmi:id="34eeceaa-d09d-463a-b059-35b77e23f768" name="linkedTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="3620cf93-860b-40c7-b850-118220b332c8">
+        <ownedComment xmi:id="1fec44c1-7961-4b4c-9d3b-cd939b622b21" annotatedElement="34eeceaa-d09d-463a-b059-35b77e23f768">
+          <body>&lt;p>The Transition that owns a certain Succession.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d2d7a16b-3e87-4fe3-aeb7-2a69543cab16" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4f34bf17-91df-4660-95fe-01ddb1c9a0d3" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="4e29b745-46f5-4abf-bf45-e2c27d2f5d38" name="StateSubactionMembership" visibility="public">
+      <ownedComment xmi:id="bb1953ca-e468-489e-89fd-eecf57cbe52c" annotatedElement="4e29b745-46f5-4abf-bf45-e2c27d2f5d38">
+        <body>&lt;p>A StateSubactionMembership is a FeatureMembership for an entry, do or exit ActionUsage of a StateDefinition or StateUsage. The &lt;code>ownedMemberFeature&lt;/code> of a StateSubactionMembership must be an ActionUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="bf00f1fa-2260-4d17-b233-4079ebbcf3b0" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="e90f223e-be15-4cf6-aaee-2e9d9b9cff82" name="kind" visibility="public" type="8e3ea644-a738-406c-81e1-2a03fa98c62a">
+        <ownedComment xmi:id="6c3b461a-6de9-4d2e-b06c-d784a514e242" annotatedElement="e90f223e-be15-4cf6-aaee-2e9d9b9cff82">
+          <body>&lt;p>Whether this StateSubactionMembership is for an entry, do or exit ActionUsage.&lt;/p></body>
+        </ownedComment>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="660493b5-176e-4df0-acbb-58ad0c3292ac" name="action" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="42756245-216e-4857-83c9-4070fa23a7ab">
+        <ownedComment xmi:id="2fb042f7-af42-4f05-927c-bb05996d9bd6" annotatedElement="660493b5-176e-4df0-acbb-58ad0c3292ac">
+          <body>&lt;p>The ActionUsage that is the &lt;tt>ownedMemberFeature&lt;/tt> of this StateSubactionMembership.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="21eadbc3-7862-4b29-9260-809cc84513d1" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="125de75c-18e4-491c-b482-90fc6365a7f2" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="31dbd7e6-18fc-4974-83d4-2b7731f86a98" name="ExhibitStateUsage" visibility="public">
+      <ownedComment xmi:id="03950328-20cc-448e-8bf4-ffb9f3946e62" annotatedElement="31dbd7e6-18fc-4974-83d4-2b7731f86a98">
+        <body>&lt;p>An ExhibitStateUsage is a StateUsage that represents the exhibiting of a StateUsage. Unless it is the StateUsage itself, the StateUsage to be exhibited is related to the ExhibitStateUsage by a ReferenceSubsetting Relationship. An ExhibitStateUsage is also a PerformActionUsage, with its &lt;code>exhibitedState&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>
+
+&lt;p>If the ExhibitStateUsage is owned by a PartDefinition or PartUsage, then it also subsets the StateUsage &lt;em>&lt;code>Part::exhibitedStates&lt;/code>&lt;/em> from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="16bef1b8-0eda-4650-82a8-97537d36a7ec" general="6eefbf37-3bc7-4a0f-be57-5bd6b2344717"/>
+      <generalization xmi:id="40abb1ba-8c2f-4dea-9f86-3b2fc173c757" general="0b38b835-cf24-4e57-8181-eb89afa4f4c4"/>
+      <ownedAttribute xmi:id="f30a978a-5471-47c6-a279-1e41e7cb51bb" name="exhibitedState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isDerived="true" redefinedProperty="a5fa4b84-c430-4318-bb02-174edd37e882" association="d7f092e1-1350-4d38-acdb-5cc55bc9c4cb">
+        <ownedComment xmi:id="7351e1e2-d45f-4530-802c-1e5d2729e296" annotatedElement="f30a978a-5471-47c6-a279-1e41e7cb51bb">
+          <body>&lt;p>The StateUsage to be exhibited by the ExhibitStateUsage. It is the &lt;code>performedAction&lt;/code> of the ExhibitStateUsage considered as an PerformActionUsage, which must be an StateUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5d605001-52d7-40bc-8f35-e5efe9732b38" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c908d8e5-c584-4366-bc70-01684fc0a39e" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="8e3ea644-a738-406c-81e1-2a03fa98c62a" name="StateSubactionKind" visibility="public">
+      <ownedComment xmi:id="e2ecebd2-3d2b-4814-90d7-2ced261ad914" annotatedElement="8e3ea644-a738-406c-81e1-2a03fa98c62a">
+        <body>&lt;p>A StateSubactionKind indicates whether the &lt;tt>action&lt;/tt> of a StateSubactionMembership is an entry, do or exit action.&lt;/p></body>
+      </ownedComment>
+      <ownedComment xmi:id="f74f7cea-664b-4ec8-b14f-39f1d6777dbe" annotatedElement="8e3ea644-a738-406c-81e1-2a03fa98c62a">
+        <body>&lt;p>A StateActionKind indicates whether a Action feature of a State is an entry, do or exit Action.</body>
+      </ownedComment>
+      <ownedLiteral xmi:id="900cc9fd-6c7d-46bd-a396-2f3d511d4e30" name="entry" visibility="public">
+        <ownedComment xmi:id="f85b0c57-ebfa-4851-a973-3032e4adc670" annotatedElement="900cc9fd-6c7d-46bd-a396-2f3d511d4e30">
+          <body>&lt;p>Indicates that a subaction of a StateUsage is an entry action.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="b4e8fef2-e7fe-449d-801b-0a25787085b6" name="do" visibility="public">
+        <ownedComment xmi:id="e17aaa33-6ae8-4649-bf1f-8a9a0d0f1d04" annotatedElement="b4e8fef2-e7fe-449d-801b-0a25787085b6">
+          <body>&lt;p>Indicates that a subaction of a StateUsage is a do action.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="6ff91042-406a-47b7-a521-ae27df26badc" name="exit" visibility="public">
+        <ownedComment xmi:id="8692d684-7569-40ab-89bd-2221d67ca8c7" annotatedElement="6ff91042-406a-47b7-a521-ae27df26badc">
+          <body>&lt;p>Indicates that a subaction of a StateUsage is an exit action.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="dba27ce7-da1a-443f-a684-b6a885852bc3" name="" visibility="public" memberEnd="8f28bf96-9be1-4b7d-8f3e-24d9a7fc3878 b3243139-31f3-42dc-9f2a-c13f7d2285c5">
+      <ownedEnd xmi:id="b3243139-31f3-42dc-9f2a-c13f7d2285c5" name="transitionFeatureMembership" visibility="public" type="3e18b934-129e-4e3d-8872-21433eb0b1f9" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="dba27ce7-da1a-443f-a684-b6a885852bc3">
+        <ownedComment xmi:id="24dc2740-491e-4aae-baaa-cb122341b17e" annotatedElement="b3243139-31f3-42dc-9f2a-c13f7d2285c5">
+          <body>&lt;p>The TransitionFeatureMembership that owns a certain Step (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e750482a-29a7-4a63-abef-159e89c48c42" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8845f41d-6f80-4c9e-ae6e-2a53251d590f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="94740f76-9d0d-4701-abb3-f4b7dcc76948" name="" visibility="public" memberEnd="5de082ff-e768-4e91-a42c-901ad8cdfddc 17622193-37ae-4f88-9a96-7b786fc75f6d">
+      <ownedEnd xmi:id="17622193-37ae-4f88-9a96-7b786fc75f6d" name="enteredStateDefinition" visibility="public" type="f0f99605-685c-4d82-9bbe-a63db3c567fc" isDerived="true" association="94740f76-9d0d-4701-abb3-f4b7dcc76948">
+        <ownedComment xmi:id="622af2b1-8998-4c38-adff-eb80f8203dcf" annotatedElement="17622193-37ae-4f88-9a96-7b786fc75f6d">
+          <body>&lt;p>The StateDefinitions with a certain &lt;tt>entryAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="14aa4180-a2b6-4cc4-bbb9-2a491a4a7694" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4ef6b76b-7387-494a-90c8-f8df38d6403e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b90750f5-e0a2-4cad-8f03-3f1353fde024" name="" visibility="public" memberEnd="45afc642-b76b-4cb9-9e5c-dea8f15ffe41 3c0a5f74-5ec1-4027-97f1-bfdbe97b0c21">
+      <ownedEnd xmi:id="3c0a5f74-5ec1-4027-97f1-bfdbe97b0c21" name="guardedTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="b90750f5-e0a2-4cad-8f03-3f1353fde024">
+        <ownedComment xmi:id="8e11c9cc-d98d-43c2-8328-3927be98b6a6" annotatedElement="3c0a5f74-5ec1-4027-97f1-bfdbe97b0c21">
+          <body>&lt;p>The TransitionUsage that is guarded by a certain Expression.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9b8943c3-cf4d-46c2-a180-50b8cf012772" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="265d7def-8dc9-471a-b3bd-4faa7ba13c04" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6f589fed-cb13-4e73-a34a-489ab8591d5b" name="" visibility="public" memberEnd="178eae3e-8ada-4dc4-af8b-2e27af326a78 9bddf75e-e81c-4eff-b62e-77084223aa18">
+      <ownedEnd xmi:id="9bddf75e-e81c-4eff-b62e-77084223aa18" name="triggeredTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="6f589fed-cb13-4e73-a34a-489ab8591d5b">
+        <ownedComment xmi:id="3fe761f4-0378-45d7-ab87-9d10021d79c4" annotatedElement="9bddf75e-e81c-4eff-b62e-77084223aa18">
+          <body>&lt;p>The TransitionUsage that is triggered by a certain AcceptActionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="902db905-d5ca-495e-92d3-e12c6d6bc585" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="147b8e38-9cd2-4c08-b1c5-8fcf8186cba8" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="254ca0fc-a6a3-426e-8aef-fd1a0878a371" name="" visibility="public" memberEnd="a652ed66-e325-4038-8768-216e067a6207 65e0b85e-8b2a-4ec1-85b1-05a93f770a5e">
+      <ownedEnd xmi:id="65e0b85e-8b2a-4ec1-85b1-05a93f770a5e" name="incomingTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" association="254ca0fc-a6a3-426e-8aef-fd1a0878a371">
+        <ownedComment xmi:id="515bb83b-6c5b-407b-b845-19377e4d4240" annotatedElement="65e0b85e-8b2a-4ec1-85b1-05a93f770a5e">
+          <body>&lt;p>The TransitionUsage incoming to a certain target &lt;tt>ActionUsage&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e365ddd-4dc5-489f-a2ea-fa640422a124" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3dd9d993-fff4-4249-90a6-aba5c1f1a634" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2359c63a-6c3c-4811-84d6-5225d028303b" name="" visibility="public" memberEnd="01730311-16da-48b5-8b5c-a432780457d1 c8e4ac4a-e3ac-4e85-9306-d7d8d1e5bbc0">
+      <ownedEnd xmi:id="c8e4ac4a-e3ac-4e85-9306-d7d8d1e5bbc0" name="activeTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="2359c63a-6c3c-4811-84d6-5225d028303b">
+        <ownedComment xmi:id="937bbcfc-0feb-4172-ac6a-0f7b7ddc0a5f" annotatedElement="c8e4ac4a-e3ac-4e85-9306-d7d8d1e5bbc0">
+          <body>&lt;p>The TransitionUsage that has a certain &lt;tt>effectAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5b2d5ac3-07c7-4f2b-bf0c-a82ab28e5b95" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b27c8759-f1e9-4f51-aae9-5907ce694e14" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="c720dc71-ad6c-45f8-93a6-25154c68d1bd" name="TransitionFeatureKind" visibility="public">
+      <ownedComment xmi:id="56a725b3-b224-4457-902d-2bcc66225194" annotatedElement="c720dc71-ad6c-45f8-93a6-25154c68d1bd">
+        <body>&lt;p>A TransitionActionKind indicates whether the &lt;tt>transitionFeature&lt;/tt> of a TransitionFeatureMembership is a trigger, guard or effect.&lt;/p></body>
+      </ownedComment>
+      <ownedLiteral xmi:id="3bffb3dc-fb65-4375-aa6b-4c6fa44171f2" name="trigger" visibility="public">
+        <ownedComment xmi:id="09acdbe2-e340-451c-a3b7-12c8b4ae1533" annotatedElement="3bffb3dc-fb65-4375-aa6b-4c6fa44171f2">
+          <body>&lt;p>Indicates that a member Transfer of a TransitionUsage represents a trigger.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="7985fc54-44ab-43ae-958b-878ab7a45b4e" name="guard" visibility="public">
+        <ownedComment xmi:id="0814197c-b1d9-48d2-a589-1bb2958df2dc" annotatedElement="7985fc54-44ab-43ae-958b-878ab7a45b4e">
+          <body>&lt;p>Indicates that a member Expression of a TransitionUsage represents a guard.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="dad294d3-737b-4726-b5e6-2eb0816a467d" name="effect" visibility="public">
+        <ownedComment xmi:id="9441cbde-9ea4-4a2e-b87c-161168df7224" annotatedElement="dad294d3-737b-4726-b5e6-2eb0816a467d">
+          <body>&lt;p>Indicates that a member Step of a TransitionUsage represents an effect.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="615effa3-df36-4ea6-af27-6a3fad5e10b8" name="" visibility="public" memberEnd="033d75dc-2ecc-415f-a55d-ca9a7437d0fb 597c8f86-4a1c-474f-99f6-9374288c0ae7">
+      <ownedEnd xmi:id="597c8f86-4a1c-474f-99f6-9374288c0ae7" name="featuringStateDefinition" visibility="public" type="f0f99605-685c-4d82-9bbe-a63db3c567fc" isDerived="true" subsettedProperty="25696705-71e7-4f65-aead-1d106b54640c" association="615effa3-df36-4ea6-af27-6a3fad5e10b8">
+        <ownedComment xmi:id="0ba069aa-4078-4926-8e64-cd1cb6fd8099" annotatedElement="597c8f86-4a1c-474f-99f6-9374288c0ae7">
+          <body>&lt;p>The StateDefinitions featuring a certain StateUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2f585cae-e1e3-4bf2-9926-0dd672d6930f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="00dc2de0-daa3-49f0-9bfc-15e10d3c6c66" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="dfa9ff9a-703e-4ba6-99bc-b7d9926216b6" name="" visibility="public" memberEnd="e708f648-e26a-4a3f-a960-2b156b0e4443 d6d5c5cc-37f1-40bc-9fda-dee48ded5d05">
+      <ownedEnd xmi:id="d6d5c5cc-37f1-40bc-9fda-dee48ded5d05" name="exitedState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isDerived="true" association="dfa9ff9a-703e-4ba6-99bc-b7d9926216b6">
+        <ownedComment xmi:id="6047f235-cafd-4eef-85a1-424cfea4aece" annotatedElement="d6d5c5cc-37f1-40bc-9fda-dee48ded5d05">
+          <body>&lt;p>The StateUsages with a certain &lt;tt>exitAction&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="42b796b2-f37d-423b-aaed-b7555068a417" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="49f18472-0093-4049-bc67-d9815928b252" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="fbcd1131-f07f-4963-a5da-33d4087b9e11" name="" visibility="public" memberEnd="2e2ac422-6617-4268-8761-134e646ad347 28859102-19a5-4860-b437-b315a3cf2a5f">
+      <ownedEnd xmi:id="28859102-19a5-4860-b437-b315a3cf2a5f" name="outgoingTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" association="fbcd1131-f07f-4963-a5da-33d4087b9e11">
+        <ownedComment xmi:id="41476eb8-cdca-4cd3-8745-b7035d39981c" annotatedElement="28859102-19a5-4860-b437-b315a3cf2a5f">
+          <body>&lt;p>The TransitionUsage outgoing from a certain source &lt;tt>ActionUsage&lt;/tt>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="27e139c4-beec-437f-8783-41b540832504" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="30d2223f-2371-42e8-b220-6eb2e99f0ae6" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="42756245-216e-4857-83c9-4070fa23a7ab" name="" visibility="public" memberEnd="660493b5-176e-4df0-acbb-58ad0c3292ac 5f9bbb74-5842-405a-af34-2e16848711d8">
+      <ownedEnd xmi:id="5f9bbb74-5842-405a-af34-2e16848711d8" name="stateSubactionMembership" visibility="public" type="4e29b745-46f5-4abf-bf45-e2c27d2f5d38" isDerived="true" subsettedProperty="b2830939-3d87-40dc-8acf-ed3f043eba1a" association="42756245-216e-4857-83c9-4070fa23a7ab">
+        <ownedComment xmi:id="15639afe-ea55-4138-a8de-220fe5db8c89" annotatedElement="5f9bbb74-5842-405a-af34-2e16848711d8">
+          <body>&lt;p>The StateSubactionMembership that is the owner of a certain ActionUsage (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fe6398d3-0173-44e8-9774-817091c6d14f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="509fa256-1c57-4623-b16f-fae05046aa8b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d7339f02-b333-4a36-a518-80642d2caee5" name="MetadataDefinition" visibility="public">
+      <ownedComment xmi:id="77b74547-92ba-4cf4-b119-efed89f6fd6f" annotatedElement="d7339f02-b333-4a36-a518-80642d2caee5">
+        <body>&lt;p>A MetadataDefinition is an ItemDefinition that is also a Metaclass.&lt;/p>
+
+&lt;p>A MetadataDefinition must subclassofy, directly or indirectly, the base MetadataDefinition MetadataItem from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="53b6af0f-47b5-4083-b7d5-aed80e3f089f" general="e2828a60-dd7a-434a-a161-1245b70f44a2"/>
+      <generalization xmi:id="b2acbec6-6f2e-42a3-ac74-76bd4577e08b" general="39dba466-47bd-4a57-aab6-e6a0524cb57e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7ad44795-c498-4b29-9af3-c1bf96867f82" name="MetadataUsage" visibility="public">
+      <ownedComment xmi:id="f8a937b2-7456-4ea1-a8ce-fc8a3f55545d" annotatedElement="7ad44795-c498-4b29-9af3-c1bf96867f82">
+        <body>&lt;p>An MetadataUsage is a Usage and a MetadataFeature, used to annotate other Elements in a system model with metadata. As a MetadataFeature, its type must be a Metaclass, which will nominally be a MetadataDefinition. However, any Kernel Metaclass is also allowed, to permit use of Metaclasses from the Kernel Library.&lt;/p>
+
+&lt;p>A MetadataUsage must subset, directly or indirectly, the base MetadataUsage &lt;code>metadataItems&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="13b48f4b-65e9-498d-8ba0-398fe8e4fd5b" general="e8388855-f13a-4505-ac2e-b342de9f7c66"/>
+      <generalization xmi:id="91f0b52d-67a1-48b9-b670-d51c9f952933" general="2b4eb448-4bfe-4fb4-9509-33764e4f1fc3"/>
+      <ownedAttribute xmi:id="202e4792-4090-4f18-a146-a4db2c6e38a8" name="metadataDefinition" visibility="public" type="39dba466-47bd-4a57-aab6-e6a0524cb57e" isDerived="true" redefinedProperty="18ab486b-757f-4c4d-8569-01e9cf669e5f 9f743946-04e1-48ce-9097-b65525c16ac4" association="295a601d-1913-4978-849e-5897234866da">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2f60ceaa-3d64-4569-a0c0-af04138cc187" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fb8aaf4b-1dec-4d81-924e-0014cc9e5758" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="295a601d-1913-4978-849e-5897234866da" name="" visibility="public" memberEnd="202e4792-4090-4f18-a146-a4db2c6e38a8 8ecd5001-d381-4c84-83c8-4d5fbdf4a34d">
+      <ownedEnd xmi:id="8ecd5001-d381-4c84-83c8-4d5fbdf4a34d" name="definedMetadata" visibility="public" type="7ad44795-c498-4b29-9af3-c1bf96867f82" isDerived="true" subsettedProperty="591eb622-a431-49b0-9c31-8fd191b9278e 739d9684-1083-4731-a7a9-08d898edd9d5" association="295a601d-1913-4978-849e-5897234866da">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e8a93d87-aa93-4e00-bce8-a2a35e2d9762" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d8c9f8cf-b55b-4b30-8d13-b027cc1521e6" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f4f87730-4061-47b9-92d7-d9e185a5f613" name="" visibility="public" memberEnd="d712c7ba-3631-4c56-a776-7d0f0192c6ee 1a2af97e-b4a4-47f0-8bf7-2bad74a4da38">
+      <ownedEnd xmi:id="1a2af97e-b4a4-47f0-8bf7-2bad74a4da38" name="featuringAllocationDefinition" visibility="public" type="e6b408d3-00b9-4b93-a8ea-08255ec016bc" isDerived="true" subsettedProperty="eb7af616-8e9c-419a-a08a-4b80d758179f" association="f4f87730-4061-47b9-92d7-d9e185a5f613">
+        <ownedComment xmi:id="8c31fa73-06b0-4d54-8270-e6bc62b4408d" annotatedElement="1a2af97e-b4a4-47f0-8bf7-2bad74a4da38">
+          <body>&lt;p>The AllocationDefinitions that feature a certain &lt;code>allocation&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d636c971-100a-41eb-8431-04ba6dea12e6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5b9eb49c-3a5b-42ff-bafd-c9a482654b10" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c4116b15-215c-4da7-87a3-8db004ecee19" name="" visibility="public" memberEnd="ae68f647-4990-4c51-9ebe-3aa90bfbf78f 5a92585d-22d9-4a6e-82a5-e7236f0a9486">
+      <ownedEnd xmi:id="5a92585d-22d9-4a6e-82a5-e7236f0a9486" name="definedAllocation" visibility="public" type="67972056-88ee-40e2-9e91-95d3ab49988c" isDerived="true" subsettedProperty="11596646-ba5d-40a3-9bee-3c4a418cd55a" association="c4116b15-215c-4da7-87a3-8db004ecee19">
+        <ownedComment xmi:id="d04bd7d2-ca04-466a-9ee9-ea59ffabfbe4" annotatedElement="5a92585d-22d9-4a6e-82a5-e7236f0a9486">
+          <body>&lt;p>The AllocationUsages that have a certain AllocationDefinition as their &lt;code>allocationDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bdd7b137-7075-4375-ab25-d6d18bad9537" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3dd6d04f-133b-46e0-a609-4ab3dfa8e74e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e6b408d3-00b9-4b93-a8ea-08255ec016bc" name="AllocationDefinition" visibility="public">
+      <ownedComment xmi:id="9675b16b-359f-47c3-af5d-b84b55a1be2b" annotatedElement="e6b408d3-00b9-4b93-a8ea-08255ec016bc">
+        <body>&lt;p>An AllocationDefinition is a ConnectionDefinition that specifies that some or all of the responsibility to realize the intent of the &lt;code>source&lt;/code> is allocated to the &lt;code>target&lt;/code> instances. Such allocations define mappings across the various structures and hierarchies of a system model, perhaps as a precursor to more rigorous specifications and implementations. An AllocationDefinition can itself be refined using nested &lt;code>allocations&lt;/code> that give a finer-grained decomposition of the containing allocation mapping.&lt;/p>
+
+&lt;p>An AllocationDefinition must subclass, directly or indirectly, the base AllocationDefinition Allocation from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="4cea6a90-f9df-4e8a-b010-b30f10f43d44" general="0850c978-a960-479b-b462-53abc686273e"/>
+      <ownedAttribute xmi:id="d712c7ba-3631-4c56-a776-7d0f0192c6ee" name="allocation" visibility="public" type="67972056-88ee-40e2-9e91-95d3ab49988c" isOrdered="true" isDerived="true" subsettedProperty="db471ae1-04e1-47b7-b6bc-2d40afdda735" association="f4f87730-4061-47b9-92d7-d9e185a5f613">
+        <ownedComment xmi:id="d42d0d3b-3e10-451c-878c-7f0046ffd689" annotatedElement="d712c7ba-3631-4c56-a776-7d0f0192c6ee">
+          <body>&lt;p>The ActionUsages that refine the allocation mapping defined by this AllocationDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="47991def-13bf-4ff1-a06c-4a7830694d51" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a5b636a6-e14d-45c8-aa35-baddf68e4308" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="67972056-88ee-40e2-9e91-95d3ab49988c" name="AllocationUsage" visibility="public">
+      <ownedComment xmi:id="e5d2bd0b-820e-4931-96fc-8f3c22ea8537" annotatedElement="67972056-88ee-40e2-9e91-95d3ab49988c">
+        <body>&lt;p>An AllocationUsage is a usage of an AllocationDefinition asserting the allocation of the &lt;code>source&lt;/code> feature to the &lt;code>target&lt;/code> feature.&lt;/p>
+
+&lt;p>An AllocationUsage must subset, directly or indirectly, the base AllocatopnUsage &lt;code>allocations&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="467f832f-6ba2-4eac-a636-9806c536d47e" general="bff72e7d-0f85-41e0-8138-4436ded8369d"/>
+      <ownedAttribute xmi:id="ae68f647-4990-4c51-9ebe-3aa90bfbf78f" name="allocationDefinition" visibility="public" type="e6b408d3-00b9-4b93-a8ea-08255ec016bc" isOrdered="true" isDerived="true" redefinedProperty="d2602be5-531e-4b57-bf07-1c6ba1f6f114" association="c4116b15-215c-4da7-87a3-8db004ecee19">
+        <ownedComment xmi:id="0bb4a5d5-553a-4ed4-bd02-403e77299418" annotatedElement="ae68f647-4990-4c51-9ebe-3aa90bfbf78f">
+          <body>&lt;p>The AllocationDefinitions that are the types of this AllocationUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c773a555-7bd3-420e-8703-176988d47d97" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2e5527e5-80c4-42d1-bc3f-0bb46f0d0dc5" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e2828a60-dd7a-434a-a161-1245b70f44a2" name="ItemDefinition" visibility="public">
+      <ownedComment xmi:id="dfca677c-e677-416c-abd1-d6c5add08df4" annotatedElement="e2828a60-dd7a-434a-a161-1245b70f44a2">
+        <body>&lt;p>An ItemDefinition is an OccurrenceDefinition of the Structure of things that may be acted on by a system or parts of a system, which do not necessarily perform actions themselves. This includes items that can be exchanged between parts of a system, such as water or electrical signals.&lt;/p>
+
+&lt;p>An ItemDefinition must subclass, directly or indirectly, the base ItemDefinition Item from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="b4c65861-558e-45a8-85b8-5a4b3602c9b0" general="eabb05a5-3e97-41e1-9668-d9bf801193a6"/>
+      <generalization xmi:id="5f71901e-c275-4cb4-b6f8-6646b82aec17" general="01787c81-d827-4988-80ba-3f358b159b5c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e8388855-f13a-4505-ac2e-b342de9f7c66" name="ItemUsage" visibility="public">
+      <ownedComment xmi:id="215705af-c76f-40ef-9448-fc76969d937b" annotatedElement="e8388855-f13a-4505-ac2e-b342de9f7c66">
+        <body>&lt;p>An ItemUsage is a Usage whose type is a Structure. Nominally, if the type is an ItemDefinition, an ItemUsage is a Usage of that ItemDefinition within a system. However, other types of Kernel Structure are also allowed, to permit use of Structures from the Kernel Library.&lt;/p>
+
+&lt;p>An ItemUsage must subset, directly or indirectly, the base ItemUsage &lt;code>items&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="de1189c6-e20d-47bf-b11d-b80a40b6ec31" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
+      <ownedAttribute xmi:id="18ab486b-757f-4c4d-8569-01e9cf669e5f" name="itemDefinition" visibility="public" type="eabb05a5-3e97-41e1-9668-d9bf801193a6" isOrdered="true" isDerived="true" subsettedProperty="48d91227-fa8b-4b65-a4f8-d27701f010c0" association="e1e0ea17-ed4b-46fd-ae36-0596aa463ba4">
+        <ownedComment xmi:id="d8522bde-8470-4d49-b0d9-149a8edd4083" annotatedElement="18ab486b-757f-4c4d-8569-01e9cf669e5f">
+          <body>&lt;p>The Structures that are the &lt;code>definitions&lt;/code> of this ItemUsage. Nominally, these are ItemDefinitions, but other kinds of Kernel Structures are also allowed, to permit use of Structures from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ffe54f83-de15-452b-a8df-c837b5cbe829" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a7744e6a-7c61-407f-8ce3-a0c3b2c9dbc2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c61a3e3d-e883-4d55-b1bb-f2033bddb900" name="" visibility="public" memberEnd="0425cbe9-87c2-479c-9137-1c4d0db84d64 0c29a636-56e6-44e1-b143-d83f8bbd491b">
+      <ownedEnd xmi:id="0c29a636-56e6-44e1-b143-d83f8bbd491b" name="supplierDependency" visibility="public" type="bc688f07-ccfb-4e85-a7c4-47b134eae0a2" subsettedProperty="c8c8655b-9eca-49d4-a0a9-bb9f5b05e4cc" association="c61a3e3d-e883-4d55-b1bb-f2033bddb900">
+        <ownedComment xmi:id="fc176cdf-6226-4188-b06f-05e6a7ee8688" annotatedElement="0c29a636-56e6-44e1-b143-d83f8bbd491b">
+          <body>&lt;p>The Dependencies that have a certain &lt;code>supplier&lt;/code> Element.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9a60801d-1511-4c45-8d4a-18ab2e37add0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="990d1d87-52ec-4ec5-8450-de0f91a4999c" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="bc688f07-ccfb-4e85-a7c4-47b134eae0a2" name="Dependency" visibility="public">
+      <ownedComment xmi:id="cf833ac6-c561-4540-8377-a151402269de" annotatedElement="bc688f07-ccfb-4e85-a7c4-47b134eae0a2">
+        <body>&lt;p>A Dependency is a Relationship that indicates that one or more &lt;code>client&lt;/code> Elements require one more &lt;code>supplier&lt;/code> Elements for their complete specification. In general, this means that a change to one of the &lt;code>supplier&lt;/code> Elements may necessitate a change to, or re-specification of, the &lt;code>client&lt;/code> Elements.&lt;/p>
+
+&lt;p>Note that a Dependency is entirely a model-level Relationship, without instance-level semantics.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="f5604832-b42c-49f2-a98e-6c659f8d82df" general="d00373f6-e7de-4c9f-9b9a-35937ead2cb2"/>
+      <ownedAttribute xmi:id="fa88481d-e047-457b-a97b-33e6614d3698" name="client" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" redefinedProperty="7aa626dc-3421-4c50-845b-0e7252b338a3" association="b28feb66-69e0-4c52-af18-2e86055c02e8">
+        <ownedComment xmi:id="a31cfcea-f390-4945-8058-b65521139fc5" annotatedElement="fa88481d-e047-457b-a97b-33e6614d3698">
+          <body>&lt;p>The Element or Elements dependent on the &lt;code>supplier&lt;/code> elements.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6decbad8-9a60-4dc5-97c1-97a4a441e5a1" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a102a586-f0a8-4c69-804a-71876f9ac9ed" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0425cbe9-87c2-479c-9137-1c4d0db84d64" name="supplier" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" redefinedProperty="f9ad7982-12c9-4ce4-b3f4-9db53977bf4f" association="c61a3e3d-e883-4d55-b1bb-f2033bddb900">
+        <ownedComment xmi:id="492a418e-934b-485b-81e6-2231bd62fc2c" annotatedElement="0425cbe9-87c2-479c-9137-1c4d0db84d64">
+          <body>&lt;p>The Element or Elements on which the &lt;code>client&lt;/code> Elements depend in some respect.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1bd811f1-ae37-46cb-b700-cb961a930d77" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5f12016c-f797-423a-b4a1-34610912ef50" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b28feb66-69e0-4c52-af18-2e86055c02e8" name="" visibility="public" memberEnd="fa88481d-e047-457b-a97b-33e6614d3698 b6abdcdb-3a49-41ce-8d5e-c845d177d236">
+      <ownedEnd xmi:id="b6abdcdb-3a49-41ce-8d5e-c845d177d236" name="clientDependency" visibility="public" type="bc688f07-ccfb-4e85-a7c4-47b134eae0a2" subsettedProperty="1807da4c-d8f2-454f-911f-8a98c3302238" association="b28feb66-69e0-4c52-af18-2e86055c02e8">
+        <ownedComment xmi:id="b904f107-f2a3-4e8a-8b98-840f0a041aee" annotatedElement="b6abdcdb-3a49-41ce-8d5e-c845d177d236">
+          <body>&lt;p>The Dependencies that have a certain &lt;code>client&lt;/code> Element.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0d987771-301d-4a24-8a18-5ed243f8dc66" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6009940b-e883-4028-a5d1-66a532f4b6db" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="26e6aa7c-46d2-4956-991d-64da16dd1acc" name="" visibility="public" memberEnd="1066b39d-39ba-4fc3-971d-bd711a49591c 938f3e99-bd1e-44a6-89f8-27cea9054f77">
+      <ownedEnd xmi:id="938f3e99-bd1e-44a6-89f8-27cea9054f77" name="constraintOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="89af2f5e-fcfa-48b7-8619-9c69476636a8" association="26e6aa7c-46d2-4956-991d-64da16dd1acc">
+        <ownedComment xmi:id="eecf3bbb-30d9-4d2f-96b2-42fda37e0ec9" annotatedElement="938f3e99-bd1e-44a6-89f8-27cea9054f77">
+          <body>&lt;p>The Usage in which the &lt;code>nestedConstraint&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="fc090096-b027-4f22-96f9-d5acfead99f3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cb4f7adc-8ef1-4032-90e5-543636d17ca7" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="83d3bbc3-2b95-4509-94b9-20a08dc428b5" name="" visibility="public" memberEnd="6ea7a0bd-fed4-4a99-86b7-92be051a0ae3 d2ecc1ac-01d9-4f0b-822b-c2ab527d841f">
+      <ownedEnd xmi:id="d2ecc1ac-01d9-4f0b-822b-c2ab527d841f" name="viewOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e02ee31c-b895-45b1-a5bb-a0a465f786e0" association="83d3bbc3-2b95-4509-94b9-20a08dc428b5">
+        <ownedComment xmi:id="e0e9dede-aba9-43bf-9e42-d6650bf0bd7a" annotatedElement="d2ecc1ac-01d9-4f0b-822b-c2ab527d841f">
+          <body>&lt;p>The Usage that owns a certain &lt;code>nestedView&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f22a982c-524c-4027-a328-c724e540ffef" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3cc00e28-acde-4a46-be3f-ac2ba3e1977a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="53836f9c-34b6-46b2-b80d-9d838b0f7907" name="" visibility="public" memberEnd="3e2a6d59-1ce1-4e97-8c51-b9cb80288403 81d65e5f-a516-4fbe-b6b9-5793a09a272e">
+      <ownedEnd xmi:id="81d65e5f-a516-4fbe-b6b9-5793a09a272e" name="constraintOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="3c1e0401-e330-4089-8c54-9a506130d046" association="53836f9c-34b6-46b2-b80d-9d838b0f7907">
+        <ownedComment xmi:id="0cbab053-08e4-4e79-840b-d510e426d29e" annotatedElement="81d65e5f-a516-4fbe-b6b9-5793a09a272e">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedConstraint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f1dc65db-db9c-423f-8860-ac73a8464819" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8137f757-3f30-42a5-9aeb-2abc3fd9f011" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8c9399db-1848-4465-a0de-452ba3b34192" name="" visibility="public" memberEnd="f90352ba-7bd0-4c54-abc6-fd410d32b4c8 21998b02-4c47-40b3-b34b-019a3cb7ba79">
+      <ownedEnd xmi:id="21998b02-4c47-40b3-b34b-019a3cb7ba79" name="metadataOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="cd556efb-5f4e-4b19-81aa-5e8c14842c3c" association="8c9399db-1848-4465-a0de-452ba3b34192">
+        <ownedComment xmi:id="0fafbb17-fdf9-4771-9acc-ecfe15c1e6ac" annotatedElement="21998b02-4c47-40b3-b34b-019a3cb7ba79">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedMetadata&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d08157f9-3b1a-4d09-b6f0-cd4004d3af6e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="670d4d6d-2f69-4c09-8cf3-731d77dce55e" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4ff10784-5cd0-49f2-91ec-087c7ddf11be" name="" visibility="public" memberEnd="bfea518a-6198-4704-9a48-e058427e2ad4 19be2d84-b7d1-4c60-b9b5-c607c64ccbf5">
+      <ownedEnd xmi:id="19be2d84-b7d1-4c60-b9b5-c607c64ccbf5" name="verificationCaseOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf" association="4ff10784-5cd0-49f2-91ec-087c7ddf11be">
+        <ownedComment xmi:id="4d8ca551-7d02-45f2-948d-a95c6c47a09e" annotatedElement="19be2d84-b7d1-4c60-b9b5-c607c64ccbf5">
+          <body>&lt;p>The Definition that owns a certain &lt;code>ownedVerificationCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="de6dc1a0-204e-4251-aeb8-dddc33ea49c8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6a94b945-a8aa-40e1-890e-8f8483f954cb" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f7294915-6686-4060-90b2-2943ad4deeac" name="" visibility="public" memberEnd="15fc9960-b3be-4ab1-bb7b-1adea032e1e0 b75c3925-7b99-4aff-85a7-ddaa55421b0b">
+      <ownedEnd xmi:id="b75c3925-7b99-4aff-85a7-ddaa55421b0b" name="verificationCaseOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="9bc76574-5dd5-415b-b578-4f8b34ca7e48" association="f7294915-6686-4060-90b2-2943ad4deeac">
+        <ownedComment xmi:id="09d9b83d-32a7-4fe3-9572-ee10712ee731" annotatedElement="b75c3925-7b99-4aff-85a7-ddaa55421b0b">
+          <body>&lt;p>The Usage that owns a certain &lt;code>nestedVerificationCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="31355f2b-7753-40f2-8618-41e1ba2574d4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="95c58b0f-72f0-4ed3-9a3d-407baaf4afec" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="bbec763b-2ef0-415f-9e22-c531739690bb" name="Definition" visibility="public">
+      <ownedComment xmi:id="577641f7-33d1-4777-b3b6-f43850838917" annotatedElement="bbec763b-2ef0-415f-9e22-c531739690bb">
+        <body>&lt;p>A Definition is a Classifier of Usages. The actual kinds of Definitions that may appear in a model are given by the subclasses of Definition (possibly as extended with user-defined &lt;em>&lt;code>SemanticMetadata&lt;/code>&lt;/em>).&lt;/p>
+
+&lt;p>Normally, a Definition has owned Usages that model &lt;code>features&lt;/code> of the thing being defined. A Definition may also have other Definitions nested in it, but this has no semantic significance, other than the nested scoping resulting from the Definition being considered as a Namespace for any nested Definitions.&lt;/p>
+
+&lt;p>However, if a Definition has &lt;code>isVariation&lt;/code> = &lt;code>true&lt;/code>, then it represents a &lt;em>variation point&lt;/em> Definition. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> Usages, related to the Definition by VariantMembership Relationships. Rather than being &lt;code>features&lt;/code> of the Definition, &lt;code>variant&lt;/code> Usages model different concrete alternatives that can be chosen to fill in for an abstract Usage of the variation point Definition.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="2d0a2214-8597-4d66-859e-a40876895ed3" name="definitionIsVariationMembership" visibility="public" constrainedElement="bbec763b-2ef0-415f-9e22-c531739690bb">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="efc810db-e959-4f53-8d34-8954b7faa299" name="" visibility="public">
+          <language>English</language>
+          <body>isVariation implies variantMembership = ownedMembership</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="92d59baa-f46a-420a-9fca-3b0b2cc0dea6" name="definitionVariant" visibility="public" constrainedElement="bbec763b-2ef0-415f-9e22-c531739690bb">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="dcc8bf50-77a5-4b81-96ea-6ec4420fe8cd" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>variant = variantMembership.ownedVariantUsage</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="fb695cca-e09d-49bd-ab7d-24a3936c516e" name="definitionVariantMembership" visibility="public" constrainedElement="bbec763b-2ef0-415f-9e22-c531739690bb">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4cb2001c-1958-46c5-868c-0d7502e267dd" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>variantMembership = ownedMembership->selectByKind(VariantMembership)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="f3a74bbb-421e-44c7-b543-a16a0ba0fc6f" name="definitionNonVariationMembership" visibility="public" constrainedElement="bbec763b-2ef0-415f-9e22-c531739690bb">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="2d01887a-58a0-4d7f-874c-08b958e6b22c" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>not isVariation implies variantMembership->isEmpty()</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="e1ba0516-06a6-409d-8599-7c3227e70cdc" general="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da"/>
+      <ownedAttribute xmi:id="ab0dbb87-5e95-4819-9217-2128904f4064" name="ownedUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67 db471ae1-04e1-47b7-b6bc-2d40afdda735" association="6afc692e-dabc-424f-bcbb-7994a6f71c84">
+        <ownedComment xmi:id="cc254e5a-7fdc-4841-a54c-bdb766355c64" annotatedElement="ab0dbb87-5e95-4819-9217-2128904f4064">
+          <body>&lt;p>The Usages that are &lt;code>ownedFeatures&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c72f0bec-3e72-4707-be65-e476c98ea35e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e57de53b-3b42-4d9f-ad5e-9bb99b6287ef" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f00ad2e5-df7c-4367-8191-0ba63c3818a5" name="ownedPort" visibility="public" type="29e9a6bd-3e49-43d3-b43f-395beda16adc" isOrdered="true" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="1133d2a0-1b95-40ee-bbd3-039516e636aa">
+        <ownedComment xmi:id="d57bbfc3-a809-4132-ba52-89745d909054" annotatedElement="f00ad2e5-df7c-4367-8191-0ba63c3818a5">
+          <body>&lt;p>The PortUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="314714f4-972a-4011-8ef9-46147211a8b9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fa1b3d41-6155-4380-96c1-966b0d6bf116" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="6d75f458-5fe0-4c99-8e0f-a41c252b972c" name="directedUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="db471ae1-04e1-47b7-b6bc-2d40afdda735 ee47daa4-a81f-4204-b23b-bfc54283691f" association="820df8ab-51c8-4d5a-bb66-70d583ab4d1b">
+        <ownedComment xmi:id="d585e16c-9cda-4878-870f-4b7676d01022" annotatedElement="6d75f458-5fe0-4c99-8e0f-a41c252b972c">
+          <body>&lt;p>The &lt;code>usages&lt;/code> of this Definition that are &lt;code>directedFeatures&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0aa99f56-d0a8-4872-9487-dbf46059a3ec" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4121cde0-6648-4fff-90d1-6136a1a7daff" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="db471ae1-04e1-47b7-b6bc-2d40afdda735" name="usage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="7aa36b16-c1ef-4a46-b5e7-2a6e803b9a70">
+        <ownedComment xmi:id="b9b50baf-39e3-4467-b548-0fccdb34c564" annotatedElement="db471ae1-04e1-47b7-b6bc-2d40afdda735">
+          <body>&lt;p>The Usages that are &lt;code>features&lt;/code> of this Definition (not necessarily owned).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4ba3f9d1-1627-474e-82a0-970e90f17af9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a6103e9e-abe2-41b5-b7c8-4c25fd88bd25" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="6f6ca85a-aeb6-493d-a191-cfca8fe6dad5" name="ownedState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isOrdered="true" isDerived="true" subsettedProperty="2d4bf0a5-00ef-4645-9c5d-777acd6d59cb" association="1d4d04e6-aebe-4aa9-9298-00f332a87556">
+        <ownedComment xmi:id="0ae1b7a6-556f-41e1-bf15-2e7399a33667" annotatedElement="6f6ca85a-aeb6-493d-a191-cfca8fe6dad5">
+          <body>&lt;p>The StateUsages that are &lt;tt>ownedUsages&lt;/tt> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="001569b3-94c9-4c9b-8390-6c5e590963ff" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="08bddea7-064c-46ec-af06-7faf3680efc1" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="3e2a6d59-1ce1-4e97-8c51-b9cb80288403" name="ownedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="f2bd28f0-4070-4e5f-8705-512fd368c9dd" association="53836f9c-34b6-46b2-b80d-9d838b0f7907">
+        <ownedComment xmi:id="44c9fae1-a50b-40ce-ab2b-8273bf571a32" annotatedElement="3e2a6d59-1ce1-4e97-8c51-b9cb80288403">
+          <body>&lt;p>The ConstraintUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6f82831c-8b32-4cb3-a835-c689399cdc98" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="53b9460c-f42d-4c8d-9c6b-f50616b1cc31" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="25886946-6e56-4ed2-b780-db818aae189e" name="ownedTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="b74e5af3-a7e7-4665-a5fb-50ed40e7f3f7">
+        <ownedComment xmi:id="9da5e134-968d-43af-af7a-86597148ab8a" annotatedElement="25886946-6e56-4ed2-b780-db818aae189e">
+          <body>&lt;p>The TransitionUsages that are &lt;tt>ownedUsages&lt;/tt> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8879ddab-b114-41aa-91d8-c0a695518369" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7fcd6937-6bd8-4c2e-8a59-24647e7a30f7" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8" name="ownedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" subsettedProperty="3e2a6d59-1ce1-4e97-8c51-b9cb80288403" association="5d14dd7d-b089-4abd-b035-a32d12db069e">
+        <ownedComment xmi:id="60e51b90-0ed0-40c9-8174-3549692660dc" annotatedElement="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8">
+          <body>&lt;p>The RequirementUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d35cb802-1dd6-41b4-996b-5630efa32ddc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5d75a8db-9337-4864-bee6-e34d3234c57e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="39599fde-2f5c-41f1-8b5a-08e27a774f5a" name="ownedCalculation" visibility="public" type="92887cda-1376-415e-86ad-315e1dcd7de8" isOrdered="true" isDerived="true" subsettedProperty="2d4bf0a5-00ef-4645-9c5d-777acd6d59cb" association="8552ebd4-bc13-4cf4-89d2-0ed28eb014fa">
+        <ownedComment xmi:id="f21b10ff-7886-47ba-885d-ae48f0b7a2c3" annotatedElement="39599fde-2f5c-41f1-8b5a-08e27a774f5a">
+          <body>&lt;p>The CalculationUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="974c24c0-2a95-4dfd-8f87-01958767ee00" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c4772e16-68bd-4f8f-a0fb-a4ffa864ae7c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8e24f413-fa0a-4a87-b76f-f9d7b22d1a97" name="isVariation" visibility="public">
+        <ownedComment xmi:id="7f82b08f-09c2-4e6a-b99a-cca992bf88c4" annotatedElement="8e24f413-fa0a-4a87-b76f-f9d7b22d1a97">
+          <body>&lt;p>Whether this Definition is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the Definition must be VariantMemberships.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="674fade2-b925-4c8b-99e7-ed712c89841a" name="variantMembership" visibility="public" type="7a990883-5206-4c30-b4cc-ba108b6189bc" aggregation="composite" isDerived="true" subsettedProperty="ec58580f-851c-4202-a5c6-27b2ec9ac376" association="6ce2ae7d-53c1-4239-9bd0-b6bc82de5225">
+        <ownedComment xmi:id="da7dbc97-3d5e-46f1-8bd4-d079011f28ba" annotatedElement="674fade2-b925-4c8b-99e7-ed712c89841a">
+          <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this Definition that are VariantMemberships. If &lt;code>isVariation&lt;/code> = true, then this must be all &lt;code>ownedMemberships&lt;/code> of the Definition. If &lt;code>isVariation&lt;/code> = false, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="92513fbe-1295-4928-bce1-f21220d2aba7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e0130f1d-f2a3-4869-9cea-1750c7bcd8a4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1bea5bf3-104c-4d5b-9cc3-b497ab54bbe9" name="ownedAnalysisCase" visibility="public" type="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" isOrdered="true" isDerived="true" subsettedProperty="45242a19-de1a-4447-8ee3-b968526d0f9a" association="37ed8019-d592-4473-80e4-5102eedf54aa">
+        <ownedComment xmi:id="2a6ca527-f709-4f2d-bcaa-2ea324f961c1" annotatedElement="1bea5bf3-104c-4d5b-9cc3-b497ab54bbe9">
+          <body>&lt;p>The AnalysisCaseUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0108e2e3-622a-4af5-88c7-1f897135452a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="82917962-2fd1-45e1-ad5d-c0cb1bbf9c65" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a7ab48c4-002a-4667-adb1-6f686d79f5e3" name="variant" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="45e2cdc1-69fe-40de-9fcf-d7cfed32f16c">
+        <ownedComment xmi:id="83b07d6b-635d-4104-835a-3296a3d18076" annotatedElement="a7ab48c4-002a-4667-adb1-6f686d79f5e3">
+          <body>&lt;p>The Usages which represent the variants of this Definition as a variation point Definition, if &lt;code>isVariation&lt;/code> = true. If &lt;code>isVariation&lt;/code> = false, the there must be no &lt;code>variants&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="89ae44a8-0c42-4f36-9d2c-2095ee8ff09e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="38823677-e846-44fd-b5f7-17c4f48febe8" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="45242a19-de1a-4447-8ee3-b968526d0f9a" name="ownedCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" isOrdered="true" isDerived="true" subsettedProperty="39599fde-2f5c-41f1-8b5a-08e27a774f5a" association="00621e08-29e7-4a2c-86f7-ac6b73a5ecc8">
+        <ownedComment xmi:id="a998884c-b796-4cd4-b2c0-1387891f4ceb" annotatedElement="45242a19-de1a-4447-8ee3-b968526d0f9a">
+          <body>&lt;p>The CaseUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3f5df3d9-66d2-4520-8de6-8d7de8a73ce0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f8a59d16-2331-4e5d-8237-89ed1673e2c6" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="fbb36072-eee7-484d-a317-a7e136fa8f06" name="ownedReference" visibility="public" type="ad315d17-6754-4a30-bcde-3b73d63d713e" isOrdered="true" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="81f427da-0f6e-4bda-8d22-ed46ae8afb56">
+        <ownedComment xmi:id="78490e59-91d8-4cf1-9d8d-03408452f43b" annotatedElement="fbb36072-eee7-484d-a317-a7e136fa8f06">
+          <body>&lt;p>The ReferenceUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b6310466-0a6c-46de-a7db-ac4620cabfff" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9ac40989-ad44-4d30-b649-f983a7cad549" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="2d4bf0a5-00ef-4645-9c5d-777acd6d59cb" name="ownedAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isOrdered="true" isDerived="true" subsettedProperty="f2bd28f0-4070-4e5f-8705-512fd368c9dd" association="eec6956a-f52e-4908-b514-221639f6646d">
+        <ownedComment xmi:id="46ee7834-63f0-40fa-a7be-95dbdeda8577" annotatedElement="2d4bf0a5-00ef-4645-9c5d-777acd6d59cb">
+          <body>&lt;p>The ActionUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/code></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="096d269f-e0fb-4dac-8c15-a3761073ef09" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8061276a-9be8-4cae-84b5-2517896971ce" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0f491f54-f387-4e6e-99bc-e6b15106a0d2" name="ownedConnection" visibility="public" type="f4b1326b-70e0-4f33-93b0-85fb497a26a1" isOrdered="true" isDerived="true" subsettedProperty="8e3f1de2-c767-4cdd-af33-aacf5abe7d73" association="c2984cd0-947a-4b13-b73a-ce65ca1fe772">
+        <ownedComment xmi:id="b37fd73b-a1e5-4b59-92e7-eba1f43e6fc6" annotatedElement="0f491f54-f387-4e6e-99bc-e6b15106a0d2">
+          <body>&lt;p>The ConnectorAsUsages that are &lt;code>ownedUsages&lt;/code> of this Definition. Note that this list includes BindingConnectorAsUsages and SuccessionAsUsages, even though these are ConnectorAsUsages but not ConnectionUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5324d792-eedd-4cd9-be20-3caef5c7d9c5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a0928587-d22c-4b2d-a068-8d4fa9af12fe" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="c0e2fc49-66a1-457d-a4bc-acca01367a03" name="ownedItem" visibility="public" type="e8388855-f13a-4505-ac2e-b342de9f7c66" isOrdered="true" isDerived="true" subsettedProperty="f2bd28f0-4070-4e5f-8705-512fd368c9dd" association="807f9988-cac2-4037-951e-97b300bd1f1c">
+        <ownedComment xmi:id="498a6b6d-8fb8-438a-9677-28a4b605bfa3" annotatedElement="c0e2fc49-66a1-457d-a4bc-acca01367a03">
+          <body>&lt;p>The ItemUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2ff94658-ce3c-403b-be6b-e2c8a7fc05c8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b66bfcfd-ea4c-4eaf-8c24-f1b85b6f0ea4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8e3f1de2-c767-4cdd-af33-aacf5abe7d73" name="ownedPart" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="c0e2fc49-66a1-457d-a4bc-acca01367a03" association="d7257e72-d5e4-4a24-8e53-dd845a3c9845">
+        <ownedComment xmi:id="83457bc1-5940-4da4-b403-250e2cf59d15" annotatedElement="8e3f1de2-c767-4cdd-af33-aacf5abe7d73">
+          <body>&lt;p>The PartUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2d0cd14d-1943-4779-ba59-88d5932acaae" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="edd4e04c-2156-4156-ba76-815627542a4b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4b4d5f24-e14a-49d6-ae33-71205fb0a918" name="ownedInterface" visibility="public" type="0e56c152-1b1c-4343-932c-0a979a2943ad" isOrdered="true" isDerived="true" subsettedProperty="0f491f54-f387-4e6e-99bc-e6b15106a0d2" association="4a6eb2f9-a767-4964-896a-45dc68f0389a">
+        <ownedComment xmi:id="69ee8d3c-53e2-4397-be3e-c961be8126f8" annotatedElement="4b4d5f24-e14a-49d6-ae33-71205fb0a918">
+          <body>&lt;p>The InterfaceUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1a774160-3bdb-4dd7-9f24-718b6af50ef5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="177c3e4a-18b6-4683-a1f2-517e7db32ffe" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4ae09425-77ed-41c4-b8aa-ba5f21631453" name="ownedAttribute" visibility="public" type="23e8be75-009b-43b9-8e7a-f88c061ac220" isOrdered="true" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="f3a19f33-1144-4054-8435-03b38a8c2e34">
+        <ownedComment xmi:id="cf240bba-4c46-4fff-9feb-eb9ec17fdd0a" annotatedElement="4ae09425-77ed-41c4-b8aa-ba5f21631453">
+          <body>&lt;p>The AttributeUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f192c0ab-891c-40f3-b350-d833b9b913bb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a94091a4-d06b-474a-8899-9a82ba3f528b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="dd297802-9103-4ec4-9c68-e434eecc029e" name="ownedView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isOrdered="true" isDerived="true" subsettedProperty="8e3f1de2-c767-4cdd-af33-aacf5abe7d73" association="b9ca572d-41f6-4738-a3d0-7f0c66966846">
+        <ownedComment xmi:id="d4ebcb6a-990e-4fa6-853e-65ce69689e22" annotatedElement="dd297802-9103-4ec4-9c68-e434eecc029e">
+          <body>&lt;p> The &lt;code>ownedUsages&lt;/code> of this Definition that are ViewUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="457805b8-7cf6-4944-98d4-1fa5754a1187" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a2665172-e131-4986-a427-dd6fa0fcc9a2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5e650689-f765-4f10-9b51-7fb42c2fc156" name="ownedViewpoint" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isOrdered="true" isDerived="true" subsettedProperty="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8" association="8d10c04f-3be4-4d67-98a9-196932bc5526">
+        <ownedComment xmi:id="ded0a440-c81d-4e34-b5b4-549657a7ab13" annotatedElement="5e650689-f765-4f10-9b51-7fb42c2fc156">
+          <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of this Definition that are ViewpointUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="42817b78-fd50-49ce-85c2-6085734c9a7e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="364f57cb-ce8a-414f-b1b5-c790a2bc4186" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d797c21a-75bf-40ef-b59c-21431852d1e6" name="ownedRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isOrdered="true" isDerived="true" subsettedProperty="8e3f1de2-c767-4cdd-af33-aacf5abe7d73" association="ed9e7928-f66c-4897-b626-61b75c24f90f">
+        <ownedComment xmi:id="537a6e62-da6b-4204-97d3-0ce74f374284" annotatedElement="d797c21a-75bf-40ef-b59c-21431852d1e6">
+          <body>&lt;p>The &lt;code>usages&lt;/code> of this Definition that are RenderingUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a874c5ba-cde6-4ef6-a356-367338c2762a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="23517839-4e45-41b7-b753-1ca829f7f57c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="bfea518a-6198-4704-9a48-e058427e2ad4" name="ownedVerificationCase" visibility="public" type="e7e9b658-76e1-4155-96e8-426f06ad1824" isOrdered="true" isDerived="true" subsettedProperty="45242a19-de1a-4447-8ee3-b968526d0f9a" association="4ff10784-5cd0-49f2-91ec-087c7ddf11be">
+        <ownedComment xmi:id="78d2c5dd-49c1-4331-b868-acbb19612d27" annotatedElement="bfea518a-6198-4704-9a48-e058427e2ad4">
+          <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of this Definition that are VerificationCaseUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b82efabe-bdc5-4391-b1d7-89935a0fec03" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fd88c723-3a92-46e9-b915-878bbfe29edc" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="455b76bb-8ccf-4f44-b97c-8cba850d9244" name="ownedEnumeration" visibility="public" type="d870f716-2ca1-4e5e-99c1-32ad80927ceb" isOrdered="true" isDerived="true" subsettedProperty="4ae09425-77ed-41c4-b8aa-ba5f21631453" association="05c726a6-34b4-4088-8011-1b6749aef12b">
+        <ownedComment xmi:id="8bec3a2c-41a8-4d0f-b02d-c8e79141ddd8" annotatedElement="455b76bb-8ccf-4f44-b97c-8cba850d9244">
+          <body>&lt;p>The EnumerationUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8f2b2c72-e950-450c-9ff1-5fdd7c99164a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3a3d8854-908f-4ba6-931f-8f48002c9959" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cc8a82a9-eec0-4f73-a79f-fc9d14d87597" name="ownedAllocation" visibility="public" type="67972056-88ee-40e2-9e91-95d3ab49988c" isOrdered="true" isDerived="true" subsettedProperty="0f491f54-f387-4e6e-99bc-e6b15106a0d2" association="93359adb-ed1e-4eaf-9aaa-d987674f7a19">
+        <ownedComment xmi:id="01bf899d-4fea-458f-ba42-6e5edbcdfaf0" annotatedElement="cc8a82a9-eec0-4f73-a79f-fc9d14d87597">
+          <body>&lt;p>The AllocationUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f649db36-28b2-401d-b296-723b105f1fb1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="be4b5544-c8bd-431d-8448-98b56da7cccb" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1635265b-d9d5-4237-8e19-2d2512ceafea" name="ownedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isDerived="true" subsettedProperty="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8" association="0d73d5ab-916b-465f-8085-20c0c1d44b9c">
+        <ownedComment xmi:id="60150fd0-7a96-4f3f-916c-211af3087ba0" annotatedElement="1635265b-d9d5-4237-8e19-2d2512ceafea">
+          <body>&lt;p>The ConcernUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1eb29f7c-a829-4c72-af9e-544a1393bac7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3ec86385-1869-4047-9c23-f5abbd4acecc" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f2bd28f0-4070-4e5f-8705-512fd368c9dd" name="ownedOccurrence" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isOrdered="true" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="186f677b-161c-422d-8f8d-328ba7fab3e3">
+        <ownedComment xmi:id="88616d33-8ca4-47a2-bc90-5adcf9e0cef1" annotatedElement="f2bd28f0-4070-4e5f-8705-512fd368c9dd">
+          <body>&lt;p>The OccurrenceUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="754f8f7d-b219-4cd1-a723-2b7a654799ef" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="20c17ace-3908-45fe-aebd-4434e46b02f2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8eae581d-db92-464c-8425-f626efc7cec8" name="ownedUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isOrdered="true" isDerived="true" subsettedProperty="45242a19-de1a-4447-8ee3-b968526d0f9a" association="9364b187-2c10-4d1f-8f72-2b1bca5eb696">
+        <ownedComment xmi:id="994ce362-34ea-40bb-acf7-26dc1fbc96b4" annotatedElement="8eae581d-db92-464c-8425-f626efc7cec8">
+          <body>&lt;p>The UseCaseUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c6c995c1-f112-4c4e-9398-fa0cbcd4b605" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d27810ed-e9df-4dce-ab07-24421d28b9d1" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="47f6f3e6-0483-4d15-80ff-fe0fb2c6718d" name="ownedFlow" visibility="public" type="fd085776-81b3-4a29-b1f9-a414d1a6556c" isDerived="true" subsettedProperty="0f491f54-f387-4e6e-99bc-e6b15106a0d2" association="5b76a2e2-1f5a-46e0-b692-b667c625c23f">
+        <ownedComment xmi:id="334f335a-14f0-402d-845a-5fa534bef0c0" annotatedElement="47f6f3e6-0483-4d15-80ff-fe0fb2c6718d">
+          <body>&lt;p>The FlowConnectionUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ecb86df9-9b60-445e-944a-94113cb61b9c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e5811217-a36b-4fbc-b4ab-bba04c2731a4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f90352ba-7bd0-4c54-abc6-fd410d32b4c8" name="ownedMetadata" visibility="public" type="7ad44795-c498-4b29-9af3-c1bf96867f82" isOrdered="true" isDerived="true" subsettedProperty="c0e2fc49-66a1-457d-a4bc-acca01367a03" association="8c9399db-1848-4465-a0de-452ba3b34192">
+        <ownedComment xmi:id="5e176f42-6426-47a4-b35a-4228eb641227" annotatedElement="f90352ba-7bd0-4c54-abc6-fd410d32b4c8">
+          <body>&lt;p>The MetadataUsages that are &lt;code>ownedUsages&lt;/code> of this Definition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d1fe7ae6-5277-43e3-8d43-74f13328de0b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9528a94d-84cb-4d00-a8b8-f2d30d5a3ea6" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6ce2ae7d-53c1-4239-9bd0-b6bc82de5225" name="" visibility="public" memberEnd="674fade2-b925-4c8b-99e7-ed712c89841a a2ad25f0-47a0-4807-9447-869020827a45">
+      <ownedEnd xmi:id="a2ad25f0-47a0-4807-9447-869020827a45" name="owningVariationDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="cfd14843-bce5-4ee1-8fb3-a2fdd0237258" association="6ce2ae7d-53c1-4239-9bd0-b6bc82de5225">
+        <ownedComment xmi:id="1f836cb6-6382-4272-b6ce-a7655a2b24c3" annotatedElement="a2ad25f0-47a0-4807-9447-869020827a45">
+          <body>&lt;p>The owning Definition of this VariantMembership, which must have &lt;code>isVariation&lt;/code> = true.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f8d9e771-c849-4091-847a-3735d0ace292" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="788b3223-1d4d-4f53-8fe5-e628cf2c37a0" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f4bb0b59-2cdf-47c8-b64f-a8373821e030" name="" visibility="public" memberEnd="ff1e3c1a-7430-4be0-8f41-bee4ac24cab8 c5e4e44f-730d-4b12-b395-438e1e3cf25d">
+      <ownedEnd xmi:id="c5e4e44f-730d-4b12-b395-438e1e3cf25d" name=" /usageWithDirectedUsage" type="46068009-84f1-4001-a9bb-fc03fd6a381c" subsettedProperty="80256afa-977a-420b-8633-5970645921d2 9eb39b11-03b6-45e0-999a-25ee6e6dda75" association="f4bb0b59-2cdf-47c8-b64f-a8373821e030">
+        <ownedComment xmi:id="9eef21da-c723-499b-b30d-158f2d769c2b" annotatedElement="c5e4e44f-730d-4b12-b395-438e1e3cf25d">
+          <body>&lt;p>The Usages that have a certain Usage as a &lt;code>flow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="6448b0a8-529f-4c41-b3b4-0ef677da8210">
+          <body></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5a2ee137-2379-4441-a836-af77eed31b3c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2ebb7ad4-406e-46b8-aeaa-badf3209d563" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="37ed8019-d592-4473-80e4-5102eedf54aa" name="" visibility="public" memberEnd="6524000d-614c-4447-8568-60360415c26f 1bea5bf3-104c-4d5b-9cc3-b497ab54bbe9">
+      <ownedEnd xmi:id="6524000d-614c-4447-8568-60360415c26f" name="analysisCaseOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf" association="37ed8019-d592-4473-80e4-5102eedf54aa">
+        <ownedComment xmi:id="c63e93f9-36bf-4100-9ef0-2bb6b515585f" annotatedElement="6524000d-614c-4447-8568-60360415c26f">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedAnalysisCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="62af828d-32f9-461f-b3d9-b118ea06f4ea" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9dfccb74-da9e-47ff-a14f-344cda846293" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="186f677b-161c-422d-8f8d-328ba7fab3e3" name="" visibility="public" memberEnd="f2bd28f0-4070-4e5f-8705-512fd368c9dd 3c1e0401-e330-4089-8c54-9a506130d046">
+      <ownedEnd xmi:id="3c1e0401-e330-4089-8c54-9a506130d046" name="occurrenceOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="186f677b-161c-422d-8f8d-328ba7fab3e3">
+        <ownedComment xmi:id="06aa2042-0072-4b66-a8f3-acacc00cb2a3" annotatedElement="3c1e0401-e330-4089-8c54-9a506130d046">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedOccurrence&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b77d0444-ebad-47fe-a80f-f288e3000895" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b5c9a9c3-f54b-4f6b-8516-ea3ca80a2764" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5d14dd7d-b089-4abd-b035-a32d12db069e" name="" visibility="public" memberEnd="ed12f69d-7f7d-4d4a-9d44-8ed02edec5b8 f0edc722-0f8b-486a-802c-2275561be411">
+      <ownedEnd xmi:id="f0edc722-0f8b-486a-802c-2275561be411" name="requirementOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="81d65e5f-a516-4fbe-b6b9-5793a09a272e" association="5d14dd7d-b089-4abd-b035-a32d12db069e">
+        <ownedComment xmi:id="cdc7e422-9247-43eb-8796-185e0d3bb2c4" annotatedElement="f0edc722-0f8b-486a-802c-2275561be411">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedRequirement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ed839453-2812-4ad9-befd-186b3d135233" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="86e79507-8256-43f4-b57c-b9a6e194c6c5" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="93df83da-3b4a-4adc-950b-fb6ecf1815d7" name="" visibility="public" memberEnd="493bdf36-17fd-4f7a-a07d-f046892b7f3f 8b4ec45f-4463-4a69-8611-7147b10ad99e">
+      <ownedEnd xmi:id="8b4ec45f-4463-4a69-8611-7147b10ad99e" name="attributeOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e3db423d-543e-47fa-864c-573abd896990" association="93df83da-3b4a-4adc-950b-fb6ecf1815d7">
+        <ownedComment xmi:id="5c35a546-781a-4599-b9a1-7e0cabebc80b" annotatedElement="8b4ec45f-4463-4a69-8611-7147b10ad99e">
+          <body>&lt;p>The Usage in which the &lt;code>nestedAttribute&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="61f3e7df-d373-4674-930b-86d2f5437fa6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="89eb1532-3334-40be-9bde-d59e3e6365c5" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b9ca572d-41f6-4738-a3d0-7f0c66966846" name="" visibility="public" memberEnd="dd297802-9103-4ec4-9c68-e434eecc029e f9c63a7e-c4f4-459c-8121-9e569534c574">
+      <ownedEnd xmi:id="f9c63a7e-c4f4-459c-8121-9e569534c574" name="viewOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="ac78893b-0ca0-443c-9f14-131910814067" association="b9ca572d-41f6-4738-a3d0-7f0c66966846">
+        <ownedComment xmi:id="5e2ef8ee-7d22-4ee3-89a8-bf48e4edfa35" annotatedElement="f9c63a7e-c4f4-459c-8121-9e569534c574">
+          <body>&lt;p>The Definition that owns a certain &lt;code>ownedView&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="80f1cadf-a132-4efd-a819-bea37c5ce468" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="35e3917d-955e-4de2-b720-fcfdfb1c0139" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="607ed208-301d-4575-84c4-d216e798351e" name="" visibility="public" memberEnd="80256afa-977a-420b-8633-5970645921d2 0dfa6ef9-8b69-40c9-b06e-5997d834a831">
+      <ownedEnd xmi:id="80256afa-977a-420b-8633-5970645921d2" name="featuringUsage" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="607ed208-301d-4575-84c4-d216e798351e">
+        <ownedComment xmi:id="49c13e98-2119-4619-bd82-da591d9b00aa" annotatedElement="80256afa-977a-420b-8633-5970645921d2">
+          <body>&lt;p>The Usages that feature a certain Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="be9fa974-1c5a-42dc-96bb-effea9d8aceb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1512e573-7ce1-48f2-8a0a-14a22aa3025f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1837d33a-ad89-4661-b726-45f263817c11" name="" visibility="public" memberEnd="4144375a-f41b-44f9-b58f-eb9ee760eba5 225334f5-579e-4959-81fd-7554683c2bb5">
+      <ownedEnd xmi:id="4144375a-f41b-44f9-b58f-eb9ee760eba5" name="analysisCaseOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="4144375a-f41b-44f9-b58f-eb9ee760eba5" association="1837d33a-ad89-4661-b726-45f263817c11">
+        <ownedComment xmi:id="3e3e706e-a592-445e-9f70-7134029b6f57" annotatedElement="4144375a-f41b-44f9-b58f-eb9ee760eba5">
+          <body>&lt;p>The Usage in which the &lt;code>nestedAnalysisCase&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="981efb5b-5673-4cf5-90a0-50d76d0898e9" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6dffbc1f-bd7f-4a1a-a7bc-263f0af2dd7b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ed9e7928-f66c-4897-b626-61b75c24f90f" name="" visibility="public" memberEnd="d797c21a-75bf-40ef-b59c-21431852d1e6 cd62bc51-f7b4-41a2-9683-e049d9f4bd1b">
+      <ownedEnd xmi:id="cd62bc51-f7b4-41a2-9683-e049d9f4bd1b" name="redenderingOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="ac78893b-0ca0-443c-9f14-131910814067" association="ed9e7928-f66c-4897-b626-61b75c24f90f">
+        <ownedComment xmi:id="0e88d1d0-420f-4cd3-80d7-a500c9ee5378" annotatedElement="cd62bc51-f7b4-41a2-9683-e049d9f4bd1b">
+          <body>&lt;p>The Definition that owns a certain &lt;code>ownedRendering&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0331a8f2-2643-4c46-850b-194b2609f869" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c1a79702-071b-4205-bcaa-6c29e38f2dbd" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="277be0d2-b5cf-40b4-8032-2cd15268e146" name="" visibility="public" memberEnd="a2eeff6d-d4e0-4fa9-95f8-20ed08dcb451 156ab9b0-1a64-4f6a-9e14-b91982153366">
+      <ownedEnd xmi:id="156ab9b0-1a64-4f6a-9e14-b91982153366" name="referenceOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e3db423d-543e-47fa-864c-573abd896990" association="277be0d2-b5cf-40b4-8032-2cd15268e146">
+        <ownedComment xmi:id="0fecc1ee-092d-4d7c-934f-aa33a1042304" annotatedElement="156ab9b0-1a64-4f6a-9e14-b91982153366">
+          <body>&lt;p>The Usage that owns the &lt;code>nestedReference&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1383103e-0a59-42fa-8610-55b0264901a0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ce4e8294-6c8d-46a1-b909-1fb2c7c4eba5" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="29ba44f9-879e-42f1-bf99-31baa0ff3ae4" name="" visibility="public" memberEnd="7a81dff0-80d6-4b51-8663-3515e035eb0b 9ed2d719-03f3-46d8-8e92-aa1367180b1d">
+      <ownedEnd xmi:id="9ed2d719-03f3-46d8-8e92-aa1367180b1d" name="viewpointOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a" association="29ba44f9-879e-42f1-bf99-31baa0ff3ae4">
+        <ownedComment xmi:id="91d90ed5-aee2-4cec-84d7-c436be3dcbb7" annotatedElement="9ed2d719-03f3-46d8-8e92-aa1367180b1d">
+          <body>&lt;p>The Usage that owns a certain &lt;code>nestedViewpoint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d94fd5db-bce3-4ce1-8bc6-1f432404b688" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7779965c-2bbb-400d-a3fb-96baad21e059" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8f20af5c-6f2a-4032-997b-66d5dc8ecfc3" name="" visibility="public" memberEnd="9fa2a9e4-c439-4f04-a86f-c899c0fb9e81 7a6f644f-f627-4685-ab51-3b65701e1947">
+      <ownedEnd xmi:id="7a6f644f-f627-4685-ab51-3b65701e1947" name="owningVariantMembership" visibility="public" type="7a990883-5206-4c30-b4cc-ba108b6189bc" isDerived="true" subsettedProperty="4e9a7462-c2c0-42cd-a715-dc21395cc779" association="8f20af5c-6f2a-4032-997b-66d5dc8ecfc3">
+        <ownedComment xmi:id="95fcf2fe-339b-4249-8426-6024fcb2771f" annotatedElement="7a6f644f-f627-4685-ab51-3b65701e1947">
+          <body>&lt;p>The VariantMembership that owns this Usage, if the Usage represents a variant in the context of some variation point Definition or Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c4b67bfb-a57b-480b-bd6b-b404ee2b04d8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ca088f55-0248-4a63-afc7-336d55bf7903" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="807f9988-cac2-4037-951e-97b300bd1f1c" name="" visibility="public" memberEnd="c0e2fc49-66a1-457d-a4bc-acca01367a03 cd556efb-5f4e-4b19-81aa-5e8c14842c3c">
+      <ownedEnd xmi:id="cd556efb-5f4e-4b19-81aa-5e8c14842c3c" name="itemOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="3c1e0401-e330-4089-8c54-9a506130d046" association="807f9988-cac2-4037-951e-97b300bd1f1c">
+        <ownedComment xmi:id="d76a6b69-53c0-4a4d-ad53-9e06d5fdb9f4" annotatedElement="cd556efb-5f4e-4b19-81aa-5e8c14842c3c">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedItem&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="22074b7e-7be1-4cf4-8cc2-afef0ace0675" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="92ae1934-ba31-42e5-85c1-9eb58d445d88" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="197ab1d2-b164-4fe2-8fe8-537bac9132f0" name="" visibility="public" memberEnd="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff 89af2f5e-fcfa-48b7-8619-9c69476636a8">
+      <ownedEnd xmi:id="89af2f5e-fcfa-48b7-8619-9c69476636a8" name="occurrenceOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e3db423d-543e-47fa-864c-573abd896990" association="197ab1d2-b164-4fe2-8fe8-537bac9132f0">
+        <ownedComment xmi:id="be2faf79-933f-4023-9cce-a97ff41c9a25" annotatedElement="89af2f5e-fcfa-48b7-8619-9c69476636a8">
+          <body>&lt;p>The Usage in which the &lt;code>nestedOccurrence&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="28e52d10-ad9c-4ff3-8766-d4f91fb39df0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="05fb16a7-0058-47e9-b691-9fe021480413" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a1f67a7a-c9ac-4ebc-b5b9-3b1a6830ffaa" name="" visibility="public" memberEnd="24787e06-37be-4e3e-9305-e11617b83782 24666980-44f3-4d00-af5e-2932b3bc9dea">
+      <ownedEnd xmi:id="24666980-44f3-4d00-af5e-2932b3bc9dea" name="owningVariationUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="a1f67a7a-c9ac-4ebc-b5b9-3b1a6830ffaa">
+        <ownedComment xmi:id="3161a886-828c-4801-b998-c70d5c7cfded" annotatedElement="24666980-44f3-4d00-af5e-2932b3bc9dea">
+          <body>&lt;p>The variation point Usage that for which this Usage represents a variant, derived as the &lt;code>owningVariationUsage&lt;/code> of the &lt;code>owningVariantMembership&lt;/code> of the Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6ad21944-01ee-496d-9f5d-f885afed1519" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0407f41f-8559-4d0b-8046-0c3e4148262b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5b76a2e2-1f5a-46e0-b692-b667c625c23f" name="" visibility="public" memberEnd="47f6f3e6-0483-4d15-80ff-fe0fb2c6718d 48c83056-7d16-4be7-901a-963a9ee78f37">
+      <ownedEnd xmi:id="48c83056-7d16-4be7-901a-963a9ee78f37" name="flowOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="24f8feda-723b-4e44-924c-e7e78716e6c0" association="5b76a2e2-1f5a-46e0-b692-b667c625c23f">
+        <ownedComment xmi:id="3042ef63-e925-4ac5-a19c-02a13784e435" annotatedElement="48c83056-7d16-4be7-901a-963a9ee78f37">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedFlow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2af634c1-4a8b-44a2-8370-a6a91e98f1ab" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cf8869c8-22b3-4e77-a584-589a97c6b0f0" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9364b187-2c10-4d1f-8f72-2b1bca5eb696" name="" visibility="public" memberEnd="8eae581d-db92-464c-8425-f626efc7cec8 27d586b3-d182-4763-80ba-b492a6c5ff4b">
+      <ownedEnd xmi:id="27d586b3-d182-4763-80ba-b492a6c5ff4b" name="useCaseOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf" association="9364b187-2c10-4d1f-8f72-2b1bca5eb696">
+        <ownedComment xmi:id="d9337a50-10dc-49dd-9c3a-e23758e647a7" annotatedElement="27d586b3-d182-4763-80ba-b492a6c5ff4b">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedUseCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6472aa04-b892-442e-9be7-d06c3bf998a4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="724378e8-b59d-4b04-8991-6b30a72284bd" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ada29145-b1a8-440f-9639-942a00a644e5" name="" visibility="public" memberEnd="e14f4e3f-03a3-4a70-a7aa-7d6a28ba6178 fcf974da-6f5f-4f24-b9ae-8ba1f809d61b">
+      <ownedEnd xmi:id="fcf974da-6f5f-4f24-b9ae-8ba1f809d61b" name="enumerationOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="8b4ec45f-4463-4a69-8611-7147b10ad99e" association="ada29145-b1a8-440f-9639-942a00a644e5">
+        <ownedComment xmi:id="5c95eba1-9ad9-477d-b51e-9190fd448bc9" annotatedElement="fcf974da-6f5f-4f24-b9ae-8ba1f809d61b">
+          <body>&lt;p>The Usage that owns the &lt;code>nestedEnumeration&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="90a51f63-8519-43c9-8c54-1b81a8345c7a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ed898243-676e-4072-87b6-c65356f702ff" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="45e2cdc1-69fe-40de-9fcf-d7cfed32f16c" name="" visibility="public" memberEnd="a7ab48c4-002a-4667-adb1-6f686d79f5e3 03fc2af2-97d1-47b6-bec0-6fad113ce3e7">
+      <ownedEnd xmi:id="03fc2af2-97d1-47b6-bec0-6fad113ce3e7" name="owningVariationDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="45e2cdc1-69fe-40de-9fcf-d7cfed32f16c">
+        <ownedComment xmi:id="be20a7de-45d2-4501-ac41-1eeaa62e1f71" annotatedElement="03fc2af2-97d1-47b6-bec0-6fad113ce3e7">
+          <body>&lt;p>The variation point Definition that for which this Usage represents a variant, derived as the &lt;code>owningVariationDefinition&lt;/code> of the &lt;code>owningVariantMembership&lt;/code> of the Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0352f0a6-3420-470f-a925-93e69dc382f3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ca9eeefb-73f6-43f3-b499-8b12e296869a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1133d2a0-1b95-40ee-bbd3-039516e636aa" name="" visibility="public" memberEnd="f00ad2e5-df7c-4367-8191-0ba63c3818a5 7f6e6b78-da95-4742-afec-5ea52574a80f">
+      <ownedEnd xmi:id="7f6e6b78-da95-4742-afec-5ea52574a80f" name="portOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="1133d2a0-1b95-40ee-bbd3-039516e636aa">
+        <ownedComment xmi:id="df417791-0128-41af-92e9-f78f5011a5ef" annotatedElement="7f6e6b78-da95-4742-afec-5ea52574a80f">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedPort&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3205c0ba-2914-4b58-8222-835f93716575" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1d4de8af-ff38-41b3-befd-4ba1fea8a644" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e1e0ea17-ed4b-46fd-ae36-0596aa463ba4" name="" visibility="public" memberEnd="18ab486b-757f-4c4d-8569-01e9cf669e5f 739d9684-1083-4731-a7a9-08d898edd9d5">
+      <ownedEnd xmi:id="739d9684-1083-4731-a7a9-08d898edd9d5" name="definedItem" visibility="public" type="e8388855-f13a-4505-ac2e-b342de9f7c66" isDerived="true" subsettedProperty="b3f1997a-fa47-4624-b4f8-5163772191d3" association="e1e0ea17-ed4b-46fd-ae36-0596aa463ba4">
+        <ownedComment xmi:id="ee43356b-86be-4f89-8472-dee3adaf475d" annotatedElement="739d9684-1083-4731-a7a9-08d898edd9d5">
+          <body>&lt;p>The ItemUsages being typed by a certain Structure.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1757477f-4a6f-4ec2-bae1-66dba97035d1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c5fe8cd2-5162-43c5-92cc-f0ef5e6ee3b4" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="00621e08-29e7-4a2c-86f7-ac6b73a5ecc8" name="" visibility="public" memberEnd="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf 45242a19-de1a-4447-8ee3-b968526d0f9a">
+      <ownedComment xmi:id="7ab5e236-d625-42d0-80c4-cbe96345ed4b" annotatedElement="00621e08-29e7-4a2c-86f7-ac6b73a5ecc8">
+        <body>&lt;p>The Definition that owns this CaseUsage (if any).&lt;/p></body>
+      </ownedComment>
+      <ownedEnd xmi:id="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf" name="caseOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="4abca074-c488-4d21-989e-33cb9f542328" association="00621e08-29e7-4a2c-86f7-ac6b73a5ecc8">
+        <ownedComment xmi:id="2e9a6047-37a5-4fe4-9771-245dc5bf1cbb" annotatedElement="9c6252ed-8d91-4012-9a5d-2d3c42b73aaf">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="48c16652-9616-41f9-acd3-8bdf3cec7332" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="60af8883-1400-4f79-aaf2-39094b1bc960" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="01aad42a-8db8-43d0-90a9-8fc066918126" name="" visibility="public" memberEnd="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820 833d5ca8-6d71-460a-bb83-1a9872fd5cdc">
+      <ownedEnd xmi:id="833d5ca8-6d71-460a-bb83-1a9872fd5cdc" name="connectionOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e02ee31c-b895-45b1-a5bb-a0a465f786e0" association="01aad42a-8db8-43d0-90a9-8fc066918126">
+        <ownedComment xmi:id="5a6ef38f-195d-46a6-8d69-69a2a8cec161" annotatedElement="833d5ca8-6d71-460a-bb83-1a9872fd5cdc">
+          <body>&lt;p>The Usage in which the &lt;code>nestedUsage&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5903fbdd-869b-4d2b-a26f-66254dadc2d6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ca673ae0-b987-4421-98f3-98427c371a69" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f3a19f33-1144-4054-8435-03b38a8c2e34" name="" visibility="public" memberEnd="4ae09425-77ed-41c4-b8aa-ba5f21631453 398dc3b4-8cf8-4430-b90f-b84b16a1c8a4">
+      <ownedEnd xmi:id="398dc3b4-8cf8-4430-b90f-b84b16a1c8a4" name="attributeOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="f3a19f33-1144-4054-8435-03b38a8c2e34">
+        <ownedComment xmi:id="d2d7b12b-d596-47df-81fd-48a27ad18e07" annotatedElement="398dc3b4-8cf8-4430-b90f-b84b16a1c8a4">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedAttribute&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="149e7243-124e-4cd7-81f4-d2d9b9881b08" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0d7e1e53-8c41-4062-a75e-bfb5b24c66cc" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="05f27107-31d5-4814-831a-b8a8bb1abef7" name="" visibility="public" memberEnd="d16ac86c-b4b3-4c5f-b6c5-a018c2a2d5d5 11065011-6853-4355-9f49-a95ffc380d37">
+      <ownedEnd xmi:id="11065011-6853-4355-9f49-a95ffc380d37" name="renderingOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e02ee31c-b895-45b1-a5bb-a0a465f786e0" association="05f27107-31d5-4814-831a-b8a8bb1abef7">
+        <ownedComment xmi:id="85fd9662-13f4-41a7-a55f-2a73c19bf04d" annotatedElement="11065011-6853-4355-9f49-a95ffc380d37">
+          <body>&lt;p>The Usage that owns a certain &lt;code>nestedRendering&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b6927f28-2c92-4b3a-bb20-eb65d0b30008" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="49006787-1914-4567-a177-db673f33ef9a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="70182db5-05eb-4654-a43a-7f71ddb98c01" name="" visibility="public" memberEnd="9e9dc675-42cf-45eb-a990-44d27e80d1e0 6d7b7866-6b50-43ab-a718-e4b3c72f6ba0">
+      <ownedEnd xmi:id="6d7b7866-6b50-43ab-a718-e4b3c72f6ba0" name="owningVariationUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="cfd14843-bce5-4ee1-8fb3-a2fdd0237258" association="70182db5-05eb-4654-a43a-7f71ddb98c01">
+        <ownedComment xmi:id="d52e8619-80c0-4586-b06f-bd54796c091c" annotatedElement="6d7b7866-6b50-43ab-a718-e4b3c72f6ba0">
+          <body>&lt;p>The owning Definition of this VariantMembership, which must have &lt;code>isVariation&lt;/code> = true.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b1506b3a-bc60-45e1-a708-8206adfb5bab" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ea33d3d0-71b6-4815-a595-b1cb578c27c2" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="003d3e45-1d43-413f-bfa2-60cbdac679ea" name="" visibility="public" memberEnd="4d38f11b-b0cd-4523-9a9e-9657b5c50265 ad75883a-fe5e-42ef-9141-cc9c7bd383ef">
+      <ownedEnd xmi:id="ad75883a-fe5e-42ef-9141-cc9c7bd383ef" name="portOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" redefinedProperty="e3db423d-543e-47fa-864c-573abd896990" association="003d3e45-1d43-413f-bfa2-60cbdac679ea">
+        <ownedComment xmi:id="57ec4755-0a44-43d6-8b94-73206beba248" annotatedElement="ad75883a-fe5e-42ef-9141-cc9c7bd383ef">
+          <body>&lt;p>The Usage in which the &lt;code>nestedPort&lt;/code> is nested (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="59ac9d1a-c2a7-42d1-a21f-016e3b42d9f8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ee1f7454-e7ac-4da9-9f74-51c8d159f3cd" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="918c83bb-1498-4900-99c2-6f6df8c34437" name="" visibility="public" memberEnd="eba0dae9-c4ee-4fd7-b842-da043eb789e3 bf85e9b3-5cff-4254-8202-75b5fcd90d95">
+      <ownedEnd xmi:id="bf85e9b3-5cff-4254-8202-75b5fcd90d95" name="interfaceOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="833d5ca8-6d71-460a-bb83-1a9872fd5cdc" association="918c83bb-1498-4900-99c2-6f6df8c34437">
+        <ownedComment xmi:id="edeaa0a9-2bac-4758-a9ce-50b9a2398e73" annotatedElement="bf85e9b3-5cff-4254-8202-75b5fcd90d95">
+          <body>&lt;p>The Usage in which the &lt;code>nestedInterface&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6706b7cb-f653-4de1-9899-9e1ab39ecae6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d27e3ea5-aeab-467b-be79-a523feb9babf" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="46068009-84f1-4001-a9bb-fc03fd6a381c" name="Usage" visibility="public">
+      <ownedComment xmi:id="65b0a739-653c-4e7c-a84a-4ab957d32b34" annotatedElement="46068009-84f1-4001-a9bb-fc03fd6a381c">
+        <body>&lt;p>A Usage is a usage of a Definition. A Usage may only be an &lt;code>ownedFeature&lt;/code> of a Definition or another Usage.&lt;/p>
+
+&lt;p>A Usage may have &lt;code>nestedUsages&lt;/code> that model &lt;code>features&lt;/code> that apply in the context of the &lt;code>owningUsage&lt;/code>. A Usage may also have Definitions nested in it, but this has no semantic significance, other than the nested scoping resulting from the Usage being considered as a Namespace for any nested Definitions.&lt;/p>
+
+&lt;p>However, if a Usage has &lt;code>isVariation&lt;/code> = true, then it represents a &lt;em>variation point&lt;/em> Usage. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> Usages, related to the Usage by VariantMembership Relationships. Rather than being &lt;code>features&lt;/code> of the Usage, &lt;code>variant&lt;/code> Usages model different concrete alternatives that can be chosen to fill in for the variation point Usage.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="c575279f-62cf-404b-a0fd-2d1203039378" name="usageVariant" visibility="public" constrainedElement="46068009-84f1-4001-a9bb-fc03fd6a381c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="b6ee99fd-1f5e-48df-a310-58f468dd1779" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>variant = variantMembership.ownedVariantUsage</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="7651c2e6-73ee-4391-b8e7-e6b37f02c1bb" name="usageVariantMembership" visibility="public" constrainedElement="46068009-84f1-4001-a9bb-fc03fd6a381c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="6b90fcd6-8a5b-4b18-bae7-6f5fb5feda8c" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>variantMembership = ownedMembership->selectByKind(VariantMembership)</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="d21c5304-4155-46b3-a6eb-d5834fcf54c1" name="usageNonVariationMembership" visibility="public" constrainedElement="46068009-84f1-4001-a9bb-fc03fd6a381c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="04826dd6-27d5-4bea-897e-37069b7c97b6" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>not isVariation implies variantMembership->isEmpty()</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="7a094e1a-4524-452c-8e18-7cc98ca0d2dd" name="usageIsVariationMembership" visibility="public" constrainedElement="46068009-84f1-4001-a9bb-fc03fd6a381c">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c13dac6f-f8a5-4aab-8259-72a4d6214231" name="" visibility="public">
+          <language>English</language>
+          <body>isVariation implies variantMembership = ownedMembership</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="964a8654-4d47-463b-b737-ab5216a24fc0" name="usageIsReference" visibility="public">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="4b556b04-dac8-4b9f-b874-1ae4137328c3" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isReference = not isComposite</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="96a87585-bb00-4cfe-8df9-b769d3cdfd19" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+      <ownedAttribute xmi:id="3aeed792-7c5b-4145-ad3c-981f4de83751" name="nestedUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67 0dfa6ef9-8b69-40c9-b06e-5997d834a831" association="c904ee3a-27ef-4aac-b233-8a2250c02c6a">
+        <ownedComment xmi:id="1208c74c-294a-431b-bfbe-49a8803cabc1" annotatedElement="3aeed792-7c5b-4145-ad3c-981f4de83751">
+          <body>&lt;p>The Usages that are &lt;code>ownedFeatures&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="88cbc55b-ad2a-4a48-b8aa-ea7e243c96ba" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="77ecb94e-db52-4bb6-ab54-c2924cf04df2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e3db423d-543e-47fa-864c-573abd896990" name="owningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="c904ee3a-27ef-4aac-b233-8a2250c02c6a">
+        <ownedComment xmi:id="7b9baa4b-f460-4fe0-9c75-2cb1222e26ec" annotatedElement="e3db423d-543e-47fa-864c-573abd896990">
+          <body>&lt;p>The Usage in which this Usage is nested (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="997be2fb-a40d-4bc6-bbba-55451bcb39cb" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="67ab9caa-06fa-4d76-a135-61305d33bc4d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="750ac38e-ae6c-4718-856d-a704775bdd8b" name="owningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a eb7af616-8e9c-419a-a08a-4b80d758179f" association="6afc692e-dabc-424f-bcbb-7994a6f71c84">
+        <ownedComment xmi:id="48e945e0-4794-4232-b317-c88f54947e0b" annotatedElement="750ac38e-ae6c-4718-856d-a704775bdd8b">
+          <body>&lt;p>The Definition that owns this Usage (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="18b4f3fd-d484-4c84-908b-abbcfc273b3d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="01cf0c36-feac-4621-8c1f-bd56d2408064" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4d38f11b-b0cd-4523-9a9e-9657b5c50265" name="nestedPort" visibility="public" type="29e9a6bd-3e49-43d3-b43f-395beda16adc" isOrdered="true" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="003d3e45-1d43-413f-bfa2-60cbdac679ea">
+        <ownedComment xmi:id="0f53666f-d162-4ba7-9ec2-a0ab9b097fa3" annotatedElement="4d38f11b-b0cd-4523-9a9e-9657b5c50265">
+          <body>&lt;p>The PortUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7e0db33d-e41a-4d0f-911d-365cb8cceee0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="05d87955-e293-4084-99a2-6718d7786fdd" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d60be625-f2a6-4ee2-acc1-a4c6e1b90105" name="nestedAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isOrdered="true" isDerived="true" subsettedProperty="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff" association="e398a46c-ea1c-4442-af1d-8c93672de206">
+        <ownedComment xmi:id="225a865f-1f0a-4052-b9fc-7b8a753d1579" annotatedElement="d60be625-f2a6-4ee2-acc1-a4c6e1b90105">
+          <body>&lt;p>The ActionUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="411f9fb5-ccc2-4294-8014-ad58803635cf" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7d246669-fc8c-4216-8816-7e886e061379" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4940c6a0-7ba8-4dcd-a339-24552456a296" name="nestedState" visibility="public" type="6eefbf37-3bc7-4a0f-be57-5bd6b2344717" isOrdered="true" isDerived="true" subsettedProperty="d60be625-f2a6-4ee2-acc1-a4c6e1b90105" association="218610f8-80dd-49cf-9cf3-903ae4197e04">
+        <ownedComment xmi:id="e140564c-dc04-44fe-abc8-4cc1d5558d39" annotatedElement="4940c6a0-7ba8-4dcd-a339-24552456a296">
+          <body>&lt;p>The StateUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3b02d542-0e05-408d-88c9-afef0a7c775f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="aa038b40-8b8c-421f-a237-3f9a3a1de339" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1066b39d-39ba-4fc3-971d-bd711a49591c" name="nestedConstraint" visibility="public" type="9ee628bb-c896-4aab-b7c8-7548359ff376" isOrdered="true" isDerived="true" subsettedProperty="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff" association="26e6aa7c-46d2-4956-991d-64da16dd1acc">
+        <ownedComment xmi:id="11b6e524-0bc5-4190-aaee-d813bca35416" annotatedElement="1066b39d-39ba-4fc3-971d-bd711a49591c">
+          <body>&lt;p>The ConstraintUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="856c73e9-ff51-429b-a960-67c6abd8ab46" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="24128c70-8fb3-48bf-a591-a1bf14559063" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="70338db9-2386-46d0-9d5b-22dad07b1984" name="nestedTransition" visibility="public" type="d6076ef0-f964-4b74-95ce-74d8c95c3539" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="ea5e3639-2227-45b2-af8b-eaa63a314862">
+        <ownedComment xmi:id="8d7d288b-85a1-494c-a9c0-c0b7f8e903e8" annotatedElement="70338db9-2386-46d0-9d5b-22dad07b1984">
+          <body>&lt;p>The TransitionUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="348bd9ba-38c9-4de4-96f1-38fbea1200b3" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="84f7ba29-f72f-448e-b737-987ca55b3b0e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="5d453801-4f2d-4df0-bc76-a99e5ce278a6" name="nestedRequirement" visibility="public" type="7248aae3-2934-47cd-bf16-f9aca7f25ad7" isOrdered="true" isDerived="true" subsettedProperty="1066b39d-39ba-4fc3-971d-bd711a49591c" association="a469a605-0ffc-4a88-a213-2a62597a0e35">
+        <ownedComment xmi:id="dbf2e35b-9efa-4c0e-877f-8182759be616" annotatedElement="5d453801-4f2d-4df0-bc76-a99e5ce278a6">
+          <body>&lt;p>The RequirementUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6c85cac2-88b1-4604-af9f-462001eefe14" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="457c1e6e-dbc1-4ab8-a3b7-a3c3acf59b08" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="16ae6b07-d65d-446e-80d9-cb171d471566" name="nestedCalculation" visibility="public" type="92887cda-1376-415e-86ad-315e1dcd7de8" isOrdered="true" isDerived="true" subsettedProperty="d60be625-f2a6-4ee2-acc1-a4c6e1b90105" association="209d05bb-038e-4a1c-8ff2-127fc0fdedce">
+        <ownedComment xmi:id="8542936c-e93d-43b6-8fa2-a30cb31cf34b" annotatedElement="16ae6b07-d65d-446e-80d9-cb171d471566">
+          <body>&lt;p>The CalculationUsage that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="460e7f2a-b246-4e4e-8604-5b87b904f681" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="cf671f27-0f2a-4fdd-b1ec-8b6bde87d52e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="af627062-d3cb-459f-a49b-e9d8f6b29381" name="isVariation" visibility="public">
+        <ownedComment xmi:id="31708a24-2858-4bb1-8ffc-bf8ac6e26994" annotatedElement="af627062-d3cb-459f-a49b-e9d8f6b29381">
+          <body>&lt;p>Whether this Usage is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the Usage must be VariantMemberships.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="ff1e3c1a-7430-4be0-8f41-bee4ac24cab8" name="directedUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="0dfa6ef9-8b69-40c9-b06e-5997d834a831 ee47daa4-a81f-4204-b23b-bfc54283691f" association="f4bb0b59-2cdf-47c8-b64f-a8373821e030">
+        <ownedComment xmi:id="f7a350c6-c30b-45ad-a59b-25a0e875c32e" annotatedElement="ff1e3c1a-7430-4be0-8f41-bee4ac24cab8">
+          <body>&lt;p>The &lt;code>usages&lt;/code> of this Usage that are &lt;code>directedFeatures&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e1b51967-f045-483f-8e22-613aea0dc25d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="127d56e2-ea4c-4159-94bc-4b29152bd38f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="af8526f8-1df3-474f-a9ea-e3d869a61b8d" name="nestedCase" visibility="public" type="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9" isOrdered="true" isDerived="true" subsettedProperty="16ae6b07-d65d-446e-80d9-cb171d471566" association="afd97c4d-bb88-476d-9333-425c74f49e19">
+        <ownedComment xmi:id="437e8f5f-fe19-4859-a3be-1de414d68c48" annotatedElement="af8526f8-1df3-474f-a9ea-e3d869a61b8d">
+          <body>&lt;p>The CaseUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="828b73fe-bf72-4912-a0ac-44231e4acd06" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5fda1291-65f8-48fa-825a-bd9dc7d27bb0" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="225334f5-579e-4959-81fd-7554683c2bb5" name="nestedAnalysisCase" visibility="public" type="42bd5675-21d5-40ad-ae7b-f1d50708d8bf" isOrdered="true" isDerived="true" subsettedProperty="af8526f8-1df3-474f-a9ea-e3d869a61b8d" association="1837d33a-ad89-4661-b726-45f263817c11">
+        <ownedComment xmi:id="dd192e4f-6b48-4f9d-a559-fb4d7c983aaf" annotatedElement="225334f5-579e-4959-81fd-7554683c2bb5">
+          <body>&lt;p>The AnalysisCaseUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="154362c5-3134-466d-97b6-9f6f678c7162" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3ffb6dfb-aac1-42d0-ba35-44841885048c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="9e9dc675-42cf-45eb-a990-44d27e80d1e0" name="variantMembership" visibility="public" type="7a990883-5206-4c30-b4cc-ba108b6189bc" aggregation="composite" isDerived="true" subsettedProperty="ec58580f-851c-4202-a5c6-27b2ec9ac376" association="70182db5-05eb-4654-a43a-7f71ddb98c01">
+        <ownedComment xmi:id="3543fe52-bb39-46c0-94d3-340333195b33" annotatedElement="9e9dc675-42cf-45eb-a990-44d27e80d1e0">
+          <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this Usage that are VariantMemberships. If &lt;code>isVariation&lt;/code> = true, then this must be all &lt;code>memberships&lt;/code> of the Usages. If &lt;code>isVariation&lt;/code> = false, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9740531b-49a4-4273-8c90-1b3e601ef10a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d88ecc46-79b5-45da-a398-2044c47d1cfb" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0dfa6ef9-8b69-40c9-b06e-5997d834a831" name="usage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" subsettedProperty="8fe48f98-83c5-4f3f-a581-d91448105000" association="607ed208-301d-4575-84c4-d216e798351e">
+        <ownedComment xmi:id="9b8845a6-8aba-4ccc-bccf-c907b8b1b299" annotatedElement="0dfa6ef9-8b69-40c9-b06e-5997d834a831">
+          <body>&lt;p>The Usages that are &lt;code>features&lt;/code> of this Usage (not necessarily owned).&lt;/p></body>
+        </ownedComment>
+        <ownedComment xmi:id="f1b6bdab-9e15-4df4-8ad0-0696526901e0">
+          <body></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="03a060d5-f7fa-4467-a031-3bcb11e27391" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9d584ece-e8d3-4e22-8510-792b7d3aa6c9" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="24787e06-37be-4e3e-9305-e11617b83782" name="variant" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="a1f67a7a-c9ac-4ebc-b5b9-3b1a6830ffaa">
+        <ownedComment xmi:id="8a347f87-df51-4d2c-acf2-39e1ad05951c" annotatedElement="24787e06-37be-4e3e-9305-e11617b83782">
+          <body>&lt;p>The Usages which represent the variants of this Usage as a variation point Usage, if &lt;code>isVariation&lt;/code> = true. If &lt;code>isVariation&lt;/code> = false, the there must be no &lt;code>variants&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9a57ab8c-f2e6-4344-ab95-82558631816f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="116c44ef-78dc-4bde-979f-57ca32185f33" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a2eeff6d-d4e0-4fa9-95f8-20ed08dcb451" name="nestedReference" visibility="public" type="ad315d17-6754-4a30-bcde-3b73d63d713e" isOrdered="true" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="277be0d2-b5cf-40b4-8032-2cd15268e146">
+        <ownedComment xmi:id="d0ebfaf2-da7b-47e4-be8c-dafcfff0356e" annotatedElement="a2eeff6d-d4e0-4fa9-95f8-20ed08dcb451">
+          <body>&lt;p>The ReferenceUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5237bc28-d064-46af-a8de-48057ee2b83f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a8b8f850-e4da-49d6-9825-d36add0cb45c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820" name="nestedConnection" visibility="public" type="f4b1326b-70e0-4f33-93b0-85fb497a26a1" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857" association="01aad42a-8db8-43d0-90a9-8fc066918126">
+        <ownedComment xmi:id="f5fadcda-1fd4-4802-851c-e0f166d25f99" annotatedElement="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820">
+          <body>&lt;p>The ConnectorAsUsages that are &lt;code>nestedUsages&lt;/code> of this Usage. Note that this list includes BindingConnectorAsUsages and SuccessionAsUsages, even though these are ConnectorAsUsages but not ConnectionUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="58823d70-248b-419b-9a41-cc41888d9430" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c9502fab-679b-4b96-bca0-f6c8f9206c3f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4b41f3e4-a7e1-4556-b5df-6c9356cf4a75" name="nestedItem" visibility="public" type="e8388855-f13a-4505-ac2e-b342de9f7c66" isOrdered="true" isDerived="true" subsettedProperty="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff" association="83818c6a-985e-4c4c-a9dd-e1301c46a4e6">
+        <ownedComment xmi:id="b15698ed-cd70-4fdc-b640-eedf2334d90f" annotatedElement="4b41f3e4-a7e1-4556-b5df-6c9356cf4a75">
+          <body>&lt;p>The ItemUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2aee0891-bd83-44b3-96f4-9d91df5bbc28" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="65c97660-e317-4115-9eed-41a4ac8d962e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="cefdac00-81bf-4ced-93c2-b11161003857" name="nestedPart" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" subsettedProperty="4b41f3e4-a7e1-4556-b5df-6c9356cf4a75" association="3223c7d1-7558-4a4f-972c-fdea72085cac">
+        <ownedComment xmi:id="cf70182b-f523-4d4a-8b2b-62f377cb7e57" annotatedElement="cefdac00-81bf-4ced-93c2-b11161003857">
+          <body>&lt;p>The PartUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4a0d276e-fb77-4aab-86ae-0a70e9f93b8b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b33d8ea6-341b-4613-a5b5-7f656f8dfed8" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="eba0dae9-c4ee-4fd7-b842-da043eb789e3" name="nestedInterface" visibility="public" type="0e56c152-1b1c-4343-932c-0a979a2943ad" isOrdered="true" isDerived="true" subsettedProperty="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820" association="918c83bb-1498-4900-99c2-6f6df8c34437">
+        <ownedComment xmi:id="9de84df5-efaf-4ccc-a715-c5a44a57c51f" annotatedElement="eba0dae9-c4ee-4fd7-b842-da043eb789e3">
+          <body>&lt;p>The InterfaceUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f0dec910-0705-4c3c-97ed-1941b73ed7b4" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="60c3ab3e-93d1-49ea-a401-c1bc08d599c6" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="493bdf36-17fd-4f7a-a07d-f046892b7f3f" name="nestedAttribute" visibility="public" type="23e8be75-009b-43b9-8e7a-f88c061ac220" isOrdered="true" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="93df83da-3b4a-4adc-950b-fb6ecf1815d7">
+        <ownedComment xmi:id="61adf760-7a25-4a72-af81-4adc198fc544" annotatedElement="493bdf36-17fd-4f7a-a07d-f046892b7f3f">
+          <body>&lt;p>The AttributeUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="015595ce-9148-47a2-b94b-a03110694481" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="15ad4671-308b-4211-bc0c-9ae007968137" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="6ea7a0bd-fed4-4a99-86b7-92be051a0ae3" name="nestedView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857" association="83d3bbc3-2b95-4509-94b9-20a08dc428b5">
+        <ownedComment xmi:id="90c52674-a9e4-4bd9-bd4c-8765188f6b7f" annotatedElement="6ea7a0bd-fed4-4a99-86b7-92be051a0ae3">
+          <body>&lt;p>The ViewUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4d9ffa45-d990-4ab5-98dd-17fac98eca49" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8518466b-3c6b-4095-945e-c7faa493dd9c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7a81dff0-80d6-4b51-8663-3515e035eb0b" name="nestedViewpoint" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isOrdered="true" isDerived="true" subsettedProperty="5d453801-4f2d-4df0-bc76-a99e5ce278a6" association="29ba44f9-879e-42f1-bf99-31baa0ff3ae4">
+        <ownedComment xmi:id="d1f16321-d037-4ff3-b2f2-fbb964268926" annotatedElement="7a81dff0-80d6-4b51-8663-3515e035eb0b">
+          <body>&lt;p>The ViewpointUsages of this Usage that are &lt;code>nestedUsages&lt;/code>.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bc116150-6d04-4f10-b0fb-fb38771d6a0e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f56041d4-f4cb-4308-84bd-311a7c62f542" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d16ac86c-b4b3-4c5f-b6c5-a018c2a2d5d5" name="nestedRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isOrdered="true" isDerived="true" subsettedProperty="cefdac00-81bf-4ced-93c2-b11161003857" association="05f27107-31d5-4814-831a-b8a8bb1abef7">
+        <ownedComment xmi:id="63dc7610-1ed0-4772-94b2-77fdc19dd37d" annotatedElement="d16ac86c-b4b3-4c5f-b6c5-a018c2a2d5d5">
+          <body>&lt;p>The RenderingUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="da75ea26-45ae-48a9-bf11-49862d54113c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8c95a40a-76df-4282-824e-1b7b1a846692" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="15fc9960-b3be-4ab1-bb7b-1adea032e1e0" name="nestedVerificationCase" visibility="public" type="e7e9b658-76e1-4155-96e8-426f06ad1824" isOrdered="true" isDerived="true" subsettedProperty="af8526f8-1df3-474f-a9ea-e3d869a61b8d" association="f7294915-6686-4060-90b2-2943ad4deeac">
+        <ownedComment xmi:id="613ec7ae-32ae-4ccd-87d3-f01fa99d2f5e" annotatedElement="15fc9960-b3be-4ab1-bb7b-1adea032e1e0">
+          <body>&lt;p>The VerificationCaseUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aabab18f-0046-4b33-9e9b-6ac53bd2b383" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1a285277-c915-4992-845b-33d31e83b686" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e14f4e3f-03a3-4a70-a7aa-7d6a28ba6178" name="nestedEnumeration" visibility="public" type="d870f716-2ca1-4e5e-99c1-32ad80927ceb" isOrdered="true" isDerived="true" subsettedProperty="493bdf36-17fd-4f7a-a07d-f046892b7f3f" association="ada29145-b1a8-440f-9639-942a00a644e5">
+        <ownedComment xmi:id="91d3e7ba-3216-41ea-9e1f-12f6b0a87a60" annotatedElement="e14f4e3f-03a3-4a70-a7aa-7d6a28ba6178">
+          <body>&lt;p>The EnumerationUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="429233f1-afee-42e1-b756-013667c42ac0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b64ec726-d13c-4c7c-8c2b-2ebfc7334a8e" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f7402e35-7ceb-4f68-8c05-67b34bd30ea5" name="nestedAllocation" visibility="public" type="67972056-88ee-40e2-9e91-95d3ab49988c" isOrdered="true" isDerived="true" subsettedProperty="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820" association="2a8fbcb2-447c-484d-9430-384b51a9024f">
+        <ownedComment xmi:id="5dc7b06b-6e43-4967-a152-b80d2739f94d" annotatedElement="f7402e35-7ceb-4f68-8c05-67b34bd30ea5">
+          <body>&lt;p>The AllocationUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="137844ab-1166-4309-854a-de20f21f8e3f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8e37ab76-8972-41e1-921e-c327ad7485ec" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f20188a5-b70b-442f-b34f-c71b45a1af20" name="nestedConcern" visibility="public" type="239221a4-785b-4526-b45d-0a747816cd1b" isDerived="true" subsettedProperty="5d453801-4f2d-4df0-bc76-a99e5ce278a6" association="0cc231f1-3dc7-40d2-aec0-5c819a566c9c">
+        <ownedComment xmi:id="8662cf6d-d647-422f-bcfc-5d7a0d5675ee" annotatedElement="f20188a5-b70b-442f-b34f-c71b45a1af20">
+          <body>&lt;p>The ConcernUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7fefb20b-462e-4e1c-86bf-2fbc5f0d7d49" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ae039f26-5d64-4c82-990e-1752f7b11933" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff" name="nestedOccurrence" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isOrdered="true" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="197ab1d2-b164-4fe2-8fe8-537bac9132f0">
+        <ownedComment xmi:id="db920a53-58e6-44a4-8513-325a17dbd1cc" annotatedElement="989c6f14-6bd7-49b7-ba9d-4e5860e7f3ff">
+          <body>&lt;p>The OccurrenceUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f10e2e8b-4078-4f04-be79-1e780eee640f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8a7d04fa-e38e-4839-a9c4-773027def151" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="201738a1-0499-47ef-8c07-ab15564d86c0" name="definition" visibility="public" type="c57280e7-ce5c-4959-96d9-7fa4e8e3e5da" isOrdered="true" isDerived="true" redefinedProperty="b727584c-d321-46a6-ab44-17b1304bc1b6" association="ebf22dba-57a7-49ab-8e9c-8b250db4a6e3">
+        <ownedComment xmi:id="a5128c5b-6257-4f0c-a8ff-4f7db078323b" annotatedElement="201738a1-0499-47ef-8c07-ab15564d86c0">
+          <body>&lt;p>The Classifiers that are the types of this Usage. Nominally, these are Definitions, but other kinds of Kernel Classifiers are also allowed, to permit use of Classifiers from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f87fbc3f-ecf2-41c1-8840-777493df38f4" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7254ba08-40e6-46b1-bb0c-9342821060ca" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="2f8b2589-4990-4acb-81e8-ae1d27c33eba" name="nestedUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isOrdered="true" isDerived="true" subsettedProperty="af8526f8-1df3-474f-a9ea-e3d869a61b8d" association="594be884-0ab8-406f-8f81-0c5eb568eacb">
+        <ownedComment xmi:id="03470f27-9fc8-4c2c-b107-7066c47826c3" annotatedElement="2f8b2589-4990-4acb-81e8-ae1d27c33eba">
+          <body>&lt;p>The UseCaseUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p>
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="86e2ca30-4aef-46df-b578-e2159ddd71e8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9a3483d3-46cc-48b0-8de9-33454e7ca346" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4b97024d-0fb2-4e8d-8d39-3132a89b44bc" name="isReference" visibility="public" isDerived="true">
+        <ownedComment xmi:id="cd4a7156-b48f-4cfe-b7f8-07376e41e2ea" annotatedElement="4b97024d-0fb2-4e8d-8d39-3132a89b44bc">
+          <body>&lt;p>Whether this Usage is a reference Usage, derived as the negation of &lt;code>isComposite&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="3f83491a-2f10-4016-bd06-ccffb403d5d4" name="nestedFlow" visibility="public" type="fd085776-81b3-4a29-b1f9-a414d1a6556c" isDerived="true" subsettedProperty="4e6959c0-d3f1-4c59-9067-7b2fdb7ea820" association="7feb0032-75b7-4a1c-87c1-03a2c70d667c">
+        <ownedComment xmi:id="a7a7c065-6227-4f43-9f62-372a1faa2aca" annotatedElement="3f83491a-2f10-4016-bd06-ccffb403d5d4">
+          <body>&lt;p>The FlowConnectionUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="70aa1c6a-b046-431b-95ac-53fb238ce9f5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9639615b-4b21-4256-8732-78fac8fc60a4" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d39fc166-a8f0-4e2d-8dc6-339522955be6" name="nestedMetadata" visibility="public" type="7ad44795-c498-4b29-9af3-c1bf96867f82" isOrdered="true" isDerived="true" subsettedProperty="4b41f3e4-a7e1-4556-b5df-6c9356cf4a75" association="cb08cf9f-fc01-4427-b76f-2b27034f8db1">
+        <ownedComment xmi:id="55338ab5-83b3-4f05-9f96-5f15185fe106" annotatedElement="d39fc166-a8f0-4e2d-8dc6-339522955be6">
+          <body>&lt;p>The MetadataUsages that are &lt;code>nestedUsages&lt;/code> of this Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="db6bfadf-db40-42a9-84fd-5837b5f6f4fc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a38ea0fe-7812-41b3-a3c4-921ab63ad88a" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="a72f751c-5ed8-482a-8c58-0a536b396eac" name="namingFeature" visibility="public" bodyCondition="93113166-52a2-46f9-8df4-ad6e551870d6" redefinedOperation="c8e0dccb-213e-4fda-ad2b-2ef20ec73ab4">
+        <ownedComment xmi:id="0d3fe6b3-8e41-4ab9-ae58-b9d4ad1fa077" annotatedElement="a72f751c-5ed8-482a-8c58-0a536b396eac">
+          <body>&lt;p>If this Usage is a variant, then its naming Feature is its first subsetted Feature (unless that Feature is the &lt;code>owner&lt;/code> of the usage).&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="93113166-52a2-46f9-8df4-ad6e551870d6" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="d0cf2ab6-90a8-48a7-90a7-4e5ec907974a" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if not owningMembership.oclIsKindOf(VariantMembership) then
+    self.oclAsType(Feature).namingFeature()
+else
+    let namingFeature : Feature = firstSubsettedFeature() in
+    if namingFeature = owner then null
+    else namingFeature
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="f78640ea-fe67-48f2-b87e-2d9788a1ef32" name="" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="db7d97ca-49a1-4afb-95de-6a182df06f7f" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bbad1df4-e693-49af-bf86-39c6b1b1c893" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="eec6956a-f52e-4908-b514-221639f6646d" name="" visibility="public" memberEnd="2d4bf0a5-00ef-4645-9c5d-777acd6d59cb 187ce9bc-8499-4f74-a487-3bc7b8666616">
+      <ownedEnd xmi:id="187ce9bc-8499-4f74-a487-3bc7b8666616" name="actionOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="3c1e0401-e330-4089-8c54-9a506130d046" association="eec6956a-f52e-4908-b514-221639f6646d">
+        <ownedComment xmi:id="368b5760-73c6-4246-b870-be962c379ab3" annotatedElement="187ce9bc-8499-4f74-a487-3bc7b8666616">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="56462f82-7730-4776-80e0-75b1a654ca6a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5c4a1d86-6c2c-4c45-83f5-9cbbf3233804" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="218610f8-80dd-49cf-9cf3-903ae4197e04" name="" visibility="public" memberEnd="4940c6a0-7ba8-4dcd-a339-24552456a296 cec7898c-1999-45ed-a9d5-2d5e54635c13">
+      <ownedEnd xmi:id="cec7898c-1999-45ed-a9d5-2d5e54635c13" name="stateOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" redefinedProperty="1b7b5463-e55a-4c54-a0bb-5130c627562a" association="218610f8-80dd-49cf-9cf3-903ae4197e04">
+        <ownedComment xmi:id="13b29c01-0dce-4156-bef6-16419aa9a262" annotatedElement="cec7898c-1999-45ed-a9d5-2d5e54635c13">
+          <body>&lt;p>The Usage in which the &lt;code>nestedState&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cacb83af-7b0f-465d-820b-f52b6a70f8c0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="37417ead-0077-49ce-8149-233dcbabcc0f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7a990883-5206-4c30-b4cc-ba108b6189bc" name="VariantMembership" visibility="public">
+      <ownedComment xmi:id="42d70757-81b2-4698-95b8-fb3c083cce04" annotatedElement="7a990883-5206-4c30-b4cc-ba108b6189bc">
+        <body>&lt;p>A VariantMembership is a Membership between a variation point Definition or Usage and a Usage that represents a variant in the context of that variation. The &lt;code>membershipOwningNamespace&lt;/code> for the VariantMembership must be either a Definition or a Usage with &lt;code>isVariation&lt;/code> = &lt;code>true&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="6ebf7531-a0da-4355-ba63-e982dd30ec6b" general="4e4d3acc-bd44-41fc-9b96-5eff8ab0cf5d"/>
+      <ownedAttribute xmi:id="9fa2a9e4-c439-4f04-a86f-c899c0fb9e81" name="ownedVariantUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" aggregation="composite" isDerived="true" redefinedProperty="50d115dd-9fe9-4a0c-8d67-bcca24186f18" association="8f20af5c-6f2a-4032-997b-66d5dc8ecfc3">
+        <ownedComment xmi:id="41456596-8686-46f9-86ab-3e624b951ff0" annotatedElement="9fa2a9e4-c439-4f04-a86f-c899c0fb9e81">
+          <body>&lt;p>The Usage that represents a variant in the context of the &lt;code>owningVariationDefinition&lt;/code> or &lt;code>owningVariationUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="73fcf863-cc40-48a7-b2b4-f3231f3de50c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="202ce866-ae4c-4068-af5b-13354c930d7f" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="2a8fbcb2-447c-484d-9430-384b51a9024f" name="" visibility="public" memberEnd="f7402e35-7ceb-4f68-8c05-67b34bd30ea5 25a2ef25-975e-4b44-9856-cd076ecc1530">
+      <ownedEnd xmi:id="25a2ef25-975e-4b44-9856-cd076ecc1530" name="allocationOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="833d5ca8-6d71-460a-bb83-1a9872fd5cdc" association="2a8fbcb2-447c-484d-9430-384b51a9024f">
+        <ownedComment xmi:id="639240a0-59f8-49e9-b479-4b9fc8f9818a" annotatedElement="25a2ef25-975e-4b44-9856-cd076ecc1530">
+          <body>&lt;p>The Usage that owns the &lt;code>nestedAllocation&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ec2bafc7-0ca6-4055-828c-673d8c55d39b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b6a72a87-80ae-446f-9715-7e0e6951ee73" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="ad315d17-6754-4a30-bcde-3b73d63d713e" name="ReferenceUsage" visibility="public">
+      <ownedComment xmi:id="9ed9b6e2-9bcb-4126-a177-9e0e700d579c" annotatedElement="ad315d17-6754-4a30-bcde-3b73d63d713e">
+        <body>&lt;p>A ReferenceUsage is a Usage that specifies a non-compositional (&lt;code>isComposite&lt;/code> = &lt;code>false&lt;/code>) reference to something. The type of a ReferenceUsage can be any kind of Classifier, with the default being the top-level Classifier Anything from the Kernel library. This allows the specification of a generic reference without distinguishing if the thing referenced is an attribute value, item, action, etc. All &lt;code>features&lt;/code> of a ReferenceUsage must also have &lt;code>isComposite&lt;/code> = &lt;code>false&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="077b8f69-293d-4adf-96c1-45d6b08edc44" general="46068009-84f1-4001-a9bb-fc03fd6a381c"/>
+      <ownedAttribute xmi:id="841c41f5-570d-42bb-8a83-79958f0bdbd5" name="isReference" visibility="public" isDerived="true" redefinedProperty="4b97024d-0fb2-4e8d-8d39-3132a89b44bc">
+        <ownedComment xmi:id="b6e60eae-ea9b-4f28-b1b4-2f500556077c" annotatedElement="841c41f5-570d-42bb-8a83-79958f0bdbd5">
+          <body>&lt;p>Always &lt;code>true&lt;/code> for a ReferenceUsage.&lt;/code></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralString" xmi:id="93fcd8b6-344e-4694-9e58-3ab11e813010" name="" visibility="public" value="true"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="05c726a6-34b4-4088-8011-1b6749aef12b" name="" visibility="public" memberEnd="455b76bb-8ccf-4f44-b97c-8cba850d9244 0145aa50-50b8-4604-af40-9eb571ca2050">
+      <ownedEnd xmi:id="0145aa50-50b8-4604-af40-9eb571ca2050" name="enumerationOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="398dc3b4-8cf8-4430-b90f-b84b16a1c8a4" association="05c726a6-34b4-4088-8011-1b6749aef12b">
+        <ownedComment xmi:id="647bfe97-5d64-4abd-a571-c72a2b99a25c" annotatedElement="0145aa50-50b8-4604-af40-9eb571ca2050">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedEnumeration&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4fb4530c-d383-4e2b-ae17-ec5d4f14be81" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6f6ac6ea-bda9-4ec4-a186-dfe2dccba67a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="820df8ab-51c8-4d5a-bb66-70d583ab4d1b" name="" visibility="public" memberEnd="6d75f458-5fe0-4c99-8e0f-a41c252b972c 3685352b-6e83-492d-984d-81a396557841">
+      <ownedEnd xmi:id="3685352b-6e83-492d-984d-81a396557841" name="definitionWithDirectedUsage" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="eb7af616-8e9c-419a-a08a-4b80d758179f 9eb39b11-03b6-45e0-999a-25ee6e6dda75" association="820df8ab-51c8-4d5a-bb66-70d583ab4d1b">
+        <ownedComment xmi:id="57cef98e-b318-4d93-a0c0-edb64504d7a7" annotatedElement="3685352b-6e83-492d-984d-81a396557841">
+          <body>&lt;p>The Definitions that have a certain Usage as a &lt;code>flow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bfa0f577-abfe-4dca-83d6-b9c1a3b1b5fc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="78578fb8-a5e9-443d-9bb5-3bce58be353f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b74e5af3-a7e7-4665-a5fb-50ed40e7f3f7" name="" visibility="public" memberEnd="25886946-6e56-4ed2-b780-db818aae189e d65081c3-9f3a-4f24-9216-af87e1f6c05f">
+      <ownedEnd xmi:id="d65081c3-9f3a-4f24-9216-af87e1f6c05f" name="transitionOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="b74e5af3-a7e7-4665-a5fb-50ed40e7f3f7">
+        <ownedComment xmi:id="43a66135-c549-4d8a-9e43-4aac1757103e" annotatedElement="d65081c3-9f3a-4f24-9216-af87e1f6c05f">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedTransition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="808edd58-0911-4a24-8618-4afb5728b171" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="46e069b5-3964-472b-bae0-600ae7411630" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ebf22dba-57a7-49ab-8e9c-8b250db4a6e3" name="" visibility="public" memberEnd="201738a1-0499-47ef-8c07-ab15564d86c0 96ec9372-1879-4d45-a114-b4276d6a9bdf">
+      <ownedEnd xmi:id="96ec9372-1879-4d45-a114-b4276d6a9bdf" name="definedUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="8627f6e3-1ebb-4b3a-b829-d9923e876aa4" association="ebf22dba-57a7-49ab-8e9c-8b250db4a6e3">
+        <ownedComment xmi:id="5d2c0dbe-5a63-40c0-a8dd-66e25f637fa2" annotatedElement="96ec9372-1879-4d45-a114-b4276d6a9bdf">
+          <body>&lt;p>The Usages that have a certain Classifier as a &lt;code>definition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1005260f-f2fe-4a95-b39f-605ba116f987" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="95b7a7fb-175a-4fbb-b254-b64ea15faa3f" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="ea5e3639-2227-45b2-af8b-eaa63a314862" name="" visibility="public" memberEnd="70338db9-2386-46d0-9d5b-22dad07b1984 f562df2e-4b48-4086-bd83-b32d399ca792">
+      <ownedEnd xmi:id="f562df2e-4b48-4086-bd83-b32d399ca792" name="transitionOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="e3db423d-543e-47fa-864c-573abd896990" association="ea5e3639-2227-45b2-af8b-eaa63a314862">
+        <ownedComment xmi:id="354a0a57-9aec-479a-b527-e46a1ad13817" annotatedElement="f562df2e-4b48-4086-bd83-b32d399ca792">
+          <body>&lt;p>The Usage in which the &lt;code>nestedTransition&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3d773d71-8625-4129-aaed-0d3b23f534bf" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3b346ee7-2891-4647-84b8-ac916e36c75f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="594be884-0ab8-406f-8f81-0c5eb568eacb" name="" visibility="public" memberEnd="2f8b2589-4990-4acb-81e8-ae1d27c33eba 115e20d0-fd77-4838-919f-50e67c1c4a8f">
+      <ownedEnd xmi:id="115e20d0-fd77-4838-919f-50e67c1c4a8f" name="useCaseOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="9bc76574-5dd5-415b-b578-4f8b34ca7e48" association="594be884-0ab8-406f-8f81-0c5eb568eacb">
+        <ownedComment xmi:id="baaabdef-c178-41b1-98d3-97aabde2abe7" annotatedElement="115e20d0-fd77-4838-919f-50e67c1c4a8f">
+          <body>&lt;p>The Usage in which the &lt;code>nestedUseCase&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="92c21182-b7f0-4eeb-9c13-c10ed0bdcf70" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4e77f02d-e7a7-4c92-8289-e12942d9ba4b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8d10c04f-3be4-4d67-98a9-196932bc5526" name="" visibility="public" memberEnd="5e650689-f765-4f10-9b51-7fb42c2fc156 cbe12906-6af5-4053-9d66-69f1b8256ab6">
+      <ownedEnd xmi:id="cbe12906-6af5-4053-9d66-69f1b8256ab6" name="viewpointOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="f0edc722-0f8b-486a-802c-2275561be411" association="8d10c04f-3be4-4d67-98a9-196932bc5526">
+        <ownedComment xmi:id="78e992e7-a2b9-4146-ade4-62a9cad5e3d2" annotatedElement="cbe12906-6af5-4053-9d66-69f1b8256ab6">
+          <body>&lt;p>The Definition that owns a certain &lt;code>ownedViewpoint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="76315c6f-93a7-4a6c-8f63-c36009c0ef10" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b0015b01-0c75-48e5-9540-00f12f774acf" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0cc231f1-3dc7-40d2-aec0-5c819a566c9c" name="" visibility="public" memberEnd="f20188a5-b70b-442f-b34f-c71b45a1af20 fef51b0b-af35-4ed4-8fca-b995cc8a9ab8">
+      <ownedEnd xmi:id="fef51b0b-af35-4ed4-8fca-b995cc8a9ab8" name="concernOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a" association="0cc231f1-3dc7-40d2-aec0-5c819a566c9c">
+        <ownedComment xmi:id="561afcde-e5f1-4556-ba6d-7f3d7b442359" annotatedElement="fef51b0b-af35-4ed4-8fca-b995cc8a9ab8">
+          <body>&lt;p>The Usage that owns the &lt;code>nestedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="82ac204f-12a3-47d8-9b35-9c039694be2f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="10f4cbad-e49a-4dcc-ae5b-863fe323ac93" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="93359adb-ed1e-4eaf-9aaa-d987674f7a19" name="" visibility="public" memberEnd="cc8a82a9-eec0-4f73-a79f-fc9d14d87597 6d8bb769-5703-4079-8e0a-34dede173fb1">
+      <ownedEnd xmi:id="6d8bb769-5703-4079-8e0a-34dede173fb1" name="allocationOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" subsettedProperty="24f8feda-723b-4e44-924c-e7e78716e6c0" association="93359adb-ed1e-4eaf-9aaa-d987674f7a19">
+        <ownedComment xmi:id="f25d2578-db98-424b-b781-cbb20d262740" annotatedElement="6d8bb769-5703-4079-8e0a-34dede173fb1">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedAllocation&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d5e38821-571f-41c8-8c3e-f7a2f5c1feba" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1d45afb1-d9ef-4887-8194-3981e442649f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1d4d04e6-aebe-4aa9-9298-00f332a87556" name="" visibility="public" memberEnd="6f6ca85a-aeb6-493d-a191-cfca8fe6dad5 c7710da0-0326-451d-8147-52d47dc4e6b2">
+      <ownedEnd xmi:id="c7710da0-0326-451d-8147-52d47dc4e6b2" name="stateOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="187ce9bc-8499-4f74-a487-3bc7b8666616" association="1d4d04e6-aebe-4aa9-9298-00f332a87556">
+        <ownedComment xmi:id="9b33d2a3-2432-4697-ab92-e53a8944eecd" annotatedElement="c7710da0-0326-451d-8147-52d47dc4e6b2">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedState&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5f376058-126f-4eba-b9d0-2441845144aa" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="97df6ef6-ada6-48ca-b37f-4c0e687d1944" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="83818c6a-985e-4c4c-a9dd-e1301c46a4e6" name="" visibility="public" memberEnd="4b41f3e4-a7e1-4556-b5df-6c9356cf4a75 d280a0cb-b281-40a1-88c5-cd2cf6c74b0c">
+      <ownedEnd xmi:id="d280a0cb-b281-40a1-88c5-cd2cf6c74b0c" name="itemOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="89af2f5e-fcfa-48b7-8619-9c69476636a8" association="83818c6a-985e-4c4c-a9dd-e1301c46a4e6">
+        <ownedComment xmi:id="c866456b-8395-4d80-9e19-e7db73b901a0" annotatedElement="d280a0cb-b281-40a1-88c5-cd2cf6c74b0c">
+          <body>&lt;p>The Usage in which the &lt;code>nestedItem&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a2167ece-4fc2-464c-9eb7-cf0d6d0e2a40" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="85419a55-25e3-4978-b722-9c9baceaf6c9" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3223c7d1-7558-4a4f-972c-fdea72085cac" name="" visibility="public" memberEnd="cefdac00-81bf-4ced-93c2-b11161003857 e02ee31c-b895-45b1-a5bb-a0a465f786e0">
+      <ownedEnd xmi:id="e02ee31c-b895-45b1-a5bb-a0a465f786e0" name="partOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="d280a0cb-b281-40a1-88c5-cd2cf6c74b0c" association="3223c7d1-7558-4a4f-972c-fdea72085cac">
+        <ownedComment xmi:id="29881085-b068-445c-b9a8-f492b56c97f8" annotatedElement="e02ee31c-b895-45b1-a5bb-a0a465f786e0">
+          <body>&lt;p>The Usage in which the &lt;code>nestedPart&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3af480f9-a466-475a-8d5c-09283574b815" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="daaec70e-8aae-457b-b68a-fd25ff6e2411" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7aa36b16-c1ef-4a46-b5e7-2a6e803b9a70" name="" visibility="public" memberEnd="db471ae1-04e1-47b7-b6bc-2d40afdda735 eb7af616-8e9c-419a-a08a-4b80d758179f">
+      <ownedEnd xmi:id="eb7af616-8e9c-419a-a08a-4b80d758179f" name="featuringDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="cc61e3eb-73e2-4836-a445-33c2c6a1013c" association="7aa36b16-c1ef-4a46-b5e7-2a6e803b9a70">
+        <ownedComment xmi:id="c7d2bf1c-420c-4f06-b589-1524c2ec460c" annotatedElement="eb7af616-8e9c-419a-a08a-4b80d758179f">
+          <body>&lt;p>The Definitions that feature a certain Usage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="eb703c84-ea9a-4182-b052-f7165c5ec3a6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="32102323-19db-45f1-a9ff-09b7a3e24d50" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d7257e72-d5e4-4a24-8e53-dd845a3c9845" name="" visibility="public" memberEnd="8e3f1de2-c767-4cdd-af33-aacf5abe7d73 ac78893b-0ca0-443c-9f14-131910814067">
+      <ownedEnd xmi:id="ac78893b-0ca0-443c-9f14-131910814067" name="partOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="cd556efb-5f4e-4b19-81aa-5e8c14842c3c" association="d7257e72-d5e4-4a24-8e53-dd845a3c9845">
+        <ownedComment xmi:id="55236829-ca36-40d8-a557-666e07ebc08b" annotatedElement="ac78893b-0ca0-443c-9f14-131910814067">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedPart&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2505c92b-278b-46ff-ae0b-5ec7231c393e" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d98026b7-893c-48a5-835d-405a9b4671f6" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e398a46c-ea1c-4442-af1d-8c93672de206" name="" visibility="public" memberEnd="d60be625-f2a6-4ee2-acc1-a4c6e1b90105 1b7b5463-e55a-4c54-a0bb-5130c627562a">
+      <ownedEnd xmi:id="1b7b5463-e55a-4c54-a0bb-5130c627562a" name="actionOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="89af2f5e-fcfa-48b7-8619-9c69476636a8" association="e398a46c-ea1c-4442-af1d-8c93672de206">
+        <ownedComment xmi:id="7d858300-49ff-4d41-827c-ee809ec6186c" annotatedElement="1b7b5463-e55a-4c54-a0bb-5130c627562a">
+          <body>&lt;p>The Usage in which the &lt;code>nestedAction&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="56cce358-be60-4fbd-b1df-f09ab0456a61" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a2a033c2-3e09-4ed3-bef5-82a75afa128f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="a469a605-0ffc-4a88-a213-2a62597a0e35" name="" visibility="public" memberEnd="5d453801-4f2d-4df0-bc76-a99e5ce278a6 3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a">
+      <ownedEnd xmi:id="3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a" name="requirementOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="938f3e99-bd1e-44a6-89f8-27cea9054f77" association="a469a605-0ffc-4a88-a213-2a62597a0e35">
+        <ownedComment xmi:id="85aabcfd-fc8a-4285-868b-52c5516d42f4" annotatedElement="3ba7b0e1-268b-4e49-a2cd-cc1d1ce44f8a">
+          <body>&lt;p>The Usage in which the &lt;code>nestedRequirement&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="1e38e1fb-d69a-421c-884c-333c330ff2b0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c328d323-b9ac-43e1-b673-0ca5a44a18d3" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="4a6eb2f9-a767-4964-896a-45dc68f0389a" name="" visibility="public" memberEnd="4b4d5f24-e14a-49d6-ae33-71205fb0a918 2e9373ee-0748-4092-ae61-b4d4e77c0d45">
+      <ownedEnd xmi:id="2e9373ee-0748-4092-ae61-b4d4e77c0d45" name="interfaceOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="24f8feda-723b-4e44-924c-e7e78716e6c0" association="4a6eb2f9-a767-4964-896a-45dc68f0389a">
+        <ownedComment xmi:id="798daddf-ea06-43d7-9f7b-77f67131cac0" annotatedElement="2e9373ee-0748-4092-ae61-b4d4e77c0d45">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedInterface&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="65d93c99-b53b-49c3-8b91-0761ec3958ad" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="09aeff96-f3f2-4250-a6f6-4a79f16c6795" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c904ee3a-27ef-4aac-b233-8a2250c02c6a" name="" visibility="public" memberEnd="3aeed792-7c5b-4145-ad3c-981f4de83751 e3db423d-543e-47fa-864c-573abd896990"/>
+    <packagedElement xmi:type="uml:Association" xmi:id="0d73d5ab-916b-465f-8085-20c0c1d44b9c" name="" visibility="public" memberEnd="1635265b-d9d5-4237-8e19-2d2512ceafea c0a302de-d938-4115-950d-1d23d1a14ec1">
+      <ownedEnd xmi:id="c0a302de-d938-4115-950d-1d23d1a14ec1" name="concernOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="f0edc722-0f8b-486a-802c-2275561be411" association="0d73d5ab-916b-465f-8085-20c0c1d44b9c">
+        <ownedComment xmi:id="a7c86eec-235d-44d3-9018-52ee47a72215" annotatedElement="c0a302de-d938-4115-950d-1d23d1a14ec1">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedConcern&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="aefa1ba8-75b6-408e-824d-c68f0ecaae97" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="43e7b0ab-449a-48ee-b3b9-c70d1a280846" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7feb0032-75b7-4a1c-87c1-03a2c70d667c" name="" visibility="public" memberEnd="3f83491a-2f10-4016-bd06-ccffb403d5d4 13cfc2cb-a0c6-4c1d-81d8-bf44907da0d3">
+      <ownedEnd xmi:id="13cfc2cb-a0c6-4c1d-81d8-bf44907da0d3" name="flowOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="833d5ca8-6d71-460a-bb83-1a9872fd5cdc" association="7feb0032-75b7-4a1c-87c1-03a2c70d667c">
+        <ownedComment xmi:id="5aa555dd-4bf4-426e-a897-948f10be99b6" annotatedElement="13cfc2cb-a0c6-4c1d-81d8-bf44907da0d3">
+          <body>&lt;p>The Usage that owns the &lt;code>nestedFlow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e4a256b8-ee1f-42e2-8b1b-607563f76cb1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="291bf1fd-6427-4e5d-a28f-3afd35d4f6c1" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="cb08cf9f-fc01-4427-b76f-2b27034f8db1" name="" visibility="public" memberEnd="d39fc166-a8f0-4e2d-8dc6-339522955be6 bb49ccb6-942c-40f7-90c6-c7e953385fe2">
+      <ownedEnd xmi:id="bb49ccb6-942c-40f7-90c6-c7e953385fe2" name="metadataOwningUsage" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isDerived="true" subsettedProperty="d280a0cb-b281-40a1-88c5-cd2cf6c74b0c" association="cb08cf9f-fc01-4427-b76f-2b27034f8db1">
+        <ownedComment xmi:id="038e0b88-6574-409a-904d-396da321108b" annotatedElement="bb49ccb6-942c-40f7-90c6-c7e953385fe2">
+          <body>&lt;p>The Usage in which the &lt;code>nestedMetadata&lt;/code> is nested.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="982ca9e9-1d24-41eb-aa85-8fef63007735" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f698bc5b-73bf-43c8-ad57-ab4b811364a1" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="81f427da-0f6e-4bda-8d22-ed46ae8afb56" name="" visibility="public" memberEnd="fbb36072-eee7-484d-a317-a7e136fa8f06 6aa543f3-2e79-4352-bb0c-7054c59edb77">
+      <ownedEnd xmi:id="6aa543f3-2e79-4352-bb0c-7054c59edb77" name="referenceOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="81f427da-0f6e-4bda-8d22-ed46ae8afb56">
+        <ownedComment xmi:id="5e0fa0a6-9f7c-4324-a7e3-5b00dc9434f3" annotatedElement="6aa543f3-2e79-4352-bb0c-7054c59edb77">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedReference&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="cfc06d3c-f5bc-4c5c-88ab-887353e07609" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6e31c067-d08f-4aa6-90e1-2766201fdcf2" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c2984cd0-947a-4b13-b73a-ce65ca1fe772" name="" visibility="public" memberEnd="0f491f54-f387-4e6e-99bc-e6b15106a0d2 24f8feda-723b-4e44-924c-e7e78716e6c0">
+      <ownedEnd xmi:id="24f8feda-723b-4e44-924c-e7e78716e6c0" name="connectionOwningDefinition" visibility="public" type="bbec763b-2ef0-415f-9e22-c531739690bb" isDerived="true" subsettedProperty="ac78893b-0ca0-443c-9f14-131910814067" association="c2984cd0-947a-4b13-b73a-ce65ca1fe772">
+        <ownedComment xmi:id="fa6ffea4-928d-4dca-a3c7-7a2d88f5845e" annotatedElement="24f8feda-723b-4e44-924c-e7e78716e6c0">
+          <body>&lt;p>The Definition that owns the &lt;code>ownedConnection&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="25fa1e61-50f5-4a3e-b1c5-2b52569124dc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="63beb8c5-d49c-41d6-9fcb-e1e32bd2346d" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6afc692e-dabc-424f-bcbb-7994a6f71c84" name="" visibility="public" memberEnd="ab0dbb87-5e95-4819-9217-2128904f4064 750ac38e-ae6c-4718-856d-a704775bdd8b"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="be0743f2-df92-4bba-a31d-18501e0c11e1" name="ViewpointDefinition" visibility="public">
+      <ownedComment xmi:id="078596fc-94d1-4022-bcd4-a35bed473b7c" annotatedElement="be0743f2-df92-4bba-a31d-18501e0c11e1">
+        <body>&lt;p>A ViewpointDefinition is a RequirementDefinition that specifies one or more stakeholder concerns that to be satisfied by created a view of a model.&lt;/p>
+
+&lt;p>A ViewpointDefinition must subclass, directly or indirectly, the base ViewpointDefinition Viewpoint from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="592a8fa6-f5f1-44d9-ab7b-c596c2712f91" general="3f439339-e30b-454e-9a33-9a90c3c37bc9"/>
+      <ownedAttribute xmi:id="35cc2875-c293-449a-86eb-5e8ed47eff95" name="viewpointStakeholder" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" association="fd75edf1-d921-4ccd-a00b-1d36834b5163">
+        <ownedComment xmi:id="f84e5cec-e181-4009-9853-d22f05244bbe" annotatedElement="35cc2875-c293-449a-86eb-5e8ed47eff95">
+          <body>&lt;p>The features that identify the stakeholders with concerns framed by this ViewpointDefinition, derived as the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this ViewpointDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a766405d-3470-415c-bfd9-2650b7706293" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a4a4f86d-6c69-400e-b789-0bc8167be20c" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0058c429-26c8-45a7-a83c-655a0b60ecab" name="" visibility="public" memberEnd="0545415c-cfaa-49bc-a79b-2d94891bf274 16b19f3a-1947-4328-ae0f-a777329db067">
+      <ownedEnd xmi:id="16b19f3a-1947-4328-ae0f-a777329db067" name="viewer" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" association="0058c429-26c8-45a7-a83c-655a0b60ecab">
+        <ownedComment xmi:id="2b6aab04-2d42-465c-88ff-0de736f7649a" annotatedElement="16b19f3a-1947-4328-ae0f-a777329db067">
+          <body>&lt;p>The ViewUsage that renders a certain &lt;code>viewElement&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6fa0026a-d2c0-4dfb-b26d-604f9dc05a35" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e8177ecc-537c-49de-ac40-ffce566652f9" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f959e3ce-d3fe-4886-a5eb-f33e228edcc0" name="" visibility="public" memberEnd="a119e966-29c5-459f-9919-9a1da02e65d6 955bafc3-bf55-4a97-a8df-cece6f128568">
+      <ownedEnd xmi:id="955bafc3-bf55-4a97-a8df-cece6f128568" name="viewpointSatisfyingView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" subsettedProperty="80256afa-977a-420b-8633-5970645921d2" association="f959e3ce-d3fe-4886-a5eb-f33e228edcc0">
+        <ownedComment xmi:id="98860ca6-85f6-4059-9dfc-591dd9284b96" annotatedElement="955bafc3-bf55-4a97-a8df-cece6f128568">
+          <body>p>The ViewUsage that owns a certain &lt;code>satisfiedViewpoint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6dbe30aa-6a26-4702-92d8-6ec342230468" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3007dd9f-abdf-41a9-b42e-6f9e2722deee" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="39cf49a1-6cb5-45c2-b84e-c3c0220879b9" name="" visibility="public" memberEnd="337b8c98-d648-4aa1-b9c4-cdffac6617b6 56d95d64-925e-4ba1-a216-a7f7150db625">
+      <ownedEnd xmi:id="56d95d64-925e-4ba1-a216-a7f7150db625" name="renderingOwningViewDefinition" visibility="public" type="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" isDerived="true" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="39cf49a1-6cb5-45c2-b84e-c3c0220879b9">
+        <ownedComment xmi:id="ba0cd69f-b6a8-4c13-bdcb-aab9aa072ec0" annotatedElement="56d95d64-925e-4ba1-a216-a7f7150db625">
+          <body>&lt;p>The ViewDefinition that owns a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="df304213-d980-4f1a-be52-0a4bef57dae7" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b545edba-88e7-4ae6-86b8-969c7477b3cf" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="2601190c-74cd-4364-aedf-e45d4cee1b37" name="ViewpointUsage" visibility="public">
+      <ownedComment xmi:id="2329bbc8-4751-4d3b-bcba-b05581fdaed7" annotatedElement="2601190c-74cd-4364-aedf-e45d4cee1b37">
+        <body>&lt;p>A ViewpointUsage is a usage of a ViewpointDefinition.&lt;/p>
+
+&lt;p>A ViewpointUsage must subset, directly or indirectly, the base ViewpointUsage &lt;code>viewpoints&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="35a234dc-b93d-4b6b-8ee2-e32753148a3a" general="7248aae3-2934-47cd-bf16-f9aca7f25ad7"/>
+      <ownedAttribute xmi:id="f4a150b0-ecce-4a20-abaf-b26f7e7b420c" name="viewpointDefinition" visibility="public" type="be0743f2-df92-4bba-a31d-18501e0c11e1" isDerived="true" redefinedProperty="ee688400-5d8a-4c4d-9fa5-a21e6047ebf2" association="17c92f19-2fc9-424d-b4b1-054192f0a7bf">
+        <ownedComment xmi:id="91daf349-0672-42b6-9f79-f86197010f37" annotatedElement="f4a150b0-ecce-4a20-abaf-b26f7e7b420c">
+          <body>&lt;p>The ViewpointDefinition that defines this ViewUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="203c6f04-1592-4034-81c0-f7b140bf17c8" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0c6ee6d7-de80-44ff-8182-84f77a476cf5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="80d8dd2f-afd0-4681-85fe-02b381180747" name="viewpointStakeholder" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isOrdered="true" isDerived="true" association="07e867f1-e862-4450-8de1-5da85bcf8249">
+        <ownedComment xmi:id="0a5a14cd-1de8-471f-8f19-556514c1601e" annotatedElement="80d8dd2f-afd0-4681-85fe-02b381180747">
+          <body>&lt;p>The features that identify the stakeholders with concerns addressed by this ViewpointUsage, derived as the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this ViewpointUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="28497c3b-20b3-45c7-898d-3c529f894cc6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="43edb6c1-1047-4b90-ac72-9b0c97ed3082" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="fd75edf1-d921-4ccd-a00b-1d36834b5163" name="" visibility="public" memberEnd="35cc2875-c293-449a-86eb-5e8ed47eff95 3f1f13c8-3cfa-4272-9ddb-b6f8a1e89819">
+      <ownedEnd xmi:id="3f1f13c8-3cfa-4272-9ddb-b6f8a1e89819" name="viewpointDefinitionForStakeholder" visibility="public" type="be0743f2-df92-4bba-a31d-18501e0c11e1" isDerived="true" association="fd75edf1-d921-4ccd-a00b-1d36834b5163">
+        <ownedComment xmi:id="d0901869-4a29-4d8c-a5bc-42de655fa9f8" annotatedElement="3f1f13c8-3cfa-4272-9ddb-b6f8a1e89819">
+          <body>&lt;p>The ViewpointDefinition that has a certain &lt;code>viewpointStakeholder&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c6738769-fb99-44d3-9c8c-8cd1a42a1f56" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c268c5f9-c03d-4a3b-ae72-35470c471baa" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="6b330802-e9a6-47ee-a875-59ee9e0adf00" name="" visibility="public" memberEnd="7d5cba43-5279-4838-a4dc-821ddf00df6a b1dbd57a-7e91-4895-ba76-5c606dafb34b">
+      <ownedEnd xmi:id="b1dbd57a-7e91-4895-ba76-5c606dafb34b" name="owningViewDefinition" visibility="public" type="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="6b330802-e9a6-47ee-a875-59ee9e0adf00">
+        <ownedComment xmi:id="3e938831-e207-46e1-a04a-bcc1f071b79b" annotatedElement="b1dbd57a-7e91-4895-ba76-5c606dafb34b">
+          <body>&lt;p>The ViewDefinition that owns a certain &lt;code>viewCondition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8244592f-da46-4d52-9c2b-a2bdfd3e4197" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e01e8f4d-b7aa-4101-b3c4-934741134679" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="81962d34-59c3-499b-9b52-e3d6c451c33c" name="" visibility="public" memberEnd="98cd9d4d-8ec6-442d-8e9e-1a4023b5c305 f0816c4a-ba3b-4daa-9c40-e58b1d3a3719">
+      <ownedEnd xmi:id="f0816c4a-ba3b-4daa-9c40-e58b1d3a3719" name="exposingView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" association="81962d34-59c3-499b-9b52-e3d6c451c33c">
+        <ownedComment xmi:id="a208c0e1-6bd3-4a9b-b222-d516797d92cc" annotatedElement="f0816c4a-ba3b-4daa-9c40-e58b1d3a3719">
+          <body>&lt;p>The ViewUsage exposing a certain &lt;code>exposedNamespace&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0dfe8014-a5a3-4f75-8c10-d23d291dfd64" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b07cf122-fec4-4165-93c6-758d49855481" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="47150cd7-a306-49c3-900a-73552eeb99fe" name="" visibility="public" memberEnd="fd8f86af-05b3-45c2-8e64-f1b0cff8d1c8 58c374cb-be7a-41b2-86a1-6e2a702c045f">
+      <ownedEnd xmi:id="58c374cb-be7a-41b2-86a1-6e2a702c045f" name="definedView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" subsettedProperty="2a91fa23-f772-4460-bfd1-8b8c60104e71" association="47150cd7-a306-49c3-900a-73552eeb99fe">
+        <ownedComment xmi:id="631962bf-04ff-4475-843f-66b4e3cab233" annotatedElement="58c374cb-be7a-41b2-86a1-6e2a702c045f">
+          <body>&lt;p>The ViewUsages that have a certain &lt;code>ViewDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="41451fde-ab2a-4110-88ce-069235a67511" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="78a7e047-b211-487d-afd7-57eaea9790c3" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="7f5e74c2-7728-4820-b49b-5efc9a013b51" name="" visibility="public" memberEnd="d589145f-3892-458a-979b-bce9541ab605 8ee83fa3-a78a-4de0-ab53-a15acf470e09">
+      <ownedEnd xmi:id="8ee83fa3-a78a-4de0-ab53-a15acf470e09" name="featuringRenderingDefinition" visibility="public" type="03745d5b-117b-43ca-9b13-3ff11a9377c1" isDerived="true" subsettedProperty="eb7af616-8e9c-419a-a08a-4b80d758179f" association="7f5e74c2-7728-4820-b49b-5efc9a013b51">
+        <ownedComment xmi:id="759e849e-a0cb-4821-879d-2d49a18c5204" annotatedElement="8ee83fa3-a78a-4de0-ab53-a15acf470e09">
+          <body>&lt;p>The RenderingDefinitions that feature a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b953bb47-ef2d-490e-a1ac-67367b449292" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4b5dda99-c9b8-4f8c-baf3-289eec174b47" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="56985611-5393-40e9-84ef-01ef4bd3140a" name="" visibility="public" memberEnd="12faddf9-b707-427f-a4ef-eba4f922e027 0f9284ec-6739-4732-a3d5-342983f6a545">
+      <ownedEnd xmi:id="0f9284ec-6739-4732-a3d5-342983f6a545" name="referencingRenderingMembership" visibility="public" type="95169eaa-ae12-49c8-bd48-a99172a75af5" isDerived="true" association="56985611-5393-40e9-84ef-01ef4bd3140a">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ac9ac3aa-6f2a-4017-9a1d-57366b86a89a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="10401bba-1945-4043-874a-da4d611492fe" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="93784dc7-2f7a-43d8-863a-e7afaec90391" name="" visibility="public" memberEnd="d59f8bd6-8fd1-4cd4-8323-4acf1ccd285d 189a38bc-336b-4271-94f4-1147ff46cdfa">
+      <ownedEnd xmi:id="189a38bc-336b-4271-94f4-1147ff46cdfa" name="viewpointSatisfyingViewDefinition" visibility="public" type="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" subsettedProperty="750ac38e-ae6c-4718-856d-a704775bdd8b" association="93784dc7-2f7a-43d8-863a-e7afaec90391">
+        <ownedComment xmi:id="f04a768e-979d-49eb-83d6-5a64852a7740" annotatedElement="189a38bc-336b-4271-94f4-1147ff46cdfa">
+          <body>&lt;p>The ViewDefinition that owns a certain &lt;code>satisfiedViewpoint&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3dec9042-631a-4b34-b5cb-3d143a47368d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b6dcef4-2910-426f-a392-1695838a4bc2" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="17c92f19-2fc9-424d-b4b1-054192f0a7bf" name="" visibility="public" memberEnd="f4a150b0-ecce-4a20-abaf-b26f7e7b420c 5abc48af-4405-4d6d-80a1-03dda959e9db">
+      <ownedEnd xmi:id="5abc48af-4405-4d6d-80a1-03dda959e9db" name="definedViewpoint" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isDerived="true" subsettedProperty="af52c6b6-b2e3-49ec-9e90-ef120c251f2b" association="17c92f19-2fc9-424d-b4b1-054192f0a7bf">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="a6d6c5c3-a6c7-4e12-bc46-e6ae8382d9d8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e481fff8-67b2-4550-a7d3-0c0d4491a185" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" name="RenderingUsage" visibility="public">
+      <ownedComment xmi:id="ec6c669e-e360-4231-b6a0-76e005b01393" annotatedElement="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608">
+        <body>&lt;p>A RenderingUsage is the usage of a RenderingDefinition to specify the rendering of a specific model view to produce a physical view artifact.&lt;/p>
+
+&lt;p>A RenderingUsage must subset, directly or indirectly, the base RenderingUsage &lt;code>renderings&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="94165c8f-9c2f-4777-a374-aa89f7c0a86d" general="8bedee11-2930-45cc-ae64-110be5d577c7"/>
+      <ownedAttribute xmi:id="590856f2-c0a1-45b9-b9f7-26e03d0aa38a" name="renderingDefinition" visibility="public" type="03745d5b-117b-43ca-9b13-3ff11a9377c1" isDerived="true" redefinedProperty="1be104f6-ea79-4e21-8050-a4bbe6735b51" association="0a1df66a-baef-4db2-b3c0-cf2bd3482203">
+        <ownedComment xmi:id="1d40e362-6da7-40a9-9c6d-3b7aede43f14" annotatedElement="590856f2-c0a1-45b9-b9f7-26e03d0aa38a">
+          <body>&lt;p>The RenderingDefinition that defines this RenderingUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e3832aae-2d5d-464f-95ce-e4a3b26ec873" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ed6813fb-6bbb-4363-a28b-4b83d2892547" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="07e867f1-e862-4450-8de1-5da85bcf8249" name="" visibility="public" memberEnd="80d8dd2f-afd0-4681-85fe-02b381180747 12744b0e-d598-485f-a6ec-1dd8f56321b6">
+      <ownedEnd xmi:id="12744b0e-d598-485f-a6ec-1dd8f56321b6" name="viewpointForStakeholder" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isDerived="true" association="07e867f1-e862-4450-8de1-5da85bcf8249">
+        <ownedComment xmi:id="ede58bab-45b4-497a-8310-a75f146e697a" annotatedElement="12744b0e-d598-485f-a6ec-1dd8f56321b6">
+          <body>&lt;p>The ViewpointUsage that has a certain &lt;code>viewpointStakeholder&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d1c81953-da6f-4a6e-a56c-f7daa281b041" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f94b3478-06b8-4716-8d31-3c6875b1bbfd" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" name="ViewDefinition" visibility="public">
+      <ownedComment xmi:id="4f36b8dc-ea16-49f9-83ef-a231ee7cafc1" annotatedElement="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16">
+        <body>&lt;p>A ViewDefinition is a PartDefinition that specifies how a view artifact is constructed to satisfy a &lt;code>viewpoint&lt;/code>. It specifies a &lt;code>viewConditions&lt;/code> to define the model content to be presented and a &lt;code>rendering&lt;/code> to define how the model content is presented.&lt;/p>
+
+&lt;/p>A ViewDefinition must subclass, directly or indirectly, the base ViewDefinition View from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="b67efc34-17f6-483f-8eaf-3dd4369fb582" general="16faf4d7-4d1b-4383-baa9-86651cb24e32"/>
+      <ownedAttribute xmi:id="a06cbda4-c0fa-4a2c-9548-df7b703cbc87" name="view" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isOrdered="true" isDerived="true" subsettedProperty="db471ae1-04e1-47b7-b6bc-2d40afdda735" association="8337d681-a96d-456d-80d0-73922c7367b2">
+        <ownedComment xmi:id="7c2d3e89-57e6-4413-a987-6ec9e8d863fe" annotatedElement="a06cbda4-c0fa-4a2c-9548-df7b703cbc87">
+          <body>&lt;p>The &lt;code>usages&lt;/code> of this ViewDefinition that are ViewUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8918ee98-b880-4d4f-8b29-87ef8cb76d00" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e67bdfd0-9b27-47a5-9caa-feeaa19683a7" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="d59f8bd6-8fd1-4cd4-8323-4acf1ccd285d" name="satisfiedViewpoint" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isOrdered="true" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="93784dc7-2f7a-43d8-863a-e7afaec90391">
+        <ownedComment xmi:id="276b7fbc-7b38-463d-a428-dbab3663ca34" annotatedElement="d59f8bd6-8fd1-4cd4-8323-4acf1ccd285d">
+          <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of this ViewDefinition that are ViewpointUsages for viewpoints satisfied by the ViewDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bb5d5e8a-cc6a-457c-bf05-54b73ec56bc0" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b23cf777-c345-478d-894b-0084e2ef5da5" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="337b8c98-d648-4aa1-b9c4-cdffac6617b6" name="viewRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isDerived="true" subsettedProperty="ab0dbb87-5e95-4819-9217-2128904f4064" association="39cf49a1-6cb5-45c2-b84e-c3c0220879b9">
+        <ownedComment xmi:id="b2252f9c-60bc-41f8-acd2-2f3da84bd0c3" annotatedElement="337b8c98-d648-4aa1-b9c4-cdffac6617b6">
+          <body>&lt;p>The RenderingUsage to be used to render views defined by this ViewDefinition. Derived as the &lt;code>referencedRendering&lt;/code> of the ViewRenderingMembership of the ViewDefinition. A ViewDefinition may have at most one.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="14b21c3b-a644-4f46-8807-3a1a131995a6" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="459b01e4-783d-4e63-be84-46b1a548fd70" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="7d5cba43-5279-4838-a4dc-821ddf00df6a" name="viewCondition" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="6b330802-e9a6-47ee-a875-59ee9e0adf00">
+        <ownedComment xmi:id="e8702e42-0b0e-4d46-9575-6b1391dae413" annotatedElement="7d5cba43-5279-4838-a4dc-821ddf00df6a">
+          <body>&lt;p>The Expressions related to this ViewDefinition by ElementFilterMemberships, which specify conditions on Elements to be rendered in a view.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="dac3853a-2a80-4574-b1d8-0068688c5e3a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e0ab48e2-9399-46bb-ac19-5263944582f9" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="4b11a587-ab81-4d39-80d1-7e50e8202683" name="ViewUsage" visibility="public">
+      <ownedComment xmi:id="e3bfc564-bcd4-45ac-83c7-57cd91e07bf4" annotatedElement="4b11a587-ab81-4d39-80d1-7e50e8202683">
+        <body>&lt;p>A ViewUsage is a usage of a ViewDefinition to specify the generation of a view of the &lt;code>members&lt;/code> of a collection of &lt;code>exposedNamespaces&lt;/code>. The ViewDefinition can satisfy more &lt;code>viewpoints&lt;/code> than its definition, and it can specialize the &lt;code>rendering&lt;/code> specified by its definition.&lt;p>
+
+&lt;p>A ViewUsage must subset, directly or indirectly, the base ViewUsage &lt;code>views&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="0fddd03f-2f21-4f83-b742-cf41a0e1872d" general="8bedee11-2930-45cc-ae64-110be5d577c7"/>
+      <ownedAttribute xmi:id="fd8f86af-05b3-45c2-8e64-f1b0cff8d1c8" name="viewDefinition" visibility="public" type="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" isDerived="true" redefinedProperty="1be104f6-ea79-4e21-8050-a4bbe6735b51" association="47150cd7-a306-49c3-900a-73552eeb99fe">
+        <ownedComment xmi:id="3e05d32f-1478-453f-a402-14b3cc55d84d" annotatedElement="fd8f86af-05b3-45c2-8e64-f1b0cff8d1c8">
+          <body>&lt;p>The definition of this ViewUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="090a2a2b-4578-4340-85a2-d61e1d076a0c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="307447d6-2877-47ab-874e-caae21f0771a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a119e966-29c5-459f-9919-9a1da02e65d6" name="satisfiedViewpoint" visibility="public" type="2601190c-74cd-4364-aedf-e45d4cee1b37" isOrdered="true" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="f959e3ce-d3fe-4886-a5eb-f33e228edcc0">
+        <ownedComment xmi:id="833b4d39-189c-4fb7-997e-78fac83e9fac" annotatedElement="a119e966-29c5-459f-9919-9a1da02e65d6">
+          <body>&lt;p>The &lt;code>nestedUsages&lt;/code> of this ViewUsage that are ViewpointUsages for (additional) viewpoints satisfied by the ViewUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2f2b325c-3ac7-440a-ae98-9a65ac079e0f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ae3e3763-67fb-4951-9925-555406ef7aa2" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="98cd9d4d-8ec6-442d-8e9e-1a4023b5c305" name="exposedNamespace" visibility="public" type="732bd40e-fb64-42e2-8663-8fcee1dac982" isOrdered="true" isDerived="true" association="81962d34-59c3-499b-9b52-e3d6c451c33c">
+        <ownedComment xmi:id="a94a2cc0-6125-43f8-9fe4-85f738aea36e" annotatedElement="98cd9d4d-8ec6-442d-8e9e-1a4023b5c305">
+          <body>&lt;p>The Namespaces that are exposed by this ViewUsage, derived as the Namespaces related to the ViewUsage by Expose Relationships.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="58ec63a7-3fd0-41df-aa3c-a93bf98f76f5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="17ada792-00a4-4b7d-bab5-cd82e0a01899" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0b742b20-07f4-46ed-83d5-0266cf0bc4fb" name="viewRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isDerived="true" subsettedProperty="3aeed792-7c5b-4145-ad3c-981f4de83751" association="3c6547f4-4f86-468e-b148-b27757ae186b">
+        <ownedComment xmi:id="102d56f0-3b9b-467c-bd99-03ba0c4cbe95" annotatedElement="0b742b20-07f4-46ed-83d5-0266cf0bc4fb">
+          <body>&lt;p>The RenderingUsage to be used to render views defined by this ViewUsage. Derived as the &lt;code>referencedRendering&lt;/code> of the ViewRenderingMembership of the ViewUsage. A ViewUsage may have at most one.&lt;p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f07c8ad3-5a0c-4e49-ae52-58e3a8487b61" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f99e1366-2f8a-4351-b7e8-bd402998bbad" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="a3c4f87b-6f48-415d-9a6e-780f2703dc74" name="viewCondition" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isOrdered="true" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="d2a669b6-b5c3-49ca-8b81-52836fe673d4">
+        <ownedComment xmi:id="7c3c385c-99c0-4da9-b734-718e72432031" annotatedElement="a3c4f87b-6f48-415d-9a6e-780f2703dc74">
+          <body>&lt;p>The Expressions related to this ViewUsage by ElementFilterMemberships, which specify conditions on Elements to be rendered in a view.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b0d1506d-733b-4d9d-85d9-b2becd527405" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6188dd64-4d43-41f9-8717-59c3e00856a8" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0545415c-cfaa-49bc-a79b-2d94891bf274" name="viewedElement" visibility="public" type="fff854cf-ff36-41d3-94f6-fb13f8063186" isOrdered="true" isDerived="true" association="0058c429-26c8-45a7-a83c-655a0b60ecab">
+        <ownedComment xmi:id="246f3306-3b31-457b-ae54-7527c88a199d" annotatedElement="0545415c-cfaa-49bc-a79b-2d94891bf274">
+          <body>&lt;p>The Elements that are rendered by this ViewUsage, derived as the &lt;code>members&lt;/code> of all the &lt;code>exposedNamespaces&lt;/code> that met all the owned and inherited &lt;code>viewConditions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="9addf6a1-5ed5-4508-beb0-c48e2f4d5b5b" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="48b0de0d-6797-443b-a6b4-71d72b4a5afd" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="95169eaa-ae12-49c8-bd48-a99172a75af5" name="ViewRenderingMembership" visibility="public">
+      <ownedComment xmi:id="4a23c2bd-8006-4392-acfd-f6ff3f55f753" annotatedElement="95169eaa-ae12-49c8-bd48-a99172a75af5">
+        <body>&lt;p>A ViewRenderingMembership is a FeatureMembership that identifies the &lt;code>viewRendering&lt;/code> of a View. The &lt;code>ownedMemberFeature&lt;/code> of a RequirementConstraintMembership must be a RenderingUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="ae6fc714-0861-4731-82ef-39b18f9e8e77" general="387c1ace-4ad1-44eb-b8b5-bfe420975a97"/>
+      <ownedAttribute xmi:id="07fb5386-724b-400c-9502-20e1c958bf4e" name="ownedRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" aggregation="composite" isDerived="true" redefinedProperty="077a3948-ff80-405a-b769-123a0a235d1f" association="5bb9118e-9abd-40fe-a889-423e68615dc4">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8762fcc8-ec7f-46d8-a393-5b150eb7e04f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fa1634bd-a9c6-4a78-9ac7-757d6639a8bb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="12faddf9-b707-427f-a4ef-eba4f922e027" name="referencedRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isDerived="true" association="56985611-5393-40e9-84ef-01ef4bd3140a">
+        <ownedComment xmi:id="06c83838-4b26-479b-9867-2765b898c8a6" annotatedElement="12faddf9-b707-427f-a4ef-eba4f922e027">
+          <body>&lt;p> The RenderingUsage that is referenced through this ViewRenderingMembership. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>ownedRendering&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedRendering&lt;/code> itself.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5ed0f749-61d0-46d4-ac6e-9386859b3dc1" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8a336bb6-bbc4-4831-92e2-1976ed33cd20" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7e16c4c2-1c96-40fd-a62d-3302941262a6" name="Expose" visibility="public">
+      <ownedComment xmi:id="cbb652b2-e46a-4ef6-93dc-0c9f9de4fefc" annotatedElement="7e16c4c2-1c96-40fd-a62d-3302941262a6">
+        <body>&lt;p>An Expose is an Import of a Namespace into a ViewUsage that provides a root for determining what Elements are to be included in a view. Visibility is always ignored for an Expose (i.e., &lt;code>isImportAll = true&lt;/code>).&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="29ed14b7-0fba-493d-8993-a46239c92733" name="exposeIsImportAll" visibility="public">
+        <ownedComment xmi:id="1ac1ec19-16f8-4d1d-bd92-8c4ae6369314" annotatedElement="29ed14b7-0fba-493d-8993-a46239c92733">
+          <body>&lt;p>An Expose always imports all Elements, regardless of visibility.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="bed8373d-020b-4c89-9a79-059f99ef196b" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isImportAll</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="fd27377c-9822-44a7-a4f4-0de0699eaf38" general="894f7139-5012-425b-8828-c525833a91b3"/>
+      <ownedAttribute xmi:id="c5b38b5f-f28c-4a50-a88a-01935d725423" name="isImportAll" visibility="public" redefinedProperty="f2def83b-f635-495b-a701-6c20493f3db1">
+        <ownedComment xmi:id="01b02d1f-0e88-43ab-b357-f8c40802ebe6" annotatedElement="c5b38b5f-f28c-4a50-a88a-01935d725423">
+          <body>&lt;p>An Expose always imports all Elements, regardless of visibility.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="1c371bb7-9d1d-463d-bc37-7438da63063a" name="" visibility="public" value="true"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="03745d5b-117b-43ca-9b13-3ff11a9377c1" name="RenderingDefinition" visibility="public">
+      <ownedComment xmi:id="d0f22307-3097-47b1-9e44-626d5cd09918" annotatedElement="03745d5b-117b-43ca-9b13-3ff11a9377c1">
+        <body>&lt;p>A RenderingDefinition is a PartDefinition that defines a specific rendering of the content of a model view (e.g., symbols, style, layout, etc.).&lt;/p>
+
+&lt;p>A RenderingDefinition must subclass, directly or indirectly, the base RenderingDefinition Rendering from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c1b5ff47-7968-43df-b7b4-284dada3eabd" general="16faf4d7-4d1b-4383-baa9-86651cb24e32"/>
+      <ownedAttribute xmi:id="d589145f-3892-458a-979b-bce9541ab605" name="rendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isOrdered="true" isDerived="true" subsettedProperty="db471ae1-04e1-47b7-b6bc-2d40afdda735" association="7f5e74c2-7728-4820-b49b-5efc9a013b51">
+        <ownedComment xmi:id="f0cffeb8-fa1c-4416-987f-8bbfae251a70" annotatedElement="d589145f-3892-458a-979b-bce9541ab605">
+          <body>&lt;p>The &lt;code>usages&lt;/code> of a RenderingDefinition that are RenderingUsages.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="20412533-8630-4534-a952-d2247a2314cd" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="99ee9194-317e-45b8-ba4d-d3105c2861fa" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="0a1df66a-baef-4db2-b3c0-cf2bd3482203" name="" visibility="public" memberEnd="590856f2-c0a1-45b9-b9f7-26e03d0aa38a 3765a257-6a81-4469-a994-4151079466ba">
+      <ownedEnd xmi:id="3765a257-6a81-4469-a994-4151079466ba" name="definedRendering" visibility="public" type="718bb9d4-b1db-48f1-9ac3-8c1a9cc01608" isDerived="true" subsettedProperty="2a91fa23-f772-4460-bfd1-8b8c60104e71" association="0a1df66a-baef-4db2-b3c0-cf2bd3482203">
+        <ownedComment xmi:id="9b6b4f28-bbee-4b2d-a6f1-b3af4425ed4c" annotatedElement="3765a257-6a81-4469-a994-4151079466ba">
+          <body>&lt;p>The RenderingUsages defined by a certain &lt;code>renderingDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c3fe38b0-f97a-4e2a-a618-a9a2d8f583c8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="25c3a7fa-403f-43f4-9562-800f960fc5ff" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8337d681-a96d-456d-80d0-73922c7367b2" name="" visibility="public" memberEnd="a06cbda4-c0fa-4a2c-9548-df7b703cbc87 2044ffa1-396c-4132-9f9a-4c5cf6e147bd">
+      <ownedEnd xmi:id="2044ffa1-396c-4132-9f9a-4c5cf6e147bd" name="featuringView" visibility="public" type="6e3c74da-6e8b-4c48-96ee-4ab5a2aaea16" isDerived="true" subsettedProperty="eb7af616-8e9c-419a-a08a-4b80d758179f" association="8337d681-a96d-456d-80d0-73922c7367b2">
+        <ownedComment xmi:id="3cd8b74f-e618-4d90-b3cc-9a64f2d5b18b" annotatedElement="2044ffa1-396c-4132-9f9a-4c5cf6e147bd">
+          <body>&lt;p>The ViewDefinitions that feature a certain ViewUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5c63ffe4-57e6-4a98-b964-da03b3040bfe" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a694d3b1-a382-46d0-972c-8de0f43ed382" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3c6547f4-4f86-468e-b148-b27757ae186b" name="" visibility="public" memberEnd="0b742b20-07f4-46ed-83d5-0266cf0bc4fb 49c655da-00c2-4dae-95a8-e618dfa1c5c1">
+      <ownedEnd xmi:id="49c655da-00c2-4dae-95a8-e618dfa1c5c1" name="renderingOwningView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" subsettedProperty="e3db423d-543e-47fa-864c-573abd896990" association="3c6547f4-4f86-468e-b148-b27757ae186b">
+        <ownedComment xmi:id="2353ef01-beab-4f5c-8706-03c4bd95cb1f" annotatedElement="49c655da-00c2-4dae-95a8-e618dfa1c5c1">
+          <body>&lt;p>The ViewUsage that owns a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="73ccd7eb-1491-4122-8e55-267a8735b9ff" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="fc418f27-caa9-413a-a8cc-6ad061fb558e" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d2a669b6-b5c3-49ca-8b81-52836fe673d4" name="" visibility="public" memberEnd="a3c4f87b-6f48-415d-9a6e-780f2703dc74 1e4e31e8-4db3-4361-bc8a-f30be21dfd93">
+      <ownedEnd xmi:id="1e4e31e8-4db3-4361-bc8a-f30be21dfd93" name="owningView" visibility="public" type="4b11a587-ab81-4d39-80d1-7e50e8202683" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="d2a669b6-b5c3-49ca-8b81-52836fe673d4">
+        <ownedComment xmi:id="197b7b50-fcfa-4a75-a468-970fd7d8ab41" annotatedElement="1e4e31e8-4db3-4361-bc8a-f30be21dfd93">
+          <body>&lt;p>The ViewUsage that owns a certain &lt;code>viewCondition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ad89fc43-686e-4b2c-93e8-59b219517e13" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0b87cac6-4953-40b9-97e6-59f9b838902c" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5bb9118e-9abd-40fe-a889-423e68615dc4" name="" visibility="public" memberEnd="07fb5386-724b-400c-9502-20e1c958bf4e 132ff9bf-e452-4926-9771-c7bc0bab3962">
+      <ownedEnd xmi:id="132ff9bf-e452-4926-9771-c7bc0bab3962" name="viewRenderingMembership" visibility="public" type="95169eaa-ae12-49c8-bd48-a99172a75af5" isDerived="true" association="5bb9118e-9abd-40fe-a889-423e68615dc4">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c559b70e-b2bd-43ab-977d-930c5315bc28" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="23fcad8e-7fbb-4d62-b007-a04f9cb38ada" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="01787c81-d827-4988-80ba-3f358b159b5c" name="OccurrenceDefinition" visibility="public">
+      <ownedComment xmi:id="fdc8af33-8483-4b0e-875d-064fe0d85e9d" annotatedElement="01787c81-d827-4988-80ba-3f358b159b5c">
+        <body>&lt;p>An OccurrenceDefinition is a Definition of a Class of individuals that have an independent life over time and potentially an extent over space. This includes both structural things and behaviors that act on such structures.&lt;/p>
+
+&lt;p>If &lt;code>isIndividual&lt;/code> is true, then the OccurrenceDefinition is constrained to represent an individual thing. The instances of such an OccurrenceDefinition include all spatial and temporal portions of the individual being represented, but only one of these can be the complete Life of the individual. All other instances must be portions of the &amp;quot;maximal portion&amp;quot; that is single Life instance, capturing the conception that all of the instances represent one individual with a single &amp;quot;identity&amp;quot;.&lt;/p>
+
+&lt;p>An OccurrenceDefinition must subclass, directly or indirectly, the base Class &lt;em>Occurrence&lt;/em> from the Kernel model library.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="cab94b56-5785-43db-a8f9-a3b84fb4d22b" name="occurrenceDefinitionLifeClass" visibility="public" constrainedElement="01787c81-d827-4988-80ba-3f358b159b5c">
+        <ownedComment xmi:id="41e0791b-ee4e-4f71-9dc9-10c9c3abbb31" annotatedElement="cab94b56-5785-43db-a8f9-a3b84fb4d22b">
+          <body>&lt;p>An OccurrenceDefinition has a &lt;code>lifeClass&lt;/code> if and only if &lt;code>isIndividual = true&lt;/code>, in which case the &lt;code>lifeClass&lt;/code> must specialize the OccurrenceDefinition.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="5752ec04-d5df-41b2-80b0-88465451a19a" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>if not isIndividual then lifeClass = null
+else
+    lifeClass &lt;> null and
+    lifeClass.allSupertypes()->includes(self)
+endif</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="4befbbbf-078e-4a4a-8ac6-25d38395ed0e" general="bbec763b-2ef0-415f-9e22-c531739690bb"/>
+      <generalization xmi:id="16a393c4-eb32-43ee-80db-6efe48302ce5" general="19920a63-7648-49b9-9666-eb0dcfbde515"/>
+      <ownedAttribute xmi:id="05e7341c-1812-4895-8728-bbba1c4006e4" name="lifeClass" visibility="public" type="7f1b57c3-ab17-4a52-a545-08b19c24a5d0" isDerived="true" subsettedProperty="d69940fb-b910-4da2-a95d-9eb8d7caf86e" association="e1036e63-7dfe-437e-b8de-7bb98cf4f0df">
+        <ownedComment xmi:id="0ba063e5-dce5-4774-ae44-f1f90b89e2ff" annotatedElement="05e7341c-1812-4895-8728-bbba1c4006e4">
+          <body>&lt;p>If &lt;code>isIndividual&lt;/code> is true, a LifeClass that specializes this OccurrenceDefinition, restricting it to represent an individual.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e3de232b-2cd9-47ce-95e3-8ca98418a430" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b477f1e-2894-46c2-939f-1bcaaf5bc0c5" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="67b22be7-fac7-4b73-90fa-02866641027a" name="isIndividual" visibility="public">
+        <ownedComment xmi:id="0472f02c-d1fb-43a8-aa9d-88abb4170b11" annotatedElement="67b22be7-fac7-4b73-90fa-02866641027a">
+          <body>&lt;p>Whether this OccurrenceDefinition is constrained to represent single individual.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="e61b21c0-cfdd-419a-b79b-3260172b3b8f" name="" visibility="public"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d5e1f78b-c81a-4a6e-9537-73c4a8b12ffe" name="EventOccurrenceUsage" visibility="public">
+      <ownedComment xmi:id="0e4c66ac-1656-4945-b525-67773968aac3" annotatedElement="d5e1f78b-c81a-4a6e-9537-73c4a8b12ffe">
+        <body>&lt;p>A EventOccurrenceUsage is an OccurrenceUsage that represents another OccurrenceUsage occurring as a suboccurrence of the containing occurrence of the EventOccurrenceUsage. Unless it is ithe EventOccurrenceUsage itself, the referenced OccurrenceUsage performed is related to the EventOccurrenceUsage by a ReferenceSubsetting relationship.&lt;/p>
+
+&lt;p>If the EventOccurrenceUsage is owned by an OccurrenceDefinition or OccurrenceUsage, then it also subsets the &lt;em>&lt;code>timeEnclosedOccurrences&lt;/code>&lt;/em> property of the Class &lt;em>&lt;code>Occurrence&lt;/code>&lt;/em> from the Kernel Semantic Library model &lt;em>&lt;code>Occurrences&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <ownedRule xmi:id="9e064279-cf3b-49a3-9067-e560481f4f88" name="eventOccurrenceUsageEventOccurrence" visibility="public" constrainedElement="d5e1f78b-c81a-4a6e-9537-73c4a8b12ffe">
+        <ownedComment xmi:id="6800486f-37bb-4bff-b9bc-5da7a0410e19" annotatedElement="9e064279-cf3b-49a3-9067-e560481f4f88">
+          <body></body>
+        </ownedComment>
+        <ownedComment xmi:id="88c23759-333f-4fe2-b81c-009ac16b2c71" annotatedElement="9e064279-cf3b-49a3-9067-e560481f4f88">
+          <body>&lt;p>If the EventOccurrenceUsage has no &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>eventOccurrence&lt;/code> is the EventOccurrenceUsage itself. Otherwise, the &lt;code>eventOccurrence&lt;/code> is the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> (which must be an OccurrenceUsage).&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="a88d857b-79da-4138-8d95-e8df1bfac85a" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>eventOccurrence =
+    if ownedReferenceSubsetting = null then self
+    else ownedReferenceSubsetting.referencedFeature.oclAsType(OccurrenceUsage)
+    endif</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="3f216b24-8ff2-42aa-a8e0-734ff88f8c00" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
+      <ownedAttribute xmi:id="fee861c4-7cc2-4854-9abe-530ec31cd5ab" name="eventOccurrence" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isDerived="true" association="96774876-6465-4735-a84b-ecdf8231b978">
+        <ownedComment xmi:id="a73d3715-9ef6-4bf8-b928-b7f5747de1bb" annotatedElement="fee861c4-7cc2-4854-9abe-530ec31cd5ab">
+          <body>&lt;p>The OccurrenceUsage referenced as an event by this EventOccurrenceUsage. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the EventOccurrenceUsage, if there is one, and, otherwise, the EventOccurrenceUsage itself.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8168bb0b-51a4-4c2d-b347-8fff254bb26a" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="73eecca1-cc87-457b-a7fa-20a0b046ae00" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="c62660b0-2a67-4a2e-90fe-d74f8440990c" name="" visibility="public" memberEnd="1274dada-7f2d-426c-9fbf-7a5846772dfa 341eef36-7af9-4cd3-80d9-197256bb5fa3">
+      <ownedEnd xmi:id="341eef36-7af9-4cd3-80d9-197256bb5fa3" name="individualUsage" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isDerived="true" association="c62660b0-2a67-4a2e-90fe-d74f8440990c">
+        <ownedComment xmi:id="12e57c6b-ad3f-4c99-afe4-4e7f3e86823f" annotatedElement="341eef36-7af9-4cd3-80d9-197256bb5fa3">
+          <body>&lt;p>The OccurrenceUsage that has a certain &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ec1891aa-6a9e-48cd-808f-7f7670e6cf63" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2948eda5-04b3-46ed-88f1-5f78511dc656" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e1036e63-7dfe-437e-b8de-7bb98cf4f0df" name="" visibility="public" memberEnd="05e7341c-1812-4895-8728-bbba1c4006e4 92a29f90-a5bb-4c41-ba2b-156a9525ad92">
+      <ownedEnd xmi:id="92a29f90-a5bb-4c41-ba2b-156a9525ad92" name="individualDefinition" visibility="public" type="01787c81-d827-4988-80ba-3f358b159b5c" isDerived="true" subsettedProperty="c1a0b88f-cde6-41fb-b4cb-ab881827eef7" association="e1036e63-7dfe-437e-b8de-7bb98cf4f0df">
+        <ownedComment xmi:id="910b0f8b-a749-4a48-86b4-893694efea0c" annotatedElement="92a29f90-a5bb-4c41-ba2b-156a9525ad92">
+          <body>&lt;p>The OccurrenceDefinition that has a certain &lt;code>lifeClass&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="124165d1-1232-4aef-877a-364749fb25cc" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="26fbcf6b-0b42-487f-a8af-a9cdd8cc013e" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="da9d7196-5acc-4b5d-bfad-15a6229d604d" name="OccurrenceUsage" visibility="public">
+      <ownedComment xmi:id="a23c780b-b305-4c31-a3e8-a97a836914b5" annotatedElement="da9d7196-5acc-4b5d-bfad-15a6229d604d">
+        <body>&lt;p>An OccurrenceUsage is a Usage whose type is a Class. Nominally, if the type is an OccurrenceDefinition, an OccurrenceUsage is a Usage of that OccurrenceDefinition within a system. However, other types of Kernel Classes are also allowed, to permit use of Classes from the Kernel Library.&lt;/p>
+
+&lt;p>An OccurrenceUsage must subset, directly or indirectly, the base Feature &lt;em>&lt;code>occurrences&lt;/code>&lt;/em> from the Kernel model library.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="c0f146bc-0a7a-481d-8423-d974270c8509" name="occurrenceUsagePortioning" visibility="public" constrainedElement="da9d7196-5acc-4b5d-bfad-15a6229d604d">
+        <ownedComment xmi:id="ec6727f1-67f7-47a2-b3e9-9d5125b58fff" annotatedElement="c0f146bc-0a7a-481d-8423-d974270c8509">
+          <body>&lt;p>An OccurrenceUsage has a &lt;code>portioningFeature&lt;/code> if and only if it has a &lt;code>portionKind&lt;/code> and, if so, the &lt;code>portionKind&lt;/code> of the &lt;code>portioningFeature&lt;/code> must be the same as that of the OccurrenceUsage and the &lt;code>types&lt;/code> of the &lt;code>portioningFeature&lt;/code> must be the same as the &lt;code>occurrenceDefinitions&lt;/code> of the OccurrenceUsage.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="c4acc3f1-7572-4d13-9380-be2968fb8420" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>if portionKind = null then portioningFeature = null
+else 
+    portioningFeature &lt;> null and
+    portionKind = portioningFeature.portionKind and
+    occurrenceDefinition.asSet() = portioningFeature.type.asSet()
+endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="41ae7ecc-3c2f-4c29-bf86-0f352ab8ae4c" name="occurrenceUsageIndividualDefinition" visibility="public" constrainedElement="da9d7196-5acc-4b5d-bfad-15a6229d604d">
+        <ownedComment xmi:id="015de967-dc3b-45c9-9642-e07c3225fdf8" annotatedElement="41ae7ecc-3c2f-4c29-bf86-0f352ab8ae4c">
+          <body>&lt;p>The &lt;code>individualDefinition&lt;/code> of an OccurrenceUsage is the &lt;code>occurrenceDefinition&lt;/code> that is an OccurrenceDefinition with &lt;code>isIndividual = true&lt;/code>, if any.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="a86f8946-5818-4769-b48a-8bb95e4d44dc" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>let individualDefinitions : Sequence(OccurrenceDefinition) = 
+    occurrenceDefinition->
+        selectByKind(OccurrenceDefinition)->
+        select(isIndividual) in
+if individualDefinitions->isEmpty() then null
+else individualDefinitions->at(1) endif</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:id="d3a4027f-ae47-4fe4-a3aa-2903561ba5da" name="occurrenceUsageIndividualUsage" visibility="public" constrainedElement="da9d7196-5acc-4b5d-bfad-15a6229d604d">
+        <ownedComment xmi:id="24ea2c32-9b49-40b6-82c8-304b92e07c59" annotatedElement="d3a4027f-ae47-4fe4-a3aa-2903561ba5da">
+          <body>&lt;p>If an OccurrenceUsage has &lt;code>isIndividual = true&lt;/code>, then it must have a single &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ad036418-9d6f-42c6-879f-be9982b16886" name="" visibility="public">
+          <language>OCL2.0</language>
+          <body>isIndividual implies individualDefinition &lt;> null</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="1697e5ce-f62b-4784-95e2-c56523c05fd1" general="46068009-84f1-4001-a9bb-fc03fd6a381c"/>
+      <ownedAttribute xmi:id="48d91227-fa8b-4b65-a4f8-d27701f010c0" name="occurrenceDefinition" visibility="public" type="19920a63-7648-49b9-9666-eb0dcfbde515" isOrdered="true" isDerived="true" redefinedProperty="201738a1-0499-47ef-8c07-ab15564d86c0" association="22671d60-25d4-4b11-9d31-d5fcb7493c6b">
+        <ownedComment xmi:id="e7969a0c-2a4e-48f7-985f-2f2c97d2da29" annotatedElement="48d91227-fa8b-4b65-a4f8-d27701f010c0">
+          <body>&lt;p>The Classes that are the types of this OccurrenceUsage. Nominally, these are OccurrenceDefinitions, but other kinds of Kernel Classes are also allowed, to permit use of Classes from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="926d2114-d9c8-4016-bd5c-c38bc49f8937" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d0747cae-3f2f-4c10-b01e-d93745a39778" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="0e649c97-dde6-4d61-b998-5eb57a9e37f9" name="portioningFeature" visibility="public" type="138e9a2f-282d-4902-8be9-99c061a66d55" isDerived="true" subsettedProperty="ea59f6ae-8a27-4163-a651-91da11bbfa67" association="9e57e5c4-95bd-47a8-aab7-9ce3f786f76c">
+        <ownedComment xmi:id="8fae6d77-291b-4969-9c46-37715fae5912" annotatedElement="0e649c97-dde6-4d61-b998-5eb57a9e37f9">
+          <body>&lt;p>A PortioningFeature typed by the &lt;code>occurrenceDefinitions&lt;/code> of this OccurrenceUsage, thereby restricting the values of the OccurrenceUsage to be general portions, time slices or snapshots of instances of those definitions, consistence with the &lt;code>portionKind&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ea98a80c-cbec-4d66-a7c2-8457c1604eaa" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="36052cff-9c8a-40db-98ab-3fd09f6eabc3" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1274dada-7f2d-426c-9fbf-7a5846772dfa" name="individualDefinition" visibility="public" type="01787c81-d827-4988-80ba-3f358b159b5c" isDerived="true" subsettedProperty="48d91227-fa8b-4b65-a4f8-d27701f010c0" association="c62660b0-2a67-4a2e-90fe-d74f8440990c">
+        <ownedComment xmi:id="1b5a19f6-f28c-4281-b8d8-ffbff7da3403" annotatedElement="1274dada-7f2d-426c-9fbf-7a5846772dfa">
+          <body>&lt;p>The one &lt;code>occurrenceDefinition&lt;/code> that has &lt;code>isIndividual = true&lt;/code> (if any).&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="08ae87f0-5f8a-43d0-a9ea-e69eba041a31" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5f1ee78b-5f5f-482b-89ef-2a8a9f1e43df" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="3edec214-87f8-4feb-90d9-9b840e6633bc" name="isIndividual" visibility="public">
+        <ownedComment xmi:id="2460a7d9-111e-41bb-b73c-4e42bc6b025a" annotatedElement="3edec214-87f8-4feb-90d9-9b840e6633bc">
+          <body>&lt;p>Whether this OccurrenceUsage represents the usage of the specific individual (or portion of it) represented by its &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="2c0897f7-0b29-4a7a-9faf-eedaf9343729" name="" visibility="public"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1e9f8501-0a94-401b-9700-4322c969d606" name="portionKind" visibility="public" type="82141fd1-6e67-49d9-9d45-ba5ddedce046">
+        <ownedComment xmi:id="9b24025a-8d53-4b96-a491-152383bc2abb" annotatedElement="1e9f8501-0a94-401b-9700-4322c969d606">
+          <body>&lt;p>The kind of portion of the instances of the &lt;code>occurrenceDefinition&lt;/code> represented by this OccurrenceUsage, if it is so restricted.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="39797fdc-805d-4869-be87-2ad08b07ea9a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a53d619e-1781-453a-bfd5-a177b67942fe" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="82141fd1-6e67-49d9-9d45-ba5ddedce046" name="PortionKind" visibility="public">
+      <ownedComment xmi:id="62dbaf6c-b1a6-4c80-a286-8a7468d66bcc" annotatedElement="82141fd1-6e67-49d9-9d45-ba5ddedce046">
+        <body>&lt;p>PortionKind is an enumeration of the possible special kinds of Occurrence portions that can be represented by an OccurrenceUsage.&lt;/p></body>
+      </ownedComment>
+      <ownedLiteral xmi:id="062c2caa-ff75-453c-a5e2-5805d32db157" name="timeslice" visibility="public">
+        <ownedComment xmi:id="9b07dd12-5db7-4eac-8ebb-aa9fc664006f" annotatedElement="062c2caa-ff75-453c-a5e2-5805d32db157">
+          <body>&lt;p>A time slice of an Occurrence (a portion over time).&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="93d8bc38-2878-4db5-ad24-252ee0e87f02" name="snapshot" visibility="public">
+        <ownedComment xmi:id="100f3f5e-4a8b-442c-995c-85f8351ab0df" annotatedElement="93d8bc38-2878-4db5-ad24-252ee0e87f02">
+          <body>&lt;p>A snapshot of an Occurrence (a time slice with zero duration).&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7f1b57c3-ab17-4a52-a545-08b19c24a5d0" name="LifeClass" visibility="public">
+      <ownedComment xmi:id="a9844075-a6e2-4dde-954d-ac980d1be8c3" annotatedElement="7f1b57c3-ab17-4a52-a545-08b19c24a5d0">
+        <body>&lt;p>A LifeClass is a Class that specializes both the &lt;em>Base::Life Class&lt;/em> from the Kernel Library and a single OccurrenceDefinition, and has a multiplicity of 0..1. This constrains the OccurrenceDefinition to have at most one instance that is a complete Life.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="7b81303b-02a8-4284-aa0f-9605864b7bd6" general="19920a63-7648-49b9-9666-eb0dcfbde515"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="96774876-6465-4735-a84b-ecdf8231b978" name="" visibility="public" memberEnd="fee861c4-7cc2-4854-9abe-530ec31cd5ab 6ff28096-f731-46d1-972c-ca1aac611d7f">
+      <ownedEnd xmi:id="6ff28096-f731-46d1-972c-ca1aac611d7f" name="referencingOccurrence" visibility="public" type="d5e1f78b-c81a-4a6e-9537-73c4a8b12ffe" isDerived="true" association="96774876-6465-4735-a84b-ecdf8231b978">
+        <ownedComment xmi:id="8cdd4ab5-67d5-4c6e-9129-3a8ad813e525" annotatedElement="6ff28096-f731-46d1-972c-ca1aac611d7f">
+          <body>&lt;p>The EventOccurrenceUsages that reference a certain &lt;code>eventOccurrence&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4a7ae2d4-c555-4304-a233-3f1c65d5d1b1" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="14944db4-7609-4b88-8ef4-b63416a219d0" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="138e9a2f-282d-4902-8be9-99c061a66d55" name="PortioningFeature" visibility="public">
+      <ownedComment xmi:id="46983911-9dd8-496d-907e-b9b8e69c9f18" annotatedElement="138e9a2f-282d-4902-8be9-99c061a66d55">
+        <body>&lt;p>A PortioningFeature is a Feature that is a redefinition of one of the Features&lt;code> &lt;em>timeSliceOf&lt;/em>&lt;/code> or &lt;em>&lt;code>snapshotOf&lt;/code>&lt;/em> of the &lt;em>&lt;code>portionOfLife&lt;/code>&lt;/em> of each of the types of its &lt;code>portioningUsage&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="4a146df9-638b-4ec4-ade8-525e4ce045bf" name="portioningFeaturePortionKind" visibility="public" constrainedElement="138e9a2f-282d-4902-8be9-99c061a66d55">
+        <ownedComment xmi:id="43a65c65-4fc4-4c18-9c70-e7f66a40d23e" annotatedElement="4a146df9-638b-4ec4-ade8-525e4ce045bf">
+          <body>&lt;p>The &lt;code>portionKind&lt;/code> of a PortioningFeature is &lt;code>timeslice&lt;/code> or &lt;code>snapshot&lt;/code>, if the PortioningFeature is a direct Redefinition of &lt;code>timeSliceOf&lt;/code> or &lt;code>snapshotOf&lt;/code>, respectively.&lt;/p></body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="071bde9b-ac76-4dba-9c7f-5c587b3f48b7" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="e47a48bb-9d72-406c-9e73-a90bae1202f8" general="124e57c2-e7ac-4bbd-8ae3-b74186c4259c"/>
+      <ownedAttribute xmi:id="9fcbaea6-7006-4dd8-bde4-703f221d2c18" name="portionKind" visibility="public" type="82141fd1-6e67-49d9-9d45-ba5ddedce046" isDerived="true">
+        <ownedComment xmi:id="cf46739a-eadd-4add-bb69-1aa033ce1c8f" annotatedElement="9fcbaea6-7006-4dd8-bde4-703f221d2c18">
+          <body>&lt;p>Whether this PortionFeature is a redefinition of &lt;code>timeSliceOf&lt;/code> or &lt;code>snapshotOf&lt;/code>.&lt;/p></body>
+        </ownedComment>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9e57e5c4-95bd-47a8-aab7-9ce3f786f76c" name="" visibility="public" memberEnd="0e649c97-dde6-4d61-b998-5eb57a9e37f9 f58d3bf6-c097-4fd5-9448-7844a1bfdfa1">
+      <ownedEnd xmi:id="f58d3bf6-c097-4fd5-9448-7844a1bfdfa1" name="portioningUsage" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isDerived="true" subsettedProperty="4e18e321-e8e9-4751-a149-4c1cf2245b7a" association="9e57e5c4-95bd-47a8-aab7-9ce3f786f76c">
+        <ownedComment xmi:id="5a192142-9290-42d4-9beb-95b426d80677" annotatedElement="f58d3bf6-c097-4fd5-9448-7844a1bfdfa1">
+          <body>&lt;p>The OccurrenceUsage with a certain &lt;code>portioningFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="27fa246a-490b-48b5-a2c7-5532ef96799c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2ad18b0b-172e-4871-8962-cf88d098ac39" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="22671d60-25d4-4b11-9d31-d5fcb7493c6b" name="" visibility="public" memberEnd="48d91227-fa8b-4b65-a4f8-d27701f010c0 b3f1997a-fa47-4624-b4f8-5163772191d3">
+      <ownedEnd xmi:id="b3f1997a-fa47-4624-b4f8-5163772191d3" name="definedOccurrence" visibility="public" type="da9d7196-5acc-4b5d-bfad-15a6229d604d" isDerived="true" subsettedProperty="96ec9372-1879-4d45-a114-b4276d6a9bdf" association="22671d60-25d4-4b11-9d31-d5fcb7493c6b">
+        <ownedComment xmi:id="21ee4289-9e5c-47a9-9092-2c3b474debd2" annotatedElement="b3f1997a-fa47-4624-b4f8-5163772191d3">
+          <body>&lt;p>The OccurrenceUsages being typed by a certain Class.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8be5223a-5cf8-4622-be0a-93dbe7b11027" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="4d3cc5cd-2254-4911-86c5-e5650f239254" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="25a2e587-73bd-49d2-894e-3c9dc1c6ef94" name="" visibility="public" memberEnd="e445f08c-7fb5-4b4e-ba2a-7693cad822cc edd7db3a-1528-4f63-8014-e5455750fe0e">
+      <ownedEnd xmi:id="edd7db3a-1528-4f63-8014-e5455750fe0e" name="connectionDefinitionWithEnd" visibility="public" type="0850c978-a960-479b-b462-53abc686273e" isDerived="true" redefinedProperty="6530016d-adb1-4acf-83f8-64a441c36f3e" association="25a2e587-73bd-49d2-894e-3c9dc1c6ef94">
+        <ownedComment xmi:id="2afafcbc-33e7-488e-bf08-9446c0499fdd" annotatedElement="edd7db3a-1528-4f63-8014-e5455750fe0e">
+          <body>&lt;p>The ConnectionDefinitions that have a certain Usage as an &lt;code>connectionEnd&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="93f569e9-7406-48dd-af9f-7f5d30e0ee6c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="004014f8-090d-4e26-a162-3824d9b52a85" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="0850c978-a960-479b-b462-53abc686273e" name="ConnectionDefinition" visibility="public">
+      <ownedComment xmi:id="a2718c80-ccc6-4b34-860a-4a2034fa8d6f" annotatedElement="0850c978-a960-479b-b462-53abc686273e">
+        <body>&lt;p>A ConnectionDefinition is a PartDefinition that is also an AssociationStructure, with two or more end features. The &lt;code>associationEnds&lt;/code> of a ConnectionDefinition must be Usages.&lt;/p>
+
+&lt;p>A ConnectionDefinition must subclass, directly or indirectly, the base ConnectionDefinition &lt;em>&lt;code>Connection&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="4ab5ab6f-1915-4d44-86b3-a05190f795de" general="aedf255c-3058-40de-837e-0444956079a2"/>
+      <generalization xmi:id="7219e258-3a94-433f-b4a7-4a069752f405" general="16faf4d7-4d1b-4383-baa9-86651cb24e32"/>
+      <ownedAttribute xmi:id="e445f08c-7fb5-4b4e-ba2a-7693cad822cc" name="connectionEnd" visibility="public" type="46068009-84f1-4001-a9bb-fc03fd6a381c" isOrdered="true" isDerived="true" redefinedProperty="7efc19cd-ce11-459e-bbe5-d6ca25e0d9c9" association="25a2e587-73bd-49d2-894e-3c9dc1c6ef94">
+        <ownedComment xmi:id="45ac17b4-0815-44fc-9087-d5a9e80041ad" annotatedElement="e445f08c-7fb5-4b4e-ba2a-7693cad822cc">
+          <body>&lt;p>The Usages that define the things related by the ConnectionDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="ed3d4d6f-df20-437e-8a10-f1dd0d38993d" name="" visibility="public" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5643b6ca-8833-42c8-af9a-f1d06d635110" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="bff72e7d-0f85-41e0-8138-4436ded8369d" name="ConnectionUsage" visibility="public">
+      <ownedComment xmi:id="051fbc17-2b5c-4a3e-b04e-50e5ab870ab7" annotatedElement="bff72e7d-0f85-41e0-8138-4436ded8369d">
+        <body>&lt;p>A ConnectionUsage is a ConnectorAsUsage that is also a PartUsage. Nominally, if its type is a ConnectionDefinition, then a ConnectionUsage is a Usage of that ConnectionDefinition, representing a connection between parts of a system. However, other kinds of kernel AssociationStructures are also allowed, to permit use of AssociationStructures from the Kernel Library (such as the default BinaryLinkObject).&lt;/p>
+
+&lt;p>A ConnectionUsage must subset the base ConnectionUsage &lt;em>&lt;code>connections&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="ee3ede37-91a6-410e-a7fd-c235de06cdfa" general="f4b1326b-70e0-4f33-93b0-85fb497a26a1"/>
+      <generalization xmi:id="109cb1dd-2300-49d3-90d0-efb20af15170" general="8bedee11-2930-45cc-ae64-110be5d577c7"/>
+      <ownedAttribute xmi:id="d2602be5-531e-4b57-bf07-1c6ba1f6f114" name="connectionDefinition" visibility="public" type="aedf255c-3058-40de-837e-0444956079a2" isOrdered="true" isDerived="true" redefinedProperty="927f6cdf-59b8-4e3c-8c17-f626bfd38a38" subsettedProperty="18ab486b-757f-4c4d-8569-01e9cf669e5f" association="1eba35df-0615-4b1d-a201-8d5ed694e570">
+        <ownedComment xmi:id="5f8eae59-4ffe-4440-ab44-7d89662bd470" annotatedElement="d2602be5-531e-4b57-bf07-1c6ba1f6f114">
+          <body>&lt;p>The AssociationStructures that are the types of this ConnectionUsage. Nominally, these are ConnectionDefinitions, but other kinds of Kernel AssociationStructures are also allowed, to permit use of AssociationStructures from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="3844e70b-40f8-49a7-9bab-b1bad2b16817" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2906066c-8baa-46da-b586-75bb4d33af3f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="1eba35df-0615-4b1d-a201-8d5ed694e570" name="" visibility="public" memberEnd="d2602be5-531e-4b57-bf07-1c6ba1f6f114 11596646-ba5d-40a3-9bee-3c4a418cd55a">
+      <ownedEnd xmi:id="11596646-ba5d-40a3-9bee-3c4a418cd55a" name="definedConnection" visibility="public" type="bff72e7d-0f85-41e0-8138-4436ded8369d" isOrdered="true" isDerived="true" subsettedProperty="68475b4b-be4c-4323-812c-5020bb7be7e4" association="1eba35df-0615-4b1d-a201-8d5ed694e570">
+        <ownedComment xmi:id="7ff6092b-c0a9-4ba1-957b-44a38a8b581b" annotatedElement="11596646-ba5d-40a3-9bee-3c4a418cd55a">
+          <body>&lt;p>The ConnectionUsages that have a certain AssociationStructure as their &lt;code>connectionDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="463130ba-125e-4c95-98cd-6bc9d1cb565a" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d4ced225-fcd2-4535-bff6-a8df1f034ed9" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fd085776-81b3-4a29-b1f9-a414d1a6556c" name="FlowConnectionUsage" visibility="public">
+      <ownedComment xmi:id="65ce68fe-4482-4853-b31a-eed0bcf36103" annotatedElement="fd085776-81b3-4a29-b1f9-a414d1a6556c">
+        <body>&lt;p>A FlowConnectionUsage is a ConnectionUsage that is also an ItemFlow.&lt;/p>
+
+&lt;p>A FlowConnectionUsage must subset the base FlowConnectionUsage &lt;em>&lt;code>flowConnections&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="15043261-cf78-4fb8-a6df-d9134f67af96" general="bff72e7d-0f85-41e0-8138-4436ded8369d"/>
+      <generalization xmi:id="7acc7401-16e8-44bb-9529-7a3fd3b763c4" general="fd27dfa3-9e11-465f-8981-00bc57981023"/>
+      <generalization xmi:id="1912f037-da5d-4a85-a81f-8230175932c4" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="28f6f4a7-be69-443e-8a38-3c42df74cf9b" name="flowConnectionDefinition" visibility="public" type="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af" isOrdered="true" isDerived="true" redefinedProperty="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b ad39eccc-e849-4f84-a77a-d890d8c26433 d2602be5-531e-4b57-bf07-1c6ba1f6f114" association="5e1c270f-3751-4508-9c62-a54e0972240a">
+        <ownedComment xmi:id="4514f56c-144a-4b07-84de-0ca1bb92340a" annotatedElement="28f6f4a7-be69-443e-8a38-3c42df74cf9b">
+          <body>&lt;p>The Interactions that are the types of this FlowConnectionUsage. Nominally, these are FlowConnectionDefinitions, but other kinds of Kernel Interactions are also allowed, to permit use of Interactions from the Kernel Library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d5224a39-c6eb-4443-9f52-57e88375c003" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="80a8c102-0056-461f-be2f-b5650d7f9f9f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="eba29963-bc4b-445c-bf11-195cf13e5f9e" name="FlowConnectionDefinition" visibility="public">
+      <ownedComment xmi:id="ede4b8da-c98c-4d52-b48f-5f3bab0fe90d" annotatedElement="eba29963-bc4b-445c-bf11-195cf13e5f9e">
+        <body>&lt;p>A FlowConnectionDefinition is a ConnectionDefinition and ActionDefinition that is also an Interaction representing flows between Usages.&lt;/p>
+
+&lt;p>A FlowConnectionDefinition must subclassify, directly or indirectly, the base FlowConnectionDefinition &lt;em>&lt;code>FlowConnection&lt;code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="195b2678-4c9c-4b4c-89f7-b0667f1b36ac" general="8ce7b0a8-dbee-43b9-a5b0-9756d0f6b6af"/>
+      <generalization xmi:id="fc7768ed-0836-4e64-ad60-974c5bd14595" general="724913be-4700-496b-accb-f45750955b14"/>
+      <generalization xmi:id="03d9c46d-f130-4793-a306-d248a7507c29" general="0850c978-a960-479b-b462-53abc686273e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d6728b7d-8c59-4dc9-9ec9-6ec81fc2aac6" name="SuccessionFlowConnectionUsage" visibility="public">
+      <ownedComment xmi:id="b69262a0-48b5-4d85-8655-f56196b009cb" annotatedElement="d6728b7d-8c59-4dc9-9ec9-6ec81fc2aac6">
+        <body>&lt;p>A SuccessionFlowConnectionUsage is a FlowConnectionUsage that is also a SuccessionItemFlow.&lt;/p>
+
+&lt;p>A FlowConnectionUsage must subset the base SuccessionFlowConnectionUsage &lt;em>&lt;code>successionFlowConnections&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="aa6de59b-d36d-4050-874b-57b8df20c901" general="23ba3ee9-5e71-4e14-ae22-71d1775ec2c8"/>
+      <generalization xmi:id="f47ad970-8cba-4854-b0b8-58d29b7c2895" general="fd085776-81b3-4a29-b1f9-a414d1a6556c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="fd3223b9-99f4-404c-b470-dccff5430e2d" name="BindingConnectorAsUsage" visibility="public">
+      <ownedComment xmi:id="124bbf51-8795-49f5-82c3-26fd40528cd3" annotatedElement="fd3223b9-99f4-404c-b470-dccff5430e2d">
+        <body>&lt;p>A BindingConnectorAsUsage is both a BindingConnector and a ConnectorAsUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="de44d919-b473-4eef-9f8f-51eadae555df" general="95e1ddab-8a9b-412b-935c-67f12e35ac12"/>
+      <generalization xmi:id="d59177ed-fea5-4209-908a-a750469d06e1" general="f4b1326b-70e0-4f33-93b0-85fb497a26a1"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="7861c564-f51a-44a1-8a36-a0abfb02558e" name="SuccessionAsUsage" visibility="public">
+      <ownedComment xmi:id="0b77f742-bb9d-47aa-8cdb-feaf03c3bb8b" annotatedElement="7861c564-f51a-44a1-8a36-a0abfb02558e">
+        <body>&lt;p>A SuccessionAsUsage is both a ConnectorAsUsage and a Succession.&lt;p></body>
+      </ownedComment>
+      <generalization xmi:id="95ca3892-5de5-4688-a7f1-954239e1f123" general="f4b1326b-70e0-4f33-93b0-85fb497a26a1"/>
+      <generalization xmi:id="8a961cbb-e48c-4e9a-ad7f-9c43a165eb26" general="fec12715-7238-4666-8f45-3e70ed179c7b"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f4b1326b-70e0-4f33-93b0-85fb497a26a1" name="ConnectorAsUsage" visibility="public" isAbstract="true">
+      <ownedComment xmi:id="1ec059d4-e9b3-4d32-b834-f0f41624d2cd" annotatedElement="f4b1326b-70e0-4f33-93b0-85fb497a26a1">
+        <body>&lt;p>A ConnectorAsUsage is both a Connector and a Usage. ConnectorAsUsage cannot itself be instantiated in a SysML model, but it is the base class for the concrete classes BindingConnectorAsUsage, SuccessionAsUsage and ConnectionUsage.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="1328e7a8-6710-4827-a78d-63b9e032e54d" general="46068009-84f1-4001-a9bb-fc03fd6a381c"/>
+      <generalization xmi:id="21956b29-6592-4020-a496-bf92b14279f1" general="f6ecf6da-3e35-489a-86f4-6c9eee938686"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5e1c270f-3751-4508-9c62-a54e0972240a" name="" visibility="public" memberEnd="28f6f4a7-be69-443e-8a38-3c42df74cf9b dc748c45-75df-4d95-83de-cc3b7bca833f">
+      <ownedEnd xmi:id="dc748c45-75df-4d95-83de-cc3b7bca833f" name="definedFlowConnection" visibility="public" type="fd085776-81b3-4a29-b1f9-a414d1a6556c" isDerived="true" redefinedProperty="11596646-ba5d-40a3-9bee-3c4a418cd55a" association="5e1c270f-3751-4508-9c62-a54e0972240a">
+        <ownedComment xmi:id="146283b1-be47-4973-884c-0fd3efca802d" annotatedElement="dc748c45-75df-4d95-83de-cc3b7bca833f">
+          <body>&lt;p>The FlowConnectionUsages that have a certain Interaction as their &lt;code>flowConnectionDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="77ed3e86-5f95-40c3-b680-71efab0fa167" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="30af5ba6-a215-4b47-9019-6638643bcc43" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="a09a1e8c-003e-4117-87c4-3b752032a03e" name="WhileLoopActionUsage" visibility="public">
+      <ownedComment xmi:id="0bf8ed94-00d4-4088-b596-cd92eed8beca" annotatedElement="a09a1e8c-003e-4117-87c4-3b752032a03e">
+        <body>&lt;p>A WhileLoopActionUsage is a LoopActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;em>WhileLoopAction&lt;/em> from the Systems model library. It specifies that the &lt;code>bodyClause&lt;/code> ActionUsage should be performed repeatedly while the result of the &lt;code>whileArgument&lt;/code> Expression is true or until the result of the &lt;code>untilArgument&lt;/code> Expression (if provided) is true. The &lt;code>whileArgument&lt;/code> Expression is evaluated before each (possible) performance of the &lt;code>bodyClause&lt;/code>, and the &lt;code>untilArgument&lt;/code> Expression is evaluated after each performance of the &lt;code>bodyClause&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c5ec50c0-4fcf-44ea-b2c0-48f1d7bb0003" general="e1012c01-4db7-49af-912f-4c7107756943"/>
+      <ownedAttribute xmi:id="50cbe4c3-20dc-44e1-aee6-3ef99e9ff2b0" name="whileArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="8ca1f108-bcab-46b6-9cd9-74713cd2f56a">
+        <ownedComment xmi:id="8c379308-9b79-4bca-b545-e4df0945948b" annotatedElement="50cbe4c3-20dc-44e1-aee6-3ef99e9ff2b0">
+          <body>&lt;p>The Expression whose result, if true, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. Derived as the owned Expression that redefines the &lt;em>&lt;code>whileTest&lt;/code>&lt;/em> parameter of the WhileLoopActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="305ec36a-c829-42c8-b200-5a0424f0f624" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1eaaf3f1-d78c-45f4-ba36-d5b814c78041" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4233fa53-3933-45d6-b237-d6943da5617e" name="untilArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="d7689877-e16b-4a94-814e-7d7d91eb1e56">
+        <ownedComment xmi:id="b6ae1471-1ce6-4a29-8895-a92b9b907248" annotatedElement="4233fa53-3933-45d6-b237-d6943da5617e">
+          <body>&lt;p>The Expression whose result, if false, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. Derived as the owned Expression that redefines the &lt;em>&lt;code>untilTest&lt;/code>&lt;em> &lt;/em>&lt;/em>parameter of the WhileLoopActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="25334457-7159-4166-8e6b-6f20c003c7ae" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="789ccea1-4f5c-4532-af13-9f8a50ba87ed" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="c53b178f-139d-4ade-92d2-af8ab6e91ef0" name="IfActionUsage" visibility="public">
+      <ownedComment xmi:id="f3be396c-ba5b-408c-8670-2dbc052cfafe" annotatedElement="c53b178f-139d-4ade-92d2-af8ab6e91ef0">
+        <body>&lt;p>An IfActionUsage is an ActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;em>IfThenAction&lt;/em> from the Systems model library, or, more specifically, by &lt;em>IfThenElseAction&lt;/em>, if it has an &lt;code>elseAction&lt;/code>. It specifies that the &lt;code>thenAction&lt;/code> ActionUsage should be performed if the result of the &lt;code>ifArgument&lt;/code> Expression is true. It may also optionally specify a &lt;code>elseAction&lt;/code> ActionUsage that is performed if the result of the &lt;code>ifArgument&lt;/code> is false.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="b8aef21e-dc79-4cf3-85e2-0c5f9036a958" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="2d1749f8-f3c0-4c78-a280-43db30411b48" name="elseAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="8d83b91f-099b-4533-b234-c41e87f4bf2a">
+        <ownedComment xmi:id="efe138e3-62db-4e60-8212-5ea5bb1a6724" annotatedElement="2d1749f8-f3c0-4c78-a280-43db30411b48">
+          <body>&lt;p>The ActionUsage that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is false. Derived as the owned ActionUsage that redefines &lt;em>&lt;code>elseClause&lt;/code>&lt;em> &lt;/em>&lt;/em>parameter of the IfActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e5ec1667-7b0c-437b-ba05-b082cd6810c8" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0cabd2a9-28e7-41f3-a974-f3e50f3961eb" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="67b7f477-c5e9-4a00-943f-1282b0a0c03e" name="thenAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="72881b40-cd9e-47d0-a0de-667421a294ac">
+        <ownedComment xmi:id="2ad7fec7-f98c-44b5-b51c-5084bec4400f" annotatedElement="67b7f477-c5e9-4a00-943f-1282b0a0c03e">
+          <body>&lt;p>The ActionUsage that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is true. Derived as the owned ActionUsage that redefines the &lt;em>&lt;code>thenClause&lt;/code>&lt;/em> parameter of the IfActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="620968a0-fadc-4022-b8e5-d58420096e24" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="5a017a7a-1cb1-4116-b40f-13139f95ce79" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="07d111da-613e-4fe8-b2dd-f05f5014e7be" name="ifArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="3bdcaf14-6006-4777-b1aa-a4653f3864ff">
+        <ownedComment xmi:id="865a9796-858f-49bb-996a-92302e5e7612" annotatedElement="07d111da-613e-4fe8-b2dd-f05f5014e7be">
+          <body>&lt;p>The Expression whose result determines whether the &lt;code>thenAction&lt;/code> or (optionally) the &lt;code>elseAction&lt;/code> is performed. Derived as the &lt;code>value&lt;/code> Expression of the FeatureValue for the redefined &lt;em>&lt;code>ifTest&lt;/code>&lt;/em> parameter of the IfActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e612bacc-5af5-416e-abe6-6623ae4e44b4" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f4da8775-0cb5-4e22-af87-9f3a4b5e3f03" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="08ae3e12-ee81-4fb9-bbcc-4c56ebdfbd16" name="" visibility="public" memberEnd="6c1ea406-e05b-4f77-bf3c-7f98040826a5 90fa330a-a935-44c7-a7a2-dfa6a40c8594">
+      <ownedEnd xmi:id="90fa330a-a935-44c7-a7a2-dfa6a40c8594" name="forLoopAction" visibility="public" type="d50a28a4-7ec8-462e-8e2f-bede5270f807" isDerived="true" association="08ae3e12-ee81-4fb9-bbcc-4c56ebdfbd16">
+        <ownedComment xmi:id="6d527e53-a2ce-4b6c-9712-38370c8f1dbe" annotatedElement="90fa330a-a935-44c7-a7a2-dfa6a40c8594">
+          <body>&lt;p>The ForLoopActionUsage that has a certain Expression as its &lt;code>seqArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="729f3927-7722-4a03-a509-21a7e65658b5" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c6131f7e-6079-4b46-b6ca-f17497ee6067" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="1bbf6e74-3284-45c3-81b4-82431ea8bf16" name="ForkNode" visibility="public">
+      <ownedComment xmi:id="575dec85-e030-4e87-9a91-518f2c139ee5" annotatedElement="1bbf6e74-3284-45c3-81b4-82431ea8bf16">
+        <body>&lt;p>A ForkNode is a ControlNode that must be followed by successor Actions as given by all its outgoing Successions. All outgoing Successions must have a target multiplicity of 1..1. A ForkNode may have at most one incoming Succession.&lt;/p>
+
+&lt;p>A ForkNode must subset, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::forks&lt;/code>&lt;/em>, implying that it is typed by &lt;code>&lt;em>ForkAction&lt;/em>&lt;/code> from the Systems model library (or a subtype of it).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="6c4299f6-087d-4ab0-8b67-465539b403ee" name="forkNodeIncomingSuccession" visibility="public" constrainedElement="1bbf6e74-3284-45c3-81b4-82431ea8bf16">
+        <ownedComment xmi:id="3aa6a58a-ffa0-4275-91d3-c90530949dc6" annotatedElement="6c4299f6-087d-4ab0-8b67-465539b403ee">
+          <body>A ForkNode may have at most one incoming Succession Connector.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="391140b2-7071-4a87-969b-99ddf3010bf3" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="d889c2a4-33d2-48a4-82ec-20fb880f72ed" general="246598eb-82a6-4240-a4e1-763a706cc81e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="fea41648-347f-4adf-8718-3d9a18ec4b51" name="" visibility="public" memberEnd="a5fa4b84-c430-4318-bb02-174edd37e882 64bfffb5-01e9-4a92-af43-0f13349797b1">
+      <ownedEnd xmi:id="64bfffb5-01e9-4a92-af43-0f13349797b1" name="performingAction" visibility="public" type="0b38b835-cf24-4e57-8181-eb89afa4f4c4" isDerived="true" subsettedProperty="6ff28096-f731-46d1-972c-ca1aac611d7f" association="fea41648-347f-4adf-8718-3d9a18ec4b51">
+        <ownedComment xmi:id="571c7500-3973-47c1-966e-ec806f3be80b" annotatedElement="64bfffb5-01e9-4a92-af43-0f13349797b1">
+          <body>&lt;p>The PerformActionUsages that have a certain ActionUsage as their &lt;code>performedAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="65adc0cf-bbf0-4c32-918a-720a9d7e8a9c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e3eeaeed-e45c-4020-bc1b-5383a628bb0a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="246598eb-82a6-4240-a4e1-763a706cc81e" name="ControlNode" visibility="public" isAbstract="true">
+      <ownedComment xmi:id="dfdbd79f-9758-43ff-939e-48810140ae9a" annotatedElement="246598eb-82a6-4240-a4e1-763a706cc81e">
+        <body>&lt;p>A ControlNode is an ActionUsage that does not have any inherent behavior but provides constraints on incoming and outgoing Succession Connectors that are used to control other Actions.&lt;/p>
+
+&lt;p>A ControlNode must be a composite owned feature of an ActionDefinition or ActionUsage, subsetting, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::controls&lt;/code>&lt;/em>. This implies that the ControlNode is typed by &lt;code>&lt;em>ControlAction&lt;/em>&lt;/code> from the Systems model library, or a subtype of it.&lt;/p>
+
+&lt;p>All outgoing Successions from a ControlNode must have source multiplicity of 1..1. All incoming Succession must have target multiplicity of 1..1.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="6ef8f9b8-8eb5-4050-9604-51e9a20dcc5a" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8ca1f108-bcab-46b6-9cd9-74713cd2f56a" name="" visibility="public" memberEnd="50cbe4c3-20dc-44e1-aee6-3ef99e9ff2b0 f54d4017-421e-4e9e-91a6-8ca74653cea1">
+      <ownedEnd xmi:id="f54d4017-421e-4e9e-91a6-8ca74653cea1" name="whileLoopAction" visibility="public" type="a09a1e8c-003e-4117-87c4-3b752032a03e" isDerived="true" association="8ca1f108-bcab-46b6-9cd9-74713cd2f56a">
+        <ownedComment xmi:id="d5200714-fd71-4268-b45b-0c65205246d2" annotatedElement="f54d4017-421e-4e9e-91a6-8ca74653cea1">
+          <body>&lt;p>The LoopActionUsage that has a certain Expression as its &lt;code>whileArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8d03c041-cfcb-4914-a79e-d9a308b68680" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0e632a67-95a1-4e21-99d0-3ac2df0173ba" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="447a73c1-7eb7-435b-a6d4-70d4f307a2b0" name="TriggerKind" visibility="public">
+      <ownedComment xmi:id="ad13b48d-ae38-4d4c-a968-03043ca2e6e6" annotatedElement="447a73c1-7eb7-435b-a6d4-70d4f307a2b0">
+        <body>&lt;p>TriggerKind enumerates the kinds of triggers that can be represented by TriggerInvocationExpression.&lt;/p></body>
+      </ownedComment>
+      <ownedLiteral xmi:id="5f246b95-cb20-40f9-906d-4fbbab6c7d86" name="when" visibility="public">
+        <ownedComment xmi:id="790dedc6-5438-4eed-9edf-635cee81e00b" annotatedElement="5f246b95-cb20-40f9-906d-4fbbab6c7d86">
+          <body>&lt;p>Indicates a change trigger, corresponding to the &lt;em>&lt;code>TriggerWhen&lt;/code>&lt;/em> Function from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> library model.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="550f06e6-b3d7-49e4-b7f7-a966dc934ed1" name="at" visibility="public">
+        <ownedComment xmi:id="1d4c8fe0-d2b7-4bd4-8010-fca0c1700e65" annotatedElement="550f06e6-b3d7-49e4-b7f7-a966dc934ed1">
+          <body>&lt;p>Indicates an absolute time trigger, corresponding to the &lt;em>&lt;code>TriggerAt&lt;/code>&lt;/em> Function from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> library model.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:id="734cc8b3-4a96-4674-b0e2-fcfeb13b1219" name="after" visibility="public">
+        <ownedComment xmi:id="a04e1539-c69b-4beb-92f6-6821de996749" annotatedElement="734cc8b3-4a96-4674-b0e2-fcfeb13b1219">
+          <body>&lt;p>Indicates a relative time trigger, corresponding to the &lt;em>&lt;code>TriggerAfter&lt;/code>&lt;/em> Function from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> library model.&lt;/p></body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e7d3a974-b384-4fc6-aa84-aa30ccf911a1" name="" visibility="public" memberEnd="8e026092-b161-436b-9c36-c6a7ac3733a7 dee8f201-18e3-4173-8b9c-fd0b0f33ab8c">
+      <ownedEnd xmi:id="dee8f201-18e3-4173-8b9c-fd0b0f33ab8c" name="owningAcceptActionUsage" visibility="public" type="27109495-ccfe-41d5-acb1-a77ceef57800" isDerived="true" subsettedProperty="156ab9b0-1a64-4f6a-9e14-b91982153366" association="e7d3a974-b384-4fc6-aa84-aa30ccf911a1">
+        <ownedComment xmi:id="7f6f780a-f49d-4089-b020-3298b6158869" annotatedElement="dee8f201-18e3-4173-8b9c-fd0b0f33ab8c">
+          <body>&lt;p>The AcceptActionUsage that owns the &lt;code>payloadParameter&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c110ddfb-9423-4c1b-ba99-a4960760f778" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="660aea03-83ff-4545-a46f-dc0d42b23106" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="878a5a4c-0999-43d3-b690-6bd50e7b34a0" name="" visibility="public" memberEnd="feb67c5e-257a-425c-9354-597577765807 eb00d48b-d135-420b-a13f-dd97e33f09da">
+      <ownedEnd xmi:id="eb00d48b-d135-420b-a13f-dd97e33f09da" name="acceptingActionUsage" visibility="public" type="27109495-ccfe-41d5-acb1-a77ceef57800" isDerived="true" association="878a5a4c-0999-43d3-b690-6bd50e7b34a0">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b3359151-544b-4840-b487-6b66a8add526" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="9aaff6a2-4cb5-4f0e-8c78-4b2f2de29bd1" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d50a28a4-7ec8-462e-8e2f-bede5270f807" name="ForLoopActionUsage" visibility="public">
+      <ownedComment xmi:id="f59ed007-fb9f-496e-88c4-10b84f3947bf" annotatedElement="d50a28a4-7ec8-462e-8e2f-bede5270f807">
+        <body>&lt;p>A ForLoopActionUsage is a LoopActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;em>ForLoopAction&lt;/em> from the Systems model library. It specifies that the &lt;code>bodyClause&lt;/code> ActionUsage should be performed once for each value, in order, from the sequence of values obtained as the result of the &lt;code>seqArgument&lt;/code> Expression. The &lt;code>bodyAction&lt;/code> must have one input parameter, which receives a value from the sequence on each iteration.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="dc992029-8945-4d9c-becd-e36d15e3fbcb" general="e1012c01-4db7-49af-912f-4c7107756943"/>
+      <ownedAttribute xmi:id="6c1ea406-e05b-4f77-bf3c-7f98040826a5" name="seqArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="08ae3e12-ee81-4fb9-bbcc-4c56ebdfbd16">
+        <ownedComment xmi:id="bd988dad-24fc-41fc-905d-a7661152851a" annotatedElement="6c1ea406-e05b-4f77-bf3c-7f98040826a5">
+          <body>&lt;p>The Expression whose result provides the sequence of values to be passed to each &lt;code>bodyAction&lt;/code> performance. Derived as the &lt;code>value&lt;/code> Expression of the FeatureValue for the redefined &lt;em>&lt;code>seq&lt;/code>&lt;em> &lt;/em>&lt;/em>parameter of the ForLoopActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7901c24f-1f6c-4256-8b7d-a533f170315d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="34e5f572-6c55-4dd4-8048-1248c0c82698" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="81dc75dd-0afa-4e10-9f78-4508c024c0a0" name="loopVariable" visibility="public" type="ad315d17-6754-4a30-bcde-3b73d63d713e" isDerived="true" association="796d4e55-e22b-4cca-9acf-33244ad6f4c5">
+        <ownedComment xmi:id="a4c17c0d-c694-4fd6-8dca-3b1cfb844963" annotatedElement="81dc75dd-0afa-4e10-9f78-4508c024c0a0">
+          <body>&lt;p>The &lt;code>feature&lt;/code> of this ForLoopActionUsage that acts as the loop variable, which is assigned the successive elements of the input sequence on each iteration. Derived as the &lt;code>feature&lt;/code> that subsets the library ReferenceUsage &lt;em>&lt;code>ForLoopAction::var&lt;/code>&lt;/em>.&lt;/p> </body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5d97efc7-4056-4a62-8df1-01f07f599c18" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6fea3cc4-46f1-4e57-b95f-8eddb1d29603" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="c7bee4bd-d57f-4fbe-bcc7-7524aae711be" name="DecisionNode" visibility="public">
+      <ownedComment xmi:id="ff321bfd-e48a-45be-ac94-12a349c04fbc" annotatedElement="c7bee4bd-d57f-4fbe-bcc7-7524aae711be">
+        <body>&lt;p>A DecisionNode is a ControlNode that makes a selection from its outgoing Successions. All outgoing Successions must be must have a target multiplicity of 0..1 and subset the Feature &lt;em>&lt;code>DecisionAction::outgoingHBLink&lt;/code>&lt;/em>. A DecisionNode may have at most one incoming Succession.&lt;/p>
+
+&lt;p>A DecisionNode must subset, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::decisions&lt;/code>&lt;/em>, implying that it is typed by &lt;code>&lt;em>DecisionAction&lt;/em>&lt;/code> from the Systems model library (or a subtype of it).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="fcbd05d7-fc7e-4f90-8538-b7594b01d71f" name="decisionNodeIncomingSuccession" visibility="public" constrainedElement="c7bee4bd-d57f-4fbe-bcc7-7524aae711be">
+        <ownedComment xmi:id="970073a5-c068-4864-bbb5-a27eb8bf68e5" annotatedElement="fcbd05d7-fc7e-4f90-8538-b7594b01d71f">
+          <body>A DecisionNode may have at most one incoming Succession Connector.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="f5b0b69c-beaa-453f-9369-fb77ec63aaa1" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="5c1e6a4b-ad5a-4253-a4d0-710cd5e291a6" general="246598eb-82a6-4240-a4e1-763a706cc81e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9a2e1a0b-e1f9-41cd-9d45-08289972aad6" name="" visibility="public" memberEnd="182a4bea-0db9-4b22-8f45-e9ee1038c944 fcc9d1ef-6fc0-466f-ada8-9a9668bd386d">
+      <ownedEnd xmi:id="fcc9d1ef-6fc0-466f-ada8-9a9668bd386d" name="acceptActionUsage" visibility="public" type="27109495-ccfe-41d5-acb1-a77ceef57800" isDerived="true" association="9a2e1a0b-e1f9-41cd-9d45-08289972aad6">
+        <ownedComment xmi:id="9d9b806a-472d-4eba-a986-3330e597a35b" annotatedElement="fcc9d1ef-6fc0-466f-ada8-9a9668bd386d">
+          <body>&lt;p>The AcceptActionUsage that has a certain Expression as its &lt;code>receiverArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2e9baa66-cbd6-428c-80ae-ab263e4c0406" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="14bde15b-d73c-4b27-a301-c68216f05fa9" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e1012c01-4db7-49af-912f-4c7107756943" name="LoopActionUsage" visibility="public" isAbstract="true">
+      <ownedComment xmi:id="c27e004f-c65e-4741-b8e1-e85cabd2a3ee" annotatedElement="e1012c01-4db7-49af-912f-4c7107756943">
+        <body>&lt;p>A LoopActionUsage is an ActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;em>LoopAction&lt;/em> from the Systems model library. It specifies that its &lt;code>bodyAction&lt;/code> should be performed repeatedly. Its subclasses WhileLoopActionUsage and ForLoopActionUsage provide different ways to determine how many times the &lt;code>bodyAction should be performed.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="a145a0d9-a661-435e-af27-7958d7ab34ee" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="94ffe7ab-7269-4234-917a-e1e3785a114a" name="bodyAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" association="36948ae4-1e52-45d4-93ab-8d5fde0e90ba">
+        <ownedComment xmi:id="c8f2101c-738f-4295-acff-05709db22fec" annotatedElement="94ffe7ab-7269-4234-917a-e1e3785a114a">
+          <body>&lt;p>The ActionUsage to be performed repeatedly by the LoopActionUsage. Derived as the owned ActionUsage that redefines the &lt;em>&lt;code>body&lt;/code>&lt;em> &lt;/em>&lt;/em>parameter of the LoopActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7110658e-1227-423f-8a55-fa8050f3ec41" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6eab6e45-46a6-4e18-8e81-711574cb687a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="72881b40-cd9e-47d0-a0de-667421a294ac" name="" visibility="public" memberEnd="67b7f477-c5e9-4a00-943f-1282b0a0c03e 24d42a96-0f5c-4d80-b135-d5a1ae1acd9a">
+      <ownedEnd xmi:id="24d42a96-0f5c-4d80-b135-d5a1ae1acd9a" name="ifThenAction" visibility="public" type="c53b178f-139d-4ade-92d2-af8ab6e91ef0" isDerived="true" association="72881b40-cd9e-47d0-a0de-667421a294ac">
+        <ownedComment xmi:id="c6f24c1e-8c00-45b5-8ffc-b9960b7590af" annotatedElement="24d42a96-0f5c-4d80-b135-d5a1ae1acd9a">
+          <body>&lt;p>The IfActionUsage that has a certain ActionUsage as its &lt;code>thenAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="689c9ba0-6f26-4b78-a10f-e1e1f93bdf8d" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="321dbecc-4b8a-4439-b87b-f94ef062a587" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d2a71472-b466-471c-b59d-a45ea2e99e5e" name="" visibility="public" memberEnd="ff9d1184-cd09-497c-b1e6-053fb44e9c69 d2c9e51f-1e2b-484d-adab-4290308db521">
+      <ownedEnd xmi:id="d2c9e51f-1e2b-484d-adab-4290308db521" name="sendActionUsage" visibility="public" type="20da60b2-9ec4-46ed-b38c-642aa37881ff" isDerived="true" association="d2a71472-b466-471c-b59d-a45ea2e99e5e">
+        <ownedComment xmi:id="d0b50602-0e79-4e97-8073-eedc79c4f781" annotatedElement="d2c9e51f-1e2b-484d-adab-4290308db521">
+          <body>&lt;p>The SendActionUsage that has a certain Expression as its &lt;code>receiverArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5101edb8-5197-4044-9348-45afbccc8226" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a5fef189-1dae-4f91-acfb-adb413f3a40f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="b197cf31-62e3-47ae-a1e6-7d2784450354" name="" visibility="public" memberEnd="1e92c8a6-f83c-4787-96c1-dd8ce37926a2 45ff2c7b-4da6-40ad-88bb-7017eb955cbe">
+      <ownedEnd xmi:id="45ff2c7b-4da6-40ad-88bb-7017eb955cbe" name="sendingActionUsage" visibility="public" type="20da60b2-9ec4-46ed-b38c-642aa37881ff" isDerived="true" association="b197cf31-62e3-47ae-a1e6-7d2784450354">
+        <ownedComment xmi:id="83cda7aa-f478-4a04-aaa8-53e4533e202c" annotatedElement="45ff2c7b-4da6-40ad-88bb-7017eb955cbe">
+          <body>&lt;p>The SendActionUsage that has a certain Expression as its &lt;code>itemsArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="e185fabf-47ad-4004-bdc6-c6da2dc98479" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ed7d20c1-1971-4f50-93fc-6b7377c5fc11" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="0b38b835-cf24-4e57-8181-eb89afa4f4c4" name="PerformActionUsage" visibility="public">
+      <ownedComment xmi:id="c071f3cb-6480-4fa8-aeb3-b2d3ebb18c92" annotatedElement="0b38b835-cf24-4e57-8181-eb89afa4f4c4">
+        <body>&lt;p>A PerformActionUsage is an ActionUsage that represents the performance of an ActionUsage. Unless it is the PerformActionUsage itself, the ActionUsage to be performed is related to the PerformActionUsage by a ReferenceSubsetting relationship. A PerformActionUsage is also an EventOccurrenceUsage, with its &lt;code>performedAction&lt;/code> as the &lt;code>eventOccurrence&lt;/code>.&lt;/p>
+
+&lt;p>If the PerformActionUsage is owned by a PartDefinition or PartUsage, then it also subsets the ActionUsage &lt;em>&lt;code>Part::performedAction&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="710261a3-e1b8-46c2-a0f4-553671b5bf3e" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <generalization xmi:id="25da78bf-7518-4abf-98d5-72c00102ce6e" general="d5e1f78b-c81a-4a6e-9537-73c4a8b12ffe"/>
+      <ownedAttribute xmi:id="a5fa4b84-c430-4318-bb02-174edd37e882" name="performedAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" redefinedProperty="fee861c4-7cc2-4854-9abe-530ec31cd5ab" association="fea41648-347f-4adf-8718-3d9a18ec4b51">
+        <ownedComment xmi:id="dca20043-1324-4664-a0cf-41bd070c2faa" annotatedElement="a5fa4b84-c430-4318-bb02-174edd37e882">
+          <body>&lt;p>The ActionUsage to be performed by this PerformedActionUsage. It is the &lt;code>eventOccurrence&lt;/code> of the PerformActionUsage considered as an EventOccurrenceUsage, which must be an ActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d1dca359-97c4-458e-8730-65977de2bd9b" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="7c8ac57a-578e-487d-8813-47a398ec1a7d" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedOperation xmi:id="edda296e-6fda-433a-bafd-d50817478ef0" name="namingFeature" visibility="public" bodyCondition="2b00f7f9-5a87-4e16-9093-be109f9696ba" redefinedOperation="a72f751c-5ed8-482a-8c58-0a536b396eac">
+        <ownedComment xmi:id="51790ffa-8d3f-496d-88df-f48e4650e503" annotatedElement="edda296e-6fda-433a-bafd-d50817478ef0">
+          <body>&lt;p>The naming Feature of an PerformActionUsage is its &lt;code>performedAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="2b00f7f9-5a87-4e16-9093-be109f9696ba" name="unnamed1" visibility="public">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="57af6ed5-23cd-4c09-b462-e83c45b78909" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>exhibitedState</body>
+          </specification>
+        </ownedRule>
+        <ownedParameter xmi:id="3ddc6ccf-4923-40aa-b26f-ddb8506b1f8d" name="" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" direction="return">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="7734b0b1-319d-4263-b3d9-578625853b3a" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="76d6817f-e24d-4bec-9fc8-1d335b410483" name="" visibility="public" value="1"/>
+        </ownedParameter>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3253c8ca-91ac-429a-b0eb-1eea1c482bca" name="ActionUsage" visibility="public">
+      <ownedComment xmi:id="7e172011-31e7-4941-a06e-57e354c3069d" annotatedElement="3253c8ca-91ac-429a-b0eb-1eea1c482bca">
+        <body>&lt;p>An ActionUsage is a Usage that is also a Step, and, so, is typed by a Behavior. Nominally, if the type is an ActionDefinition, an ActionUsage is a Usage of that ActionDefinition within a system. However, other kinds of kernel Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p>
+
+&lt;p>An ActionUsage must subset, directly or indirectly, the base ActionUsage &lt;em>&lt;code>actions&lt;/code>&lt;/em> from the Systems model library. if it is a &lt;code>feature&lt;/code> of an ActionDefinition or ActionUsage, then it must subset, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::subactions&lt;/code>&lt;/em>.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="8a3371ec-97ec-4155-97fc-47f316e1ed5b" general="b1a2875a-af89-47c5-ad2b-d5763c43aafd"/>
+      <generalization xmi:id="b7fbc1ee-fb1a-4f7a-b4b2-9f447188a56a" general="da9d7196-5acc-4b5d-bfad-15a6229d604d"/>
+      <ownedAttribute xmi:id="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b" name="actionDefinition" visibility="public" type="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba" isOrdered="true" isDerived="true" redefinedProperty="1f2423e8-9b61-4497-af7c-8de89dbda20c 48d91227-fa8b-4b65-a4f8-d27701f010c0" association="28d7d847-d8df-47dd-b1b5-37c5d6c4cf3e">
+        <ownedComment xmi:id="2af35c08-99b6-4102-83ef-1c50f241c35c" annotatedElement="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b">
+          <body>&lt;p>The Behaviors that are the types of this ActionUsage. Nominally, these would be ActionDefinitions, but other kinds of Kernel Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5fae59dd-a24c-4a55-bbb4-79244c22e4ea" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="d629b227-5d8e-47b8-8f99-413897d26e5b" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="08ec4bec-fa13-4d1b-8006-f9e30dec24ce" name="TriggerInvocationExpression" visibility="public">
+      <ownedComment xmi:id="d1d553f8-0f80-4c84-b438-14a2e49acc48" annotatedElement="08ec4bec-fa13-4d1b-8006-f9e30dec24ce">
+        <body>&lt;p>A TriggerInvocationExpression is an InvocationExpression that invokes one of the trigger Functions from the Kernel &lt;em>Triggers&lt;em> package, as indicated by its &lt;code>kind&lt;/code>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="ac112972-a968-425c-af09-abca2efb0922" general="7195c02a-f102-4843-88a2-4f3a0217284f"/>
+      <ownedAttribute xmi:id="b3d38f8d-7598-4d5a-acf6-4816f4c84ef6" name="kind" visibility="public" type="447a73c1-7eb7-435b-a6d4-70d4f307a2b0">
+        <ownedComment xmi:id="78b9329b-4a51-4ed5-9f26-fe564135dd39" annotatedElement="b3d38f8d-7598-4d5a-acf6-4816f4c84ef6">
+          <body>&lt;p>Indicates which of the Functions from the Kernel &lt;em>Triggers&lt;/em> package is to be invoked by this TriggerInvocationExpression.&lt;/p></body>
+        </ownedComment>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="166f37b5-4c99-4de1-ba27-081e67c41037" name="" visibility="public" memberEnd="e527b56c-1106-4170-a052-a1689359b92d 10fb3958-c10c-4a8f-b7e8-e9d683504a9f">
+      <ownedEnd xmi:id="10fb3958-c10c-4a8f-b7e8-e9d683504a9f" name="assigningAction" visibility="public" type="e65f0ae2-b24a-4fd5-bc8f-6856e085cca1" isDerived="true" association="166f37b5-4c99-4de1-ba27-081e67c41037">
+        <ownedComment xmi:id="c7759b99-0c4d-41c9-8318-82391e554764" annotatedElement="10fb3958-c10c-4a8f-b7e8-e9d683504a9f">
+          <body>&lt;p>The AssignmentActionUsage that has a certain Expression as its &lt;code>valueArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f6bb45ac-d06b-4d06-9cd1-17c14d4fa827" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ecba8d42-1f00-468f-a870-bb036620eaff" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="f6af250c-3e8d-4623-acba-c66907ebd846" name="" visibility="public" memberEnd="f1d2448f-70a6-4cfb-8c0a-033ddb3d3ebf 7e29a9fb-9602-4f16-8151-f1650256433a">
+      <ownedEnd xmi:id="7e29a9fb-9602-4f16-8151-f1650256433a" name="assignment" visibility="public" type="e65f0ae2-b24a-4fd5-bc8f-6856e085cca1" isDerived="true" subsettedProperty="8a78149d-9cec-4086-b8f5-55013c10635a" association="f6af250c-3e8d-4623-acba-c66907ebd846">
+        <ownedComment xmi:id="98416aac-8d2f-4f53-aeaa-0ed8202136f2" annotatedElement="7e29a9fb-9602-4f16-8151-f1650256433a">
+          <body>&lt;p>The AssignmentActionUsages that gave a certain &lt;code>referent&lt;/code> Expression.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d602e4d7-cc7c-4730-a4ac-fb96d5afae91" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="dbe0625b-f7f4-4488-9232-6514b7a64639" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="8d83b91f-099b-4533-b234-c41e87f4bf2a" name="" visibility="public" memberEnd="2d1749f8-f3c0-4c78-a280-43db30411b48 d5e2e451-006f-4801-8267-7aeb27d860fe">
+      <ownedEnd xmi:id="d5e2e451-006f-4801-8267-7aeb27d860fe" name="ifElseAction" visibility="public" type="c53b178f-139d-4ade-92d2-af8ab6e91ef0" isDerived="true" association="8d83b91f-099b-4533-b234-c41e87f4bf2a">
+        <ownedComment xmi:id="3d0e88b8-1741-46dc-ba2d-4f1ffa42a73f" annotatedElement="d5e2e451-006f-4801-8267-7aeb27d860fe">
+          <body>&lt;p>The IfActionUsage that has a certain ActionUsage as its &lt;code>elseAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="50c970c9-a786-4e39-aefb-8cf5f9945160" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3490f340-6073-4024-9223-aae6b858569b" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="d7689877-e16b-4a94-814e-7d7d91eb1e56" name="" visibility="public" memberEnd="4233fa53-3933-45d6-b237-d6943da5617e ae031fad-95aa-4df3-8b90-b5e18006435b">
+      <ownedEnd xmi:id="ae031fad-95aa-4df3-8b90-b5e18006435b" name="untilLoopAction" visibility="public" type="a09a1e8c-003e-4117-87c4-3b752032a03e" isDerived="true" association="d7689877-e16b-4a94-814e-7d7d91eb1e56">
+        <ownedComment xmi:id="b08aa7ec-949a-416d-b91c-b7bfab6bc26c" annotatedElement="ae031fad-95aa-4df3-8b90-b5e18006435b">
+          <body>&lt;p>The LoopActionUsage that has a certain Expression as its &lt;code>untilArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b3f671aa-546a-41c3-a072-2fbf339ebc20" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="1b68c86e-ad50-4df1-bb1c-fd05b581066f" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="796d4e55-e22b-4cca-9acf-33244ad6f4c5" name="" visibility="public" memberEnd="81dc75dd-0afa-4e10-9f78-4508c024c0a0 7e8dce33-f43a-4686-a283-6ee29c115af0">
+      <ownedEnd xmi:id="7e8dce33-f43a-4686-a283-6ee29c115af0" name="forLoopAction" visibility="public" type="d50a28a4-7ec8-462e-8e2f-bede5270f807" isDerived="true" association="796d4e55-e22b-4cca-9acf-33244ad6f4c5">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="37b51a17-e11f-46a5-bab8-e39380399c58" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="45a3ed83-f7cb-4b0b-a101-29cefd9ecc2a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="20da60b2-9ec4-46ed-b38c-642aa37881ff" name="SendActionUsage" visibility="public">
+      <ownedComment xmi:id="e1a8138a-f8ba-44d3-838d-22ffdc82610a" annotatedElement="20da60b2-9ec4-46ed-b38c-642aa37881ff">
+        <body>&lt;p>A SendActionUsage is an ActionUsage that is typed, directly or indirectly, by the ActionDefinition SendAction from the Systems model library. It specifies the sending of a payload given by the result of its &lt;code>itemsArgument&lt;/code> Expression via a Transfer that becomes and &lt;em>&lt;code>incomingTransfer&lt;/code>&lt;/em> of the &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> given by the result of its &lt;code>receiverArgument&lt;/code> Expression.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="be5360e7-8b97-45d9-bd83-6e36dac0610f" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="ff9d1184-cd09-497c-b1e6-053fb44e9c69" name="receiverArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="d2a71472-b466-471c-b59d-a45ea2e99e5e">
+        <ownedComment xmi:id="9957e923-fcd3-4e41-beee-f7c1dbf23186" annotatedElement="ff9d1184-cd09-497c-b1e6-053fb44e9c69">
+          <body>&lt;p>An Expression whose result is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input parameter of this SendActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6b802fdd-beff-4e89-9d6b-af8a78f6c500" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="8404df06-013c-4845-ba6d-80c055ed97b8" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="1e92c8a6-f83c-4787-96c1-dd8ce37926a2" name="payloadArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="b197cf31-62e3-47ae-a1e6-7d2784450354">
+        <ownedComment xmi:id="f1e2abb6-50a0-44a4-83af-9be1cd190525" annotatedElement="1e92c8a6-f83c-4787-96c1-dd8ce37926a2">
+          <body>&lt;p>An Expression whose result is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> input parameter of this SendActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c60153bd-ad8f-446c-87b9-b551cfec375d" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e87d9bcc-6b7a-4fe0-b9f7-a7a276b13900" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="27109495-ccfe-41d5-acb1-a77ceef57800" name="AcceptActionUsage" visibility="public">
+      <ownedComment xmi:id="0a7a2e3b-8ccb-401f-b12f-2eb4d57e1621" annotatedElement="27109495-ccfe-41d5-acb1-a77ceef57800">
+        <body>&lt;p>An AcceptActionUsage is an ActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;code>&lt;em>AcceptAction&lt;/em>&lt;/code> from the Systems model library. It specifies the acceptance of an &lt;em>&lt;code>incomingTransfer&lt;/code>&lt;/em> from the &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> given by the result of its &lt;code>receiverArgument&lt;/code> Expression. The payload of the accepted &lt;em>&lt;code>Transfer&lt;/em>&lt;/code> is output on its &lt;code>payloadParameter&lt;/code>.&lt;/p>
+
+&lt;p>Which &lt;em>&lt;code>Transfers&lt;/em>&lt;/code> may be accepted is determined by the typing and binding of the &lt;code>payloadParameter&lt;/code>. If the &lt;code>triggerKind&lt;/code> has any value other than &lt;code>accept&lt;/code>, then the &lt;code>payloadParameter&lt;/code> must be bound to a &lt;code>payloadArgument&lt;/code> that is an InvocationExpression whose &lt;code>function&lt;/code> is determined by the &lt;code>triggerKind&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="3d259a15-f1fb-45cc-a01a-77252aad4b38" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="182a4bea-0db9-4b22-8f45-e9ee1038c944" name="receiverArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="9a2e1a0b-e1f9-41cd-9d45-08289972aad6">
+        <ownedComment xmi:id="476c7c3c-0cc1-4e01-a958-292713abc72a" annotatedElement="182a4bea-0db9-4b22-8f45-e9ee1038c944">
+          <body>&lt;p>An Expression whose result is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input parameter of this AcceptActionUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c1408403-798f-40da-9d08-8ad3aeb96ea7" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e62919c3-b394-4059-a2cc-a41249dbf3bf" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="8e026092-b161-436b-9c36-c6a7ac3733a7" name="payloadParameter" visibility="public" type="ad315d17-6754-4a30-bcde-3b73d63d713e" isDerived="true" subsettedProperty="a2eeff6d-d4e0-4fa9-95f8-20ed08dcb451" association="e7d3a974-b384-4fc6-aa84-aa30ccf911a1">
+        <ownedComment xmi:id="adb465d3-438e-4e35-87b9-7cc56fc927f5" annotatedElement="8e026092-b161-436b-9c36-c6a7ac3733a7">
+          <body>&lt;p>The &lt;code>nestedReference&lt;/code> of this AcceptActionUsage that redefines the &lt;code>payload&lt;/code> output parameter of the base AcceptActionUsage &lt;em>&lt;code>AcceptAction&lt;/code>&lt;/em> from the Systems model library.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5f6806cf-962c-4132-b7fe-969b8ea41e10" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="243546d6-e8ec-48e2-96e1-37bd7ef85896" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="feb67c5e-257a-425c-9354-597577765807" name="payloadArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="878a5a4c-0999-43d3-b690-6bd50e7b34a0">
+        <ownedComment xmi:id="53731d0f-b6b5-43f9-902c-90bee13f4dd7" annotatedElement="feb67c5e-257a-425c-9354-597577765807">
+          <body>&lt;p>An Expression whose result is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> parameter of this AcceptActionUsage. If provided, the AcceptActionUsage will only accept a &lt;code>&lt;em>Transfer&lt;/em>&lt;/code> with exactly this &lt;code>&lt;em>payload&lt;/em>&lt;/code>.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6febeda7-894f-4d6a-9a3b-a1f9cf05cb79" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3ff5e369-405d-423f-bff6-83a871ddaf7b" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="36948ae4-1e52-45d4-93ab-8d5fde0e90ba" name="" visibility="public" memberEnd="94ffe7ab-7269-4234-917a-e1e3785a114a 92a9016f-09e0-4dca-84d2-71b19539c4d1">
+      <ownedEnd xmi:id="92a9016f-09e0-4dca-84d2-71b19539c4d1" name="loopAction" visibility="public" type="e1012c01-4db7-49af-912f-4c7107756943" isDerived="true" association="36948ae4-1e52-45d4-93ab-8d5fde0e90ba">
+        <ownedComment xmi:id="cb008d65-dfe3-4a4a-a318-a18b6c3f8b67" annotatedElement="92a9016f-09e0-4dca-84d2-71b19539c4d1">
+          <body>&lt;p>The LoopActionUsage that has a certain ActionUsage as its &lt;code>bodyAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="8dfcddad-861b-48ec-9eee-7a00eb0ca774" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="555575ff-d1d8-40d9-acbf-809e2faf0c68" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3bdcaf14-6006-4777-b1aa-a4653f3864ff" name="" visibility="public" memberEnd="07d111da-613e-4fe8-b2dd-f05f5014e7be bc379bf2-acbe-482f-a786-48b29915a30d">
+      <ownedEnd xmi:id="bc379bf2-acbe-482f-a786-48b29915a30d" name="ifAction" visibility="public" type="c53b178f-139d-4ade-92d2-af8ab6e91ef0" isDerived="true" association="3bdcaf14-6006-4777-b1aa-a4653f3864ff">
+        <ownedComment xmi:id="2486482c-da52-4d4f-8ec8-71ca790ae4ec" annotatedElement="bc379bf2-acbe-482f-a786-48b29915a30d">
+          <body>&lt;p>The IfActionUsage that has a certain Expression as its &lt;code>ifArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="dc2f69ee-a053-4508-ad57-c0498429fd4f" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="ab04d1b1-1fa4-438c-8ef8-26fa3195aed1" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="3474947d-2d08-4f35-b155-52bc1e679a39" name="" visibility="public" memberEnd="2395e3f3-0e90-4cb8-acdf-0627ed5dbff9 8b816102-c0f3-4f15-8bf3-e859fcacb55c">
+      <ownedEnd xmi:id="8b816102-c0f3-4f15-8bf3-e859fcacb55c" name="assignmentAction" visibility="public" type="e65f0ae2-b24a-4fd5-bc8f-6856e085cca1" isDerived="true" association="3474947d-2d08-4f35-b155-52bc1e679a39">
+        <ownedComment xmi:id="9b3e3eb2-c82b-423f-94b5-29a1731aa5ea" annotatedElement="8b816102-c0f3-4f15-8bf3-e859fcacb55c">
+          <body>&lt;p>The AssignmentActionUsage that has a certain Expression as its &lt;code>targetArgument&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="4a19c0dd-164e-4f9b-abea-23d9155c9400" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="bf1b8910-7e71-47f1-a621-f2df3901a07a" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="9e0eb835-6b1d-4c1b-8c1d-f7e607d5458e" name="" visibility="public" memberEnd="58a4f97e-ec9b-405a-a512-c223a347970e cb023d69-80e9-4e0f-9a9d-7420ac84da10">
+      <ownedEnd xmi:id="cb023d69-80e9-4e0f-9a9d-7420ac84da10" name="featuringActionDefinition" visibility="public" type="724913be-4700-496b-accb-f45750955b14" isDerived="true" subsettedProperty="25696705-71e7-4f65-aead-1d106b54640c eb7af616-8e9c-419a-a08a-4b80d758179f" association="9e0eb835-6b1d-4c1b-8c1d-f7e607d5458e">
+        <ownedComment xmi:id="e9464fc3-bb95-4be4-869e-de26ef9932c0" annotatedElement="cb023d69-80e9-4e0f-9a9d-7420ac84da10">
+          <body>&lt;p>The Activities that feature a certain ActionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5fa30812-f5f9-4e9c-ab1e-589c30cde096" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3c050ab3-3060-45ca-945e-94de72f90dce" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="724913be-4700-496b-accb-f45750955b14" name="ActionDefinition" visibility="public">
+      <ownedComment xmi:id="1b4d3865-7bd5-4eb0-90de-d1d62fa9c354" annotatedElement="724913be-4700-496b-accb-f45750955b14">
+        <body>&lt;p>An ActionDefinition is a Definition that is also a Behavior that defines an action performed by a system or part of a system.&lt;/p>
+
+&lt;p>An ActionDefinition must subclass, directly or indirectly, the base ActionDefinition &lt;code>&lt;em>Action&lt;/em>&lt;/code> from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="b3a2e9bc-5d15-438e-a05b-e34cfe63acfd" general="2b6b71d4-57a9-4df4-badc-6ee2bfd7f8ba"/>
+      <generalization xmi:id="a60f3c08-9baf-4184-8996-ff188a5813b5" general="01787c81-d827-4988-80ba-3f358b159b5c"/>
+      <ownedAttribute xmi:id="58a4f97e-ec9b-405a-a512-c223a347970e" name="action" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isOrdered="true" isDerived="true" subsettedProperty="c559f3c7-96bd-45da-a2c7-1770af2759aa db471ae1-04e1-47b7-b6bc-2d40afdda735" association="9e0eb835-6b1d-4c1b-8c1d-f7e607d5458e">
+        <ownedComment xmi:id="ff346dc6-e359-4fb6-b3cd-53c5e559a7f8" annotatedElement="58a4f97e-ec9b-405a-a512-c223a347970e">
+          <body>&lt;p>The ActionUsages that are Steps in this ActionDefinition, which define the actions that specify the behavior of the ActionDefinition.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="efbf3678-fae7-4460-b90a-00348ab9ea20" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="08d29d14-526e-416d-972b-295b2534fd40" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="92eb60a8-758c-4621-bc85-8edcf0c2b17d" name="MergeNode" visibility="public">
+      <ownedComment xmi:id="04f58492-bf5a-47ff-9ac7-f4a5b33907c3" annotatedElement="92eb60a8-758c-4621-bc85-8edcf0c2b17d">
+        <body>&lt;p>A MergeNode is a ControlNode that asserts the merging of its incoming Successions. All incoming Successions must have a source multiplicity of 0..1 and subset the Feature &lt;em>&lt;code>MergeAction::incomingHBLink&lt;/code>&lt;/em>. A MergeNode may have at most one outgoing Succession.&lt;/p>
+
+&lt;p>A MergeNode must subset, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::merges&lt;/code>&lt;/em>, implying that it is typed by &lt;code>&lt;em>MergeAction&lt;/em>&lt;/code> from the Systems model library (or a subtype of it).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="3a7b490a-1832-4e6c-bf5d-38ecb091133b" name="mergeNodeOutgoingSuccession" visibility="public" constrainedElement="92eb60a8-758c-4621-bc85-8edcf0c2b17d">
+        <ownedComment xmi:id="6cffbd1f-3401-4ade-bbe0-c1d959749ac0" annotatedElement="3a7b490a-1832-4e6c-bf5d-38ecb091133b">
+          <body>A MergeNode may have at most one outgoing Succession Connector.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="a65d7d50-5837-42f5-a518-2a9551f794ee" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="44403ff6-fad0-40e8-a829-33cb44e9072c" general="246598eb-82a6-4240-a4e1-763a706cc81e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="28d7d847-d8df-47dd-b1b5-37c5d6c4cf3e" name="" visibility="public" memberEnd="5ef4cd7f-9d79-44b5-ad54-30bbd8f1b16b fb464d93-e7f2-4d5d-9e9c-aaf2c4fdd16c">
+      <ownedEnd xmi:id="fb464d93-e7f2-4d5d-9e9c-aaf2c4fdd16c" name="definedAction" visibility="public" type="3253c8ca-91ac-429a-b0eb-1eea1c482bca" isDerived="true" subsettedProperty="f160608e-ca2e-4daa-9b89-f6dad7620456 b3f1997a-fa47-4624-b4f8-5163772191d3" association="28d7d847-d8df-47dd-b1b5-37c5d6c4cf3e">
+        <ownedComment xmi:id="ec3a63fc-06da-407a-a62e-e9b881fc8ab1" annotatedElement="fb464d93-e7f2-4d5d-9e9c-aaf2c4fdd16c">
+          <body>&lt;p>The ActionUsages being typed by a certain Behavior.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c270f7a2-3c13-494a-a1f9-5bce6ce70621" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="10113ca4-f03c-4678-bc8f-66a0f1a92c4e" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="e65f0ae2-b24a-4fd5-bc8f-6856e085cca1" name="AssignmentActionUsage" visibility="public">
+      <ownedComment xmi:id="3491f0bf-b458-476d-882b-8eccf8e2687e" annotatedElement="e65f0ae2-b24a-4fd5-bc8f-6856e085cca1">
+        <body>&lt;p>An AssignmentActionUsage is an ActionUsage that is typed, directly or indirectly, by the ActionDefinition &lt;em>&lt;code>AssignmentAction&lt;/code> &lt;/em>from the Systems model library. It specifies that the value of the &lt;code>referent&lt;/code> Feature, relative to the target given by the result of the &lt;code>targetArgument&lt;/code> Expression, should be set to the result of the &lt;code>valueExpression&lt;/code>.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="e61879f7-fcd3-4f6c-bdb2-c6d51b8f4f0e" general="3253c8ca-91ac-429a-b0eb-1eea1c482bca"/>
+      <ownedAttribute xmi:id="2395e3f3-0e90-4cb8-acdf-0627ed5dbff9" name="targetArgument" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="3474947d-2d08-4f35-b155-52bc1e679a39">
+        <ownedComment xmi:id="0df1df4a-619c-477b-94d9-bfe0ccbfabf9" annotatedElement="2395e3f3-0e90-4cb8-acdf-0627ed5dbff9">
+          <body>&lt;p>The Expression whose value is an occurrence in the domain of the &lt;code>referent&lt;/code> Feature, for which the value of the &lt;code>referent&lt;/code> will be set to the result of the &lt;code>valueExpression&lt;/code> by this AssignmentActionUsage. Derived as the &lt;code>value&lt;/code> of the FeatureValue of the redefined &lt;em>&lt;code>target&lt;/code>&lt;/em> parameter of the AssignmentActionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="68d3b799-3b11-4032-b669-adb6653c333f" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="b97f635f-94de-4c25-9704-fe937add579a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="e527b56c-1106-4170-a052-a1689359b92d" name="valueExpression" visibility="public" type="b32c4dd3-88a2-4418-b414-e75ceb0bb432" isDerived="true" association="166f37b5-4c99-4de1-ba27-081e67c41037">
+        <ownedComment xmi:id="454da15f-3a2c-475a-aed1-e73e53891c44" annotatedElement="e527b56c-1106-4170-a052-a1689359b92d">
+          <body>&lt;p>The Expression whose result is to be assigned to the &lt;code>referent&lt;/code> Feature. Derived as the &lt;code>value&lt;/code> of the FeatureValue of the redefined &lt;em>&lt;code>replacementValues&lt;/code>&lt;/em> parameter of the AssignmentActionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="f410f025-074c-4659-9400-1be317ccaef6" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e60c5fd2-6497-4b97-929a-33546d7ba43a" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="f1d2448f-70a6-4cfb-8c0a-033ddb3d3ebf" name="referent" visibility="public" type="124e57c2-e7ac-4bbd-8ae3-b74186c4259c" isDerived="true" subsettedProperty="f214bf22-c5eb-4468-9610-e8c47f940ac5" association="f6af250c-3e8d-4623-acba-c66907ebd846">
+        <ownedComment xmi:id="0811aa2d-5719-4c4e-9c00-6f801a0ce35f" annotatedElement="f1d2448f-70a6-4cfb-8c0a-033ddb3d3ebf">
+          <body>&lt;p>The Feature whose value is to be set, derived as an unowned &lt;code>member&lt;/code> of the AssignmentActionUsage. It shall not be a FeatureChain. It is redefined by the &lt;em>&lt;code>target::accessedFeature&lt;/code>&lt;/em> of the AssignmentActionUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="0cf8eb46-0da8-4b9a-8805-70ec7db44665" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="16a47ab0-4b2c-4259-9ecf-2f5d967285c8" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="f937e1da-9761-45bc-b357-f35371365192" name="JoinNode" visibility="public">
+      <ownedComment xmi:id="7ad83c0b-7121-46fc-97dd-4eeff5b8c947" annotatedElement="f937e1da-9761-45bc-b357-f35371365192">
+        <body>&lt;p>A JoinNode is a ControlNode that waits for the completion of all the predecessor Actions given by incoming Successions. All incoming Successions must have a source multiplicity of 1..1. A JoinNode may have at most one outgoing Succession.&lt;/p>
+
+&lt;p>A JoinNode must subset, directly or indirectly, the ActionUsage &lt;em>&lt;code>Action::joins&lt;/code>&lt;/em>, implying that it is typed by &lt;code>&lt;em>JoinAction&lt;/em>&lt;/code> from the Systems model library (or a subtype of it).&lt;/p>
+</body>
+      </ownedComment>
+      <ownedRule xmi:id="0005b207-e593-45b4-ae38-38c5ad9df4db" name="joinNodeOutgoingSuccession" visibility="public" constrainedElement="f937e1da-9761-45bc-b357-f35371365192">
+        <ownedComment xmi:id="f5952cef-d578-4521-9fd2-58b8f6662640" annotatedElement="0005b207-e593-45b4-ae38-38c5ad9df4db">
+          <body>A JoinNode may have at most one outgoing Succession Connector.</body>
+        </ownedComment>
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="ebfebd44-41be-43b8-a384-a2b616ebaaf4" name="" visibility="public">
+          <language>English</language>
+        </specification>
+      </ownedRule>
+      <generalization xmi:id="1b94856a-2975-4f80-b130-7deab873d55d" general="246598eb-82a6-4240-a4e1-763a706cc81e"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" name="UseCaseUsage" visibility="public">
+      <ownedComment xmi:id="9da80fff-4902-4478-bcc4-f339415608c9" annotatedElement="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980">
+        <body>&lt;p>A UseCaseUsage is a Usage of a UseCaseDefinition.&lt;/p>
+
+&lt;p>A UseCaseUsage must subset, directly or indirectly, either the base UseCaseUsage &lt;em>&lt;code>useCases&lt;/code>&lt;/em> from the Systems model library. If it is owned by a UseCaseDefinition or UseCaseUsage then it must subset the UseCaseUsage &lt;em>&lt;code>UseCase::subUseCases&lt;/code>&lt;/em>.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="c20c6b5f-5837-446c-ad8b-83ff27e95c27" general="6dc193b7-e6f9-4cfe-96e2-3051ee5195c9"/>
+      <ownedAttribute xmi:id="1ffcdfeb-82ff-444d-bc66-aecdb6bcf9fb" name="useCaseDefinition" visibility="public" type="9659319e-4155-46f9-b712-b77bb6b67b02" isDerived="true" redefinedProperty="71c31818-03f0-478b-b70c-b2b99a975562" association="e3df464c-1ac2-45b5-beac-d9a1d7494706">
+        <ownedComment xmi:id="3a32ca67-e113-4750-acff-31a784407aba" annotatedElement="1ffcdfeb-82ff-444d-bc66-aecdb6bcf9fb">
+          <body>&lt;p>The UseCaseDefinition that is the type of this UseCaseUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c614106c-3996-4f41-9532-f7241b167ea5" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="83215c77-b340-4eed-8712-10a8df3c11ec" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="78a7d44f-701e-45fe-b648-a6e72b5091a7" name="includedUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isOrdered="true" isDerived="true" association="5bddad83-984f-405f-893a-cd2442f5ceac">
+        <ownedComment xmi:id="f7a4714c-55fc-450d-99e2-ec5873d86d2f" annotatedElement="78a7d44f-701e-45fe-b648-a6e72b5091a7">
+          <body>&lt;p>The UseCaseUsages that are included by this UseCaseUsage. Derived as the &lt;code>includedUseCase&lt;/code> of the IncludeUseCaseUsages owned by this UseCaseUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="b3ccdc4b-6e38-4d88-afd8-37e1556a5069" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="e6b6aeb5-437f-4f11-b9aa-f7ce29833873" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e3df464c-1ac2-45b5-beac-d9a1d7494706" name="" visibility="public" memberEnd="1ffcdfeb-82ff-444d-bc66-aecdb6bcf9fb 0e132101-9244-47e6-9bb0-34be84d61e15">
+      <ownedEnd xmi:id="0e132101-9244-47e6-9bb0-34be84d61e15" name="definedUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isDerived="true" subsettedProperty="68ef8977-70e3-45c6-b3d6-88ce8e43d10a" association="e3df464c-1ac2-45b5-beac-d9a1d7494706">
+        <ownedComment xmi:id="14cf9fa9-153a-4c93-92fb-0f2e46f55c1a" annotatedElement="0e132101-9244-47e6-9bb0-34be84d61e15">
+          <body>&lt;p>The UseCaseUsages being typed by a certain UseCaseDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="2cbfc522-0c5b-4579-b40d-c49441bdd440" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="f7b8a2bc-0c63-4388-8f43-5ace88532491" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="9659319e-4155-46f9-b712-b77bb6b67b02" name="UseCaseDefinition" visibility="public">
+      <ownedComment xmi:id="c4ee45c6-8e23-4c8e-9d3b-4585200147d0" annotatedElement="9659319e-4155-46f9-b712-b77bb6b67b02">
+        <body>&lt;p>A UseCaseDefinition is a CaseDefinition that specifies a set of actions performed by its subject, in interaction with one or more actors external to the subject. The objective is to yield an observable result that is of value for one or more of the actors.&lt;/p>
+
+&lt;p>A UseCaseDefinition must subclass, directly or indirectly, the base UseCaseDefinition &lt;em>UseCase&lt;/em> from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="36beecd8-58ea-41e9-b185-fa10e2ff1296" general="20e23891-303c-400f-909a-032f49ef946d"/>
+      <ownedAttribute xmi:id="53d2889e-bfd9-4efa-a9d5-c3ce325f95bf" name="includedUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isOrdered="true" isDerived="true" association="e8252ede-5346-4c0c-b550-758d704054e7">
+        <ownedComment xmi:id="f030bd2c-b3bc-462c-9992-5e6e60908122" annotatedElement="53d2889e-bfd9-4efa-a9d5-c3ce325f95bf">
+          <body>&lt;p>The UseCaseUsages that are included by this UseCaseDefinition. Derived as the &lt;code>includedUseCase&lt;/code> of the IncludeUseCaseUsages owned by this UseCaseDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="53cc1c05-3a18-47fa-84d3-872617fa7871" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="69838529-3556-4e10-995e-bcff16344b50" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="6cfa119a-9303-4a93-af9a-4e98df0534eb" name="IncludeUseCaseUsage" visibility="public">
+      <ownedComment xmi:id="a7885cdf-734c-4ff6-b104-3b1b12b15d61" annotatedElement="6cfa119a-9303-4a93-af9a-4e98df0534eb">
+        <body>&lt;p>An IncludeUseCaseUsage is a UseCaseUsage that represents the inclusion of a UseCaseUsage by a UseCaseDefinition or UseCaseUsage. Unless it is the IncludeUseCaseUsage itself, the UseCaseUsage to be included is related to the &lt;code>includedUseCase&lt;/code> by a ReferenceSubsetting Relationship. An IncludeUseCaseUsage is also a PerformActionUsage, with its &lt;code>includedUseCase&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>
+
+&lt;p>If the IncludeUseCaseUsage is owned by a UseCaseDefinition or UseCaseUsage, then it also subsets the UseCaseUsage &lt;em>&lt;code>UseCase::includedUseCases&lt;/code>&lt;/em> from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="e7271071-c3eb-4605-abf0-b1d2af632bdb" general="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980"/>
+      <generalization xmi:id="35fcf0e9-fc0a-4237-99ef-a1c9d40e72df" general="0b38b835-cf24-4e57-8181-eb89afa4f4c4"/>
+      <ownedAttribute xmi:id="f61a4f5d-0ff2-40b3-a33e-2b9116c30b85" name="useCaseIncluded" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isDerived="true" redefinedProperty="a5fa4b84-c430-4318-bb02-174edd37e882" association="5dec02ea-52ee-4ce8-ac50-cb8067500b1b">
+        <ownedComment xmi:id="5e58b72f-92e8-463b-a486-909b6221e0d2" annotatedElement="f61a4f5d-0ff2-40b3-a33e-2b9116c30b85">
+          <body>&lt;p>The UseCaseUsage to be included by this IncludeUseCaseUsage. It is the &lt;code>subsettedFeature&lt;/code> of the first owned Subsetting Relationship of the IncludeUseCaseUsage.&lt;/p> 
+</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="29de31fd-4775-49b7-a5a0-1338f4314a16" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="6b8e1d2f-392a-46e9-8461-2dbe4384e316" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5dec02ea-52ee-4ce8-ac50-cb8067500b1b" name="" visibility="public" memberEnd="f61a4f5d-0ff2-40b3-a33e-2b9116c30b85 51369a28-902e-4dd8-a7ae-5778ec4f157e">
+      <ownedEnd xmi:id="51369a28-902e-4dd8-a7ae-5778ec4f157e" name="useCaseInclusion" visibility="public" type="6cfa119a-9303-4a93-af9a-4e98df0534eb" isDerived="true" subsettedProperty="64bfffb5-01e9-4a92-af43-0f13349797b1" association="5dec02ea-52ee-4ce8-ac50-cb8067500b1b">
+        <ownedComment xmi:id="a7066f90-026e-4dae-8716-2a5337b30582" annotatedElement="51369a28-902e-4dd8-a7ae-5778ec4f157e">
+          <body>&lt;p>The IncludeUseCaseUsages that have a certain UseCaseUsage as their &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="6b6e9dd7-9eef-4ef2-801c-57aac2fa0084" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="0c275708-cfd8-4651-bbb5-f44cad1b9d01" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e8252ede-5346-4c0c-b550-758d704054e7" name="" visibility="public" memberEnd="53d2889e-bfd9-4efa-a9d5-c3ce325f95bf 0b14cb08-aa48-4640-920b-5c846669925d">
+      <ownedEnd xmi:id="0b14cb08-aa48-4640-920b-5c846669925d" name="includingUseCaseDefinition" visibility="public" type="9659319e-4155-46f9-b712-b77bb6b67b02" isDerived="true" association="e8252ede-5346-4c0c-b550-758d704054e7">
+        <ownedComment xmi:id="5c01941b-4d1e-4284-b656-5e6dd905ec28" annotatedElement="0b14cb08-aa48-4640-920b-5c846669925d">
+          <body>&lt;p>The UseCaseDefinition that includes a certain &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="91c0fc65-9435-4def-9fb0-43acccd49d86" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c30bcae5-76f4-4b5a-8b73-d29402070b0d" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="5bddad83-984f-405f-893a-cd2442f5ceac" name="" visibility="public" memberEnd="78a7d44f-701e-45fe-b648-a6e72b5091a7 4484cc16-32cd-4fe7-aab2-9007cc500953">
+      <ownedEnd xmi:id="4484cc16-32cd-4fe7-aab2-9007cc500953" name="includingUseCase" visibility="public" type="3fc01c7e-9269-4bfe-8cb6-1a6bca5e2980" isDerived="true" association="5bddad83-984f-405f-893a-cd2442f5ceac">
+        <ownedComment xmi:id="a9a4d87b-e30b-4893-b120-9ae5f836de41" annotatedElement="4484cc16-32cd-4fe7-aab2-9007cc500953">
+          <body>&lt;p>The UseCaseUsage that includes a certain &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="5e1450a8-30e9-4664-b4fe-4014511eb55c" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="3366034b-bb37-4740-a847-48ad5f5365ca" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="33416908-d1f4-4cbb-9fa8-f6636037b605" name="" visibility="public" memberEnd="4aed6c73-8f7e-49eb-aecd-0fa76eaea65d 503da39c-004d-4c1a-9979-d709da7372a5">
+      <ownedEnd xmi:id="503da39c-004d-4c1a-9979-d709da7372a5" name="owningEnumerationDefinition" visibility="public" type="9531421d-37e4-469c-948a-c628dc13a50c" isDerived="true" subsettedProperty="03fc2af2-97d1-47b6-bec0-6fad113ce3e7" association="33416908-d1f4-4cbb-9fa8-f6636037b605">
+        <ownedComment xmi:id="731d8c87-96b5-4de7-b285-dbf9f67b1456" annotatedElement="503da39c-004d-4c1a-9979-d709da7372a5">
+          <body>&lt;p>The EnumerationDefinition that owns a certain &lt;code>enumeratedValue&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="751d8d94-2c47-4049-a0d5-0fabad5feb68" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="083b9307-1132-428f-9dce-a88e439bc513" name="" visibility="public" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="e98cc360-5cd9-4e4a-b8f5-c6efc2f50028" name="" visibility="public" memberEnd="ee40beb4-2dcb-4efc-bbda-13ad6cda4213 343f0240-2860-45f7-8cfd-59f18d6131de">
+      <ownedEnd xmi:id="343f0240-2860-45f7-8cfd-59f18d6131de" name="definedEnumeration" visibility="public" type="d870f716-2ca1-4e5e-99c1-32ad80927ceb" isDerived="true" subsettedProperty="4c0295f7-0b08-44ab-b5ab-22d823fae8e4" association="e98cc360-5cd9-4e4a-b8f5-c6efc2f50028">
+        <ownedComment xmi:id="ee4c5718-de20-483c-9563-24b5d7793149" annotatedElement="343f0240-2860-45f7-8cfd-59f18d6131de">
+          <body>&lt;p>The EnumerationUsages that are typed by a certain EnumerationDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="bca717d8-9e0e-4923-a9b1-4d83c9251685" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="76cfbd28-8264-4d2a-bbd2-3180d04b6833" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="9531421d-37e4-469c-948a-c628dc13a50c" name="EnumerationDefinition" visibility="public">
+      <ownedComment xmi:id="288f3b44-1177-4187-9ff6-510848071c17" annotatedElement="9531421d-37e4-469c-948a-c628dc13a50c">
+        <body>&lt;p>An EnumerationDefinition is an AttributeDefinition all of whose instances are given by an explicit list of &lt;code>enumeratedValues&lt;/code>.&lt;/p> 
+
+&lt;p>An EnumerationDefinition must subclass, directly or indirectly, the base EnumerationDefinition EnumerationValue from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="b82abf54-4c45-46ba-9df3-a9a2caa02d3c" general="fb0b0e03-353a-4661-aaad-e229afb2f5e8"/>
+      <ownedAttribute xmi:id="4aed6c73-8f7e-49eb-aecd-0fa76eaea65d" name="enumeratedValue" visibility="public" type="d870f716-2ca1-4e5e-99c1-32ad80927ceb" isOrdered="true" isDerived="true" redefinedProperty="a7ab48c4-002a-4667-adb1-6f686d79f5e3" association="33416908-d1f4-4cbb-9fa8-f6636037b605">
+        <ownedComment xmi:id="28f6a7b1-8f28-426f-9779-0674adad61b1" annotatedElement="4aed6c73-8f7e-49eb-aecd-0fa76eaea65d">
+          <body>&lt;p>A EnumerationUsage of this EnumerationDefinition with a fixed value, distinct from the value of all other &lt;code>enumerationValues&lt;/code>, which specifies one of the allowed instances of the EnumerationDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="32d72d02-626b-43f2-8569-cc78dca8b774" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="68c14942-6199-44ee-8e74-890a15e8fd7f" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:id="4d21f605-b503-4400-b7af-7fbd909cc99d" name="isVariation" visibility="public" redefinedProperty="8e24f413-fa0a-4a87-b76f-f9d7b22d1a97">
+        <ownedComment xmi:id="baf207fa-1192-4b74-a480-5febe6a066ef" annotatedElement="4d21f605-b503-4400-b7af-7fbd909cc99d">
+          <body>&lt;p>An EnumerationDefinition is considered semantically to be a variation whose allowed variants are its &lt;code>enumerationValues&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="807b54ef-ee06-4556-812d-863c2e172993" name="" visibility="public" value="true"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="d870f716-2ca1-4e5e-99c1-32ad80927ceb" name="EnumerationUsage" visibility="public">
+      <ownedComment xmi:id="5b0fa7b8-53e4-44c5-beef-564d6d8cd108" annotatedElement="d870f716-2ca1-4e5e-99c1-32ad80927ceb">
+        <body>&lt;p>An EnumerationUsage is an AttributeUsage whose &lt;code>attributeDefinition&lt;/code> is an EnumerationDefinition.&lt;/p>
+
+&lt;p>An EnumerationUsage must subset, directly or indirectly, the base EnumerationUsage &lt;code>enumerationValues&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="a0e2a5d7-d4c0-40d1-bec1-8c3b072d474e" general="23e8be75-009b-43b9-8e7a-f88c061ac220"/>
+      <ownedAttribute xmi:id="ee40beb4-2dcb-4efc-bbda-13ad6cda4213" name="enumerationDefinition" visibility="public" type="9531421d-37e4-469c-948a-c628dc13a50c" isDerived="true" redefinedProperty="0e5e08ee-b091-4594-bce0-e3cf0d351488" association="e98cc360-5cd9-4e4a-b8f5-c6efc2f50028">
+        <ownedComment xmi:id="754c35a6-a2a1-4b04-9e95-995d2ce834fd" annotatedElement="ee40beb4-2dcb-4efc-bbda-13ad6cda4213">
+          <body>&lt;p>The single EnumerationDefinition that is the type of this EnumerationUsage.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c24eca8d-41ab-4757-826e-68b0b7e5441e" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="a3ac4f00-6cff-454d-8115-52cb3159aab7" name="" visibility="public" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="178e1afa-696c-4936-a8d1-0abf9269b786" name="" visibility="public" memberEnd="1be104f6-ea79-4e21-8050-a4bbe6735b51 2a91fa23-f772-4460-bfd1-8b8c60104e71">
+      <ownedEnd xmi:id="2a91fa23-f772-4460-bfd1-8b8c60104e71" name="definedPart" visibility="public" type="8bedee11-2930-45cc-ae64-110be5d577c7" isDerived="true" subsettedProperty="739d9684-1083-4731-a7a9-08d898edd9d5" association="178e1afa-696c-4936-a8d1-0abf9269b786">
+        <ownedComment xmi:id="667e24f2-f24a-4608-99ad-b9158577427a" annotatedElement="2a91fa23-f772-4460-bfd1-8b8c60104e71">
+          <body>&lt;p>The PartUsages typed by a certain PartDefinition.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="c3499466-4deb-4373-831d-38d7d5e59bad" name="" visibility="public"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="c8f34d04-7ebc-41d9-9699-a75d23c4354a" name="" visibility="public" value="*"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="16faf4d7-4d1b-4383-baa9-86651cb24e32" name="PartDefinition" visibility="public">
+      <ownedComment xmi:id="ce56b582-c687-4a06-89ee-034ddb9fc757" annotatedElement="16faf4d7-4d1b-4383-baa9-86651cb24e32">
+        <body>&lt;p>A PartDefinition is a ItemDefinition of a Class of systems or parts of systems. Note that all parts may be considered items for certain purposes, but not all items are parts that can perform actions within a system.&lt;/p>
+
+&lt;/p>A PartDefinition must subclass, directly or indirectly, the base PartDefinition Part from the Systems model library.&lt;/p>
+</body>
+      </ownedComment>
+      <generalization xmi:id="01c99405-0c77-4033-bf66-27ddacaf2b09" general="e2828a60-dd7a-434a-a161-1245b70f44a2"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="8bedee11-2930-45cc-ae64-110be5d577c7" name="PartUsage" visibility="public">
+      <ownedComment xmi:id="4cfd5432-08c2-41df-bf41-a83f6589e6da" annotatedElement="8bedee11-2930-45cc-ae64-110be5d577c7">
+        <body>&lt;p>A PartUsage is a usage of a PartDefinition to represent a system or a part of a system. At least one of the types of the PartUsage must be a PartDefinition.&lt;/p>
+
+&lt;p>A PartUsage must subset, directly or indirectly, the base PartUsage &lt;code>parts&lt;/code> from the Systems model library.&lt;/p></body>
+      </ownedComment>
+      <generalization xmi:id="e5ab366b-7451-4c7d-a40d-d11a06d85c70" general="e8388855-f13a-4505-ac2e-b342de9f7c66"/>
+      <ownedAttribute xmi:id="1be104f6-ea79-4e21-8050-a4bbe6735b51" name="partDefinition" visibility="public" type="16faf4d7-4d1b-4383-baa9-86651cb24e32" isOrdered="true" isDerived="true" subsettedProperty="18ab486b-757f-4c4d-8569-01e9cf669e5f" association="178e1afa-696c-4936-a8d1-0abf9269b786">
+        <ownedComment xmi:id="fbba4def-4170-4fc6-afc1-0d2418c77cac" annotatedElement="1be104f6-ea79-4e21-8050-a4bbe6735b51">
+          <body>&lt;p>The &lt;code>itemDefinitions&lt;/code> of this PartUsage that are PartDefinitions.&lt;/p></body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="d58bbb10-cccf-44a5-9243-2757e167d95c" name="" visibility="public" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="2a2443bd-e0ef-4614-acd5-bddec1a50447" name="" visibility="public" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+  </packagedElement>
+</uml:Model>

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -217,8 +217,19 @@ public class ElementUtil {
 	// Metaclass
 	
 	public static Metaclass getMetaclassOf(Element element) {
+		Element context = element;
+		
+		// Use the annotated element of a MetadataFeature as the context, because, if it
+		// is a metaclass feature, it will not be contained in a resource.
+		if (element instanceof MetadataFeature) {
+			List<Element> annotatedElements = ((MetadataFeature)element).getAnnotatedElement();
+			if (!annotatedElements.isEmpty()) {
+				context = annotatedElements.get(0);
+			}
+		}
+		
 		String metaclassName = element.eClass().getName();
-		return (Metaclass)SysMLLibraryUtil.getLibraryType(element, 
+		return (Metaclass)SysMLLibraryUtil.getLibraryType(context, 
 				"KerML::Root::" + metaclassName,  "KerML::Core::" + metaclassName, "KerML::Kernel::" + metaclassName, 
 				"SysML::" + metaclassName);
 	}

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -40,9 +40,11 @@ import org.omg.sysml.lang.sysml.Annotation;
 import org.omg.sysml.lang.sysml.Comment;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Metaclass;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
 
 public class ElementUtil {
 	
@@ -147,25 +149,27 @@ public class ElementUtil {
 	}
 	
 	/**
-	 * Get all the MetadataFeatures relevant to this Element.
+	 * Get all the MetadataFeatures owned by this Element.
+	 * 
 	 */
 	public static List<MetadataFeature> getAllMetadataFeaturesOf(Element element) {
-		List<MetadataFeature> annotatingFeatures =  element.getOwnedAnnotation().stream().
+		// Get MetadataFeatures owned via Annotations.
+		List<MetadataFeature> metadataFeatures =  element.getOwnedAnnotation().stream().
 				map(Annotation::getAnnotatingElement).
 				filter(MetadataFeature.class::isInstance).
 				map(MetadataFeature.class::cast).
 				collect(Collectors.toList());
+		
+		// Include MetadataFeatures that are members of the Element if it is a Namespace.
 		if (element instanceof Namespace) {
-			/**
-			 * Include MetadataFeatures that are members of a Namespace.
-			 */
 			(((Namespace)element).getOwnedMember()).stream().
 				filter(MetadataFeature.class::isInstance).
 				map(MetadataFeature.class::cast).
 				filter(feature->feature.getAnnotatedElement().contains(element)).
-				forEach(annotatingFeatures::add);
-			}
-		return annotatingFeatures;
+				forEach(metadataFeatures::add);
+		}
+
+		return metadataFeatures;
 	}
 
 	public static String processCommentBody(String body) {
@@ -210,6 +214,19 @@ public class ElementUtil {
 		getElementAdapter(element).clearCaches();
 	}
 	
+	// Metaclass
+	
+	public static Metaclass getMetaclassOf(Element element) {
+		String metaclassName = element.eClass().getName();
+		return (Metaclass)SysMLLibraryUtil.getLibraryType(element, 
+				"KerML::Root::" + metaclassName,  "KerML::Core::" + metaclassName, "KerML::Kernel::" + metaclassName, 
+				"SysML::" + metaclassName);
+	}
+
+	public static Feature getMetaclassFeatureFor(Element element) {
+		return element == null? null: getElementAdapter(element).getMetaclassFeature();
+	}
+
 	// Transformation 
 	
 	public static void transformAll(ResourceSet resourceSet, boolean addImplicitElements) {

--- a/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
@@ -35,13 +35,11 @@ import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
-import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 import org.omg.sysml.lang.sysml.LiteralBoolean;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.ParameterMembership;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
-import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.TransitionFeatureKind;
 import org.omg.sysml.lang.sysml.TransitionFeatureMembership;
 import org.omg.sysml.lang.sysml.Type;
@@ -52,6 +50,12 @@ public class ExpressionUtil {
 	private ExpressionUtil() {
 	}
 
+	public static final String SELF_REFERENCE_FEATURE = "Base::Anything::self";
+	
+	public static Feature getSelfReferenceFeature(Element context) {
+		return (Feature)SysMLLibraryUtil.getLibraryType(context, SELF_REFERENCE_FEATURE);
+	}
+	
 	public static ExpressionAdapter getExpressionAdapter(Expression expression) {
 		return ((ExpressionAdapter)ElementUtil.getElementAdapter(expression));
 	}
@@ -97,7 +101,7 @@ public class ExpressionUtil {
 		} else {
 			List<Feature> metadataFeatures = new ArrayList<>(); 
 			metadataFeatures.addAll(ElementUtil.getAllMetadataFeaturesOf(element));
-			Feature metaclassFeature = getMetaclassFeatureFor(element);
+			Feature metaclassFeature = ElementUtil.getMetaclassFeatureFor(element);
 			if (metaclassFeature != null) {
 				metadataFeatures.add(metaclassFeature);
 			}
@@ -118,22 +122,18 @@ public class ExpressionUtil {
 		}
 	}
 	
+	/**
+	 * @deprecated Use {@link ElementUtil#getMetaclassFeatureFor(Element)} instead
+	 */
 	public static Feature getMetaclassFeatureFor(Element element) {
-		Type metaclass = getMetaclassOf(element);
-		if (metaclass == null) {
-			return null;
-		} else {
-			FeatureTyping typing = SysMLFactory.eINSTANCE.createFeatureTyping();
-			typing.setType(metaclass);
-			Feature metaclassFeature = SysMLFactory.eINSTANCE.createFeature();
-			metaclassFeature.getOwnedRelationship().add(typing);
-			return metaclassFeature;
-		}
+		return ElementUtil.getMetaclassFeatureFor(element);
 	}
 	
+	/**
+	 * @deprecated Use {@link ElementUtil#getMetaclassOf(Element)} instead
+	 */
 	public static Type getMetaclassOf(Element element) {
-		String metaclassName = element.eClass().getName();
-		return SysMLLibraryUtil.getLibraryType(element, "KerML::" + metaclassName, "SysML::" + metaclassName);
+		return ElementUtil.getMetaclassOf(element);
 	}
 	
 	public static InvocationExpression getInvocationExpressionFor(Expression argument) {
@@ -161,12 +161,6 @@ public class ExpressionUtil {
 
 	public static String[] getOperatorQualifiedNames(String op) {
 		return Stream.of(OperatorExpressionAdapter.LIBRARY_PACKAGE_NAMES).map(pack -> pack + "::'" + op + "'").toArray(String[]::new);
-	}
-	
-	public static final String SELF_REFERENCE_FEATURE = "Base::Anything::self";
-	
-	public static Feature getSelfReferenceFeature(Element context) {
-		return (Feature)SysMLLibraryUtil.getLibraryType(context, SELF_REFERENCE_FEATURE);
 	}
 	
 	public static Expression getResultExpressionOf(Type type) {

--- a/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ExpressionUtil.java
@@ -116,8 +116,7 @@ public class ExpressionUtil {
 			return true;
 		} else {
 			EList<Element> result = condition.evaluate(element);
-			return result == null || // If condition is ill-formed, ignore it.
-					result.size() == 1 && result.get(0) instanceof LiteralBoolean && 
+			return result != null && result.size() == 1 && result.get(0) instanceof LiteralBoolean && 
 					((LiteralBoolean)result.get(0)).isValue();
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -301,15 +301,22 @@ public class TypeUtil {
 		return membership;
 	}
 	
-	public static ParameterMembership addOwnedParameterTo(Type type, Expression value) {
+	private static <T extends FeatureMembership> T addBoundFeatureTo(Type type, Expression value, T membership) {
 		Feature feature = SysMLFactory.eINSTANCE.createFeature();
 		if (value != null) {
 			FeatureUtil.addFeatureValueTo(feature, value);
 		}
-		ParameterMembership membership = SysMLFactory.eINSTANCE.createParameterMembership();
 		membership.setOwnedMemberFeature(feature);
 		type.getOwnedRelationship().add(membership);
 		return membership;
+	}
+	
+	public static FeatureMembership addBoundFeatureTo(Type type, Expression value) {
+		return addBoundFeatureTo(type, value, SysMLFactory.eINSTANCE.createFeatureMembership());
+	}
+	
+	public static ParameterMembership addOwnedParameterTo(Type type, Expression value) {
+		return addBoundFeatureTo(type, value, SysMLFactory.eINSTANCE.createParameterMembership());
 	}
 	
 	// Implicit general types

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureReferenceExpressionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureReferenceExpressionImpl.java
@@ -31,8 +31,6 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 
-import org.omg.sysml.util.ExpressionUtil;
-
 /**
  * <!-- begin-user-doc --> An implementation of the model object '<em><b>Feature
  * Reference Expression</b></em>'. <!-- end-user-doc -->
@@ -88,10 +86,7 @@ public class FeatureReferenceExpressionImpl extends ExpressionImpl implements Fe
 	 * @generated
 	 */
 	public Feature basicGetReferent() {
-		Element referent = ExpressionUtil.getReferentFor(this);
-		return referent instanceof Feature? (Feature)referent:
-			   referent == null? ExpressionUtil.getSelfReferenceFeature(this):
-			   null;
+		return (Feature)REFERENT__ESETTING_DELEGATE.dynamicGet(this, null, 0, false, false);
 	}
 	
 	/**

--- a/org.omg.sysml/transforms/PrepareMetamodelPackages.qvto
+++ b/org.omg.sysml/transforms/PrepareMetamodelPackages.qvto
@@ -1,0 +1,68 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2022 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Ed Seidewitz
+ * 
+ *****************************************************************************/
+
+modeltype UML uses "http://www.eclipse.org/uml2/5.0.0/UML";
+
+transformation PrepareMetamodelPackages(in export: UML, out prepared: UML);
+
+main() {
+	var syntax := export.objects()[Package]![name = "1. Abstract Syntax"];
+	assert fatal (syntax <> null) with log ("Abstract Syntax not found.");
+	
+	var model = object Model { 
+		name := "sysml";
+		URI := "http://www.omg.org/spec/SysML/2.0";
+	};
+	syntax.ownedMember[Package].map Package(model);
+
+}
+
+mapping Package::Package(inout model: Model) {
+	log("Top-level package " + nameOf(self));
+	if self <> model then {
+		var package = object Package {
+			name := self.name;
+		};
+		model.packagedElement += package;
+		self.ownedMember[Package]->map Namespace(package);
+		package.packagedElement[Package]->destroy();
+	} endif;
+}
+
+mapping Package::Namespace(inout package: Package) 
+	when { self.name = null or not self.name.endsWith("TBD") } {
+	log("Package " + if self.namespace = null then "" else nameOf(self.namespace) + "::" endif + nameOf(self));
+	self.ownedMember[Package]->map Namespace(package);
+	if self <> package then {
+		package.packagedElement += self.packagedElement;
+	} endif;
+}
+
+query nameOf(element: NamedElement): String {
+	return 
+		if element = null then "<null>"
+		else if element.name = null or element.name = "" then "<empty>"
+		else element.name
+		endif endif
+}

--- a/org.omg.sysml/xtend-gen/org/omg/sysml/generation/.gitignore
+++ b/org.omg.sysml/xtend-gen/org/omg/sysml/generation/.gitignore
@@ -1,0 +1,4 @@
+/*.java
+/.MOF2KerMLText.*
+/.MOF2SysML.*
+/.MOF2SysMLText.*

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/KerML.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/KerML.kerml
@@ -1,93 +1,454 @@
 package KerML {
-	doc
-	/*
-	 * This package contains a reflective KerML model of the KerML abstract syntax.
-	 * 
-	 * NOTE: This model is currently incomplete. It includes all KerML abstract syntax metaclasses,
-	 * but none of their properties.
-	 */
+	private import ScalarValues::*;
+	import Kernel::*;
 	
-	metaclass Element;
-	metaclass Relationship :> Element;
+	package Root {
+		metaclass AnnotatingElement specializes Element {
+			feature annotation : Annotation[0..*];
+			derived feature annotatedElement : Element[1..*] redefines annotatedElement;
+		}		
+				
+		metaclass Annotation specializes Relationship {
+			feature annotatingElement : AnnotatingElement[1..1] redefines source;
+			feature annotatedElement : Element[1..1] redefines target, annotatedElement;
+			derived feature owningAnnotatedElement : Element[0..1] subsets annotatedElement, owningRelatedElement;
+		}		
+				
+		metaclass Comment specializes AnnotatingElement {
+			feature locale : String[0..1];
+			feature body : String[1..1];
+		}		
+				
+		metaclass Documentation specializes Comment {
+			derived feature documentedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		metaclass Element {
+			feature elementId : String[1..1];
+			feature aliasIds : String[0..*];
+			feature shortName : String[0..1];
+			feature name : String[0..1];
+			feature isImpliedIncluded : Boolean[1..1];
+			derived feature effectiveName : String[0..1];
+			derived feature qualifiedName : String[0..1];
+			
+			feature owningRelationship : Relationship[0..1];
+			composite feature ownedRelationship : Relationship[0..*];
+			derived feature owningMembership : OwningMembership[0..1] subsets owningRelationship;
+			derived feature owningNamespace : Namespace[0..1];
+			derived feature owner : Element[0..1];
+			derived feature ownedElement : Element[0..*];
+			derived feature documentation : Documentation[0..*] subsets ownedElement;
+			composite derived feature ownedAnnotation : Annotation[0..*] subsets ownedRelationship;
+			derived feature textualRepresentation : TextualRepresentation[0..*] subsets ownedElement;
+		}		
+				
+		metaclass Import specializes Relationship {
+			feature visibility : VisibilityKind[1..1];
+			feature importedMemberName : String[0..1];
+			feature isRecursive : Boolean[1..1];
+			feature isImportAll : Boolean[1..1];
+			
+			feature importedNamespace : Namespace[1..1] redefines target;
+			derived feature importOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Membership specializes Relationship {
+			feature memberShortName : String[0..1];
+			feature memberName : String[0..1];
+			feature visibility : VisibilityKind[1..1];
+			derived feature memberElementId : String[1..1];
+			
+			feature memberElement : Element[1..1] redefines target;
+			derived feature membershipOwningNamespace : Namespace[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Namespace specializes Element {
+			abstract derived feature membership : Membership[0..*];
+			composite derived feature ownedImport : Import[0..*] subsets ownedRelationship;
+			derived feature 'member' : Element[0..*];
+			derived feature ownedMember : Element[0..*] subsets 'member';
+			composite derived feature ownedMembership : Membership[0..*] subsets membership, ownedRelationship;
+			derived feature importedMembership : Membership[0..*] subsets membership;
+		}		
+				
+		metaclass OwningMembership specializes Membership {
+			derived feature ownedMemberElementId : String[1..1] redefines memberElementId;
+			derived feature ownedMemberShortName : String[0..1] redefines memberShortName;
+			derived feature ownedMemberName : String[0..1] redefines memberName;
+			
+			composite derived feature ownedMemberElement : Element[1..1] subsets ownedRelatedElement redefines memberElement;
+		}		
+				
+		metaclass Relationship specializes Element {
+			feature isImplied : Boolean[1..1];
+			
+			feature target : Element[0..*] subsets relatedElement;
+			feature source : Element[0..*] subsets relatedElement;
+			feature owningRelatedElement : Element[0..1] subsets relatedElement;
+			composite feature ownedRelatedElement : Element[0..*] subsets relatedElement;
+			derived feature relatedElement : Element[2..*];
+		}		
+				
+		metaclass TextualRepresentation specializes AnnotatingElement {
+			feature 'language' : String[1..1];
+			feature body : String[1..1];
+			
+			derived feature representedElement : Element[1..1] subsets owner redefines annotatedElement;
+		}		
+				
+		datatype VisibilityKind {
+			member feature 'private' : VisibilityKind[1];
+			member feature 'protected' : VisibilityKind[1];
+			member feature 'public' : VisibilityKind[1];
+		}
+				
+	}
 	
-	metaclass AnnotatingElement :> Element;
-	metaclass Annotation :> Relationship;
-	metaclass Comment :> AnnotatingElement;
-	metaclass Documentation :> Annotation;
-	metaclass TextualRepresentation :> AnnotatingElement;
+	package Core {
+		import Root::*;
+		
+		metaclass Classifier specializes Type {
+			composite derived feature ownedSubclassification : Subclassification[0..*] subsets ownedSpecialization;
+		}		
+				
+		metaclass Conjugation specializes Relationship {
+			feature originalType : Type[1..1] redefines target;
+			feature conjugatedType : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets conjugatedType, owningRelatedElement;
+		}		
+				
+		metaclass Differencing specializes Relationship {
+			feature differencingType : Type[1..1] redefines target;
+			derived feature typeDifferenced : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Disjoining specializes Relationship {
+			feature typeDisjoined : Type[1..1] redefines source;
+			feature disjoiningType : Type[1..1] redefines target;
+			derived feature owningType : Type[0..1] subsets typeDisjoined, owningRelatedElement;
+		}		
+				
+		metaclass EndFeatureMembership specializes FeatureMembership {
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Feature specializes Type {
+			feature isUnique : Boolean[1..1];
+			feature isOrdered : Boolean[1..1];
+			feature isComposite : Boolean[1..1];
+			feature isEnd : Boolean[1..1];
+			feature isDerived : Boolean[1..1];
+			feature isReadOnly : Boolean[1..1];
+			feature isPortion : Boolean[1..1];
+			feature direction : FeatureDirectionKind[0..1];
+			
+			derived feature owningType : Type[0..1] subsets owningNamespace, featuringType;
+			derived feature 'type' : Type[1..*];
+			composite derived feature ownedRedefinition : Redefinition[0..*] subsets ownedSubsetting;
+			composite derived feature ownedSubsetting : Subsetting[0..*] subsets ownedSpecialization;
+			derived feature owningFeatureMembership : FeatureMembership[0..1] subsets owningMembership;
+			derived feature endOwningType : Type[0..1] subsets owningType;
+			composite derived feature ownedTyping : FeatureTyping[0..*] subsets ownedSpecialization;
+			derived feature featuringType : Type[0..*];
+			composite derived feature ownedTypeFeaturing : TypeFeaturing[0..*] subsets ownedRelationship;
+			derived feature chainingFeature : Feature[0..*];
+			composite derived feature ownedFeatureInverting : FeatureInverting[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureChaining : FeatureChaining[0..*] subsets ownedRelationship;
+			composite derived feature ownedReferenceSubsetting : ReferenceSubsetting[0..1] subsets ownedSubsetting;
+		}		
+				
+		metaclass FeatureChaining specializes Relationship {
+			feature chainingFeature : Feature[1..1] redefines target;
+			derived feature featureChained : Feature[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		datatype FeatureDirectionKind {
+			member feature 'in' : FeatureDirectionKind[1];
+			member feature 'inout' : FeatureDirectionKind[1];
+			member feature 'out' : FeatureDirectionKind[1];
+		}
+				
+		metaclass FeatureInverting specializes Relationship {
+			feature featureInverted : Feature[1..1] redefines source;
+			feature invertingFeature : Feature[1..1] redefines target;
+			derived feature owningFeature : Feature[0..1] subsets owningRelatedElement, featureInverted;
+		}		
+				
+		metaclass FeatureMembership specializes OwningMembership, Featuring {
+			derived feature owningType : Type[1..1] redefines membershipOwningNamespace, 'type';
+			composite derived feature ownedMemberFeature : Feature[1..1] redefines ownedMemberElement, 'feature';
+		}		
+				
+		metaclass FeatureTyping specializes Specialization {
+			feature typedFeature : Feature[1..1] redefines specific;
+			feature 'type' : Type[1..1] redefines general;
+			derived feature owningFeature : Feature[0..1] subsets typedFeature redefines owningType;
+		}		
+				
+		abstract metaclass Featuring specializes Relationship {
+			feature 'type' : Type[1..1] subsets relatedElement;
+			feature 'feature' : Feature[1..1] subsets relatedElement;
+		}		
+				
+		metaclass Intersecting specializes Relationship {
+			feature intersectingType : Type[1..1] redefines target;
+			derived feature typeIntersected : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+		metaclass Multiplicity specializes Feature;		
+				
+		metaclass Redefinition specializes Subsetting {
+			feature redefiningFeature : Feature[1..1] redefines subsettingFeature;
+			feature redefinedFeature : Feature[1..1] redefines subsettedFeature;
+		}		
+				
+		metaclass Specialization specializes Relationship {
+			feature general : Type[1..1] redefines target;
+			feature specific : Type[1..1] redefines source;
+			derived feature owningType : Type[0..1] subsets specific, owningRelatedElement;
+		}		
+				
+		metaclass Subclassification specializes Specialization {
+			feature superclassifier : Classifier[1..1] redefines general;
+			feature 'subclassifier' : Classifier[1..1] redefines specific;
+			derived feature owningClassifier : Classifier[0..1] redefines owningType;
+		}		
+				
+		metaclass Subsetting specializes Specialization {
+			feature subsettedFeature : Feature[1..1] redefines general;
+			feature subsettingFeature : Feature[1..1] redefines specific;
+			derived feature owningFeature : Feature[1..1] subsets subsettingFeature redefines owningType;
+		}		
+				
+		metaclass Type specializes Namespace {
+			feature isAbstract : Boolean[1..1];
+			feature isSufficient : Boolean[1..1];
+			derived feature isConjugated : Boolean[1..1];
+			
+			composite derived feature ownedSpecialization : Specialization[0..*] subsets ownedRelationship;
+			composite derived feature ownedFeatureMembership : FeatureMembership[0..*] subsets ownedMembership, featureMembership;
+			derived feature 'feature' : Feature[0..*] subsets 'member';
+			derived feature ownedFeature : Feature[0..*] subsets ownedMember;
+			derived feature input : Feature[0..*] subsets directedFeature;
+			derived feature output : Feature[0..*] subsets directedFeature;
+			derived feature inheritedMembership : Membership[0..*] subsets membership;
+			derived feature endFeature : Feature[0..*] subsets 'feature';
+			derived feature ownedEndFeature : Feature[0..*] subsets endFeature, ownedFeature;
+			composite derived feature ownedConjugator : Conjugation[0..1] subsets ownedRelationship;
+			derived feature inheritedFeature : Feature[0..*] subsets 'feature';
+			derived feature 'multiplicity' : Multiplicity[0..1] subsets 'member';
+			derived feature unioningType : Type[0..*];
+			composite derived feature ownedIntersecting : Intersecting[0..*] subsets ownedRelationship;
+			derived feature intersectingType : Type[0..*];
+			composite derived feature ownedUnioning : Unioning[0..*] subsets ownedRelationship;
+			composite derived feature ownedDisjoining : Disjoining[0..*] subsets ownedRelationship;
+			derived feature featureMembership : FeatureMembership[0..*];
+			derived feature differencingType : Type[0..*];
+			composite derived feature ownedDifferencing : Differencing[0..*] subsets ownedRelationship;
+			derived feature directedFeature : Feature[0..*] subsets 'feature';
+		}		
+				
+		metaclass TypeFeaturing specializes Featuring {
+			feature featureOfType : Feature[1..1] redefines source, 'feature';
+			feature featuringType : Type[1..1] redefines target, 'type';
+			derived feature owningFeatureOfType : Feature[0..1] subsets featureOfType, owningRelatedElement;
+		}		
+				
+		metaclass Unioning specializes Relationship {
+			feature unioningType : Type[1..1] redefines target;
+			derived feature typeUnioned : Type[1..1] subsets owningRelatedElement redefines source;
+		}		
+				
+	}
 	
-	metaclass Import :> Relationship;
-	metaclass Membership :> Relationship;
-	metaclass Namespace :> Element;
-	
-	metaclass Type :> Namespace;
-	metaclass Multiplicity :> Feature;
-	metaclass FeatureMembership :> Membership, TypeFeaturing;
-	metaclass Specialization :> Relationship;
-	metaclass Conjugation :> Relationship;
-	metaclass Disjoining :> Relationship;
-	
-	metaclass Classifier :> Type;
-	metaclass Subclassification :> Specialization;
-	
-	metaclass Feature :> Type;
-	metaclass Subsetting :> Specialization;
-	metaclass Redefinition :> Subsetting;
-	metaclass FeatureTyping :> Specialization;
-	metaclass TypeFeaturing :> Relationship;
-	metaclass FeatureChaining :> Relationship;
-	metaclass EndFeatureMembersip :> FeatureMembership;
-	
-	metaclass Class :> Classifier;
-	metaclass DataType :> Classifier;
-	
-	metaclass Structure :> Class;
-	
-	metaclass Association :> Classifier, Relationship;
-	metaclass AssociationStructure :> Association, Structure;
-	
-	metaclass Connector :> Feature, Relationship;
-	metaclass BindingConnector :> Connector;
-	metaclass Succession :> Connector;
-	
-	metaclass Behavior :> Class;
-	metaclass Step :> Feature;
-	metaclass ParameterMembership :> FeatureMembership;
-	
-	metaclass Function :> Behavior;
-	metaclass Predicate :> Function;
-	metaclass Expression :> Step;
-	metaclass BooleanExpression :> Expression;
-	metaclass Invariant :> BooleanExpression;
-	metaclass ReturnParameterMembership :> ParameterMembership;
-	metaclass ResultExpressionMembership :> FeatureMembership;
-	
-	metaclass FeatureReferenceExpression :> Expression;
-	metaclass InvocationExpression :> Expression;
-	metaclass LiteralExpression :> Expression;
-	metaclass LiteralInteger :> LiteralExpression;
-	metaclass LiteralRational :> LiteralExpression;
-	metaclass LiteralBoolean :> LiteralExpression;
-	metaclass LiteralString :> LiteralExpression;
-	metaclass LiteralInfinity :> LiteralExpression;
-	metaclass NullExpression :> Expression;
-	metaclass OperatorExpression :> InvocationExpression;
-	metaclass FeatureChainExpression :> OperatorExpression;
-	metaclass CollectExpression :> OperatorExpression;
-	metaclass SelectExpression :> OperatorExpression;
-	
-	metaclass Interaction :> Behavior, Association;
-	metaclass ItemFlow :> Step, Connector;
-	metaclass SuccessionItemFlow :> ItemFlow, Succession;
-	
-	metaclass FeatureValue :> Membership;
-	
-	metaclass MultiplicityRange :> Multiplicity;
-	
-	metaclass Metaclass :> Structure;
-	metaclass MetadataFeature :> AnnotatingElement, Feature;
-	
-	metaclass Package :> Namespace;
-	metaclass ElementFilterMembership :> Membership;
-	
+	package Kernel {
+		import Core::*;
+		
+		metaclass Association specializes Classifier, Relationship {
+			derived feature relatedType : Type[2..*] redefines relatedElement;
+			derived feature sourceType : Type[0..1] subsets relatedType redefines source;
+			derived feature targetType : Type[1..*] subsets relatedType redefines target;
+			derived feature associationEnd : Feature[2..*] redefines endFeature;
+		}		
+				
+		metaclass AssociationStructure specializes Structure, Association;		
+				
+		metaclass Behavior specializes Class {
+			derived feature 'step' : Step[0..*] subsets 'feature';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass BindingConnector specializes Connector;		
+				
+		metaclass BooleanExpression specializes Expression {
+			derived feature 'predicate' : Predicate[1..1] redefines 'function';
+		}		
+				
+		metaclass Class specializes Classifier;		
+				
+		metaclass CollectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass Connector specializes Feature, Relationship {
+			feature isDirected : Boolean[1..1];
+			
+			derived feature relatedFeature : Feature[2..*] redefines relatedElement;
+			derived feature association : Association[1..*] redefines 'type';
+			derived feature connectorEnd : Feature[2..*] redefines endFeature;
+			derived feature sourceFeature : Feature[0..1] subsets relatedFeature redefines source;
+			derived feature targetFeature : Feature[1..*] subsets relatedFeature redefines target;
+		}		
+				
+		metaclass DataType specializes Classifier;		
+				
+		metaclass ElementFilterMembership specializes OwningMembership {
+			composite derived feature condition : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Expression specializes Step {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature 'function' : Function[1..1] redefines 'behavior';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass FeatureChainExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+			
+			derived feature targetFeature : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureReferenceExpression specializes Expression {
+			derived feature referent : Feature[1..1] subsets 'member';
+		}		
+				
+		metaclass FeatureValue specializes OwningMembership {
+			feature isInitial : Boolean[1..1];
+			feature isDefault : Boolean[1..1];
+			
+			derived feature featureWithValue : Feature[1..1] subsets membershipOwningNamespace;
+			composite derived feature value : Expression[1..1] redefines ownedMemberElement;
+		}		
+				
+		metaclass Function specializes Behavior {
+			derived feature isModelLevelEvaluable : Boolean[1..1];
+			
+			derived feature expression : Expression[0..*] subsets 'step';
+			derived feature result : Feature[1..1] subsets parameter, output;
+		}		
+				
+		metaclass Interaction specializes Behavior, Association;		
+				
+		metaclass Invariant specializes BooleanExpression {
+			feature isNegated : Boolean[1..1];
+		}		
+				
+		metaclass InvocationExpression specializes Expression {
+			derived feature argument : Expression[0..*] subsets ownedFeature;
+		}		
+				
+		metaclass ItemFeature specializes Feature;		
+				
+		metaclass ItemFlow specializes Connector, Step {
+			derived feature itemType : Classifier[0..*];
+			derived feature targetInputFeature : Feature[0..1];
+			derived feature sourceOutputFeature : Feature[0..1];
+			derived feature itemFlowEnd : ItemFlowEnd[2..*] redefines connectorEnd;
+			derived feature itemFeature : ItemFeature[0..1] subsets ownedFeature;
+			derived feature itemFlowFeature : ItemFlowFeature[2..*];
+			derived feature 'interaction' : Interaction[1..*] redefines association, 'behavior';
+		}		
+				
+		metaclass ItemFlowEnd specializes Feature;		
+				
+		metaclass ItemFlowFeature specializes Feature;		
+				
+		metaclass LiteralBoolean specializes LiteralExpression {
+			feature value : Boolean[1..1];
+		}		
+				
+		metaclass LiteralExpression specializes Expression;		
+				
+		metaclass LiteralInfinity specializes LiteralExpression;		
+				
+		metaclass LiteralInteger specializes LiteralExpression {
+			feature value : Integer[1..1];
+		}		
+				
+		metaclass LiteralRational specializes LiteralExpression {
+			feature value : Real[1..1];
+		}		
+				
+		metaclass LiteralString specializes LiteralExpression {
+			feature value : String[1..1];
+		}		
+				
+		metaclass Metaclass specializes Structure;		
+				
+		metaclass MetadataFeature specializes AnnotatingElement, Feature {
+			derived feature 'metaclass' : Metaclass[1..1] redefines 'type';
+		}		
+				
+		metaclass MultiplicityRange specializes Multiplicity {
+			derived feature lowerBound : Expression[0..1] subsets bound;
+			derived feature upperBound : Expression[1..1] subsets bound;
+			abstract derived feature bound : Expression[1..2] redefines ownedMember;
+		}		
+				
+		metaclass NullExpression specializes Expression;		
+				
+		metaclass OperatorExpression specializes InvocationExpression {
+			feature operator : String[1..1];
+			
+			composite derived feature operand : Expression[0..*];
+		}		
+				
+		metaclass Package specializes Namespace {
+			derived feature filterCondition : Expression[0..*] subsets ownedMember;
+		}		
+				
+		metaclass ParameterMembership specializes FeatureMembership {
+			composite derived feature ownedMemberParameter : Feature[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass Predicate specializes Function;		
+				
+		metaclass ReferenceSubsetting specializes Subsetting {
+			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
+			derived feature referencingFeature : Feature[1..1] redefines owningFeature, subsettingFeature;
+		}		
+				
+		metaclass ResultExpressionMembership specializes FeatureMembership {
+			composite derived feature ownedResultExpression : Expression[1..1] redefines ownedMemberFeature;
+		}		
+				
+		metaclass ReturnParameterMembership specializes ParameterMembership;		
+				
+		metaclass SelectExpression specializes OperatorExpression {
+			feature operator : String[1..1] redefines operator;
+		}		
+				
+		metaclass SourceEnd specializes Feature;		
+				
+		metaclass Step specializes Feature {
+			derived feature 'behavior' : Behavior[1..*] redefines 'type';
+			derived feature parameter : Feature[0..*] redefines directedFeature;
+		}		
+				
+		metaclass Structure specializes Class;		
+				
+		metaclass Succession specializes Connector {
+			derived feature transitionStep : Step[0..1] subsets ownedFeature;
+			derived feature triggerStep : Step[0..*];
+			derived feature effectStep : Step[0..*];
+			derived feature guardExpression : Expression[0..*];
+		}		
+				
+		metaclass SuccessionItemFlow specializes Succession, ItemFlow;		
+				
+		metaclass TargetEnd specializes Feature;		
+				
+	}
 }

--- a/sysml.library/Systems Library/SysML.sysml
+++ b/sysml.library/Systems Library/SysML.sysml
@@ -1,129 +1,530 @@
 package SysML {
-	doc
-	/*
-	 * This package contains a reflective SysML model of the SysML abstract syntax.
-	 * 
-	 * NOTE: This model is currently incomplete. It includes all SysML abstract syntax metaclasses,
-	 * but none of their properties.
-	 */
-
-	import KerML::*;
-
-	metadata def Dependency :> Relationship;
+	private import ScalarValues::*;
+	import KerML::Kernel::*;
 	
-	metadata def Definition :> Classifier;
-	metadata def Usage :> Feature;
-	metadata def ReferenceUsage :> Usage;
-	metadata def VariantMembership :> Membership;
-	
-	metadata def EnumerationDefinition :> AttributeDefinition;
-	metadata def EnumerationUsage :> AttributeUsage;
-	
-	metadata def AttributeDefinition :> Definition, DataType;
-	metadata def AttributeUsage :> Usage;
-	
-	metadata def OccurrenceDefinition :> Definition, Class;
-	metadata def OccurrenceUsage :> Usage;
-	metadata def LifeClass :> Class;
-	metadata def PortioningFeature :> Feature;
-	metadata def EventOccurrenceUsage :> OccurrenceUsage;
-	
-	metadata def ItemDefinition :> OccurrenceDefinition, Structure;
-	metadata def ItemUsage :> OccurrenceUsage;
-	
-	metadata def MetadataDefinition :> ItemDefinition, Metaclass;
-	metadata def MetadataUsage :> ItemDefinition, MetadataFeature;
-	
-	metadata def PartDefinition :> ItemDefinition;
-	metadata def PartUsage :> ItemUsage;
-	
-	metadata def PortDefinition :> OccurrenceDefinition, Structure;
-	metadata def ConjugatePortDefinition :> PortDefinition;
-	metadata def PortUsage :> OccurrenceUsage;
-	metadata def PortConjuation :> Conjugation;
-	metadata def ConjugatePortTyping :> FeatureTyping;
-	
-	metadata def ConnectionDefinition :> PartDefinition, AssociationStructure;
-	abstract metadata def ConnectorAsUsage :> Connector, Usage;
-	metadata def BindingConnectorAsUsage :> BindingConnector, ConnectorAsUsage;
-	metadata def SuccessionAsUsage :> Succession, ConnectorAsUsage;
-	metadata def ConnectionUsage :> PartUsage, ConnectorAsUsage;
-	metadata def FlowConnectionUsage :> ItemFlow, ConnectionUsage;
-	metadata def SuccessionFlowConnectionUsage :> SuccessionItemFlow, ConnectionUsage;
-	
-	metadata def InterfaceDefinition :> ConnectionDefinition;
-	metadata def InterfaceUsage :> ConnectionUsage;
-	
-	metadata def AllocationDefinition :> ConnectionDefinition;
-	metadata def AllocationUsage :> ConnectionUsage;
-	
-	metadata def ActionDefinition :> OccurrenceDefinition, Behavior;
-	metadata def ActionUsage :> OccurrenceUsage, Step;
-	metadata def PerformActionUsage :> EventOccurrenceUsage, ActionUsage;
-	metadata def SendActionUsage :> ActionUsage;
-	metadata def AcceptActionUsage :> ActionUsage;
-	metadata def ControlNode :> ActionUsage;
-	metadata def MergeNode :> ControlNode;
-	metadata def DecisionNode :> ControlNode;
-	metadata def ForkNode :> ControlNode;
-	metadata def JoinNode :> ControlNode;
-	metadata def AssignmentActionUsage :> ActionUsage;
-	metadata def IfActionUsage :> ActionUsage;
-	abstract metadata def LoopActionUsage :> ActionUsage;
-	metadata def WhileLoopActionUsage :> LoopActionUsage;
-	metadata def ForLoopActionUsage :> LoopActionUsage;
-	metadata def TriggerInvocationExpression :> InvocationExpression;
-	
-	metadata def StateDefinition :> ActionDefinition;
-	metadata def StateUsage :> ActionUsage;
-	metadata def ExhibitStateUsage :> PerformActionUsage, StateUsage;
-	metadata def TransitionUsage :> ActionUsage;
-	metadata def StateSubactionMembership :> FeatureMembership;
-	metadata def TransitionFeatureMembership :> FeatureMembership;
-	
-	metadata def CalculationDefinition :> ActionDefinition, Function;
-	metadata def CalculationUsage :> ActionUsage, Expression;
-	
-	metadata def ConstraintDefinition :> OccurrenceDefinition, Predicate;
-	metadata def ConstraintUsage :> OccurrenceUsage, BooleanExpression;
-	metadata def AssertConstraintUsage :> ConstraintUsage, Invariant;
-	
-	metadata def RequirementDefinition :> ConstraintDefinition;
-	metadata def RequirementUsage :> ConstraintUsage;
-	metadata def SatisfyRequirementUsage :> RequirementUsage, AssertConstraintUsage;
-	metadata def SubjectMembership :> FeatureMembership;
-	metadata def ActorMembership :> FeatureMembership;
-	metadata def StakeholderMembership :> FeatureMembership;
-	metadata def RequirementConstraintMembership :> FeatureMembership;
-	
-	metadata def ConcernDefinition :> RequirementDefinition;
-	metadata def ConcernUsage :> RequirementUsage;
-	metadata def FramedConcernMembership :> RequirementConstraintMembership;
-	
-	metadata def CaseDefinition :> CalculationDefinition;
-	metadata def CaseUsage :> CalculationUsage;
-	metadata def ObjectiveMembership :> FeatureMembership;
-	
-	metadata def AnalysisCaseDefinition :> CaseDefinition;
-	metadata def AnalysisCaseUsage :> CaseUsage;
-	
-	metadata def VerificationCaseDefinition :> CaseDefinition;
-	metadata def VerificationCaseUsage :> CaseUsage;
-	metadata def RequirementVerificationMembership :> FeatureMembership;
-	
-	metadata def UseCaseDefinition :> CaseDefinition;
-	metadata def UseCaseUsage :> CaseUsage;
-	metadata def IncludeUseCaseUsage :> PerformActionUsage, UseCaseUsage;
-	
-	metadata def ViewDefinition :> PartDefinition;
-	metadata def ViewUsage :> PartUsage;
-	metadata def Expose :> Import;
-	
-	metadata def ViewpointDefinition :> RequirementDefinition;
-	metadata def ViewpointUsage :> RequirementUsage;
-	
-	metadata def RenderingDefinition :> PartDefinition;
-	metadata def RenderingUsage :> PartUsage;
-	metadata def ViewRenderingMembership :> FeatureMembership;
+	metadata def AcceptActionUsage specializes ActionUsage {
+		derived ref item receiverArgument : Expression[1..1];
+		derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference;
+		derived ref item payloadArgument : Expression[0..1];
+	}		
+			
+	metadata def ActionDefinition specializes Behavior, OccurrenceDefinition {
+		derived ref item 'action' : ActionUsage[0..*] subsets step, usage;
+	}		
+			
+	metadata def ActionUsage specializes Step, OccurrenceUsage {
+		derived ref item actionDefinition : Behavior[1..*] redefines behavior, occurrenceDefinition;
+	}		
+			
+	metadata def ActorMembership specializes ParameterMembership {
+		derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def AllocationDefinition specializes ConnectionDefinition {
+		derived ref item 'allocation' : AllocationUsage[0..*] subsets usage;
+	}		
+			
+	metadata def AllocationUsage specializes ConnectionUsage {
+		derived ref item allocationDefinition : AllocationDefinition[1..*] redefines connectionDefinition;
+	}		
+			
+	metadata def AnalysisCaseDefinition specializes CaseDefinition {
+		derived ref item analysisAction : ActionUsage[0..*] subsets 'action';
+		derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature;
+	}		
+			
+	metadata def AnalysisCaseUsage specializes CaseUsage {
+		derived ref item analysisAction : ActionUsage[0..*] subsets feature;
+		derived ref item analysisCaseDefinition : AnalysisCaseDefinition[1..1] redefines caseDefinition;
+		derived ref item resultExpression : Expression[0..1] subsets ownedFeature;
+	}		
+			
+	metadata def AssertConstraintUsage specializes ConstraintUsage, Invariant {
+		derived ref item assertedConstraint : ConstraintUsage[1..1];
+	}		
+			
+	metadata def AssignmentActionUsage specializes ActionUsage {
+		derived ref item targetArgument : Expression[1..1];
+		derived ref item valueExpression : Expression[1..1];
+		derived ref item referent : Feature[1..1] subsets member;
+	}		
+			
+	metadata def AttributeDefinition specializes DataType, Definition;		
+			
+	metadata def AttributeUsage specializes Usage {
+		attribute isReference : Boolean[1..1] redefines isReference;
+		
+		derived ref item attributeDefinition : DataType[1..*] redefines definition;
+	}		
+			
+	metadata def BindingConnectorAsUsage specializes BindingConnector, ConnectorAsUsage;		
+			
+	metadata def CalculationDefinition specializes Function, ActionDefinition {
+		derived ref item calculation : CalculationUsage[0..*] subsets 'action', expression;
+	}		
+			
+	metadata def CalculationUsage specializes Expression, ActionUsage {
+		derived ref item calculationDefinition : Function[1..1] redefines function, actionDefinition;
+	}		
+			
+	metadata def CaseDefinition specializes CalculationDefinition {
+		derived ref item objectiveRequirement : RequirementUsage[0..1] subsets ownedRequirement;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, ownedUsage;
+		derived ref item actorParameter : PartUsage[0..*] subsets parameter, ownedPart;
+	}		
+			
+	metadata def CaseUsage specializes CalculationUsage {
+		derived ref item objectiveRequirement : RequirementUsage[0..1] subsets nestedRequirement;
+		derived ref item caseDefinition : CaseDefinition[1..1] redefines calculationDefinition;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, nestedUsage;
+		derived ref item actorParameter : PartUsage[0..*] subsets nestedPart, parameter;
+	}		
+			
+	metadata def ConcernDefinition specializes RequirementDefinition;		
+			
+	metadata def ConcernUsage specializes RequirementUsage {
+		derived ref item concernDefinition : ConcernDefinition[1..1] redefines requirementDefinition;
+	}		
+			
+	metadata def ConjugatedPortDefinition specializes PortDefinition {
+		derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace;
+		derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator;
+	}		
+			
+	metadata def ConjugatedPortTyping specializes FeatureTyping {
+		ref item portDefinition : PortDefinition[1..1] subsets target;
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type;
+	}		
+			
+	metadata def ConnectionDefinition specializes AssociationStructure, PartDefinition {
+		derived ref item connectionEnd : Usage[2..*] redefines associationEnd;
+	}		
+			
+	metadata def ConnectionUsage specializes ConnectorAsUsage, PartUsage {
+		derived ref item connectionDefinition : AssociationStructure[1..*] subsets itemDefinition redefines association;
+	}		
+			
+	abstract metadata def ConnectorAsUsage specializes Usage, Connector;		
+			
+	metadata def ConstraintDefinition specializes OccurrenceDefinition, Predicate;		
+			
+	metadata def ConstraintUsage specializes BooleanExpression, OccurrenceUsage {
+		derived ref item constraintDefinition : Predicate[1..1] redefines predicate;
+	}		
+			
+	abstract metadata def ControlNode specializes ActionUsage;		
+			
+	metadata def DecisionNode specializes ControlNode;		
+			
+	metadata def Definition specializes Classifier {
+		attribute isVariation : Boolean[1..1];
+		
+		derived ref item ownedUsage : Usage[0..*] subsets ownedFeature, usage;
+		derived ref item ownedPort : PortUsage[0..*] subsets ownedUsage;
+		derived ref item directedUsage : Usage[0..*] subsets usage, directedFeature;
+		derived ref item usage : Usage[0..*] subsets feature;
+		derived ref item ownedState : StateUsage[0..*] subsets ownedAction;
+		derived ref item ownedConstraint : ConstraintUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage;
+		derived ref item ownedRequirement : RequirementUsage[0..*] subsets ownedConstraint;
+		derived ref item ownedCalculation : CalculationUsage[0..*] subsets ownedAction;
+		derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
+		derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] subsets ownedCase;
+		derived ref item 'variant' : Usage[0..*] subsets ownedMember;
+		derived ref item ownedCase : CaseUsage[0..*] subsets ownedCalculation;
+		derived ref item ownedReference : ReferenceUsage[0..*] subsets ownedUsage;
+		derived ref item ownedAction : ActionUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedConnection : ConnectorAsUsage[0..*] subsets ownedPart;
+		derived ref item ownedItem : ItemUsage[0..*] subsets ownedOccurrence;
+		derived ref item ownedPart : PartUsage[0..*] subsets ownedItem;
+		derived ref item ownedInterface : InterfaceUsage[0..*] subsets ownedConnection;
+		derived ref item ownedAttribute : AttributeUsage[0..*] subsets ownedUsage;
+		derived ref item ownedView : ViewUsage[0..*] subsets ownedPart;
+		derived ref item ownedViewpoint : ViewpointUsage[0..*] subsets ownedRequirement;
+		derived ref item ownedRendering : RenderingUsage[0..*] subsets ownedPart;
+		derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] subsets ownedCase;
+		derived ref item ownedEnumeration : EnumerationUsage[0..*] subsets ownedAttribute;
+		derived ref item ownedAllocation : AllocationUsage[0..*] subsets ownedConnection;
+		derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement;
+		derived ref item ownedOccurrence : OccurrenceUsage[0..*] subsets ownedUsage;
+		derived ref item ownedUseCase : UseCaseUsage[0..*] subsets ownedCase;
+		derived ref item ownedFlow : FlowConnectionUsage[0..*] subsets ownedConnection;
+		derived ref item ownedMetadata : MetadataUsage[0..*] subsets ownedItem;
+	}		
+			
+	metadata def Dependency specializes Relationship {
+		ref item client : Element[1..*] redefines source;
+		ref item supplier : Element[1..*] redefines target;
+	}		
+			
+	metadata def EnumerationDefinition specializes AttributeDefinition {
+		attribute isVariation : Boolean[1..1] redefines isVariation;
+		
+		derived ref item enumeratedValue : EnumerationUsage[0..*] redefines 'variant';
+	}		
+			
+	metadata def EnumerationUsage specializes AttributeUsage {
+		derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition;
+	}		
+			
+	metadata def EventOccurrenceUsage specializes OccurrenceUsage {
+		derived ref item eventOccurrence : OccurrenceUsage[1..1];
+	}		
+			
+	metadata def ExhibitStateUsage specializes StateUsage, PerformActionUsage {
+		derived ref item exhibitedState : StateUsage[1..1] redefines performedAction;
+	}		
+			
+	metadata def Expose specializes Import {
+		attribute isImportAll : Boolean[1..1] redefines isImportAll;
+	}		
+			
+	metadata def FlowConnectionDefinition specializes Interaction, ActionDefinition, ConnectionDefinition;		
+			
+	metadata def FlowConnectionUsage specializes ConnectionUsage, ItemFlow, ActionUsage {
+		derived ref item flowConnectionDefinition : Interaction[1..*] redefines actionDefinition, interaction, connectionDefinition;
+	}		
+			
+	metadata def ForLoopActionUsage specializes LoopActionUsage {
+		derived ref item seqArgument : Expression[1..1];
+		derived ref item loopVariable : ReferenceUsage[1..1];
+	}		
+			
+	metadata def ForkNode specializes ControlNode;		
+			
+	metadata def FramedConcernMembership specializes RequirementConstraintMembership {
+		attribute kind : RequirementConstraintKind[1..1] redefines kind;
+		
+		derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint;
+		derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint;
+	}		
+			
+	metadata def IfActionUsage specializes ActionUsage {
+		derived ref item elseAction : ActionUsage[0..1];
+		derived ref item thenAction : ActionUsage[1..1];
+		derived ref item ifArgument : Expression[1..1];
+	}		
+			
+	metadata def IncludeUseCaseUsage specializes UseCaseUsage, PerformActionUsage {
+		derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction;
+	}		
+			
+	metadata def InterfaceDefinition specializes ConnectionDefinition {
+		derived ref item interfaceEnd : PortUsage[2..*] redefines connectionEnd;
+	}		
+			
+	metadata def InterfaceUsage specializes ConnectionUsage {
+		derived ref item interfaceDefinition : InterfaceDefinition[1..*] redefines connectionDefinition;
+	}		
+			
+	metadata def ItemDefinition specializes Structure, OccurrenceDefinition;		
+			
+	metadata def ItemUsage specializes OccurrenceUsage {
+		derived ref item itemDefinition : Structure[1..*] subsets occurrenceDefinition;
+	}		
+			
+	metadata def JoinNode specializes ControlNode;		
+			
+	metadata def LifeClass specializes Class;		
+			
+	abstract metadata def LoopActionUsage specializes ActionUsage {
+		derived ref item bodyAction : ActionUsage[1..1];
+	}		
+			
+	metadata def MergeNode specializes ControlNode;		
+			
+	metadata def MetadataDefinition specializes ItemDefinition, Metaclass;		
+			
+	metadata def MetadataUsage specializes ItemUsage, MetadataFeature {
+		derived ref item metadataDefinition : Metaclass[1..1] redefines itemDefinition, metaclass;
+	}		
+			
+	metadata def ObjectiveMembership specializes FeatureMembership {
+		derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def OccurrenceDefinition specializes Definition, Class {
+		attribute isIndividual : Boolean[1..1];
+		
+		derived ref item lifeClass : LifeClass[0..1] subsets ownedMember;
+	}		
+			
+	metadata def OccurrenceUsage specializes Usage {
+		attribute isIndividual : Boolean[1..1];
+		attribute portionKind : PortionKind[0..1];
+		
+		derived ref item occurrenceDefinition : Class[1..*] redefines definition;
+		derived ref item portioningFeature : PortioningFeature[0..1] subsets ownedFeature;
+		derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition;
+	}		
+			
+	metadata def PartDefinition specializes ItemDefinition;		
+			
+	metadata def PartUsage specializes ItemUsage {
+		derived ref item partDefinition : PartDefinition[1..*] subsets itemDefinition;
+	}		
+			
+	metadata def PerformActionUsage specializes ActionUsage, EventOccurrenceUsage {
+		derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence;
+	}		
+			
+	metadata def PortConjugation specializes Conjugation {
+		ref item originalPortDefinition : PortDefinition[1..1] redefines originalType;
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType;
+	}		
+			
+	metadata def PortDefinition specializes OccurrenceDefinition, Structure {
+		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember;
+	}		
+			
+	metadata def PortUsage specializes OccurrenceUsage {
+		derived ref item portDefinition : PortDefinition[1..*] redefines occurrenceDefinition;
+	}		
+			
+	enum def PortionKind {
+		enum 'timeslice';
+		enum 'snapshot';
+	}
+			
+	metadata def PortioningFeature specializes Feature {
+		derived attribute portionKind : PortionKind[1..1];
+	}		
+			
+	metadata def ReferenceUsage specializes Usage {
+		derived attribute isReference : Boolean[1..1] redefines isReference;
+	}		
+			
+	metadata def RenderingDefinition specializes PartDefinition {
+		derived ref item 'rendering' : RenderingUsage[0..*] subsets usage;
+	}		
+			
+	metadata def RenderingUsage specializes PartUsage {
+		derived ref item renderingDefinition : RenderingDefinition[1..1] redefines partDefinition;
+	}		
+			
+	enum def RequirementConstraintKind {
+		enum assumption;
+		enum 'requirement';
+	}
+			
+	metadata def RequirementConstraintMembership specializes FeatureMembership {
+		attribute kind : RequirementConstraintKind[1..1];
+		
+		derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature;
+		derived ref item referencedConstraint : ConstraintUsage[1..1];
+	}		
+			
+	metadata def RequirementDefinition specializes ConstraintDefinition {
+		attribute reqId : String[0..1] redefines shortName;
+		derived attribute text : String[0..*];
+		
+		derived ref item assumedConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item requiredConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, ownedUsage;
+		derived ref item framedConcern : ConcernUsage[0..*] subsets requiredConstraint;
+		derived ref item actorParameter : PartUsage[0..*] subsets ownedPart, parameter;
+		derived ref item stakeholderParameter : PartUsage[0..*] subsets ownedPart, parameter;
+	}		
+			
+	metadata def RequirementUsage specializes ConstraintUsage {
+		attribute reqId : String[0..1] redefines shortName;
+		derived attribute text : String[0..*];
+		
+		derived ref item requirementDefinition : RequirementDefinition[1..1] redefines constraintDefinition;
+		derived ref item requiredConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item assumedConstraint : ConstraintUsage[0..*] subsets ownedFeature;
+		derived ref item subjectParameter : Usage[1..1] subsets parameter, nestedUsage;
+		derived ref item framedConcern : ConcernUsage[0..*] subsets requiredConstraint;
+		derived ref item actorParameter : PartUsage[0..*] subsets nestedPart, parameter;
+		derived ref item stakeholderParameter : PartUsage[0..*] subsets nestedPart, parameter;
+	}		
+			
+	metadata def RequirementVerificationMembership specializes RequirementConstraintMembership {
+		attribute kind : RequirementConstraintKind[1..1] redefines kind;
+		
+		derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint;
+		derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint;
+	}		
+			
+	metadata def SatisfyRequirementUsage specializes RequirementUsage, AssertConstraintUsage {
+		derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint;
+		derived ref item satisfyingFeature : Feature[1..1];
+	}		
+			
+	metadata def SendActionUsage specializes ActionUsage {
+		derived ref item receiverArgument : Expression[1..1];
+		derived ref item payloadArgument : Expression[1..1];
+	}		
+			
+	metadata def StakeholderMembership specializes ParameterMembership {
+		derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def StateDefinition specializes ActionDefinition {
+		attribute isParallel : Boolean[1..1];
+		
+		derived ref item 'state' : StateUsage[0..*] subsets step;
+		derived ref item entryAction : ActionUsage[0..1];
+		derived ref item doAction : ActionUsage[0..1];
+		derived ref item exitAction : ActionUsage[0..1];
+	}		
+			
+	enum def StateSubactionKind {
+		enum 'entry';
+		enum 'do';
+		enum 'exit';
+	}
+			
+	metadata def StateSubactionMembership specializes FeatureMembership {
+		attribute kind : StateSubactionKind[1..1];
+		
+		derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def StateUsage specializes ActionUsage {
+		attribute isParallel : Boolean[1..1];
+		
+		derived ref item stateDefinition : Behavior[1..*] redefines actionDefinition;
+		derived ref item entryAction : ActionUsage[0..1];
+		derived ref item doAction : ActionUsage[0..1];
+		derived ref item exitAction : ActionUsage[0..1];
+	}		
+			
+	metadata def SubjectMembership specializes ParameterMembership {
+		derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter;
+	}		
+			
+	metadata def SuccessionAsUsage specializes ConnectorAsUsage, Succession;		
+			
+	metadata def SuccessionFlowConnectionUsage specializes SuccessionItemFlow, FlowConnectionUsage;		
+			
+	enum def TransitionFeatureKind {
+		enum trigger;
+		enum guard;
+		enum effect;
+	}
+			
+	metadata def TransitionFeatureMembership specializes FeatureMembership {
+		attribute kind : TransitionFeatureKind[1..1];
+		
+		derived item transitionFeature : Step[1..1] redefines ownedMemberFeature;
+	}		
+			
+	metadata def TransitionUsage specializes ActionUsage {
+		derived ref item source : ActionUsage[1..1];
+		derived ref item target : ActionUsage[1..1];
+		derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature;
+		derived ref item guardExpression : Expression[0..*] subsets ownedFeature;
+		derived ref item effectAction : ActionUsage[0..*] subsets feature;
+		derived ref item 'succession' : Succession[1..1] subsets ownedMember;
+	}		
+			
+	metadata def TriggerInvocationExpression specializes InvocationExpression {
+		attribute kind : TriggerKind[1..1];
+	}		
+			
+	enum def TriggerKind {
+		enum 'when';
+		enum 'at';
+		enum 'after';
+	}
+			
+	metadata def Usage specializes Feature {
+		attribute isVariation : Boolean[1..1];
+		derived attribute isReference : Boolean[1..1];
+		
+		derived ref item nestedUsage : Usage[0..*] subsets ownedFeature, usage;
+		derived ref item owningUsage : Usage[0..1] subsets owningType;
+		derived ref item owningDefinition : Definition[0..1] subsets owningType;
+		derived ref item nestedPort : PortUsage[0..*] subsets nestedUsage;
+		derived ref item nestedAction : ActionUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedState : StateUsage[0..*] subsets nestedAction;
+		derived ref item nestedConstraint : ConstraintUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage;
+		derived ref item nestedRequirement : RequirementUsage[0..*] subsets nestedConstraint;
+		derived ref item nestedCalculation : CalculationUsage[0..*] subsets nestedAction;
+		derived ref item directedUsage : Usage[0..*] subsets usage, directedFeature;
+		derived ref item nestedCase : CaseUsage[0..*] subsets nestedCalculation;
+		derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] subsets nestedCase;
+		derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
+		derived ref item usage : Usage[0..*] subsets feature;
+		derived ref item 'variant' : Usage[0..*] subsets ownedMember;
+		derived ref item nestedReference : ReferenceUsage[0..*] subsets nestedUsage;
+		derived ref item nestedConnection : ConnectorAsUsage[0..*] subsets nestedPart;
+		derived ref item nestedItem : ItemUsage[0..*] subsets nestedOccurrence;
+		derived ref item nestedPart : PartUsage[0..*] subsets nestedItem;
+		derived ref item nestedInterface : InterfaceUsage[0..*] subsets nestedConnection;
+		derived ref item nestedAttribute : AttributeUsage[0..*] subsets nestedUsage;
+		derived ref item nestedView : ViewUsage[0..*] subsets nestedPart;
+		derived ref item nestedViewpoint : ViewpointUsage[0..*] subsets nestedRequirement;
+		derived ref item nestedRendering : RenderingUsage[0..*] subsets nestedPart;
+		derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] subsets nestedCase;
+		derived ref item nestedEnumeration : EnumerationUsage[0..*] subsets nestedAttribute;
+		derived ref item nestedAllocation : AllocationUsage[0..*] subsets nestedConnection;
+		derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement;
+		derived ref item nestedOccurrence : OccurrenceUsage[0..*] subsets nestedUsage;
+		derived ref item definition : Classifier[1..*] redefines type;
+		derived ref item nestedUseCase : UseCaseUsage[0..*] subsets nestedCase;
+		derived ref item nestedFlow : FlowConnectionUsage[0..*] subsets nestedConnection;
+		derived ref item nestedMetadata : MetadataUsage[0..*] subsets nestedItem;
+	}		
+			
+	metadata def UseCaseDefinition specializes CaseDefinition {
+		derived ref item includedUseCase : UseCaseUsage[0..*];
+	}		
+			
+	metadata def UseCaseUsage specializes CaseUsage {
+		derived ref item useCaseDefinition : UseCaseDefinition[1..1] redefines caseDefinition;
+		derived ref item includedUseCase : UseCaseUsage[0..*];
+	}		
+			
+	metadata def VariantMembership specializes OwningMembership {
+		derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement;
+	}		
+			
+	metadata def VerificationCaseDefinition specializes CaseDefinition {
+		derived ref item verifiedRequirement : RequirementUsage[0..*];
+	}		
+			
+	metadata def VerificationCaseUsage specializes CaseUsage {
+		derived ref item verificationCaseDefinition : VerificationCaseDefinition[1..1] subsets caseDefinition;
+		derived ref item verifiedRequirement : RequirementUsage[0..*];
+	}		
+			
+	metadata def ViewDefinition specializes PartDefinition {
+		derived ref item 'view' : ViewUsage[0..*] subsets usage;
+		derived ref item satisfiedViewpoint : ViewpointUsage[0..*] subsets ownedUsage;
+		derived ref item viewRendering : RenderingUsage[0..1] subsets ownedUsage;
+		derived ref item viewCondition : Expression[0..*] subsets ownedMember;
+	}		
+			
+	metadata def ViewRenderingMembership specializes FeatureMembership {
+		derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature;
+		derived ref item referencedRendering : RenderingUsage[1..1];
+	}		
+			
+	metadata def ViewUsage specializes PartUsage {
+		derived ref item viewDefinition : ViewDefinition[1..1] redefines partDefinition;
+		derived ref item satisfiedViewpoint : ViewpointUsage[0..*] subsets nestedUsage;
+		derived ref item exposedNamespace : Namespace[0..*];
+		derived ref item viewRendering : RenderingUsage[0..1] subsets nestedUsage;
+		derived ref item viewCondition : Expression[0..*] subsets ownedMember;
+		derived ref item viewedElement : Element[0..*];
+	}		
+			
+	metadata def ViewpointDefinition specializes RequirementDefinition {
+		derived ref item viewpointStakeholder : PartUsage[0..*];
+	}		
+			
+	metadata def ViewpointUsage specializes RequirementUsage {
+		derived ref item viewpointDefinition : ViewpointDefinition[1..1] redefines requirementDefinition;
+		derived ref item viewpointStakeholder : PartUsage[0..*];
+	}		
+			
+	metadata def WhileLoopActionUsage specializes LoopActionUsage {
+		derived ref item whileArgument : Expression[1..1];
+		derived ref item untilArgument : Expression[0..1];
+	}		
+			
 	
 }

--- a/sysml.library/Systems Library/SysML.sysml
+++ b/sysml.library/Systems Library/SysML.sysml
@@ -92,7 +92,7 @@ package SysML {
 	}		
 			
 	metadata def ConjugatedPortTyping specializes FeatureTyping {
-		ref item portDefinition : PortDefinition[1..1] subsets target;
+//		ref item portDefinition : PortDefinition[1..1] subsets target;
 		derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type;
 	}		
 			


### PR DESCRIPTION
This pull request updates the reflective library models `KerML.kerml` in the Kernel Semantic Library and `SysML.kerml` in the Systems Library to include all metaclasses, enumerations and (navigable) properties from the abstract syntax models for KerML and SysML. These are generated using a model-to-text transformation implemented by Xtend programs added to the `org.omg.sysml` project in the package `org.omg.sysml.generation`. These programs use a special `SysML.uml` (in the package directory) that retains the top-level packaging from the abstract syntax (i.e., `Root`, `Core`, `Kernel` and `Systems`), which is created using a new QVT transform `PrepareMetamodelPackages`.

**Abstract Syntax Mapping**

The MOF abstract syntax model is mapped to KerML and SysML as follows.

1. The `KerML` model contains subpackages for `Root`, `Core` and `Kernel`, but all elements are also imported into the top-level package, so they can be referenced directly from the `KerML` namespace. The `SysML` model imports all elements from `KerML` and directly contains all elements mapped from the `Systems` package, without any subpackaging.
2. A metaclass from the MOF model is mapped into a **`metaclass`** (in KerML) or a **`metadata def`** (in SysML). 
    - The MOF metaclass name is mapped unchanged.
    - Generalizations of the MOF metaclass are mapped to owned specializations (e.g., **`specializes`**`OwningMembership, Featuring`)
    - All properties from the MOF metaclass are mapped to features of the corresponding KerML metaclass or SysML metadata definition (see below). All non-association-end properties are grouped before association-end properties.
3. A property from the MOF model is mapped into a **`feature`** (in KerML) or an **`attribute`** or **`item`** (in SysML, depending on whether the property type is a data type or a class). 
   - The following prefix keywords are used as appropriate:
      - **`abstract`** if the MOF property is a derived union
      - In KerML only, **`composite`** if the MOF property is composite.
      - **`readonly`** if the MOF property is read-only.
      - **`derived`** if the MOF property is derived.
      - In SysML only, **`ref`** if the MOF property is _not_ composite.
   - The MOF property name is mapped unchanged, but is surrounded in single quotes if it is the same as a keyword (e.g., `'type'` in KerML).
   - The MOF property type is mapped to an owned feature typing (e.g., `: Type`).
   - The MOF property multiplicity is mapped to an owned multiplicity range (e.g., `[0..*]`)
   - Subsetted properties from the MOF property are mapped to owned subsettings (e.g., **`subsets`**`annotatedElement, owningRelatedElement`).
   - Redefined properties from the MOF property are mapped to owned redefinitions (e.g., **`redefines`**`target, annotatedElement`).
   - If the MOF property is `annotatedElement`, then `annotatedElement` is added to the list of redefined properties for the mapping because, otherwise, there would be a conflict with the `annotatedElement` property inherited from `Metaobject`.
4. An enumeration from the MOF model is mapped into a **`datatype`** (in KerML) or an **`enum def`** (in SysML).
   - The MOF enumeration name is mapped unchanged.
   - Each enumeration literal from the MOF enumeration is mapped into a **`member feature`** (in KerML) or an **`enum`** (in SysML).
      - The MOF enumeration literal name is mapped unchanged, but is surrounded in single quotes if it is the same as a keyword (e.g., `'private'`).
      - In KerML only, the **`member feature`** is explicitly typed by the containing data type and has multiplicity `[1]`.

Note that associations are _not_ mapped from the MOF model and, hence, non-navigable association-owned end properties are not included in the reflective models.

**Note:** There is an inconsistency in the abstract syntax model for `ConjugatedPortTyping` in the `Systems` abstract syntax, which results in a validation error on the mapping of `ConjugatedPortTyping::portDefinition`. As a result, this feature is currently commented-out in `SysML.sysml`. This issue needs to be resolved in the 2022-09 baseline metamodel before it can be fixed in the reflective abstract syntax model. When the baseline is updated under ST6RI-597, this will be fixed in `SysML.sysml`.

**Reflection Implementation**

The implementation of reflection for model-level evaluable expressions has been updated as follows.

1. "Meta-casting" of a feature using **`as`** now returns a special metadata feature known as the "metaclass feature" for an element. This feature is typed by the appropriate metaclass from the reflective abstract syntax. It is generated on request and cached in the `ElementAdapter` for the element. 
**Note:** "Meta-casting" will be replaced with a more specific notation for metaclass access under ST6RI-597, and the implementation here will be further refined at that time.
2. References to reflective abstract syntax metaclass features can now be evaluated when the target is a metaclass feature. The evaluation is done by making a dynamic EMF call to get the value of the Ecore structural feature of the annotated element of the metaclass feature with the same name as the referenced feature.
3. The implementation of model-level evaluation has also been generally updated to, as much as possible, return an "unevaluated expression" as the result when an expression is not evaluable at some point, rather than returning null as before. For import filtering, unevaluable expressions are now treated as if they were "false", rather than being ignored as before.