### PR TITLE
ST6RI-652 Implicit specialization broken for ActionUsage as enclosedPerformance

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -155,7 +155,7 @@ public class ImplicitGeneralizationMap {
 		put(ActionUsageImpl.class, "base", "Actions::actions");
 		put(ActionUsageImpl.class, "subaction", "Actions::Action::subactions");
 		put(ActionUsageImpl.class, "ownedAction", "Parts::Part::ownedActions");
-		put(ActionUsageImpl.class, "enclosedPerformance", "Performances::performance::enclosedPerformance");
+		put(ActionUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(ActionUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
 		put(AllocationDefinitionImpl.class, "base", "Allocations::Allocation");

--- a/sysml/src/examples/Simple Tests/ActionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ActionTest.sysml
@@ -27,6 +27,7 @@ package ActionTest {
 	
 	action b {
 		attribute f : ScalarValues::Boolean;
+		ref action a : A;
 	}
 	
 }


### PR DESCRIPTION
The the `ImplicitGeneralizationMap` included the following entry for `ActionUsageImpl`:

`put(ActionUsageImpl.class, "enclosedPerformance", "Performances::performance::enclosedPerformance");`

The qualified name in this entry contains two errors: the `p` in `performance` should be upper case, and `enclosedPerfromance` should have a final `s`. As a result, the name was not resolving and, e.g., a referential `ActionUsage` nested in and `ActionDefinition` or `ActionUsage` was not getting the required implicit specialization to `Performances::Performance::enclosedPerformance`.

This PR corrects the above errors.