### PR TITLE
ST6RI-641 Access to triggering event from target state

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/StatePerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/StatePerformances.kerml
@@ -45,7 +45,7 @@ standard library package StatePerformances {
 		private succession middle[*] then exit[1];
 
 
-		readonly feature incomingTransitionTrigger : MessageTransfer [0..1] {
+		readonly feature incomingTransitionTrigger : MessageTransfer [0..1] default null {
 			doc
 			/*
 			 * Transfer that triggered a transition into this state performance. 

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/StatePerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/StatePerformances.kerml
@@ -8,8 +8,10 @@ standard library package StatePerformances {
 	private import ScalarValues::Boolean;
 	private import ScalarValues::Natural;
 	private import TransitionPerformances::TransitionPerformance;
+	private import Occurrences::Occurrence;
 	private import Occurrences::HappensDuring;
 	private import Transfers::Transfer;
+	private import Transfers::MessageTransfer;
 	private import Performances::Performance;
 	private import ControlPerformances::DecisionPerformance;
 	private import ControlFunctions::forAll;
@@ -41,6 +43,14 @@ standard library package StatePerformances {
 		private succession entry[1] then middle[*];
 		private succession do.startShot[1] then nonDoMiddle.startShot[*];
 		private succession middle[*] then exit[1];
+
+
+		readonly feature incomingTransitionTrigger : MessageTransfer [0..1] {
+			doc
+			/*
+			 * Transfer that triggered a transition into this state performance. 
+			 */
+		}
 
 		private inv { isEmpty(accepted) == isEmpty(acceptable) }
 		feature accepted: Transfer[0..1] subsets acceptable {
@@ -111,6 +121,11 @@ standard library package StatePerformances {
 			feature redefines StatePerformance::acceptable;
 		}
 		private succession transitionLinkSource.nonDoMiddle[*] then Performance::self[1];
+
+		private feature transitionLinkTarget [0..1] : Occurrence = transitionLink.laterOccurrence {
+			inv { (that istype StatePerformance) implies
+			      (that as StatePerformance).incomingTransitionTrigger == trigger }
+		}
 		
 		feature acceptable: Transfer [*] subsets transitionLinkSource.acceptable, triggerTarget.incomingTransfersToSelf;
 


### PR DESCRIPTION
Adds StatePerformance::incomingTransitionTrigger, constrained in StateTransitionPerformance to be a MessageTransfer accepted to trigger into the transition target (if it's a StatePerformance).