### PR TITLE
ST6RI-649 Decision/MergePerformance outgoing/incomingHBLink should come from/go to the performance

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
@@ -30,6 +30,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions going out of a decision step.
 			 */
+
+			 feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -49,6 +51,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions coming into a merge step.
 			 */
+
+			 feature redefines laterOccurrence subsets that;
 		}
 	}
 


### PR DESCRIPTION
Constrains earlier/laterOccurrence of Decision/MergePerformance::outgoing/incomingHBLink to be the performance.