### PR TITLE
ST6RI-574 Organize model libraries into interchange projects

### DIFF
--- a/sysml.library/Domain Libraries/Analysis/.meta
+++ b/sysml.library/Domain Libraries/Analysis/.meta
@@ -1,0 +1,10 @@
+{
+  "index": {
+    "AnalysisTooling": "AnalysisTooling.sysml",
+    "SampledFunctions": "SampledFunctions.sysml",
+    "StateSpaceRepresentation": "StateSpaceRepresentation.sysml",
+    "TradeStudies": "TradeStudies.sysml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Analysis/.meta
+++ b/sysml.library/Domain Libraries/Analysis/.meta
@@ -5,6 +5,6 @@
     "StateSpaceRepresentation": "StateSpaceRepresentation.sysml",
     "TradeStudies": "TradeStudies.sysml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Analysis/.project
+++ b/sysml.library/Domain Libraries/Analysis/.project
@@ -1,0 +1,27 @@
+{
+  "name": "SysML Analysis Library",
+  "version": "0.30.0",
+  "description": "Standard analysis domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Quantities-and-Units-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Analysis/StateSpaceRepresentation.sysml
+++ b/sysml.library/Domain Libraries/Analysis/StateSpaceRepresentation.sysml
@@ -5,9 +5,9 @@ standard library package StateSpaceRepresentation {
 	 * commonly used in control systems.
 	 */
 
-    import ISQ::DurationValue;
-    import Quantities::VectorQuantityValue;
-    import VectorCalculations::*;
+    private import ISQ::DurationValue;
+    private import Quantities::VectorQuantityValue;
+    private import VectorCalculations::*;
 
     abstract attribute def StateSpace :> VectorQuantityValue;
     abstract attribute def Input :> VectorQuantityValue;

--- a/sysml.library/Domain Libraries/Cause and Effect/.meta
+++ b/sysml.library/Domain Libraries/Cause and Effect/.meta
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "CausationConnections": "CausationConnections.sysml",
+    "CauseAndEffect": "CauseAndEffect.sysml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Cause and Effect/.meta
+++ b/sysml.library/Domain Libraries/Cause and Effect/.meta
@@ -3,6 +3,6 @@
     "CausationConnections": "CausationConnections.sysml",
     "CauseAndEffect": "CauseAndEffect.sysml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project
@@ -12,6 +12,10 @@
       "versionConstraint": "0.30.0"
     },
     {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
       "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
       "versionConstraint": "0.30.0"
     }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project
@@ -1,0 +1,19 @@
+{
+  "name": "SysML Cause and Effect Library",
+  "version": "0.30.0",
+  "description": "Standard cause-and-effect domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
+++ b/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
@@ -5,6 +5,10 @@ standard library package CausationConnections {
 	 * between them.
 	 */
 
+	private import SequenceFunctions::isEmpty;
+	private import SequenceFunctions::size;
+	private import SequenceFunctions::intersection;
+		 
 	abstract occurrence causes[*] {
 		doc /* Occurrences that are causes. */
 	}
@@ -24,8 +28,6 @@ standard library package CausationConnections {
 		 * should subset 'causes', while ends representing effects should subset 'effects'.
 		 * There must be at least one cause and at least one effect.
 		 */
-		 
-		private import SequenceFunctions::*;
 		 
 		ref occurrence causes[1..*] :>> causes :> participant {
 			doc /* The causing occurrences. */

--- a/sysml.library/Domain Libraries/Geometry/.meta
+++ b/sysml.library/Domain Libraries/Geometry/.meta
@@ -3,6 +3,6 @@
     "ShapeItems": "ShapeItems.sysml",
     "SpatialItems": "SpatialItems.sysml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Geometry/.meta
+++ b/sysml.library/Domain Libraries/Geometry/.meta
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "ShapeItems": "ShapeItems.sysml",
+    "SpatialItems": "SpatialItems.sysml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Geometry/.project
+++ b/sysml.library/Domain Libraries/Geometry/.project
@@ -1,0 +1,27 @@
+{
+  "name": "SysML Geometry Library",
+  "version": "0.30.0",
+  "description": "Standard geometry domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Quantities-and-Units-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Metadata/.meta
+++ b/sysml.library/Domain Libraries/Metadata/.meta
@@ -5,6 +5,6 @@
     "ParametersOfInterestMetadata": "ParametersOfInterestMetadata.sysml",
     "RiskMetadata": "RiskMetadata.sysml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Metadata/.meta
+++ b/sysml.library/Domain Libraries/Metadata/.meta
@@ -1,0 +1,10 @@
+{
+  "index": {
+    "ImageMetadata": "ImageMetadata.sysml",
+    "ModelingMetadata": "ModelingMetadata.sysml",
+    "ParametersOfInterestMetadata": "ParametersOfInterestMetadata.sysml",
+    "RiskMetadata": "RiskMetadata.sysml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Metadata/.project
+++ b/sysml.library/Domain Libraries/Metadata/.project
@@ -1,0 +1,19 @@
+{
+  "name": "SysML Metadata Library",
+  "version": "0.30.0",
+  "description": "Standard metadata domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ImageMetadata.sysml
@@ -6,7 +6,7 @@ standard library package ImageMetadata {
 	 * adorn graphical or textual renderings.
 	 */
 	 
-	import ScalarValues::String;
+	private import ScalarValues::String;
 	
 	attribute def Image {
 		doc

--- a/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
+++ b/sysml.library/Domain Libraries/Metadata/ParametersOfInterestMetadata.sysml
@@ -5,7 +5,7 @@ standard library package ParametersOfInterestMetadata {
 	 * including measures of effectiveness (MOE) and other key measures of performance (MOP).
 	 */
 	 
-	 import Metaobjects::SemanticMetadata;
+	 private import Metaobjects::SemanticMetadata;
 	 
 	 attribute measuresOfEffectiveness[*] nonunique {
 	 	doc /* Base feature for attributes that are measures of effectiveness. */

--- a/sysml.library/Domain Libraries/Quantities and Units/.meta
+++ b/sysml.library/Domain Libraries/Quantities and Units/.meta
@@ -22,6 +22,6 @@
     "USCustomaryUnits": "USCustomaryUnits.sysml",
     "VectorCalculations": "VectorCalculations.sysml",
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/.meta
+++ b/sysml.library/Domain Libraries/Quantities and Units/.meta
@@ -1,0 +1,27 @@
+{
+  "index": {
+    "ISQ": "ISQ.sysml",
+    "ISQAcoustics": "ISQAcoustics.sysml",
+    "ISQAtomicNuclear": "ISQAtomicNuclear.sysml",
+    "ISQBase": "ISQBase.sysml",
+    "ISQCharacteristicNumbers": "ISQCharacteristicNumbers.sysml",
+    "ISQChemistryMolecular": "ISQChemistryMolecular.sysml",
+    "ISQCondensedMatter": "ISQCondensedMatter.sysml",
+    "ISQElectromagnetism": "ISQElectromagnetism.sysml",
+    "ISQInformation": "ISQInformation.sysml",
+    "ISQLight": "ISQLight.sysml",
+    "ISQMechanics": "ISQMechanics.sysml",
+    "ISQSpaceTime": "ISQSpaceTime.sysml",
+    "ISQThermodynamics": "ISQThermodynamics.sysml",
+    "MeasurementReferences": "MeasurementReferences.sysml",
+    "Quantities": "Quantities.sysml",
+    "QuantityCalculations": "QuantityCalculations.sysml",
+    "SI": "SI.sysml",
+    "SIPrefixes": "SIPrefixes.sysml",
+    "Time": "Time.sysml",
+    "USCustomaryUnits": "USCustomaryUnits.sysml",
+    "VectorCalculations": "VectorCalculations.sysml",
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Quantities and Units/.project
+++ b/sysml.library/Domain Libraries/Quantities and Units/.project
@@ -1,0 +1,23 @@
+{
+  "name": "SysML Quantities and Units Library",
+  "version": "0.30.0",
+  "description": "Standard quantities and units domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Requirement Derivation/.meta
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.meta
@@ -3,6 +3,6 @@
     "DerivationConnections": "DerivationConnections.sysml",
     "RequirementsDerivation": "RequirementsDerivation.sysml",
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Domain Libraries/Requirement Derivation/.meta
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.meta
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "DerivationConnections": "DerivationConnections.sysml",
+    "RequirementsDerivation": "RequirementsDerivation.sysml",
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Domain Libraries/Requirement Derivation/.project
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.project
@@ -1,0 +1,19 @@
+{
+  "name": "SysML Requirement Derivation Library",
+  "version": "0.30.0",
+  "description": "Standard requirements derivation domain library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
@@ -3,6 +3,9 @@ standard library package DerivationConnections {
 	/*
 	 * This package provides a library model for derivation connections between requirements.
 	 */
+	 
+	import SequenceFunctions::excludes;
+	import ControlFunctions::allTrue;
 	
 	requirement originalRequirements[*] {
 		doc /* originalRequirements are the original requirements in Derivation connections. */
@@ -38,7 +41,7 @@ standard library package DerivationConnections {
 		private assert constraint originalNotDerived {
 			doc /* The original requirement must not be a derived requirement. */
 			
-			derivedRequirements->SequenceFunctions::excludes(originalRequirement)
+			derivedRequirements->excludes(originalRequirement)
 		}
 		
 		private assert constraint originalImpliesDerived {
@@ -48,7 +51,7 @@ standard library package DerivationConnections {
 			 * be satisfied.
 			 */
 			 
-			originalRequirement.result implies ControlFunctions::allTrue(derivedRequirements.result)
+			originalRequirement.result implies allTrue(derivedRequirements.result)
 		}	
 	}
 	

--- a/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
@@ -4,8 +4,8 @@ standard library package DerivationConnections {
 	 * This package provides a library model for derivation connections between requirements.
 	 */
 	 
-	import SequenceFunctions::excludes;
-	import ControlFunctions::allTrue;
+	private import SequenceFunctions::excludes;
+	private import ControlFunctions::allTrue;
 	
 	requirement originalRequirements[*] {
 		doc /* originalRequirements are the original requirements in Derivation connections. */

--- a/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/RequirementDerivation.sysml
@@ -2,7 +2,7 @@ standard library package RequirementDerivation {
 	doc /* This package provides language-extension metadata for modeling requirement derivation. */
 	
 	import DerivationConnections::*;
-	import Metaobjects::SemanticMetadata;
+	private import Metaobjects::SemanticMetadata;
 	
 	metadata def <original> OriginalRequirementMetadata :> SemanticMetadata {
 		doc

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta
@@ -4,6 +4,6 @@
     "ScalarValues": "ScalarValues.kerml",
     "VectorValues": "VectorValues.kerml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/KerML/20230201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta
@@ -1,0 +1,9 @@
+{
+  "index": {
+    "Collections": "Collections.kerml",
+    "ScalarValues": "ScalarValues.kerml",
+    "VectorValues": "VectorValues.kerml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+}

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.project
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.project
@@ -1,0 +1,11 @@
+{
+  "name": "Kernel Data Type Library",
+  "version": "0.30.0",
+  "description": "Standard data type library for the Kernel Modeling Language (KerML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.meta
@@ -17,6 +17,6 @@
     "TrigFunctions": "TrigFunctions.kerml",
     "VectorFunctions": "VectorFunctions.kerml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/KerML/20230201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.meta
@@ -1,0 +1,22 @@
+{
+  "index": {
+    "BaseFunctions": "BaseFunctions.kerml",
+    "BooleanFunctions": "BooleanFunctions.kerml",
+    "CollectionFunctions": "CollectionFunctions.kerml",
+    "ComplexFunctions": "ComplexFunctions.kerml",
+    "ControlFunctions": "ControlFunctions.kerml",
+    "DataFunctions": "DataFunctions.kerml",
+    "IntegerFunctions": "IntegerFunctions.kerml",
+    "NaturalFunctions": "NaturalFunctions.kerml",
+    "OccurrenceFunctions": "OccurrenceFunctions.kerml",
+    "RationalFunctions": "RationalFunctions.kerml",
+    "RealFunctions": "RealFunctions.kerml",
+    "ScalarFunctions": "ScalarFunctions.kerml",
+    "SequenceFunctions": "SequenceFunctions.kerml",
+    "StringFunctions": "StringFunctions.kerml",
+    "TrigFunctions": "TrigFunctions.kerml",
+    "VectorFunctions": "VectorFunctions.kerml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+}

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.project
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.project
@@ -1,0 +1,15 @@
+{
+  "name": "Kernel Function Library",
+  "version": "0.30.0",
+  "description": "Standard function library for the Kernel Modeling Language (KerML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }  
+  ]
+}

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta
@@ -3,7 +3,7 @@
     "Base": "Base.kerml",
     "Clocks": "Clocks.kerml",
     "ControlPerformances": "ControlPerformances.kerml",
-    "FeatureReferencingPerformances": "FeatureReferencingPerformances".kerml,
+    "FeatureReferencingPerformances": "FeatureReferencingPerformances.kerml",
     "KerML": "KerML.kerml",
     "Links": "Links.kerml",
     "Metaobjects": "Metaobjects.kerml",
@@ -17,6 +17,6 @@
     "TransitionPerformances": "TransitionPerformances.kerml",
     "Triggers": "Triggers.kerml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/KerML/20230201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta
@@ -1,0 +1,22 @@
+{
+  "index": {
+    "Base": "Base.kerml",
+    "Clocks": "Clocks.kerml",
+    "ControlPerformances": "ControlPerformances.kerml",
+    "FeatureReferencingPerformances": "FeatureReferencingPerformances".kerml,
+    "KerML": "KerML.kerml",
+    "Links": "Links.kerml",
+    "Metaobjects": "Metaobjects.kerml",
+    "Objects": "Objects.kerml",
+    "Observation": "Observation.kerml",
+    "Occurrences": "Occurrences.kerml",
+    "Performances": "Performances.kerml",
+    "SpatialFrames": "SpatialFrames.kerml",
+    "StatePerformances": "StatePerformances.kerml",
+    "Transfers": "Transfers.kerml",
+    "TransitionPerformances": "TransitionPerformances.kerml",
+    "Triggers": "Triggers.kerml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+}

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.project
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.project
@@ -1,0 +1,15 @@
+{
+  "name": "Kernel Semantic Library",
+  "version": "0.30.0",
+  "description": "Standard semantic library for the Kernel Modeling Language (KerML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}

--- a/sysml.library/Systems Library/.meta
+++ b/sysml.library/Systems Library/.meta
@@ -1,0 +1,25 @@
+{
+  "index": {
+    "Actions": "Actions.sysml",
+    "Allocations": "Allocations.sysml",
+    "AnalysisCases": "AnalysisCase.sysml",
+    "Attributes": "Attributes.sysml",
+    "Calculations": "Calculations.sysml",
+    "Cases": "Cases.sysml",
+    "Connections": "Connections.sysml",
+    "Constraints": "Constraints.sysml",
+    "Interfaces": "Interfaces.sysml",
+    "Items": "Items.sysml",
+    "Metadata": "Metadata.sysml",
+    "Parts": "Parts.sysml",
+    "Ports": "Ports.sysml",
+    "Requirements": "Requirements.sysml",
+    "StandardViewDefinitions": "StandardViewDefinitions.sysml",
+    "States": "States.sysml",
+    "UseCases": "UseCases.sysml",
+    "VerificationCases": "VerificationCases.sysml",
+    "Views": "Views.sysml"
+  },
+  "created": "2022-12-16",
+  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+}

--- a/sysml.library/Systems Library/.meta
+++ b/sysml.library/Systems Library/.meta
@@ -20,6 +20,6 @@
     "VerificationCases": "VerificationCases.sysml",
     "Views": "Views.sysml"
   },
-  "created": "2022-12-16",
+  "created": "2022-12-16T00:00:00Z",
   "metamodel": "https://www.omg.org/spec/SysML/20230201"
 }

--- a/sysml.library/Systems Library/.project
+++ b/sysml.library/Systems Library/.project
@@ -1,0 +1,19 @@
+{
+  "name": "SysML Systems Library",
+  "version": "0.30.0",
+  "description": "Standard semantic library for the Systems Modeling Language (SysML)",
+  "usage": [
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "versionConstraint": "0.30.0"
+    },
+    {
+      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "versionConstraint": "0.30.0"
+    }
+  ]
+}


### PR DESCRIPTION
Added hand-created `.project` and `.meta` files to each model library directory under `sysml.library`, consistent with the 2022-11 baseline specification for project interchange. With these metadata files included, compressing each directory into an archive gives a legal project interchange (`.kpar`) file using the textual notation as the model interchange format (`.sysml`).

Creating project interchange files using JSON as the interchange format will be handled in a future task.