### PR TITLE
ST6RI-653 Entry and exit actions incorrectly subset Action::subactions

### DIFF
--- a/org.omg.sysml.xpect.tests/library.systems/States.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/States.sysml
@@ -24,7 +24,7 @@ standard library package States {
 		 */
 	
 		entry action entryAction :>> 'entry';
-		do action doAction: Action :>> 'do' :> subactions;
+		do action doAction: Action :>> 'do';
 		exit action exitAction: Action :>> 'exit';
 		
 		attribute :>> isTriggerDuring;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -81,7 +81,7 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 			   isPartOwnedComposite()? "ownedAction":
 			   null;	
 	}
-		
+	
 	// Used in subclasses.
 	public boolean isPerformedAction() {		
 		Type owningType = getTarget().getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -33,13 +33,10 @@ import org.omg.sysml.lang.sysml.PartUsage;
 import org.omg.sysml.lang.sysml.StateSubactionMembership;
 import org.omg.sysml.lang.sysml.TransitionFeatureMembership;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.ImplicitGeneralizationMap;
 import org.omg.sysml.util.TypeUtil;
 
 public class ActionUsageAdapter extends OccurrenceUsageAdapter {
-	
-	public static final String STATE_BASE = "States::StateAction";
-	public static final String TRANSITION_BASE = "Actions::TransitionAction";
-	public static final String[] TRANSITION_REDEFINED_FEATURES = {"accepter", "guard", "effect"};
 	
 	public ActionUsageAdapter(ActionUsage element) {
 		super(element);
@@ -116,11 +113,14 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	
 	protected static String getRedefinedFeature(Feature target) {
 		FeatureMembership membership = target.getOwningFeatureMembership();
-		return membership instanceof StateSubactionMembership?
-					STATE_BASE + "::" + ((StateSubactionMembership)membership).getKind().toString() + "Action": 
-			   membership instanceof TransitionFeatureMembership? 
-					TRANSITION_BASE + "::" + TRANSITION_REDEFINED_FEATURES[((TransitionFeatureMembership)membership).getKind().getValue()]: 
-					null;
+		String kind = 
+				membership instanceof StateSubactionMembership?
+					((StateSubactionMembership)membership).getKind().toString():
+				membership instanceof TransitionFeatureMembership?
+					((TransitionFeatureMembership)membership).getKind().toString():
+				null;
+		return kind == null? null:
+			   ImplicitGeneralizationMap.getDefaultSupertypeFor(target.getClass(), kind);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -44,8 +44,10 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 	}		
 		
 	public boolean isSubcalculation() {
-		Type owningType = getTarget().getOwningType();
-		return owningType instanceof CalculationDefinition || owningType instanceof CalculationUsage;
+		CalculationUsage target = getTarget();
+		Type owningType = target.getOwningType();
+		return !isEntryExitAction() && target.isComposite() &&
+			   owningType instanceof CalculationDefinition || owningType instanceof CalculationUsage;
 	}
 	
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
@@ -51,7 +51,8 @@ public class StateUsageAdapter extends ActionUsageAdapter {
 		
 	public boolean isSubstate() {
 		Type owningType = getTarget().getOwningType();
-		return owningType instanceof StateDefinition || owningType instanceof StateUsage;
+		return !isEntryExitAction() && 
+			   (owningType instanceof StateDefinition || owningType instanceof StateUsage);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -30,9 +30,12 @@ import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Definition;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.PartDefinition;
 import org.omg.sysml.lang.sysml.PartUsage;
+import org.omg.sysml.lang.sysml.StateSubactionKind;
+import org.omg.sysml.lang.sysml.StateSubactionMembership;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.SysMLFactory;
@@ -67,7 +70,8 @@ public class UsageAdapter extends FeatureAdapter {
 	public boolean isActionOwnedComposite() {
 		Usage target = getTarget();
 		Type owningType = target.getOwningType();
-		return target.isComposite() && (owningType instanceof ActionDefinition || owningType instanceof ActionUsage);
+		return target.isComposite() && !isEntryExitAction() && 
+			   (owningType instanceof ActionDefinition || owningType instanceof ActionUsage);
 	}
 	
 	public boolean isPartOwnedComposite() {
@@ -76,7 +80,17 @@ public class UsageAdapter extends FeatureAdapter {
 		return target.isComposite() && (owningType instanceof PartDefinition || owningType instanceof PartUsage);
 	}
 	
-	// Implicit Generalization
+	public boolean isEntryExitAction() {
+		FeatureMembership owningFeatureMembership = getTarget().getOwningFeatureMembership();
+		if (!(owningFeatureMembership instanceof StateSubactionMembership)) {
+			return false;
+		} else {
+			StateSubactionKind kind = ((StateSubactionMembership)owningFeatureMembership).getKind();
+			return kind == StateSubactionKind.ENTRY || kind == StateSubactionKind.EXIT;
+		}
+	}
+		
+// Implicit Generalization
 	
 	protected void addSubsetting(String subsettedFeatureName) {
 		Feature feature = (Feature)getLibraryType(subsettedFeatureName);

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -148,7 +148,6 @@ public class ImplicitGeneralizationMap {
 		// SysML
 		
 		put(AcceptActionUsageImpl.class, "base", "Actions::acceptActions");
-		put(AcceptActionUsageImpl.class, "trigger", "Actions::acceptMessageActions");
 		put(AcceptActionUsageImpl.class, "subaction", "Actions::Action::acceptSubactions");
 		
 		put(ActionDefinitionImpl.class, "base", "Actions::Action");		
@@ -157,6 +156,12 @@ public class ImplicitGeneralizationMap {
 		put(ActionUsageImpl.class, "ownedAction", "Parts::Part::ownedActions");
 		put(ActionUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(ActionUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
+		put(ActionUsageImpl.class, "entry", "States::StateAction::entryAction");
+		put(ActionUsageImpl.class, "do", "States::StateAction::doAction");
+		put(ActionUsageImpl.class, "exit", "States::StateAction::exitAction");
+		put(ActionUsageImpl.class, "trigger", "Actions::TransitionAction::accepter");
+		put(ActionUsageImpl.class, "guard", "Actions::TransitionAction::guard");
+		put(ActionUsageImpl.class, "effect", "Actions::TransitionAction::effect");
 		
 		put(AllocationDefinitionImpl.class, "base", "Allocations::Allocation");
 		put(AllocationDefinitionImpl.class, "binary", "Allocations::Allocation");

--- a/sysml.library/Systems Library/States.sysml
+++ b/sysml.library/Systems Library/States.sysml
@@ -24,7 +24,7 @@ standard library package States {
 		 */
 	
 		entry action entryAction :>> 'entry';
-		do action doAction: Action :>> 'do' :> subactions;
+		do action doAction: Action :>> 'do';
 		exit action exitAction: Action :>> 'exit';
 		
 		attribute :>> isTriggerDuring;

--- a/sysml/src/examples/Simple Tests/StateTest.sysml
+++ b/sysml/src/examples/Simple Tests/StateTest.sysml
@@ -9,8 +9,8 @@ package StateTest {
 	action act;
 	
 	state def S {
-		do action B;
-		entry action A; then S1;
+		do action A;
+		entry; then S1;
 		
 		state S1;
 			accept s : Sig


### PR DESCRIPTION
1. Revises the implicit specialization in `ActionUsageAdapter` so that composite entry and exit actions do _not_ subset `Action::subactions`, since `StateAction` redefines `subaction` to exclude entry and exit actions.
2. Updates `ActionUsageAdapter` to use the `ImplicitGeneralizationMap` to get the target of computed redefinitions of `ActionUsages` owned via `StateSubactionMembership` or `TransitionFeatureMembership` (rather than using hardcoded constants in the adapter).
3. Removes the subsetting by `StateAction::doAction` of `subaction`, because `subaction` is composite and `doAction` is not.