### PR TITLE
ST6RI-617 Base types switched in RequirementDerivation

### DIFF
--- a/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
@@ -12,7 +12,7 @@ standard library package RequirementDerivation {
 		 */
 		 
 		:> annotatedElement : SysML::Usage;
-		:>> baseType = derivedRequirements meta SysML::Usage;
+		:>> baseType = originalRequirements meta SysML::Usage;
 	}
 	
 	metadata def <derive> DerivedRequirementMetadata :> SemanticMetadata {
@@ -23,7 +23,7 @@ standard library package RequirementDerivation {
 		 */
 		 
 		:> annotatedElement : SysML::Usage;	
-		:>> baseType = originalRequirements meta SysML::Usage;
+		:>> baseType = derivedRequirements meta SysML::Usage;
 	}
 	
 	metadata def <derivation> DerivationMetadata :> SemanticMetadata {


### PR DESCRIPTION
This PR corrects the `baseTypes` for `OriginalRequirementMetadata`  to `originalRequirements` and `DerivedRequirementMetadata` to `derivedRequirements`. These had been switched.