### PR TITLE
ST6RI-627: Render bindings between ports

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
@@ -132,6 +132,7 @@ public class VComposite extends VMixed {
 
     @Override
     public String casePortUsage(PortUsage pu) {
+        addFeatureValueBindings(pu);
         String name = extractTitleName(pu);
         if (name == null) return "";
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -32,6 +32,7 @@ import org.omg.sysml.lang.sysml.AnnotatingElement;
 import org.omg.sysml.lang.sysml.Annotation;
 import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.BindingConnector;
+import org.omg.sysml.lang.sysml.BindingConnectorAsUsage;
 import org.omg.sysml.lang.sysml.Comment;
 import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
@@ -192,6 +193,12 @@ public class VDefault extends VTraverser {
     @Override
     public String caseConnector(Connector c) {
         addConnector(c, c.getName());
+        return "";
+    }
+
+    @Override
+    public String caseBindingConnectorAsUsage(BindingConnectorAsUsage bcau) {
+        addConnector(bcau, "=");
         return "";
     }
 


### PR DESCRIPTION
The current visualizer does not render bindings between ports in interconnection view.   So far we tested parameters but had not tested ports.