### PR TITLE
ST6RI-632 LiteralBooleanImpl.VALUE_EDEFAULT is set to "true"

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LiteralBooleanImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LiteralBooleanImpl.java
@@ -45,16 +45,15 @@ import org.omg.sysml.lang.sysml.SysMLPackage;
  */
 public class LiteralBooleanImpl extends LiteralExpressionImpl implements LiteralBoolean {
 	/**
-	 * The default value of the '{@link #isValue() <em>Value</em>}' attribute. 
+	 * The default value of the '{@link #isValue() <em>Value</em>}' attribute.
 	 * <!-- begin-user-doc --> 
 	 * Default value for a LiteralBoolean is true.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isValue()
-	 * @generated NOT
+	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean VALUE_EDEFAULT = true;
+	protected static final boolean VALUE_EDEFAULT = false;
 
 	/**
 	 * The cached value of the '{@link #isValue() <em>Value</em>}' attribute. <!--


### PR DESCRIPTION
In the Kernel abstract syntax, no default value is given for `LiteralBoolean::value`. Normally, if no default is specified in the Ecore metamodel for a Boolean property, the EMF generation will give the field in the Java `Impl` class the default value `false`. However, the constant `VALUE_EDEFAULT` the `LiteralBooleanImpl`was marked as `@generated NOT` and given a value of `true`. This had been done to support the initial implementation of `Invariant` and `AssertConstraintUsage` elements, for reasons that no longer apply. So, this pull request returns `LiteralBooleanImpl.VALUE_EDEFAULT` to its generated value of `false`.