### PR TITLE
ST6RI-644 Add the new editor projects to the Eclipse installation

### DIFF
--- a/org.omg.sysml.editor.feature/.project
+++ b/org.omg.sysml.editor.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.omg.sysml.editor.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/org.omg.sysml.editor.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.omg.sysml.editor.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.omg.sysml.editor.feature/build.properties
+++ b/org.omg.sysml.editor.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/org.omg.sysml.editor.feature/feature.xml
+++ b/org.omg.sysml.editor.feature/feature.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.omg.sysml.editor.feature"
+      label="SysML v2 XMI Editor Feature"
+      version="0.31.0.qualifier">
+
+   <description url="http://www.example.com/description">
+      UI plugins for the SysML v2 pilot implementation of editors for
+the XMI representation of SysML v2.
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      Copyright (c) 2019-2023 Model Driven Solutions, Inc.
+Copyright (c) 2019-2023 California Institute of Technology (Jet
+Propulsion Laboratory)
+Copyright (c) 2019-2023 IncQuery Labs Ltd.
+Copyright (c) 2019-2023 Itemis
+Copyright (c) 2019-2023 Maplesoft (Waterloo Maple, Inc.)
+Copyright (c) 2019-2023 Mgnite Inc.
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      SysML v2 Pilot Implementation Licensing Agreement
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to use and redistribute the Software and to permit persons to whom the Software is furnished to do so, subject to the conditions that the copyright notice and this permission notice shall be included in all copies of the Software. No permission is granted to modify, merge, and/or sell copies of the Software, or to create derivative works based on the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   </license>
+
+   <requires>
+      <import plugin="org.omg.sysml"/>
+   </requires>
+
+   <plugin
+         id="org.omg.sysml.edit"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.omg.sysml.editor"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/org.omg.sysml.feature/feature.xml
+++ b/org.omg.sysml.feature/feature.xml
@@ -10,26 +10,19 @@
    </description>
 
    <copyright>
-      Copyright (c) 2019-2020 Model Driven Solutions, Inc.
-Copyright (c) 2019-2020 California Institute of Technology (Jet Propulsion
-Laboratory)
-Copyright (c) 2019-2020 IncQuery Labs Ltd.
-Copyright (c) 2019-2020 Itemis
-Copyright (c) 2019-2020 Maplesoft (Waterloo Maple, Inc.)
-Copyright (c) 2019-2020 Mgnite Inc.
+      Copyright (c) 2019-2023 Model Driven Solutions, Inc.
+Copyright (c) 2019-2023 California Institute of Technology (Jet
+Propulsion Laboratory)
+Copyright (c) 2019-2023 IncQuery Labs Ltd.
+Copyright (c) 2019-2023 Itemis
+Copyright (c) 2019-2023 Maplesoft (Waterloo Maple, Inc.)
+Copyright (c) 2019-2023 Mgnite Inc.
    </copyright>
 
    <license url="">
       SysML v2 Pilot Implementation Licensing Agreement
 
-Copyright (c) 2019-2020 Model Driven Solutions, Inc.
-Copyright (c) 2019-2020 California Institute of Technology (Jet Propulsion Laboratory)
-Copyright (c) 2019-2020 IncQuery Labs Ltd.
-Copyright (c) 2019-2020 Itemis
-Copyright (c) 2019-2020 Maplesoft (Waterloo Maple, Inc.)
-Copyright (c) 2019-2020 Mgnite Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to use and redistribute the Software and to permit persons to whom the Software is furnished to do so, subject to the conditions that the above copyright notice and this permission notice shall be included in all copies of the Software. No permission is granted to modify, merge, and/or sell copies of the Software, or to create derivative works based on the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to use and redistribute the Software and to permit persons to whom the Software is furnished to do so, subject to the conditions that the copyright notice and this permission notice shall be included in all copies of the Software. No permission is granted to modify, merge, and/or sell copies of the Software, or to create derivative works based on the Software.
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    </license>
@@ -106,20 +99,6 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 
    <plugin
          id="org.omg.sysml.execution"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.omg.sysml.edit"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.omg.sysml.editor"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/org.omg.sysml.feature/feature.xml
+++ b/org.omg.sysml.feature/feature.xml
@@ -111,4 +111,18 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.omg.sysml.edit"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.omg.sysml.editor"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.omg.sysml.site/category.xml
+++ b/org.omg.sysml.site/category.xml
@@ -6,14 +6,19 @@
    <feature id="org.omg.sysml.feature">
       <category name="KerML and SysML Editors"/>
    </feature>
+   <feature id="org.omg.sysml.editor.feature">
+      <category name="KerML and SysML Editors"/>
+   </feature>
    <feature id="org.omg.sysml.plantuml.feature">
       <category name="KerML and SysML Editors"/>
    </feature>
    <category-def name="KerML and SysML Editors" label="KerML and SysML Editors">
       <description>
          Xtext editors for the KerML and SysML textual notations.
+         Generated editor for SysML XMI.
+         PlantUML-base graphical visualization for XMI.
       </description>
    </category-def>
-   <repository-reference location="https://download.eclipse.org/releases/2020-06" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2022-09" enabled="true" />
    <repository-reference location="https://github.com/himi/p2-update-puml-sysmlv2/raw/main/updates" enabled="true" />
 </site>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <module>org.omg.sysml.jupyter.jupyterlab</module>
     <module>org.omg.sysml.jupyter.installer</module>
     <module>org.omg.sysml.feature</module>
+    <module>org.omg.sysml.editor.feature</module>
     <module>org.omg.sysml.plantuml</module>
     <module>org.omg.sysml.plantuml.eclipse</module>
     <module>org.omg.sysml.plantuml.feature</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
 
   <modules>
     <module>org.omg.sysml</module>
+    <module>org.omg.sysml.edit</module>
+    <module>org.omg.sysml.editor</module>
     <module>org.omg.sysml.execution</module>
     <module>org.omg.kerml.expressions.xtext</module>
     <module>org.omg.kerml.xtext</module>


### PR DESCRIPTION
This PR adds the new `org.omg.sysml.edit` and `org.omg.sysml.editor` plugins to the Maven build and to `org.omg.sysml.feature`, so they are included in the `org.omg.sysml.site` for Eclipse installation. (This was accidentally not included in PR #449 for the 2022-12 release.

**Note.** This update is intentionally consistent with 2022-12, and does not include the planned URI and abstract sytnax updates from ST6RI-622 and ST6RI-643 for 2023-01.