### PR TITLE
ST6RI-626 Feature chains with intermediate redefinitions evaluate incorrectly

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
@@ -252,4 +252,30 @@ public class ExpressionEvaluationTest extends SysMLInteractiveTest {
 		assertElement("LiteralInteger 120", instance.eval("test.fact5", "EvalTest7"));
 		assertElement("LiteralInteger 6", instance.eval("Fact(3)", "EvalTest7"));
 	}
+	
+	// Tests recursive invocation and binding of feature references in invocation arguments.
+	public final String chainTest =
+			"package ChainTest {"
+			+ "  part def A {\n"
+			+ "    attribute z;\n"
+			+ " }\n"
+			+  "part x {\n"
+			+ "    part a = b;\n"
+			+ "    part b : A {\n"
+			+ "        attribute :>> z = 0;\n"
+			+ "    }\n"
+			+ " }\n"
+			+ " part y :> x {\n"
+			+ "    part :>> b {\n"
+			+ "        attribute :>> z = 1;\n"
+			+ "    }\n"
+			+ " }"
+			+ "}";
+	
+	@Test
+	public void testChainEvaluation() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		process(instance, chainTest);
+		assertElement("LiteralInteger 1", instance.eval("y.a.z", "ChainTest"));
+	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
@@ -143,16 +143,20 @@ public class ModelLevelExpressionEvaluator {
 					}
 				} else {
 					// Evaluate the feature as a regular binding.
-					Expression valueExpression = EvaluationUtil.getValueExpressionFor(feature, t);
-					if (valueExpression != null) {
-						EList<Element> results = evaluate(valueExpression, type);
-						if (results != null) {
-							return results;
+					Feature typeFeature = EvaluationUtil.getTypeFeatureFor(feature, t);
+					if (typeFeature != null) {
+						Expression valueExpression = FeatureUtil.getValueExpressionFor(typeFeature);
+						if (valueExpression != null) {
+							EList<Element> results = evaluate(valueExpression, type);
+							if (results != null) {
+								return results;
+							}
 						}
+						return EvaluationUtil.singletonList(typeFeature);
 					}
 				}
 			}
-			Expression valueExpression = EvaluationUtil.getValueExpressionFor(feature, null);			
+			Expression valueExpression = FeatureUtil.getValueExpressionFor(feature);			
 			if (valueExpression != null) {
 				EList<Element> results = evaluate(valueExpression, type);
 				if (results != null) {

--- a/org.omg.sysml/src/org/omg/sysml/expressions/util/EvaluationUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/util/EvaluationUtil.java
@@ -23,7 +23,6 @@ package org.omg.sysml.expressions.util;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
@@ -251,19 +250,13 @@ public class EvaluationUtil {
 		}
 	}
 	
-	public static Optional<Feature> getTypeFeatureFor(Feature feature, Type type) {
-		return type.getFeature().stream().
-				filter(f->f == feature || FeatureUtil.getRedefinedFeaturesOf(f).contains(feature)).
-				findFirst();
+	public static Feature getTypeFeatureFor(Feature feature, Type type) {
+		return type == null? null :
+			type.getFeature().stream().
+				filter(f->FeatureUtil.getAllRedefinedFeaturesOf(f).contains(feature)).
+				findFirst().orElse(null);
 	}
 
-	public static Expression getValueExpressionFor(Feature feature, Type type) {
-		return type == null? FeatureUtil.getValueExpressionFor(feature):
-			   getTypeFeatureFor(feature, type).
-					map(FeatureUtil::getValueExpressionFor).
-					orElse(null);
-	}
-	
 	public static boolean isMetaclassFeature(Element element) {
 		return getMetaclassReferenceOf(element) != null;
 	}


### PR DESCRIPTION
Feature chains in which intermediate features are redefined were evaluated incorrectly. For example, in the model
```
part def A {
    attribute z;
}
part x {
    part a = b;
    part b : A {
        attribute :>> z = 0;
    }
}
part y :> x {
    part :>> b {
        attribute :>> z = 1;
    }
}
```
evaluating `y.a.z` resulted in 0, while 1 would be expected due to the redefinition of `b::z` in `y`. This update corrects that.