### PR TITLE
ST6RI-329 Transfer::isMove,isPush,isInstant and Link::participants should be constant/read-only

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
@@ -13,7 +13,7 @@ standard library package Links {
 		 * Link is the most general association between two or more things.
 		 */
 
-		feature participant: Anything[2..*] nonunique ordered;
+		readonly feature participant: Anything[2..*] nonunique ordered;
 	}
 	
 	assoc all BinaryLink specializes Link {
@@ -25,8 +25,8 @@ standard library package Links {
 		 
 	    feature participant: Anything[2] nonunique ordered redefines Link::participant;
 		
-		end feature source: Anything[0..*] nonunique subsets participant;
-	    end feature target: Anything[0..*] nonunique subsets participant;
+		readonly end feature source: Anything[0..*] subsets participant;
+	    readonly end feature target: Anything[0..*] subsets participant;
 	}
 	
 	assoc all SelfLink specializes BinaryLink {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -39,7 +39,7 @@ standard library package Transfers {
 			in feature targetInput: Occurrence[0..*];
 		}
 		
-		feature isInstant: Boolean[1] = notEmpty(instant) {
+		readonly feature isInstant: Boolean[1] = notEmpty(instant) {
 			doc
 			/*
 			 * If isInstance is true, then the transfer is instantaneous.
@@ -80,7 +80,7 @@ standard library package Transfers {
 		 * start when items are available at the source and move or copy them to the target.
 		 */
 		 
-		feature isMove: Boolean[1] default true {
+		readonly feature isMove: Boolean[1] default true {
 			doc
 			/*
 			 * If isMove is true, then all items leave the source at the start
@@ -88,7 +88,7 @@ standard library package Transfers {
 			 */
 		}
 		
-		feature isPush: Boolean[1] default true {
+		readonly feature isPush: Boolean[1] default true {
 			doc
 			/*
 			 * If isPush is true, then the transfer begins when the items are available


### PR DESCRIPTION
Adds readonly to
- Link::`participant`
- BinaryLink::`source`/`target`
    - Otherwise the values could be flipped and potentially not affect `participant` (couldn't find where the libs formally require these values to appear in `participant` in the order declared)
    - Removed `nonunique`, since these features always have exactly one value.

- Transfer::`isInstant`, FlowTransfer::`iMove`/`isPush`
    These indicate what a transfer as a whole (life) will be doing, shouldn't change during it.
