### PR TITLE
ST6RI-624: Short names are not rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -408,7 +408,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
         if (shortName != null) {
             String shortNameDesc;
             if (creole) {
-                shortNameDesc = "<b>~<" + shortName + "></b>";
+                shortNameDesc = "~<" + shortName + ">";
             } else {
                 shortNameDesc = '<' + shortName + '>';
             }


### PR DESCRIPTION
Due to my mistake in ST6RI-565 (PR #385), short names are not rendered.  This PR fix this issue by rendering short names in every element.