### PR TITLE
ST6RI-650 '^' should be implemented as a exponential operator

### DIFF
--- a/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
+++ b/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -50,11 +50,14 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 			return super.evaluateInvocation(expression, target);
 		} else {
 			Type type = expression.getOwnedTyping().stream().map(FeatureTyping::getType).findFirst().orElse(null);
-			Expression resultExpression = ExpressionUtil.getResultExpressionOf(type);
-			if (resultExpression == null) {
-				Feature resultParameter = TypeUtil.getResultParameterOf(type);
-				if (resultParameter != null) {
-					resultExpression = FeatureUtil.getValueExpressionFor(resultParameter);
+			Expression resultExpression = null;
+			if (type != null) {
+				resultExpression = ExpressionUtil.getResultExpressionOf(type);
+				if (resultExpression == null) {
+					Feature resultParameter = TypeUtil.getResultParameterOf(type);
+					if (resultParameter != null) {
+						resultExpression = FeatureUtil.getValueExpressionFor(resultParameter);
+					}
 				}
 			}
 			if (resultExpression == null) {

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Mgnite, Inc.
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -278,4 +278,16 @@ public class ExpressionEvaluationTest extends SysMLInteractiveTest {
 		process(instance, chainTest);
 		assertElement("LiteralInteger 1", instance.eval("y.a.z", "ChainTest"));
 	}
+	
+	@Test
+	public void testArithmeticEvaluation() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		assertElement("LiteralInteger 5", instance.eval("2 + 3", null));
+		assertElement("LiteralInteger -1", instance.eval("2 - 3", null));
+		assertElement("LiteralInteger 6", instance.eval("2 * 3", null));
+		assertElement("LiteralRational " + 2.0/3, instance.eval("2.0 / 3", null));
+		assertElement("LiteralRational 4.0", instance.eval("2.0 ** 2", null));
+		assertElement("LiteralRational 4.0", instance.eval("2.0 ^ 2", null));
+	}
+
 }

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -238,6 +238,7 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		assertEquals(2.0d * 3.0d, evaluateRealValue(null, null, "2.0 * 3"), 0);
 		assertEquals(2.0d/3.0d, evaluateRealValue(null, null, "2.0 / 3"), 0);
 		assertEquals(4.0d, evaluateRealValue(null, null, "2.0 ** 2"), 0);
+		assertEquals(4.0d, evaluateRealValue(null, null, "2.0 ^ 2"), 0);
 	}
 	
 	@Test

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/PowerFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/PowerFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -28,8 +28,8 @@ import org.omg.sysml.lang.sysml.Element;
 public class PowerFunction extends ArithmeticFunction {
 
 	@Override
-	public String getOperatorName() {
-		return "'**'";
+	public String[] getOperatorNames() {
+		return new String[]{"'**'", "'^'"};
 	}
 	
 	@Override


### PR DESCRIPTION
This PR adds `^` as an allowable alternative name for the exponentiation operator `**` during model-level expression evaluation. It also fixes a null-pointer exception that can occur during full expression evaluation when an invocation expression is ill-formed without any type.