### PR TITLE
ST6RI-640 Deterministic UUIDs for standard library elements

### DIFF
--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysML2XMI.java
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/SysML2XMI.java
@@ -24,6 +24,7 @@
 
 package org.omg.sysml.xtext.util;
 
+import org.eclipse.emf.common.util.URI;
 import org.omg.kerml.xtext.util.KerML2XMI;
 import org.omg.sysml.xtext.SysMLStandaloneSetup;
 
@@ -50,23 +51,16 @@ public class SysML2XMI extends KerML2XMI {
 	}
 
 	/**
-	 * Get an output path to be used for the given input path. If the input path indicates a SysML file, then
-	 * return an output path that is the same as the input path, but with the extension replaced by the SysML
-	 * XMI extension. Otherwise, replace the input extension with the KerML XMI extension.
+	 * Get the output extension to be used for the given input URI. If the input path indicates a SysML file,
+	 * return the SysML XMI extension. Otherwise, return the KerML XMI extension.
 	 * 
-	 * @param 	inputPath		the path of a resource that is to be written to a corresponding output resource
-	 * @return	the path for the output resource
-	 */
+	 * @param 	inputUri		the URI of the input resource
+	 * @return the extension to be used for the output file of the corresponding output resource
+	 */	
 	@Override
-	protected String getOutputPath(String inputPath) {
-		int i = inputPath.lastIndexOf('.');
-		if (i >= 0) {
-			String extension = inputPath.substring(i + 1);
-			if (SYSML_EXTENSION.equals(extension)) {
-				return inputPath.substring(0, i) + "." + SYSML_XMI_EXTENSION;
-			}
-		}
-		return super.getOutputPath(inputPath);
+	protected String getExtension(URI inputUri) {
+		return SYSML_EXTENSION.equals(inputUri.fileExtension())?
+				SYSML_XMI_EXTENSION: super.getExtension(inputUri);
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/delegate/Element_qualifiedName_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/Element_qualifiedName_SettingDelegate.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022-2023 Model Driven Solutions, Inc.
  * Copyright (c) 2022 Siemens AG
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -38,11 +38,14 @@ public class Element_qualifiedName_SettingDelegate extends BasicDerivedPropertyS
 		Namespace owningNamespace = ((Element) owner).getOwningNamespace();
 		if (owningNamespace == null) {
 			return null;
-		} else if (owningNamespace.getOwner() == null) {
-			return ((Element) owner).escapedName();
 		} else {
-			String qualification = owningNamespace.getQualifiedName();
-			return qualification == null? null: qualification + "::" + ((Element) owner).escapedName();
+			String name = ((Element) owner).escapedName();
+			if (name == null || owningNamespace.getOwner() == null) {
+				return name;
+			} else {
+				String qualification = owningNamespace.getQualifiedName();
+				return qualification == null? null: qualification + "::" + name;
+			}
 		}
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -24,8 +24,11 @@
 
 package org.omg.sysml.util;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EObject;
@@ -134,6 +137,19 @@ public class ElementUtil {
 		Namespace libraryNamespace = element.libraryNamespace();
 		return libraryNamespace instanceof LibraryPackage && 
 				((LibraryPackage)libraryNamespace).isStandard();
+	}
+	
+	public static UUID constructNameUUID(UUID namespaceUUID, String name) {
+		try {
+			byte[] nameBytes = name.getBytes("UTF-8");
+			ByteBuffer bb = ByteBuffer.wrap(new byte[16 + nameBytes.length]);
+			bb.putLong(namespaceUUID.getMostSignificantBits());
+			bb.putLong(namespaceUUID.getLeastSignificantBits());
+			bb.put(nameBytes);
+			return UUID.nameUUIDFromBytes(bb.array());
+		} catch (UnsupportedEncodingException e) {
+			return null;
+		}
 	}
 	
 	// Annotation

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -139,17 +139,12 @@ public class ElementUtil {
 				((LibraryPackage)libraryNamespace).isStandard();
 	}
 	
+	// It will use nameUUIDFromBytes();
+	// private static final UUIDDigest uuidDigest0 = new UUIDDigest();
+	private static final UUIDDigest uuidDigest = new UUIDDigest(5, "SHA-1");
+
 	public static UUID constructNameUUID(UUID namespaceUUID, String name) {
-		try {
-			byte[] nameBytes = name.getBytes("UTF-8");
-			ByteBuffer bb = ByteBuffer.wrap(new byte[16 + nameBytes.length]);
-			bb.putLong(namespaceUUID.getMostSignificantBits());
-			bb.putLong(namespaceUUID.getLeastSignificantBits());
-			bb.put(nameBytes);
-			return UUID.nameUUIDFromBytes(bb.array());
-		} catch (UnsupportedEncodingException e) {
-			return null;
-		}
+		return uuidDigest.hash(namespaceUUID, name);
 	}
 	
 	// Annotation

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -1,6 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2019, 2020, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2023 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,13 +20,12 @@
  * 
  * Contributors:
  *  Ed Seidewitz
+ *  Hisashi Miyashita
  * 
  *****************************************************************************/
 
 package org.omg.sysml.util;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -139,8 +139,7 @@ public class ElementUtil {
 				((LibraryPackage)libraryNamespace).isStandard();
 	}
 	
-	// It will use nameUUIDFromBytes();
-	// private static final UUIDDigest uuidDigest0 = new UUIDDigest();
+	// For version 5 name-base UUIDs using SHA-1 digest.
 	private static final UUIDDigest uuidDigest = new UUIDDigest(5, "SHA-1");
 
 	public static UUID constructNameUUID(UUID namespaceUUID, String name) {

--- a/org.omg.sysml/src/org/omg/sysml/util/UUIDDigest.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UUIDDigest.java
@@ -1,0 +1,94 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2023 Mgnite Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Hisashi Miyashita
+ * 
+ *****************************************************************************/
+
+package org.omg.sysml.util;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+public class UUIDDigest {
+	private final MessageDigest md;
+
+	private final long versionMask;
+    private static final int VERSION_BIT = 12;
+    private static final long MSB_MASK = -1L ^ (0x0F << VERSION_BIT);
+    
+	private static byte[] makeNamespaceBytes(UUID ns) {
+		ByteBuffer buf = ByteBuffer.allocate(16);
+		buf.putLong(ns.getMostSignificantBits());
+		buf.putLong(ns.getLeastSignificantBits());
+		return buf.array();		
+	}
+    
+	public UUID hash(UUID ns, String str) {
+		byte[] nsBytes = makeNamespaceBytes(ns);
+		byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+		if (md == null) {
+			ByteBuffer bb = ByteBuffer.allocate(16 + bytes.length);
+            bb.put(nsBytes);
+            bb.put(bytes);
+			return UUID.nameUUIDFromBytes(bb.array());
+		} else {
+            md.reset();
+            md.update(nsBytes);
+            md.update(bytes);
+
+            ByteBuffer bb = ByteBuffer.wrap(md.digest());
+            long msb = (bb.getLong() & MSB_MASK) | versionMask;
+            long lsb = (bb.getLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+
+            return new UUID(msb, lsb);
+        }
+	}
+	
+	public UUIDDigest(int version, String algorithm) {
+		this.versionMask = (version & 0x0F) << VERSION_BIT;
+		try {
+			this.md = MessageDigest.getInstance(algorithm);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("Hash algorithm: " + algorithm + " could not be used");
+		}
+	}
+	
+	public UUIDDigest() {
+		this.versionMask = 0;
+		this.md = null;
+	}
+
+    public static void main(String[] args) {
+        UUIDDigest[] dds = { new UUIDDigest(), new UUIDDigest(3, "MD5"), new UUIDDigest(3, "SHA-1"), new UUIDDigest(5, "SHA-1") };
+        
+        UUID ns = UUID.randomUUID();
+        
+        System.out.println("Namespace UUID: " + ns);
+        for (String arg : args) {
+            for (UUIDDigest dd : dds) {
+                System.out.println(arg + " -> " + dd.hash(ns, arg));
+            }
+        }
+    }
+}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ElementImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ElementImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -315,7 +315,18 @@ public abstract class ElementImpl extends MinimalEObjectImpl.Container implement
 	@Override
 	public String getElementId() {
 		if (elementId == null) {
-			elementId = UUID.randomUUID().toString();
+			UUID uuid = UUID.randomUUID();
+			if (ElementUtil.isStandardLibraryElement(this)) {
+				String qualifiedName = getQualifiedName();
+				if (qualifiedName != null) {
+					Namespace libraryNamespace = libraryNamespace();
+					if (this != libraryNamespace) {
+						UUID namespaceUUID = UUID.fromString(libraryNamespace.getElementId());
+						uuid = ElementUtil.constructNameUUID(namespaceUUID, qualifiedName);
+					}
+				}
+			}
+			elementId = uuid.toString();
 		}
 		return elementId;
 	}
@@ -710,10 +721,10 @@ public abstract class ElementImpl extends MinimalEObjectImpl.Container implement
 	 * @generated NOT
 	 */
 	public String escapedName() {
-		String effectiveName = getName();
-		String shortName = getDeclaredShortName();
+		String name = getName();
+		String shortName = getShortName();
 		String elementName = 
-				effectiveName != null? effectiveName:
+				name != null? name:
 				shortName != null? shortName:
 				null;
 		return ElementUtil.escapeName(elementName);

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
@@ -1,15 +1,36 @@
-/**
- */
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2022-2023 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
 package org.omg.sysml.lang.sysml.impl;
+
+import java.util.UUID;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
-
+import org.eclipse.emf.ecore.resource.Resource;
 import org.omg.sysml.lang.sysml.LibraryPackage;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.util.ElementUtil;
 
 /**
  * <!-- begin-user-doc -->
@@ -75,6 +96,28 @@ public class LibraryPackageImpl extends PackageImpl implements LibraryPackage {
 	}
 	
 	// Additional overrides
+	
+	public final String KERML_LIBRARY_BASE_URI = "https://www.omg.org/spec/KerML/";
+	public final String SYSML_LIBRARY_BASE_URI = "https://www.omg.org/spec/SysML/";
+	
+	// UUID for "NameSpace_URL", per ITU-T Rec. X.667 (10/2012), Annex D.9
+	public final UUID UUID_NAMESPACE_URL = UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+	
+	@Override
+	public String getElementId() {
+		if (elementId == null && isStandard()) {
+			Resource resource = eResource();
+			if (resource != null) {
+				String uri = resource.getURI().toString().contains("Kernel")?
+						KERML_LIBRARY_BASE_URI: SYSML_LIBRARY_BASE_URI;
+				String qualifiedName = getQualifiedName();
+				if (qualifiedName != null) {
+					return ElementUtil.constructNameUUID(UUID_NAMESPACE_URL, uri + qualifiedName).toString();
+				}
+			}
+		}
+		return super.getElementId();
+	}
 	
 	@Override
 	public Namespace libraryNamespace() {


### PR DESCRIPTION
This PR revises `ElementImpl::getElementId` and `LibraryPackage::getElementId` so that the UUIDs for standard library elements with a non-null `qualifiedName` are generated deterministically as name-based UUIDs. Each such UUID is constructed from a _name space identifier_ and a _name_ (as defined in the UUID specification), which are determined as follows:

- For the top-level standard library package:
  - _name space identifier_ is the `NameSpace_URL` UUID given in the UUID specification (which is `6ba7b812-9dad-11d1-80b4-00c04fd430c8`).
  - _name_ is the URL constructed by prepending `https://www.omg.org/KerML/` to the name of the package, converted to bytes using a `UTF-8` encoding.

- For any element directly or indirectly contained in the top-level standard library package (for which that package will be the `libraryNamespace`):
  - _name space identifier_ is the UUID of the top-level standard library package (as determined above).
  - _name_ is the `qualifiedName` of the element , converted to bytes using a `UTF-8` encoding.

Other changes:

1. Corrected the derivation of `Element::qualifiedName `so that it is
always null if the `Element` `name` is null.

2. Corrected the implementation of `Element::escapedName` so that it uses
the effective `shortName` (not `declaredShortName`) if the `name` is null.

3. Added a `-o` option for an output directory to `org.omg.kerml.xtext.util.KerML2XMI` (and hence to `org.omg.sysml.xtext.util.SysML2XMI`, too).