### PR TITLE
ST6RI-618: Show subjects as distinct nodes (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -476,7 +476,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseSubjectMembership(SubjectMembership sm) {
-            return " ..> ";
+            return " o-- ";
 		}
 
 		@Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
@@ -32,6 +32,7 @@ import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.RequirementUsage;
+import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Succession;
 import org.omg.sysml.lang.sysml.TransitionUsage;
 import org.omg.sysml.lang.sysml.Type;
@@ -93,6 +94,12 @@ public class VCase extends VTree {
             processSubtrees(vr, subtrees);
         }
         addSpecializations(id, ru);
+        return "";
+    }
+
+    @Override
+    public String caseSubjectMembership(SubjectMembership sm) {
+        addSubjectMembership(sm, true);
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
@@ -30,13 +30,11 @@ import java.util.List;
 import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Usage;
 
 public class VCaseMembers extends VBehavior {
     private List<VCase> queue = new ArrayList<>();
@@ -95,18 +93,14 @@ public class VCaseMembers extends VBehavior {
     }
 
     @Override
-    public String caseObjectiveMembership(ObjectiveMembership om) {
-        recMembership(om, true);
+    public String caseSubjectMembership(SubjectMembership sm) {
+        recMembership(sm, false);
         return "";
     }
 
     @Override
-    public String caseSubjectMembership(SubjectMembership sm) {
-        Usage u = sm.getOwnedSubjectParameter();
-        for (FeatureTyping ft: u.getOwnedTyping()) {
-            Type typ = ft.getType();
-            addPRelation(sm.getMembershipOwningNamespace(), typ, sm, "<<subject>>");
-        }
+    public String caseObjectiveMembership(ObjectiveMembership om) {
+        recMembership(om, true);
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -175,6 +175,14 @@ public class VDefault extends VTraverser {
         return null;
     }
 
+    protected Element resolveRelatedElement(Element tgt) {
+        if (tgt instanceof FeatureReferenceExpression) {
+            FeatureReferenceExpression fre = (FeatureReferenceExpression) tgt;
+            return fre.getReferent();
+        }
+        return tgt;
+    }
+
     @Override
     public String caseExpression(Expression e) {
         // Do not show Expression

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.omg.sysml.lang.sysml.AnnotatingElement;
 import org.omg.sysml.lang.sysml.Annotation;
 import org.omg.sysml.lang.sysml.AssignmentActionUsage;
+import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.Comment;
 import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
@@ -39,7 +40,9 @@ import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureChainExpression;
+import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
+import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.Import;
 import org.omg.sysml.lang.sysml.ItemFlow;
@@ -236,6 +239,31 @@ public class VDefault extends VTraverser {
         return "";
     }
 
+    protected static boolean isEmptyFeature(Feature f) {
+        for (FeatureMembership fm: f.getOwnedFeatureMembership()) {
+            if (fm.getOwnedMemberFeature() instanceof BindingConnector) continue;
+            return false;
+        }
+        return true;
+    }
+
+    protected Relationship findBindingLikeRel(Feature f) {
+        Relationship ret = null;
+        for (Relationship rel : f.getOwnedRelationship()) {
+            if (rel instanceof FeatureValue) {
+                // first priority
+                return rel;
+            } else if (rel instanceof Subsetting) {
+                // second priority
+                ret = rel;
+            } else if (rel instanceof FeatureTyping) {
+                if (ret != null) continue;
+                ret = rel;
+            }
+        }
+        return ret;
+    }
+
     @Override
     public String caseImport(Import imp) {
         VImport v = new VImport(this);
@@ -252,7 +280,7 @@ public class VDefault extends VTraverser {
     VDefault(Visitor v) {
         super(v);
     }
-    
+
     VDefault() {
     	super();
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -602,6 +602,7 @@ public class VPath extends VTraverser {
             if (g == null) continue;
             if (checkVisited(g)) continue;
             visit(g);
+            traverse(g);
             // visit(s); // Typically this will cause double traverse but checkVisit() stops it..
         }
         return null;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
@@ -44,6 +44,7 @@ public class VSSRMembers extends VStructure {
         return isRedefining(f, "StateSpaceRepresentation::StateSpaceDynamics::");
     }
 
+    @Override
     public String caseFeature(Feature f) {
         addType(f, "comp usage ");
         VCompartment vc = new VCompartment(this);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -90,6 +90,7 @@ public abstract class VTraverser extends Visitor {
                 setInherited(false);
                 Element e = ms.getMemberElement();
                 markRedefining(e, covered);
+                this.currentMembership = ms;
                 visit(ms);
                 for (Relationship r2: ms.getOwnedRelationship()) {
                     setInherited(false);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -36,9 +36,11 @@ import org.omg.sysml.lang.sysml.Multiplicity;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;
 import org.omg.sysml.lang.sysml.ReferenceUsage;
+import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.RequirementConstraintMembership;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
+import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.lang.sysml.VariantMembership;
@@ -129,6 +131,31 @@ public class VTree extends VStructure {
         RequirementUsage ru = om.getOwnedObjectiveRequirement();
         addRel(ru, om, "<<objective>>");
         addReq("comp usage ", ru);
+        return "";
+    }
+
+    protected boolean addSubjectMembership(SubjectMembership sm, boolean force) {
+        Usage u = sm.getOwnedSubjectParameter();
+        Relationship rel = findBindingLikeRel(u);
+        if (force || (u.getName() != null && rel != null)) {
+            addRel(u, sm, null);
+            String name = getNameAnyway(u);
+            int id = addPUMLLine(u, "comp usage ", name, "<<subject>>");
+            process(new VCompartment(this), u);
+            if (rel != null) {
+                for (Element tgt : rel.getTarget()) {
+                    PRelation pr2 = new PRelation(id, tgt, rel, null);
+                    addPRelation(pr2);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String caseSubjectMembership(SubjectMembership sm) {
+        addSubjectMembership(sm, false);
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -143,13 +143,8 @@ public class VTree extends VStructure {
             String name = getNameAnyway(u);
             int id = addPUMLLine(u, "comp usage ", name, "<<subject>>");
             process(new VCompartment(this), u);
-            if (rel != null) {
-                for (Element tgt : rel.getTarget()) {
-                    tgt = resolveRelatedElement(tgt);
-                    PRelation pr2 = new PRelation(id, tgt, rel, null);
-                    addPRelation(pr2);
-                }
-            }
+            addSpecializations(id, u);
+            addFeatureValueBindings(u);
             return true;
         }
         return false;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -30,6 +30,7 @@ import org.omg.sysml.lang.sysml.AttributeUsage;
 import org.omg.sysml.lang.sysml.CalculationUsage;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;
@@ -144,6 +145,7 @@ public class VTree extends VStructure {
             process(new VCompartment(this), u);
             if (rel != null) {
                 for (Element tgt : rel.getTarget()) {
+                    tgt = resolveRelatedElement(tgt);
                     PRelation pr2 = new PRelation(id, tgt, rel, null);
                     addPRelation(pr2);
                 }


### PR DESCRIPTION
Previously, the visualizer could show subjects with typeOf relationship only such as
```
  subject s : Part;
```
However, it could not render bindings nor substrings such as:
```
  subject sub = part;
  subject sub :> part;
```
So we decided to render subjects with distinct nodes to show these relationships.
