### PR TITLE
ST6RI-639 Incorrect rendering if no separator before a feature value (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -128,7 +128,7 @@ public abstract class VStructure extends VDefault {
             } else {
                 append(' '); // appendText() trims the text.
                 Matcher m = patEqFeatureValue.matcher(text);
-                if (!m.matches()) {
+                if (!m.lookingAt()) {
                     text = "= " + text;
                 }
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -27,6 +27,8 @@
 package org.omg.sysml.plantuml;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.ActorMembership;
@@ -111,6 +113,8 @@ public abstract class VStructure extends VDefault {
         return true;
     }
 
+    private static Pattern patEqFeatureValue = Pattern.compile("^\\s*=");
+
     protected boolean appendFeatureValue(FeatureValue fv) {
         Expression ex = fv.getValue();
         String text = getText(fv);
@@ -120,6 +124,12 @@ public abstract class VStructure extends VDefault {
                 int pos = text.indexOf("default");
                 if (pos >= 0) {
                     text = text.substring(pos + "default".length()); // 
+                }
+            } else {
+                append(' '); // appendText() trims the text.
+                Matcher m = patEqFeatureValue.matcher(text);
+                if (!m.matches()) {
+                    text = "= " + text;
                 }
             }
             boolean flag = appendText(text, true);


### PR DESCRIPTION
The current visualizer prints textual notation for feature values and if it does not have a separator such as leading spaces or equal sign, the results looks just concatenated with the feature name.  This PR inserts an equal or space before the feature values if the corresponding text has no leading spaces.