### PR TITLE
ST6RI-630: Connections referring to redefined features are not properly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -24,20 +24,34 @@
 
 package org.omg.sysml.plantuml;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
+import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Type;
 
 class InheritKey {
     public final Type[] keys;
     private final boolean isDirect;
 
+    private static boolean containsWithRedefined(List<Feature> fs, Feature ft) {
+        for (Feature f : fs) {
+            if (f.equals(ft)) return true;
+            if (matchRedefined(f, ft)) return true;
+        }
+        return false;
+    }
+
     private static boolean isBelonging(Type typ, Feature f) {
-        if (typ.getOwnedFeature().contains(f)) return true;
-        if (typ.getInheritedFeature().contains(f)) return true;
+        if (containsWithRedefined(typ.getOwnedFeature(), f)) return true;
+        // if (typ.getOwnedFeature().contains(f)) return true;
+        if (containsWithRedefined(typ.getInheritedFeature(), f)) return true;
+        // if (typ.getInheritedFeature().contains(f)) return true;
         return false;
     }
 
@@ -164,6 +178,29 @@ class InheritKey {
         return constructInternal(ctx, inheritIdices, idx);
     }
 
+    private static boolean matchRedefined(Feature f, Feature ft, Set<Feature> visited) {
+        if (visited.contains(f)) return false;
+        visited.add(f);
+        for (Redefinition rd: f.getOwnedRedefinition()) {
+            Feature rf = rd.getRedefinedFeature();
+            if (ft.equals(rf)) return true;
+            return matchRedefined(rf, ft, visited);
+        }
+        return false;
+    }
+
+    private static boolean matchRedefined(Feature f, Feature ft) {
+        return matchRedefined(f, ft, new HashSet<Feature>());
+    }
+
+    public static boolean matchElement(Element e, Element et) {
+        if (e.equals(et)) return true;
+        if ((e instanceof Feature) && (et instanceof Feature)) {
+            return matchRedefined((Feature) e, (Feature) et);
+        }
+        return false;
+    }
+
     public static boolean match(InheritKey ik, List<Namespace> ctx, List<Integer> inheritIdices) {
         if (ik == null) {
             return inheritIdices.isEmpty();
@@ -179,11 +216,11 @@ class InheritKey {
             for (int i = 0; i < iSize; i++) {
                 int idx = inheritIdices.get(i);
                 Namespace ns = ctx.get(idx);
-                if (!ik.keys[i].equals(ns)) return false;
+                if (!matchElement(ns, ik.keys[i])) return false;
             }
             if (diff == 0) return true;
             // In the case that ik is in the form of [..., ^ow]
-            return ik.keys[kLen - 1].equals(ctx.get(ctxSize - 1));
+            return matchElement(ctx.get(ctxSize - 1), ik.keys[kLen - 1]);
         }
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -419,10 +419,9 @@ public class VPath extends VTraverser {
         }
     }
 
-    // InheritKey->Element->Integer
+    // InheritKey->Element->ID
     private final Map<InheritKey, Map<Element, Integer>> inheritedPathIdMap = new HashMap<>();
-
-    // Element -> Integer or Map<Element, Integer>
+    // ID -> Elements
     private final Map<Integer, Set<Element>> pathIdRevMap = new HashMap<Integer, Set<Element>>();
 
     private void putPathIdMap(Integer id, InheritKey ik, Element pt) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -112,7 +112,7 @@ public class VPath extends VTraverser {
         private boolean match(Element e) {
             if (isTerminal()) return false;
             Element et = getTarget();
-            return e.equals(et);
+            return InheritKey.matchElement(e, et);
         }
 
         public Element requiredElement() {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -30,7 +30,6 @@ import org.omg.sysml.lang.sysml.AttributeUsage;
 import org.omg.sysml.lang.sysml.CalculationUsage;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;


### PR DESCRIPTION
Connections referring to redefined features could not be rendered correctly.  Rather, the visualizer connected to the original feature rather than the redefined feature.  This PR fixes this issue.