### PR TITLE
ST6RI-635 Conditional successions need to be typed by DecisionTransitionAction

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -60,7 +60,7 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 		TransitionUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return target.isComposite() && 
-			   (target instanceof ActionDefinition || owningType instanceof ActionUsage);
+			   (owningType instanceof ActionDefinition || owningType instanceof ActionUsage);
 	}	
 	
 	protected boolean isStateTransition() {

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -294,7 +294,7 @@ public class ImplicitGeneralizationMap {
 		put(SuccessionFlowConnectionUsageImpl.class, "subperformance", "Performances::Performance::subtransfersBefore");
 
 		put(TransitionUsageImpl.class, "base", "Actions::transitionActions");
-		put(TransitionUsageImpl.class, "actionTransition", "Actions::Action::transitions");
+		put(TransitionUsageImpl.class, "actionTransition", "Actions::Action::decisionTransitions");
 		put(TransitionUsageImpl.class, "stateTransition", "States::StateAction::stateTransitions");
 		
 		put(TriggerInvocationExpressionImpl.class, "when", "Triggers::TriggerWhen");

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -124,6 +124,13 @@ standard library package Actions {
 			 */
 		}
 		
+		abstract action decisionTransitions : DecisionTransitionAction[0..*] :> transitionActions {
+			doc
+			/*
+			 * The subactions of this Action that are DecisionTransitionActions. 
+			 */
+		}
+		
 		abstract action assignments : AssignmentAction[0..*] :> subactions, assignmentActions {
 			doc
 			/*


### PR DESCRIPTION
The implicit specialization implemented for `TransitionUsages `used as "conditional successions" in action models has been `Action::transitions`. However, this is typed by `TransitionAction,` while conditional-succession `TransitionUsages` need to be typed by `DecisionTransitionAction`. This pull request adds the feature `Action::decisionTransitions`, subsetting `Actions::transition`, which is then used as the implicit specialization for conditional successions.

The pull request also fixes a bug in `TransitionUsageAdapter::getDefaultSupertype` for the case of a conditional succession in an `ActionDefinition`.