### PR TITLE
ST6RI-651 Implicit specialization for ItemFlows/FlowConnectionUsages is wrong

### DIFF
--- a/org.omg.kerml.xpect.tests/library/Base.kerml
+++ b/org.omg.kerml.xpect.tests/library/Base.kerml
@@ -31,7 +31,7 @@ standard library package Base {
 		feature self: DataValue redefines Anything::self;
 	}
 	
-	abstract feature things: Anything [0..*] nonunique {
+	abstract feature things: Anything [1..*] nonunique {
 		doc
 		/*
 		 * things is the top-level feature in the language.
@@ -87,7 +87,7 @@ standard library package Base {
 	multiplicity zeroToMany [0..*] {
 		doc
 		/*
-		 * oneToMany is a multiplicity range allowing any cardinality of ozero or more
+		 * zeroToMany is a multiplicity range allowing any cardinality of zero or more
 		 * (that is, no restriction).
 		 */
 	}

--- a/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
@@ -30,6 +30,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions going out of a decision step.
 			 */
+
+			 feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -49,6 +51,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions coming into a merge step.
 			 */
+
+			 feature redefines laterOccurrence subsets that;
 		}
 	}
 

--- a/org.omg.kerml.xpect.tests/library/KerML.kerml
+++ b/org.omg.kerml.xpect.tests/library/KerML.kerml
@@ -256,7 +256,7 @@ standard library package KerML {
 			derived feature ownedEndFeature : Feature[0..*] subsets endFeature, ownedFeature;
 			composite derived feature ownedConjugator : Conjugation[0..1] subsets ownedRelationship;
 			derived feature inheritedFeature : Feature[0..*] subsets 'feature';
-			derived feature 'multiplicity' : Multiplicity[0..1] subsets 'member';
+			derived feature 'multiplicity' : Multiplicity[0..1] subsets ownedMember;
 			derived feature unioningType : Type[0..*];
 			composite derived feature ownedIntersecting : Intersecting[0..*] subsets ownedRelationship;
 			derived feature intersectingType : Type[0..*];
@@ -439,7 +439,7 @@ standard library package KerML {
 				
 		metaclass ReferenceSubsetting specializes Subsetting {
 			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
-			derived feature referencingFeature : Feature[1..1] redefines owningFeature, subsettingFeature;
+			derived feature referencingFeature : Feature[1..1] redefines subsettingFeature, owningFeature;
 		}		
 				
 		metaclass ResultExpressionMembership specializes FeatureMembership {

--- a/org.omg.kerml.xpect.tests/library/Links.kerml
+++ b/org.omg.kerml.xpect.tests/library/Links.kerml
@@ -13,7 +13,7 @@ standard library package Links {
 		 * Link is the most general association between two or more things.
 		 */
 
-		feature participant: Anything[2..*] nonunique ordered;
+		readonly feature participant: Anything[2..*] nonunique ordered;
 	}
 	
 	assoc all BinaryLink specializes Link {
@@ -25,8 +25,8 @@ standard library package Links {
 		 
 	    feature participant: Anything[2] nonunique ordered redefines Link::participant;
 		
-		end feature source: Anything[0..*] nonunique subsets participant;
-	    end feature target: Anything[0..*] nonunique subsets participant;
+		readonly end feature source: Anything[0..*] subsets participant;
+	    readonly end feature target: Anything[0..*] subsets participant;
 	}
 	
 	assoc all SelfLink specializes BinaryLink {

--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -72,14 +72,15 @@ standard library package Occurrences {
 			 feature redefines incomingTransferSort default (that as Occurrence).incomingTransferSort;
 		}
 		
-		feature withoutOccurrences: Occurrence[0..*] subsets occurrences inverse of withoutOccurrences {
+		feature withoutOccurrences: Occurrence[0..*] unions successors, predecessors, outsideOfOccurrences
+			inverse of withoutOccurrences {
 			doc
 			/*
 			 * Occurrences that are completely separate either in time or space or both.
 			 */
 
 			/* withoutOccurrences is irreflexive. */
-			inv { (that as Occurrence) != (self as Occurrence) }
+			inv { (that as Occurrence) != (that.that as Occurrence) }
 		}
 
 		feature predecessors: Occurrence[0..*] subsets withoutOccurrences {
@@ -322,7 +323,7 @@ standard library package Occurrences {
 			 * is none when the startShot and endShot are the same.
 			 */
 		}
-		inv { isEmpty(middleTimeSlice) == (startShot == endShot) }
+		inv { isEmpty((that as Occurrence).middleTimeSlice) == ((that as Occurrence).startShot == (that as Occurrence).endShot) }
 
 		connector :HappensJustBefore
 			from earlierOccurrence references startShot [1]
@@ -377,10 +378,10 @@ standard library package Occurrences {
 			 */
 		}
 
-		feature spaceShotOf: Occurrence[0..*] subsets spaceSliceOf inverse of spaceShots {
+		feature all spaceShotOf: Occurrence[0..*] subsets spaceSliceOf inverse of spaceShots {
 			doc
 			/*
-			 * Occurrences of which this occurrence is a space shot.
+			 * All occurrences of which this occurrence is a space shot.
 			 */
 
 			feature spaceShotOccurrence: Occurrence[1] subsets that;
@@ -491,7 +492,7 @@ standard library package Occurrences {
 
 			feature redefines isClosed = true;
 
-			feature spaceBounder: Occurrence subsets self;
+			feature spaceBounder: Occurrence [1] subsets self;
 
 			outer: Occurrence [0..1] subsets spaceSlices {
 				feature redefines isClosed = true;
@@ -518,7 +519,7 @@ standard library package Occurrences {
 			inv { spaceBounderOf.spaceBoundary == that.that }
 		}
 
-		inv { not isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+		inv { not isClosed implies contains((that as Occurrence).unionsOf, union(spaceBoundary, spaceInterior)) }
 		inv { innerSpaceDimension == 0 implies isEmpty(spaceBoundary) }
 
 		connector :SurroundedBy
@@ -529,7 +530,7 @@ standard library package Occurrences {
 			from surroundedSpace references spaceBoundary.inner [0..*]
 			to surroundingSpace references spaceInterior [1];
 
-		feature innerSpaceOccurrences: Occurrence [0..*] {
+		feature innerSpaceOccurrences: Occurrence [0..*] subsets outsideOfOccurrences {
 			doc
 			/*
 			 * Occurrences that completely occupy the space surrounded by an inner space boundary of this occurrence.
@@ -547,7 +548,7 @@ standard library package Occurrences {
 			inv { (isEmpty(hbi) == notEmpty(hbo)) & (notEmpty(hbo) == outerSpace.isClosed) }
 		}
 
-		feature surroundedByOccurrences: Occurrence [0..*] {
+		feature surroundedByOccurrences: Occurrence [0..*] subsets outsideOfOccurrences {
 			doc
 			/*
 			 * Occurrences that have inner spaces that completely include this occurrence.
@@ -567,7 +568,7 @@ standard library package Occurrences {
 			 * Tells whether an occurrence has a spaceBoundary, true if it does, false otherwise.
 			 */
 		}
-		inv { isClosed == isEmpty(spaceBoundary) }
+		inv { isClosed == isEmpty((that as Occurrence).spaceBoundary) }
 
 		feature incomingTransfers: Transfers::Transfer[0..*] subsets Transfers::transfers {
 			doc
@@ -613,9 +614,8 @@ standard library package Occurrences {
 			 */
 
 			end feature redefines source;
-			end feature redefines target;
+			end feature redefines target = that;
 		}
-		binding incomingTransfersToSelf.target = self;
 
 		feature outgoingTransfers: Transfers::Transfer[0..*] subsets Transfers::transfers {
 			doc
@@ -633,10 +633,9 @@ standard library package Occurrences {
 			 * The outgoing transfers with this occurrence as the source.
 			 */
 
-			end feature redefines source;
+			end feature redefines source = that;
 			end feature redefines target;
 		}
-		binding outgoingTransfersFromSelf.source = self;
 	}
 
 	abstract class all Life specializes Occurrence {
@@ -688,7 +687,7 @@ standard library package Occurrences {
 		/*
 		 * HappensLink is the most general associations that assert temporal relationships between a
 		 * sourceOccurrence and a targetOccurrence. Because HappensLinks assert temporal
-		 * relationships, they cannot themselves be Occurrences that happen in time.  Therefore
+		 * relationships, they cannot also be Occurrences that happen in time.  Therefore
 		 * HappensLink is disjoint with LinkObject, that is, no HappensLink can also be a
 		 * LinkObject.
 		 */

--- a/org.omg.kerml.xpect.tests/library/Performances.kerml
+++ b/org.omg.kerml.xpect.tests/library/Performances.kerml
@@ -76,28 +76,7 @@ standard library package Performances {
 			}
 		
 			feature redefines thisPerformance default (that as Performance).thisPerformance;
-		}
-		
-		expr enclosedEvaluations: Evaluation[0..*] subsets evaluations, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this Performance that are Evaluations.
-			 */
-		}
-		
-		step enclosedTransfers: Transfer[0..*] subsets transfers, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this performance that are transfers.
-			 */
-		}
-		
-		step enclosedTransfersBefore: TransferBefore[0..*] subsets transfersBefore, enclosedTransfers {
-			doc
-			/*
-			 * enclosedTransfers of this performance that are transfers-before.
-			 */
-		}
+		}		
 	}
 	
 	abstract function Evaluation specializes Performance {

--- a/org.omg.kerml.xpect.tests/library/StatePerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/StatePerformances.kerml
@@ -8,8 +8,10 @@ standard library package StatePerformances {
 	private import ScalarValues::Boolean;
 	private import ScalarValues::Natural;
 	private import TransitionPerformances::TransitionPerformance;
+	private import Occurrences::Occurrence;
 	private import Occurrences::HappensDuring;
 	private import Transfers::Transfer;
+	private import Transfers::MessageTransfer;
 	private import Performances::Performance;
 	private import ControlPerformances::DecisionPerformance;
 	private import ControlFunctions::forAll;
@@ -42,11 +44,19 @@ standard library package StatePerformances {
 		private succession do.startShot[1] then nonDoMiddle.startShot[*];
 		private succession middle[*] then exit[1];
 
+
+		readonly feature incomingTransitionTrigger : MessageTransfer [0..1] default null {
+			doc
+			/*
+			 * Transfer that triggered a transition into this state performance. 
+			 */
+		}
+
 		private inv { isEmpty(accepted) == isEmpty(acceptable) }
 		feature accepted: Transfer[0..1] subsets acceptable {
 			doc
 			/* A transfer to the trigger target of an outgoing transition performance
-			 * for an outoging successon that is taken for this state occurrence.
+			 * for an outgoing successon that is taken for this state occurrence.
 			 */
 		}
 		feature deferrable: Transfer[0..*] subsets acceptable {
@@ -99,8 +109,9 @@ standard library package StatePerformances {
 			return  : TransitionPerformance [*] =
 				union(subtransitionPerformances,  
 		      		subtransitionPerformances->collect{in sp:TransitionPerformance; 
-							 		allSubtransitionPerformances(sp) } ); }
-		}
+							 		allSubtransitionPerformances(sp) } ); 
+ 		}
+	}
 	
 	behavior StateTransitionPerformance specializes TransitionPerformance {
 		feature isTriggerDuring: Boolean[1];
@@ -111,6 +122,11 @@ standard library package StatePerformances {
 			feature redefines StatePerformance::acceptable;
 		}
 		private succession transitionLinkSource.nonDoMiddle[*] then Performance::self[1];
+
+		private feature transitionLinkTarget [0..1] : Occurrence = transitionLink.laterOccurrence {
+			inv { (that istype StatePerformance) implies
+			      (that as StatePerformance).incomingTransitionTrigger == trigger }
+		}
 		
 		feature acceptable: Transfer [*] subsets transitionLinkSource.acceptable, triggerTarget.incomingTransfersToSelf;
 

--- a/org.omg.kerml.xpect.tests/library/Transfers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Transfers.kerml
@@ -39,7 +39,7 @@ standard library package Transfers {
 			in feature targetInput: Occurrence[0..*];
 		}
 		
-		feature isInstant: Boolean[1] = notEmpty(instant) {
+		readonly feature isInstant: Boolean[1] = notEmpty(instant) {
 			doc
 			/*
 			 * If isInstance is true, then the transfer is instantaneous.
@@ -80,7 +80,7 @@ standard library package Transfers {
 		 * start when items are available at the source and move or copy them to the target.
 		 */
 		 
-		feature isMove: Boolean[1] default true {
+		readonly feature isMove: Boolean[1] default true {
 			doc
 			/*
 			 * If isMove is true, then all items leave the source at the start
@@ -88,7 +88,7 @@ standard library package Transfers {
 			 */
 		}
 		
-		feature isPush: Boolean[1] default true {
+		readonly feature isPush: Boolean[1] default true {
 			doc
 			/*
 			 * If isPush is true, then the transfer begins when the items are available

--- a/org.omg.sysml.xpect.tests/library.kernel/Base.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Base.kerml
@@ -31,7 +31,7 @@ standard library package Base {
 		feature self: DataValue redefines Anything::self;
 	}
 	
-	abstract feature things: Anything [0..*] nonunique {
+	abstract feature things: Anything [1..*] nonunique {
 		doc
 		/*
 		 * things is the top-level feature in the language.
@@ -87,7 +87,7 @@ standard library package Base {
 	multiplicity zeroToMany [0..*] {
 		doc
 		/*
-		 * oneToMany is a multiplicity range allowing any cardinality of ozero or more
+		 * zeroToMany is a multiplicity range allowing any cardinality of zero or more
 		 * (that is, no restriction).
 		 */
 	}

--- a/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
@@ -30,6 +30,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions going out of a decision step.
 			 */
+
+			 feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -49,6 +51,8 @@ standard library package ControlPerformances {
 			 * Specializations subset this by all
 			 * successions coming into a merge step.
 			 */
+
+			 feature redefines laterOccurrence subsets that;
 		}
 	}
 

--- a/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
@@ -256,7 +256,7 @@ standard library package KerML {
 			derived feature ownedEndFeature : Feature[0..*] subsets endFeature, ownedFeature;
 			composite derived feature ownedConjugator : Conjugation[0..1] subsets ownedRelationship;
 			derived feature inheritedFeature : Feature[0..*] subsets 'feature';
-			derived feature 'multiplicity' : Multiplicity[0..1] subsets 'member';
+			derived feature 'multiplicity' : Multiplicity[0..1] subsets ownedMember;
 			derived feature unioningType : Type[0..*];
 			composite derived feature ownedIntersecting : Intersecting[0..*] subsets ownedRelationship;
 			derived feature intersectingType : Type[0..*];
@@ -439,7 +439,7 @@ standard library package KerML {
 				
 		metaclass ReferenceSubsetting specializes Subsetting {
 			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
-			derived feature referencingFeature : Feature[1..1] redefines owningFeature, subsettingFeature;
+			derived feature referencingFeature : Feature[1..1] redefines subsettingFeature, owningFeature;
 		}		
 				
 		metaclass ResultExpressionMembership specializes FeatureMembership {

--- a/org.omg.sysml.xpect.tests/library.kernel/Links.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Links.kerml
@@ -13,7 +13,7 @@ standard library package Links {
 		 * Link is the most general association between two or more things.
 		 */
 
-		feature participant: Anything[2..*] nonunique ordered;
+		readonly feature participant: Anything[2..*] nonunique ordered;
 	}
 	
 	assoc all BinaryLink specializes Link {
@@ -25,8 +25,8 @@ standard library package Links {
 		 
 	    feature participant: Anything[2] nonunique ordered redefines Link::participant;
 		
-		end feature source: Anything[0..*] nonunique subsets participant;
-	    end feature target: Anything[0..*] nonunique subsets participant;
+		readonly end feature source: Anything[0..*] subsets participant;
+	    readonly end feature target: Anything[0..*] subsets participant;
 	}
 	
 	assoc all SelfLink specializes BinaryLink {

--- a/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
@@ -72,14 +72,15 @@ standard library package Occurrences {
 			 feature redefines incomingTransferSort default (that as Occurrence).incomingTransferSort;
 		}
 		
-		feature withoutOccurrences: Occurrence[0..*] subsets occurrences inverse of withoutOccurrences {
+		feature withoutOccurrences: Occurrence[0..*] unions successors, predecessors, outsideOfOccurrences
+			inverse of withoutOccurrences {
 			doc
 			/*
 			 * Occurrences that are completely separate either in time or space or both.
 			 */
 
 			/* withoutOccurrences is irreflexive. */
-			inv { (that as Occurrence) != (self as Occurrence) }
+			inv { (that as Occurrence) != (that.that as Occurrence) }
 		}
 
 		feature predecessors: Occurrence[0..*] subsets withoutOccurrences {
@@ -322,7 +323,7 @@ standard library package Occurrences {
 			 * is none when the startShot and endShot are the same.
 			 */
 		}
-		inv { isEmpty(middleTimeSlice) == (startShot == endShot) }
+		inv { isEmpty((that as Occurrence).middleTimeSlice) == ((that as Occurrence).startShot == (that as Occurrence).endShot) }
 
 		connector :HappensJustBefore
 			from earlierOccurrence references startShot [1]
@@ -377,10 +378,10 @@ standard library package Occurrences {
 			 */
 		}
 
-		feature spaceShotOf: Occurrence[0..*] subsets spaceSliceOf inverse of spaceShots {
+		feature all spaceShotOf: Occurrence[0..*] subsets spaceSliceOf inverse of spaceShots {
 			doc
 			/*
-			 * Occurrences of which this occurrence is a space shot.
+			 * All occurrences of which this occurrence is a space shot.
 			 */
 
 			feature spaceShotOccurrence: Occurrence[1] subsets that;
@@ -491,7 +492,7 @@ standard library package Occurrences {
 
 			feature redefines isClosed = true;
 
-			feature spaceBounder: Occurrence subsets self;
+			feature spaceBounder: Occurrence [1] subsets self;
 
 			outer: Occurrence [0..1] subsets spaceSlices {
 				feature redefines isClosed = true;
@@ -518,7 +519,7 @@ standard library package Occurrences {
 			inv { spaceBounderOf.spaceBoundary == that.that }
 		}
 
-		inv { not isClosed implies contains(self.unionsOf, union(spaceBoundary, spaceInterior)) }
+		inv { not isClosed implies contains((that as Occurrence).unionsOf, union(spaceBoundary, spaceInterior)) }
 		inv { innerSpaceDimension == 0 implies isEmpty(spaceBoundary) }
 
 		connector :SurroundedBy
@@ -529,7 +530,7 @@ standard library package Occurrences {
 			from surroundedSpace references spaceBoundary.inner [0..*]
 			to surroundingSpace references spaceInterior [1];
 
-		feature innerSpaceOccurrences: Occurrence [0..*] {
+		feature innerSpaceOccurrences: Occurrence [0..*] subsets outsideOfOccurrences {
 			doc
 			/*
 			 * Occurrences that completely occupy the space surrounded by an inner space boundary of this occurrence.
@@ -547,7 +548,7 @@ standard library package Occurrences {
 			inv { (isEmpty(hbi) == notEmpty(hbo)) & (notEmpty(hbo) == outerSpace.isClosed) }
 		}
 
-		feature surroundedByOccurrences: Occurrence [0..*] {
+		feature surroundedByOccurrences: Occurrence [0..*] subsets outsideOfOccurrences {
 			doc
 			/*
 			 * Occurrences that have inner spaces that completely include this occurrence.
@@ -567,7 +568,7 @@ standard library package Occurrences {
 			 * Tells whether an occurrence has a spaceBoundary, true if it does, false otherwise.
 			 */
 		}
-		inv { isClosed == isEmpty(spaceBoundary) }
+		inv { isClosed == isEmpty((that as Occurrence).spaceBoundary) }
 
 		feature incomingTransfers: Transfers::Transfer[0..*] subsets Transfers::transfers {
 			doc
@@ -613,9 +614,8 @@ standard library package Occurrences {
 			 */
 
 			end feature redefines source;
-			end feature redefines target;
+			end feature redefines target = that;
 		}
-		binding incomingTransfersToSelf.target = self;
 
 		feature outgoingTransfers: Transfers::Transfer[0..*] subsets Transfers::transfers {
 			doc
@@ -633,10 +633,9 @@ standard library package Occurrences {
 			 * The outgoing transfers with this occurrence as the source.
 			 */
 
-			end feature redefines source;
+			end feature redefines source = that;
 			end feature redefines target;
 		}
-		binding outgoingTransfersFromSelf.source = self;
 	}
 
 	abstract class all Life specializes Occurrence {
@@ -688,7 +687,7 @@ standard library package Occurrences {
 		/*
 		 * HappensLink is the most general associations that assert temporal relationships between a
 		 * sourceOccurrence and a targetOccurrence. Because HappensLinks assert temporal
-		 * relationships, they cannot themselves be Occurrences that happen in time.  Therefore
+		 * relationships, they cannot also be Occurrences that happen in time.  Therefore
 		 * HappensLink is disjoint with LinkObject, that is, no HappensLink can also be a
 		 * LinkObject.
 		 */

--- a/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
@@ -76,28 +76,7 @@ standard library package Performances {
 			}
 		
 			feature redefines thisPerformance default (that as Performance).thisPerformance;
-		}
-		
-		expr enclosedEvaluations: Evaluation[0..*] subsets evaluations, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this Performance that are Evaluations.
-			 */
-		}
-		
-		step enclosedTransfers: Transfer[0..*] subsets transfers, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this performance that are transfers.
-			 */
-		}
-		
-		step enclosedTransfersBefore: TransferBefore[0..*] subsets transfersBefore, enclosedTransfers {
-			doc
-			/*
-			 * enclosedTransfers of this performance that are transfers-before.
-			 */
-		}
+		}		
 	}
 	
 	abstract function Evaluation specializes Performance {

--- a/org.omg.sysml.xpect.tests/library.kernel/StatePerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/StatePerformances.kerml
@@ -8,8 +8,10 @@ standard library package StatePerformances {
 	private import ScalarValues::Boolean;
 	private import ScalarValues::Natural;
 	private import TransitionPerformances::TransitionPerformance;
+	private import Occurrences::Occurrence;
 	private import Occurrences::HappensDuring;
 	private import Transfers::Transfer;
+	private import Transfers::MessageTransfer;
 	private import Performances::Performance;
 	private import ControlPerformances::DecisionPerformance;
 	private import ControlFunctions::forAll;
@@ -42,11 +44,19 @@ standard library package StatePerformances {
 		private succession do.startShot[1] then nonDoMiddle.startShot[*];
 		private succession middle[*] then exit[1];
 
+
+		readonly feature incomingTransitionTrigger : MessageTransfer [0..1] default null {
+			doc
+			/*
+			 * Transfer that triggered a transition into this state performance. 
+			 */
+		}
+
 		private inv { isEmpty(accepted) == isEmpty(acceptable) }
 		feature accepted: Transfer[0..1] subsets acceptable {
 			doc
 			/* A transfer to the trigger target of an outgoing transition performance
-			 * for an outoging successon that is taken for this state occurrence.
+			 * for an outgoing successon that is taken for this state occurrence.
 			 */
 		}
 		feature deferrable: Transfer[0..*] subsets acceptable {
@@ -99,8 +109,9 @@ standard library package StatePerformances {
 			return  : TransitionPerformance [*] =
 				union(subtransitionPerformances,  
 		      		subtransitionPerformances->collect{in sp:TransitionPerformance; 
-							 		allSubtransitionPerformances(sp) } ); }
-		}
+							 		allSubtransitionPerformances(sp) } ); 
+ 		}
+	}
 	
 	behavior StateTransitionPerformance specializes TransitionPerformance {
 		feature isTriggerDuring: Boolean[1];
@@ -111,6 +122,11 @@ standard library package StatePerformances {
 			feature redefines StatePerformance::acceptable;
 		}
 		private succession transitionLinkSource.nonDoMiddle[*] then Performance::self[1];
+
+		private feature transitionLinkTarget [0..1] : Occurrence = transitionLink.laterOccurrence {
+			inv { (that istype StatePerformance) implies
+			      (that as StatePerformance).incomingTransitionTrigger == trigger }
+		}
 		
 		feature acceptable: Transfer [*] subsets transitionLinkSource.acceptable, triggerTarget.incomingTransfersToSelf;
 

--- a/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
@@ -39,7 +39,7 @@ standard library package Transfers {
 			in feature targetInput: Occurrence[0..*];
 		}
 		
-		feature isInstant: Boolean[1] = notEmpty(instant) {
+		readonly feature isInstant: Boolean[1] = notEmpty(instant) {
 			doc
 			/*
 			 * If isInstance is true, then the transfer is instantaneous.
@@ -80,7 +80,7 @@ standard library package Transfers {
 		 * start when items are available at the source and move or copy them to the target.
 		 */
 		 
-		feature isMove: Boolean[1] default true {
+		readonly feature isMove: Boolean[1] default true {
 			doc
 			/*
 			 * If isMove is true, then all items leave the source at the start
@@ -88,7 +88,7 @@ standard library package Transfers {
 			 */
 		}
 		
-		feature isPush: Boolean[1] default true {
+		readonly feature isPush: Boolean[1] default true {
 			doc
 			/*
 			 * If isPush is true, then the transfer begins when the items are available

--- a/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
@@ -124,6 +124,13 @@ standard library package Actions {
 			 */
 		}
 		
+		abstract action decisionTransitions : DecisionTransitionAction[0..*] :> transitionActions {
+			doc
+			/*
+			 * The subactions of this Action that are DecisionTransitionActions. 
+			 */
+		}
+		
 		abstract action assignments : AssignmentAction[0..*] :> subactions, assignmentActions {
 			doc
 			/*
@@ -148,14 +155,14 @@ standard library package Actions {
 		abstract action whileLoops : WhileLoopAction[0..*] :> loops, whileLoopActions {
 			doc
 			/*
-			 * The subactions of this Action that are LoopActions.
+			 * The loops of this Action that are WhileLoopActions.
 			 */
 		}
 		
 		abstract action forLoops : ForLoopAction[0..*] :> loops, forLoopActions {
 			doc
 			/*
-			 * The subactions of this Action that are LoopActions.
+			 * The loops of this Action that are ForLoopActions.
 			 */
 		}
 	}

--- a/org.omg.sysml.xpect.tests/library.systems/Constraints.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Constraints.sysml
@@ -30,14 +30,14 @@ standard library package Constraints {
 	abstract constraint assertedConstraintChecks :> constraintChecks, trueEvaluations {
 		doc
 		/*
-		 * assertedConstraintChecks is the subset of constraintChecks for Constraints asserted to be true.
+		 * assertedConstraintChecks is the subset of constraintChecks for ConstraintChecks asserted to be true.
 		 */
 	}
 		
 	abstract constraint negatedConstraintChecks :> constraintChecks, falseEvaluations {
 		doc
 		/*
-		 * negatedConstraintChecks is the subset of constraintChecks for Constraints asserted to be false.
+		 * negatedConstraintChecks is the subset of constraintChecks for ConstraintChecks asserted to be false.
 		 */
 	}
 		

--- a/org.omg.sysml.xpect.tests/library.systems/Requirements.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Requirements.sysml
@@ -51,8 +51,6 @@ standard library package Requirements {
 		/*
 		 * RequirementCheck is the most general class for requirements checking. RequirementsCheck is the base
 		 * type of all requirement definitions.
-		 * 
-		 * 
 		 */
 	
 		ref requirement :>> self: RequirementCheck;

--- a/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
@@ -184,10 +184,10 @@ standard library package SysML {
 			attribute isImportAll : Boolean[1..1] redefines isImportAll;
 		}		
 				
-		metadata def FlowConnectionDefinition specializes Interaction, ActionDefinition, ConnectionDefinition;		
+		metadata def FlowConnectionDefinition specializes Interaction, ConnectionDefinition, ActionDefinition;		
 				
 		metadata def FlowConnectionUsage specializes ConnectionUsage, ItemFlow, ActionUsage {
-			derived ref item flowConnectionDefinition : Interaction[0..*] redefines actionDefinition, interaction, connectionDefinition;
+			derived ref item flowConnectionDefinition : Interaction[0..*] redefines actionDefinition, connectionDefinition, interaction;
 		}		
 				
 		metadata def ForLoopActionUsage specializes LoopActionUsage {
@@ -238,7 +238,7 @@ standard library package SysML {
 			derived ref item bodyAction : ActionUsage[1..1];
 		}		
 				
-		metadata def MembershipExpose specializes Expose, MembershipImport;		
+		metadata def MembershipExpose specializes MembershipImport, Expose;		
 				
 		metadata def MergeNode specializes ControlNode;		
 				
@@ -265,7 +265,6 @@ standard library package SysML {
 			attribute portionKind : PortionKind[0..1];
 			
 			derived ref item occurrenceDefinition : Class[0..*] redefines definition;
-			derived ref item portioningFeature : PortioningFeature[0..1] subsets ownedFeature;
 			derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition;
 		}		
 				
@@ -296,10 +295,6 @@ standard library package SysML {
 			enum 'timeslice';
 			enum 'snapshot';
 		}
-				
-		metadata def PortioningFeature specializes Feature {
-			derived attribute portionKind : PortionKind[1..1];
-		}		
 				
 		metadata def ReferenceUsage specializes Usage {
 			derived attribute isReference : Boolean[1..1] redefines isReference;
@@ -375,7 +370,7 @@ standard library package SysML {
 		metadata def StateDefinition specializes ActionDefinition {
 			attribute isParallel : Boolean[1..1];
 			
-			derived ref item 'state' : StateUsage[0..*] subsets step;
+			derived ref item 'state' : StateUsage[0..*] subsets 'action';
 			derived ref item entryAction : ActionUsage[0..1];
 			derived ref item doAction : ActionUsage[0..1];
 			derived ref item exitAction : ActionUsage[0..1];

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
@@ -13,6 +13,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 		File {from ="/library.systems/Parts.sysml"}
 		File {from ="/library.systems/Ports.sysml"}
 		File {from ="/library.systems/Connections.sysml"}
+		File {from ="/library.systems/Actions.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -29,6 +30,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 				File {from ="/library.systems/Parts.sysml"}
 				File {from ="/library.systems/Ports.sysml"}
 				File {from ="/library.systems/Connections.sysml"}
+				File {from ="/library.systems/Actions.sysml"}
 			}
 		}
 	}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Relationship_invalid_relatedElement1.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Relationship_invalid_relatedElement1.sysml.xt
@@ -11,6 +11,7 @@
 		File {from ="/library.systems/Parts.sysml"}
 		File {from ="/library.systems/Ports.sysml"}
 		File {from ="/library.systems/Connections.sysml"}
+		File {from ="/library.systems/Actions.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -26,6 +27,7 @@
 				File {from ="/library.systems/Parts.sysml"}
 				File {from ="/library.systems/Ports.sysml"}
 				File {from ="/library.systems/Connections.sysml"}
+				File {from ="/library.systems/Actions.sysml"}
 			}
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,7 +24,6 @@ package org.omg.sysml.adapter;
 import java.util.Collections;
 import java.util.List;
 
-import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
@@ -60,9 +59,9 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 		if (subactionType != null) {
 			addDefaultGeneralType(subactionType);
 		} 
-		if (isOwnedPerformance()) {
+		if (isStructureOwnedComposite()) {
 			addDefaultGeneralType("ownedPerformance");
-		} else if (isEnclosedPerformance()) {
+		} else if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}
@@ -74,27 +73,15 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	
 	@Override
 	protected boolean isSuboccurrence() {
-		return super.isSuboccurrence() && !isSubaction();
+		return super.isSuboccurrence() && !isActionOwnedComposite();
 	}
 	
 	protected String getSubactionType() {
-		return isSubaction()? "subaction": 
-			   isOwnedAction()? "ownedAction":
+		return isActionOwnedComposite()? "subaction": 
+			   isPartOwnedComposite()? "ownedAction":
 			   null;	
 	}
 		
-	public boolean isSubaction() {
-		ActionUsage target = getTarget();
-		Type owningType = target.getOwningType();
-		return target.isComposite() && (owningType instanceof ActionDefinition || owningType instanceof ActionUsage);
-	}
-	
-	public boolean isOwnedAction() {
-		ActionUsage target = getTarget();
-		Type owningType = target.getOwningType();
-		return target.isComposite() && (owningType instanceof PartDefinition || owningType instanceof PartUsage);
-	}
-	
 	// Used in subclasses.
 	public boolean isPerformedAction() {		
 		Type owningType = getTarget().getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AssertConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AssertConstraintUsageAdapter.java
@@ -44,7 +44,7 @@ public class AssertConstraintUsageAdapter extends ConstraintUsageAdapter {
 	}
 	
 	@Override
-	public boolean isEnclosedPerformance() {
+	public boolean isBehaviorOwned() {
 		Type owningType = getTarget().getOwningType();
 		return owningType instanceof ActionDefinition || owningType instanceof ActionUsage;
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -93,13 +93,13 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 		if (isCheckedConstraint()) {
 			addDefaultGeneralType("checkedConstraint");
 		}
-		if (isOwnedPerformance()) {
+		if (isStructureOwnedComposite()) {
 			addDefaultGeneralType("ownedPerformance");
 		} 
-		if (isSubperformance()) {
+		if (isBehaviorOwnedComposite()) {
 			addDefaultGeneralType("subperformance");
 		}
-		if (isEnclosedPerformance()) {
+		if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -72,13 +72,13 @@ public class ExpressionAdapter extends StepAdapter {
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
-		if (isOwnedPerformance()) {
+		if (isStructureOwnedComposite()) {
 			addDefaultGeneralType("ownedPerformance");
 		}
-		if (isSubperformance()) {
+		if (isBehaviorOwnedComposite()) {
 			addDefaultGeneralType("subperformance");
 		}
-		if (isEnclosedPerformance()) {
+		if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -139,15 +139,15 @@ public class FeatureAdapter extends TypeAdapter {
 				collect(Collectors.toList());
 	}
 	
-	protected boolean isEnclosedPerformance() {
+	protected boolean isBehaviorOwned() {
 		return FeatureUtil.isPerformanceFeature(getTarget());
 	}
 	
-	protected boolean isSubperformance() {
-		return isEnclosedPerformance() && getTarget().isComposite();
+	protected boolean isBehaviorOwnedComposite() {
+		return isBehaviorOwned() && getTarget().isComposite();
 	}
 	
-	protected boolean isOwnedPerformance() {
+	protected boolean isStructureOwnedComposite() {
 		Feature target = getTarget();
 		Type owningType = target.getOwningType();
 		return target.isComposite() && 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowConnectionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowConnectionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -42,13 +42,16 @@ public class FlowConnectionUsageAdapter extends ConnectionUsageAdapter {
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
-		if (isOwnedPerformance()) {
+		if (isPartOwnedComposite()) {
+			addDefaultGeneralType("ownedAction");
+		} else if (isStructureOwnedComposite()) {
 			addDefaultGeneralType("ownedPerformance");
-		} 
-		if (isSubperformance()) {
+		}
+		if (isActionOwnedComposite()) {
+			addDefaultGeneralType("subaction");
+		} else if (isBehaviorOwnedComposite()) {
 			addDefaultGeneralType("subperformance");
-		} 
-		if (isEnclosedPerformance()) {
+		} else if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ItemFlowAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ItemFlowAdapter.java
@@ -42,13 +42,13 @@ public class ItemFlowAdapter extends ConnectorAdapter {
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
-		if (isOwnedPerformance()) {
+		if (isStructureOwnedComposite()) {
 			addDefaultGeneralType("ownedPerformance");
 		}
-		if (isSubperformance()) {
+		if (isBehaviorOwnedComposite()) {
 			addDefaultGeneralType("subperformance");
 		}
-		if (isEnclosedPerformance()) {
+		if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
@@ -42,11 +42,11 @@ public class StepAdapter extends FeatureAdapter {
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype(
-			isOwnedPerformance()?
+			isStructureOwnedComposite()?
 				"ownedPerformance":
-			isSubperformance()?
+			isBehaviorOwnedComposite()?
 				"subperformance":
-			isEnclosedPerformance()? 
+			isBehaviorOwned()? 
 				"enclosedPerformance":
 			isIncomingTransfer()?
 				"incomingTransfer":

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -25,10 +25,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.omg.sysml.lang.sysml.ActionDefinition;
+import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Definition;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureValue;
+import org.omg.sysml.lang.sysml.PartDefinition;
+import org.omg.sysml.lang.sysml.PartUsage;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.SysMLFactory;
@@ -58,6 +62,18 @@ public class UsageAdapter extends FeatureAdapter {
 	
 	public boolean hasRelevantSubjectParameter() {
 		return false;
+	}
+	
+	public boolean isActionOwnedComposite() {
+		Usage target = getTarget();
+		Type owningType = target.getOwningType();
+		return target.isComposite() && (owningType instanceof ActionDefinition || owningType instanceof ActionUsage);
+	}
+	
+	public boolean isPartOwnedComposite() {
+		Usage target = getTarget();
+		Type owningType = target.getOwningType();
+		return target.isComposite() && (owningType instanceof PartDefinition || owningType instanceof PartUsage);
 	}
 	
 	// Implicit Generalization

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -68,7 +68,7 @@ public class ImplicitGeneralizationMap {
 		put(DataTypeImpl.class, "base", "Base::DataValue");
 		
 		put(ExpressionImpl.class, "base", "Performances::evaluations");
-		put(ExpressionImpl.class, "enclosedPerformance", "Performances::Performance::enclosedEvaluations");
+		put(ExpressionImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		
 		put(FeatureImpl.class, "base", "Base::things");
 		put(FeatureImpl.class, "dataValue", "Base::dataValues");
@@ -90,7 +90,7 @@ public class ImplicitGeneralizationMap {
 		put(ItemFeatureImpl.class, "payload", "Transfers::Transfer::item");
 		
 		put(ItemFlowImpl.class, "base", "Transfers::flowTransfers");
-		put(ItemFlowImpl.class, "enclosedPerformance", "Performances::Performance::enclosedTransfers");
+		put(ItemFlowImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(ItemFlowImpl.class, "subperformance", "Performances::Performance::subperformances");
 		put(ItemFlowImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
@@ -139,7 +139,7 @@ public class ImplicitGeneralizationMap {
 		put(SuccessionImpl.class, "binary", "Occurrences::happensBeforeLinks");
 		
 		put(SuccessionItemFlowImpl.class, "base", "Transfers::flowTransfersBefore");
-		put(SuccessionItemFlowImpl.class, "enclosedperformance", "Performances::Performance::enclosedTransfersBefore");
+		put(SuccessionItemFlowImpl.class, "enclosedperformance", "Performances::Performance::enclosedPerformances");
 		put(SuccessionItemFlowImpl.class, "subperformance", "Performances::Performance::subperformances");
 		put(SuccessionItemFlowImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 
@@ -200,7 +200,7 @@ public class ImplicitGeneralizationMap {
 		put(ConstraintDefinitionImpl.class, "base", "Constraints::ConstraintCheck");
 		put(ConstraintUsageImpl.class, "base", "Constraints::constraintChecks");
 		put(ConstraintUsageImpl.class, "checkedConstraint", "Items::Item::checkedConstraints");
-		put(ConstraintUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedEvaluations");
+		put(ConstraintUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(ConstraintUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
 		put(ConstraintUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
@@ -213,7 +213,9 @@ public class ImplicitGeneralizationMap {
 		put(FlowConnectionDefinitionImpl.class, "binary", "Connections::MessageConnection");		
 		put(FlowConnectionUsageImpl.class, "base", "Connections::flowConnections");
 		put(FlowConnectionUsageImpl.class, "message", "Connections::messageConnections");
-		put(FlowConnectionUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedTransfers");
+		put(FlowConnectionUsageImpl.class, "subaction", "Actions::Action::subactions");
+		put(FlowConnectionUsageImpl.class, "ownedAction", "Parts::Part::ownedActions");
+		put(FlowConnectionUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(FlowConnectionUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
 		put(FlowConnectionUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
@@ -293,7 +295,7 @@ public class ImplicitGeneralizationMap {
 		put(SuccessionAsUsageImpl.class, "binary", "Occurrences::happensBeforeLinks");
 		
 		put(SuccessionFlowConnectionUsageImpl.class, "base", "Connections::successionFlowConnections");
-		put(SuccessionFlowConnectionUsageImpl.class, "subperformance", "Performances::Performance::subtransfersBefore");
+		put(SuccessionFlowConnectionUsageImpl.class, "message", "Connections::successionFlowConnections");
 
 		put(TransitionUsageImpl.class, "base", "Actions::transitionActions");
 		put(TransitionUsageImpl.class, "actionTransition", "Actions::Action::decisionTransitions");

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
@@ -76,28 +76,7 @@ standard library package Performances {
 			}
 		
 			feature redefines thisPerformance default (that as Performance).thisPerformance;
-		}
-		
-		expr enclosedEvaluations: Evaluation[0..*] subsets evaluations, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this Performance that are Evaluations.
-			 */
-		}
-		
-		step enclosedTransfers: Transfer[0..*] subsets transfers, enclosedPerformances {
-			doc
-			/*
-			 * enclosedPerformances of this performance that are transfers.
-			 */
-		}
-		
-		step enclosedTransfersBefore: TransferBefore[0..*] subsets transfersBefore, enclosedTransfers {
-			doc
-			/*
-			 * enclosedTransfers of this performance that are transfers-before.
-			 */
-		}
+		}		
 	}
 	
 	abstract function Evaluation specializes Performance {


### PR DESCRIPTION
1. Removed the no longer relevant features `enclosedEvaluations`, `enclosedTransfers` and `enclosedTransfersBefore` from `Performances::Performance`.
2. Corrected the implicit specialization implementation for `ItemFlows`, `SuccessionItemFlows`, `FlowConnectionUsages` and `SuccessionFlowConnectionUsages`.