### PR TITLE
ST6RI-636 Update multiplicity derivation

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -1,6 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
  * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,6 +20,7 @@
  * 
  * Contributors:
  *  Hisashi Miyashita, Mgnite Inc.
+ *  Ed Seidewitz, MDS
  * 
  *****************************************************************************/
 
@@ -347,7 +349,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
     private MultiplicityRange getEffectiveMultiplicityRange(Element e) {
         if (!(e instanceof Type)) return null;
         Type typ = (Type) e;
-        Multiplicity m = typ.getMultiplicity();
+        Multiplicity m = FeatureUtil.getMultiplicityOf(typ);
         return FeatureUtil.getMultiplicityRangeOf(m);
     }
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/Type_multiplicity_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/Type_multiplicity_SettingDelegate.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,6 @@
 package org.omg.sysml.delegate;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -30,8 +29,6 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.impl.TypeImpl;
-import org.omg.sysml.util.TypeUtil;
 
 public class Type_multiplicity_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -45,21 +42,10 @@ public class Type_multiplicity_SettingDelegate extends BasicDerivedObjectSetting
 	}
 	
 	protected static Multiplicity getMultiplicityOf(Type type, Set<Type> visited) {
-		Multiplicity multiplicity = (Multiplicity)type.getOwnedMembership().stream().
+		return (Multiplicity)type.getOwnedMembership().stream().
 				map(Membership::getMemberElement).
 				filter(Multiplicity.class::isInstance).
 				findFirst().orElse(null);
-		if (multiplicity == null) {
-			visited.add(type);
-			List<Type> superTypes = TypeUtil.getSupertypesOf(type);
-			if (!superTypes.isEmpty()) {
-				Type general = TypeUtil.getSupertypesOf(type).get(0);
-				if (general != null && !visited.contains(general)) { 
-					multiplicity = getMultiplicityOf((TypeImpl)general, visited);
-				}
-			}
-		}
-		return multiplicity;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -229,7 +229,7 @@ public class FeatureUtil {
 				collect(Collectors.toList());
 	}
 
-// Feature values
+	// Feature values
 	
 	public static FeatureValue getValuationFor(Feature feature) {
 		return (FeatureValue)feature.getOwnedMembership().stream().
@@ -395,4 +395,23 @@ public class FeatureUtil {
 		}
 	}
 	
+	public static Multiplicity getMultiplicityOf(Type type) {
+		return getMultiplicityOf(type, new HashSet<>());
+	}
+	
+	public static Multiplicity getMultiplicityOf(Type type, Set<Type> visited) {
+		Multiplicity multiplicity = type.getMultiplicity();
+		if (multiplicity == null) {
+			visited.add(type);
+			for (Type general: TypeUtil.getGeneralTypesOf(type)){
+				if (general != null && !visited.contains(general)) { 
+					multiplicity = getMultiplicityOf(general, visited);
+					if (multiplicity != null) {
+						break;
+					}
+				}
+			}
+		}
+		return multiplicity;
+	}
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Base.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Base.kerml
@@ -31,7 +31,7 @@ standard library package Base {
 		feature self: DataValue redefines Anything::self;
 	}
 	
-	abstract feature things: Anything [0..*] nonunique {
+	abstract feature things: Anything [1..*] nonunique {
 		doc
 		/*
 		 * things is the top-level feature in the language.
@@ -87,7 +87,7 @@ standard library package Base {
 	multiplicity zeroToMany [0..*] {
 		doc
 		/*
-		 * oneToMany is a multiplicity range allowing any cardinality of ozero or more
+		 * zeroToMany is a multiplicity range allowing any cardinality of zero or more
 		 * (that is, no restriction).
 		 */
 	}

--- a/sysml/src/examples/Simple Tests/PartTest.sysml
+++ b/sysml/src/examples/Simple Tests/PartTest.sysml
@@ -11,7 +11,9 @@ package PartTest {
 	}
 	
 	abstract part def <xx> B {
-		public abstract part a: A;
+		public abstract part a: A[1..2];
+		public abstract part b subsets a;
+		public abstract part c[0..1] subsets a;
 		port x: ~C;
 		package P { }
 		


### PR DESCRIPTION
The `Type_multiplicity_SettingDelegate` implements the derivation of the `Type::multiplicity` property. The current implementation returns the first `ownedMember` of a `Type` that is a `Multiplicity`, if there is one, and, if there isn’t, returns the `multiplicity` of the first direct supertype of the `Type` (if any). However, a `Type` (particularly a `Feature`) can have multiple supertypes with `multiplicities`, and it is not clear what rule should be used to pick one. Picking the first one, as currently done, is not really justified unless all the supertype `multiplicites` are required to be the same, which is too tight a restriction. On the other hand, picking, say, the `multiplicity` with the narrowest range would require that the bounds of the `multiplicities` be model-level evaluable, which is not required in general.

So, this PR changes the derivation for `multiplicity` to just be the (at most one) `ownedMember` that is a `Multiplicity`. The semantics are then that, if the `multiplicity` of a `Type` is non-null, that is what is used to constraint the cardinality of the `Type`. Otherwise, the `Type` is constrained by the `Multiplicity` constraints of all its direct supertypes (if any).