### PR TITLE
ST6RI-587: Documentation is redundantly rendered as comments (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/CompartmentEntry.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/CompartmentEntry.java
@@ -1,0 +1,200 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation, PlantUML Visualization
+ * Copyright (c) 2022 Mgnite Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Hisashi Miyashita, Mgnite Inc.
+ *
+ *****************************************************************************/
+
+package org.omg.sysml.plantuml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.omg.sysml.lang.sysml.AttributeUsage;
+import org.omg.sysml.lang.sysml.BindingConnector;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.EnumerationUsage;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureDirectionKind;
+import org.omg.sysml.lang.sysml.FlowConnectionUsage;
+import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.OwningMembership;
+import org.omg.sysml.lang.sysml.SuccessionFlowConnectionUsage;
+import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.lang.sysml.util.SysMLSwitch;
+
+class CompartmentEntry implements Comparable<CompartmentEntry> {
+    public final Feature f;
+    public final OwningMembership om;
+    public final String alias;
+    public final String prefix;
+    public final boolean isInherited;
+
+    public String getParameterPrefix() {
+        FeatureDirectionKind fdk = f.getDirection();
+        if (fdk == null) return "";
+        switch (fdk) {
+        case IN:
+            return "<b>in</b> ";
+        case OUT:
+            return "<b>out</b> ";
+        case INOUT:
+            return "<b>inout</b> ";
+        }
+        return null; // MUST NOT happen.
+    }
+
+    public boolean isParameter() {
+        return f.getDirection() != null;
+    }
+
+    private static class ToTitle extends SysMLSwitch<String> {
+        public String caseBindingConnector(BindingConnector bc) {
+            return "bindings";
+        }
+        public String caseFlowConnectionUsage(FlowConnectionUsage fcu) {
+            return "flows";
+        }
+        public String caseSuccessionFlowConnectionUsage(SuccessionFlowConnectionUsage sfcu) {
+            return "succession flows";
+        }
+    }
+    private static ToTitle toTitle = new ToTitle();
+
+    public String getTitle() {
+        if (isParameter()) {
+            return "parameters";
+        }
+        String s = toTitle.doSwitch(f);
+        if (s != null) return s;
+        s = SysML2PlantUMLText.getStereotypeName(f);
+        if (s.endsWith("s")) {
+            return s + "es";
+        } else {
+            return s + "s";
+        }
+    }
+
+    private static int featureParameterCompare(Feature f1, Feature f2) {
+        FeatureDirectionKind fdk1 = f1.getDirection();
+        FeatureDirectionKind fdk2 = f2.getDirection();
+        if (fdk1 == null) {
+            if (fdk2 == null) return 0;
+            return 1;
+        }
+        if (fdk2 == null) return -1;
+        if (fdk1.ordinal() < fdk2.ordinal()) return -1;
+        if (fdk1.ordinal() > fdk2.ordinal()) return 1;
+        return 0;
+    }
+
+    private static int featureMetaclassCompare(Feature f1, Feature f2) {
+        if (f1 instanceof AttributeUsage) {
+            if (!(f2 instanceof AttributeUsage)) {
+                return -1;
+            }
+        } else if (f2 instanceof AttributeUsage) {
+            return 1;
+        } else if (f1 instanceof Usage) {
+            if (!(f2 instanceof Usage)) {
+                return -1;
+            }
+        } else if (f2 instanceof Usage) {
+            return 1;
+        }
+            
+        String ec1 = f1.eClass().getName();
+        String ec2 = f2.eClass().getName();
+        return ec1.compareTo(ec2);
+    }
+
+    /*
+      private static int featureTypeCompare(Feature f1, Feature f2) {
+      List<Type> ts1 = f1.getType();
+      List<Type> ts2 = f2.getType();
+      }
+    */
+
+    private static int featureNameCompare(Feature f1, Feature f2) {
+        String name1 = f1.getName();
+        String name2 = f2.getName();
+        if (name1 == null) {
+            if (name2 == null) return 0;
+            return -1;
+        }
+        if (name2 == null) return 1;
+        return name1.compareTo(name2);
+    }
+
+    private static int featureCompare(Feature f1, Feature f2) {
+        int v = featureParameterCompare(f1, f2);
+        if (v != 0) return v;
+        v = featureMetaclassCompare(f1, f2);
+        if (v != 0) return v;
+        // The order or EnumerationUsage needs to be stable.
+        if (f1 instanceof EnumerationUsage) return 0;
+        return featureNameCompare(f1, f2);
+    }
+
+    public int compareTo(CompartmentEntry o) {
+        int v = featureCompare(f, o.f);
+        if (v != 0) return v;
+        if (alias == null) {
+            if (o.alias == null) return 0;
+            return -1;
+        }
+        if (o.alias == null) return 1;
+        return alias.compareTo(o.alias);
+    }
+
+    public List<CompartmentEntry> children;
+    public void add(CompartmentEntry fe) {
+        if (children == null) {
+            children = new ArrayList<CompartmentEntry>();
+        }
+        children.add(fe);
+    }
+
+    private CompartmentEntry(Feature f, OwningMembership om, String alias, String prefix, boolean isInherited) {
+        this.f = f;
+        this.om = om;
+        this.alias = alias;
+        this.prefix = prefix;
+        this.isInherited = isInherited;
+        this.children = null;
+    }
+
+    public static CompartmentEntry feature(OwningMembership om, String prefix, boolean isInherited) {
+        Element e = om.getOwnedMemberElement();
+        if (!(e instanceof Feature)) return null;
+        return new CompartmentEntry((Feature)e, om, null, prefix, isInherited);
+    }
+        
+    public static CompartmentEntry alias(Membership ms, boolean isInherited) {
+        Element e = ms.getMemberElement();
+        if (!(e instanceof Feature)) return null;
+        return new CompartmentEntry((Feature) e, null, ms.getMemberName(), null, isInherited);
+    }
+
+    public static CompartmentEntry feature(Feature f, boolean isInherited) {
+        return new CompartmentEntry(f, null, null, null, isInherited);
+    }
+
+}

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/CompartmentEntry.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/CompartmentEntry.java
@@ -33,6 +33,7 @@ import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.EnumerationUsage;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureDirectionKind;
+import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.FlowConnectionUsage;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.OwningMembership;
@@ -79,6 +80,9 @@ class CompartmentEntry implements Comparable<CompartmentEntry> {
     private static ToTitle toTitle = new ToTitle();
 
     public String getTitle() {
+        if (om instanceof FeatureValue) {
+            return "values";
+        }
         if (isParameter()) {
             return "parameters";
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -550,10 +550,21 @@ public class VCompartment extends VStructure {
 
     private void addDocumentations() {
     	if (documentations == null) return;
+
+        boolean single = documentations.size() == 1;
     	/* PlantUML needs to be updated to support centering.  */
         append("==== //    documentation  //\n");
         for (Documentation doc: documentations) {
-            append("* ");
+            String name = doc.getName();
+            if (name != null && !name.isEmpty()) {
+                append("\"\"");
+                appendText(name, true);
+                append("\"\": ");
+            } else {
+                if (!single) {
+                    append("* ");
+                }
+            }
             appendText(doc.getBody(), true);
             append('\n');
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -552,8 +552,10 @@ public class VCompartment extends VStructure {
     	if (documentations == null) return;
 
         boolean flag = false;
-    	/* PlantUML needs to be updated to support centering.  */
-        append("==== //    documentation  //\n");
+    	/* PlantUML needs to be updated to support centering.
+         * Before that, we do not add a title to documentation compartment.
+         * append("==== //    documentation  //\n");
+         */ 
         for (Documentation doc: documentations) {
             String name = doc.getName();
             if (name != null && !name.isEmpty()) {
@@ -566,7 +568,10 @@ public class VCompartment extends VStructure {
             } else {
                 flag = true;
             }
-            appendText(doc.getBody(), false);
+            String body = doc.getBody();
+            if (body != null) {
+                appendText(body.trim(), false);
+            }
             append('\n');
         }
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -551,7 +551,7 @@ public class VCompartment extends VStructure {
     private void addDocumentations() {
     	if (documentations == null) return;
 
-        boolean single = documentations.size() == 1;
+        boolean flag = false;
     	/* PlantUML needs to be updated to support centering.  */
         append("==== //    documentation  //\n");
         for (Documentation doc: documentations) {
@@ -560,12 +560,13 @@ public class VCompartment extends VStructure {
                 append("\"\"");
                 appendText(name, true);
                 append("\"\": ");
-            } else {
-                if (!single) {
-                    append("* ");
-                }
             }
-            appendText(doc.getBody(), true);
+            if (flag) {
+                append(".. ..\n");
+            } else {
+                flag = true;
+            }
+            appendText(doc.getBody(), false);
             append('\n');
         }
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -39,6 +39,7 @@ import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.Definition;
+import org.omg.sysml.lang.sysml.Documentation;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.EnumerationDefinition;
 import org.omg.sysml.lang.sysml.EnumerationUsage;
@@ -274,7 +275,10 @@ public class VCompartment extends VStructure {
     @Override
     public String caseOwningMembership(OwningMembership m) {
         Element e = m.getOwnedMemberElement();
-        rec(m, e, true);
+        if (e instanceof Documentation) {
+            return visitMembership(m);
+        }
+        rec(m, e, false);
         return "";
     }
 
@@ -346,9 +350,16 @@ public class VCompartment extends VStructure {
     private String addTitle(String prev, CompartmentEntry ce) {
         String title = ce.getTitle();
         if (title.equals(prev)) return prev;
-        append("-- ");
+
+        /* Still PlantUML fails the indentation and need to be updated.
+         * if (prev != null) {
+         *     append("____\n");
+         * }
+         * append("==== ");
+         */
+        append("--");
         append(title);
-        append(" --\n");
+        append("--\n");
         return title;
     }
 
@@ -480,6 +491,9 @@ public class VCompartment extends VStructure {
         Collections.sort(es);
         final int size = es.size();
         String title = null;
+        if (documentations != null) {
+            title = "";
+        }
         for (int i = 0; i < size; i++) {
             CompartmentEntry ce = es.get(i);
             if (level == 0) {
@@ -524,9 +538,31 @@ public class VCompartment extends VStructure {
         }
     }
 
+    private List<Documentation> documentations;
+    private boolean addDocumentation(Documentation doc) {
+        if (!currentType.equals(doc.getDocumentedElement())) return false;
+        if (documentations == null) {
+            documentations = new ArrayList<>(1);
+        }
+        documentations.add(doc);
+        return true;
+    }
+
+    private void addDocumentations() {
+    	if (documentations == null) return;
+    	/* PlantUML needs to be updated to support centering.  */
+        append("==== //    documentation  //\n");
+        for (Documentation doc: documentations) {
+            append("* ");
+            appendText(doc.getBody(), true);
+            append('\n');
+        }
+    }
+
     public void startType(Type typ) {
         this.currentType = typ;
         traverse(typ, false, true);
+        addDocumentations();
         addCompartmentEntries(compartmentEntries, 0);
         popNamespace();
     }
@@ -585,4 +621,11 @@ public class VCompartment extends VStructure {
         addEntry(fv, null);
         return "";
     }
+
+    @Override
+    public String caseDocumentation(Documentation doc) {
+        if (addDocumentation(doc)) return "";
+        return null;
+    }
+    
 }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.omg.sysml.lang.sysml.AnnotatingElement;
 import org.omg.sysml.lang.sysml.Annotation;
+import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.Comment;
 import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
@@ -239,6 +240,12 @@ public class VDefault extends VTraverser {
     public String caseImport(Import imp) {
         VImport v = new VImport(this);
         v.addImport(imp);
+        return "";
+    }
+
+    @Override
+    public String caseAssignmentActionUsage(AssignmentActionUsage aau) {
+        // TO be ignored.
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VRequirement.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VRequirement.java
@@ -75,8 +75,7 @@ public class VRequirement extends VCompartment {
             default:
                 return "";
             }
-            ConstraintUsage c = rcm.getOwnedConstraint();
-            addFeature(c, null, prefix, true);
+            addEntry(rcm, prefix);
         }
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VRequirement.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VRequirement.java
@@ -28,32 +28,9 @@ import java.util.List;
 
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.RequirementConstraintMembership;
-import org.omg.sysml.lang.sysml.RequirementDefinition;
-import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
 
 public class VRequirement extends VCompartment {
-
-    private void addReqText(List<String> ss) {
-        boolean added = false;
-        for (String text: ss) {        	
-            appendText(text, true);
-            append('\n');
-            added = true;
-        }
-        if (added) {
-            append("--\n");
-        }
-    }
-
-    private void addReqText(Type typ) {
-        if (typ instanceof RequirementUsage) {
-            addReqText(((RequirementUsage) typ).getText());
-        } else if (typ instanceof RequirementDefinition) {
-            addReqText(((RequirementDefinition) typ).getText());
-        }
-    }
-
     private boolean isAnonymousConstraint(RequirementConstraintMembership rcm) {
         ConstraintUsage c = rcm.getOwnedConstraint();
         return c.getName() == null;
@@ -82,7 +59,6 @@ public class VRequirement extends VCompartment {
 
     @Override
     public List<VTree> process(VTree parent, Type typ) {
-        addReqText(typ);
         return super.process(parent, typ);
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -27,7 +27,6 @@
 package org.omg.sysml.plantuml;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.ActorMembership;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -56,9 +56,9 @@ public abstract class VStructure extends VDefault {
         }
         text = text.trim();
         if (text.endsWith(";")) {
-        	append(text, 0, text.length() - 1);
+        	cQuote(text.substring(0, text.length() - 1));
         } else {
-        	append(text);
+        	cQuote(text);
         }
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -47,7 +47,8 @@ import org.omg.sysml.lang.sysml.StakeholderMembership;
 import org.omg.sysml.lang.sysml.Type;
 
 public abstract class VStructure extends VDefault {
-    protected void appendText(String text, boolean unfold) {
+    protected boolean appendText(String text, boolean unfold) {
+        if (text == null) return false;
         text = text.replace("\r", "");
         if (unfold) {
             text = text.replace("\n", "");
@@ -55,11 +56,13 @@ public abstract class VStructure extends VDefault {
             text = text.replace("\n", "\\n");
         }
         text = text.trim();
+        if (text.isEmpty()) return false;
         if (text.endsWith(";")) {
         	cQuote(text.substring(0, text.length() - 1));
         } else {
         	cQuote(text);
         }
+        return true;
     }
 
     protected String getEvaluatedResults(Element elem) {
@@ -109,23 +112,30 @@ public abstract class VStructure extends VDefault {
         return true;
     }
 
-    private static Pattern patEq = Pattern.compile("^\\s*:?=");
+    protected boolean appendFeatureValue(FeatureValue fv) {
+        Expression ex = fv.getValue();
+        String text = getText(ex);
+        if (text != null) {
+            append(' ');
+            if (fv.isDefault()) {
+                append("<b> default </b>");
+            } else if (fv.isInitial()) {
+                text = ":= " + text; 
+            } else {
+                text = "= " + text; 
+            }
+            boolean flag = appendText(text, true);
+            return addEvaluatedResults(ex) || flag;
+        } else {
+            return addEvaluatedResults(ex);
+        }
+    }
+
     private boolean addFeatureMembershipText(Feature f) {
         boolean flag = false;
         for (Membership m: f.getOwnedMembership()) {
             if (m instanceof FeatureValue) {
-                FeatureValue fv = (FeatureValue) m;
-                String text = getText(fv);
-                if (text != null) {
-                    if (!patEq.matcher(text).lookingAt()) {
-                        append('=');
-                    }
-                    appendText(text, true);
-                    append("; ");
-                    flag = true;
-                }
-                Expression ex = fv.getValue();
-                flag = addEvaluatedResults(ex) || flag;
+                return appendFeatureValue((FeatureValue) m);
             } else if (m instanceof ResultExpressionMembership) {
                 ResultExpressionMembership rem = (ResultExpressionMembership) m;
                 Expression ex = rem.getOwnedResultExpression();

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -255,6 +255,20 @@ public abstract class Visitor extends SysMLSwitch<String> {
         append('"');
     }
 
+    private static final String creoleSpecials = "<'-_*/=#~";
+
+    protected void cQuote(String s) {
+        int len = s.length();
+        for (int i = 0; i < len; i++) {
+        	char ch = s.charAt(i);
+            if (creoleSpecials.indexOf(ch) >= 0) {
+                append(String.format("<U+%04X>", (int) ch));
+            } else {
+                append(ch);
+            }
+        }
+    }
+
     protected int addNameWithId(Element e, String name, boolean force) {
         quote(name);
         append(" as ");


### PR DESCRIPTION
Documentations in RequirementUsages were redundantly rendered in the form of comments as well as in compartments because they are a kind of comments so that the visualizer render them as comments as well.  By this fix, the visualizer render documents in compartments and if it's the case, it does not render them as comments.