### PR TITLE
ST6RI-608 Recursion can cause problems with expression evaluation

### DIFF
--- a/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
+++ b/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
@@ -88,9 +88,9 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 		for (Feature parameter: TypeUtil.getOwnedParametersOf(expression)) {
 			Feature newParameter = SysMLFactory.eINSTANCE.createFeature();
 			newParameter.setDirection(parameter.getDirection());
-			for (Redefinition redefinition: parameter.getOwnedRedefinition()) {
+			for (Feature redefinedFeature: FeatureUtil.getRedefinedFeaturesWithComputedOf(parameter, null)) {
 				Redefinition newRedefinition = SysMLFactory.eINSTANCE.createRedefinition();
-				newRedefinition.setRedefinedFeature(redefinition.getRedefinedFeature());
+				newRedefinition.setRedefinedFeature(redefinedFeature);
 				newParameter.getOwnedRelationship().add(newRedefinition);
 			}
 			

--- a/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
+++ b/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
@@ -102,7 +102,7 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 				if (values != null) {
 					// Set the value expression for the new parameter to an expression representing
 					// the evaluated result of the original value expression.
-					Expression evaluatedExpression = EvaluationUtil.expressionFor(values);
+					Expression evaluatedExpression = EvaluationUtil.expressionFor(values, expression);
 					if (evaluatedExpression != null) {
 						FeatureValue newFeatureValue = SysMLFactory.eINSTANCE.createFeatureValue();
 						newFeatureValue.setValue(evaluatedExpression);

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
@@ -226,4 +226,30 @@ public class ExpressionEvaluationTest extends SysMLInteractiveTest {
 		assertElement("LiteralInteger 17", instance.eval("p1.b(1,2,3)", "EvalTest6"));
 		assertElement("LiteralInteger 27", instance.eval("p2.b(1,2,3)", "EvalTest6"));
 	}
+	
+	// Tests recursive invocation and binding of feature references in invocation arguments.
+	public final String evalTest7 =
+			"package EvalTest7 {\n"
+			+ "	calc def Fact {\n"
+			+ "		in x;\n"
+			+ "		\n"
+			+ "		// 'x' in x-1 is evaluated in context of caller,\n"
+			+ "		// not in context of the invocation.\n"
+			+ "		if x <= 0? 1 else x * Fact(x = x - 1)\n"
+			+ "	}\n"
+			+ "	\n"
+			+ "	part test {\n"
+			+ "		attribute fact1 = Fact(1);\n"
+			+ "		attribute fact5 = Fact(5);\n"
+			+ "	}\n"
+			+ "}";
+	
+	@Test
+	public void testEvaluation7() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		process(instance, evalTest7);
+		assertElement("LiteralInteger 1", instance.eval("test.fact1", "EvalTest7"));
+		assertElement("LiteralInteger 120", instance.eval("test.fact5", "EvalTest7"));
+		assertElement("LiteralInteger 6", instance.eval("Fact(3)", "EvalTest7"));
+	}
 }


### PR DESCRIPTION
This PR fixes a bug in user-defined function evaluation as implemented in ST6RI-599 (PR #405). In particular, the problem will occur if a function recursively calls itself with a binding for a parameter that depends on the previous value of that parameter (for example `Fact(x - 1)` in the recursive definition of a factorial function). In this case, a reference to the parameter results in evaluation of the argument expression, which causes an infinite regress of access to the parameter.

This is a result of the evaluation algorithm (as previously implemented) not really fully instantiating invocations. The argument expressions of an invocation should be evaluated in the context of the caller of the invocation, and the evaluated result then being bound to the parameter for the invocation. This is implemented in this PR by creating an effective "instantiation" of the invocation with the proper parameter bindings, which is then used in the evulation target feature chain rather than the original invocation expression itself.

The instantiation of an invocation is itself an invocation expression, such that the instantiation has:

1. The same type as the original.
2. An owned parameter corresponding to each owned parameter of the original, with:
   - The same redefined features as the original parameter.
   - If the original parameter parameter has a feature value, then a feature value whose value expression is an expression representing the result of evaluating the original value expression. The new value expression will be either a literal expression, a feature reference expression or an invocation expression for list construction.