### PR TITLE
ST6RI-604 Textual package ordering breaks derivation of owner properties

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/traversal/facade/impl/JsonElementProcessingFacade.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/traversal/facade/impl/JsonElementProcessingFacade.java
@@ -157,11 +157,10 @@ public class JsonElementProcessingFacade implements ElementProcessingFacade {
 	 * Create an Identified object containing the identifier of the given element.
 	 * 
 	 * @param 	element				the Element to be identified
-	 * @return	an Identified object the the given Element (or null if the input is null).
+	 * @return	an Identified object for the given Element (or null if the input is null).
 	 */
 	protected Identified getIdentified(Element element) {
-		Object identifier = this.traversal.getIdentifier(element);
-		return identifier instanceof UUID? identified((UUID)identifier): null;
+		return element == null? null: identified(UUID.fromString(element.getElementId()));
 	}
 	
 	/**


### PR DESCRIPTION
The reported bug happened when an import relationship to a package appeared in a model before the declaration of that package. The graph traversal utility traverses the model graph by following the owned relationships of elements, so, in this case, the package referenced in the import had not yet been processed when the import relationship was processed, and neither had the owning elements of the package. Unfortunately, for historical reasons, the traversal algorithm was only considering elements to have identifiers after they had been processed, which means no IDs were yet available to set the `owner` (and other `owning...`) properties of the package, causing the bug.

This pull request updates  `JsonElementProcessingFacade::getIdentified` so that it uses the `elementId` of an Element, rather than looking up its identifier in the `traversal`. This means that the ID can be obtained before the Element is processed in the `traversal`, resolving the bug.