### PR TITLE
ST6RI-655 Assumed and required constraints should be composite

### DIFF
--- a/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
@@ -22,7 +22,7 @@ standard library package AnalysisCases {
 		subject subj :>> Case::subj;
 		objective obj :>> Case::obj;
 		
-		abstract ref analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
+		abstract analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
 			doc
 			/*
 			 * Other AnalysisCases carried out as part of the performance of this AnalysisCase.

--- a/org.omg.sysml.xpect.tests/library.systems/Cases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Cases.sysml
@@ -53,7 +53,7 @@ standard library package Cases {
 			 */
 		}
 		
-		abstract ref case subcases : Case[0..*] :> cases, subcalculations {
+		abstract case subcases : Case[0..*] :> cases, subcalculations {
 			doc
 			/*
 			 * Other Cases carried out as part of the performance of this Case.

--- a/org.omg.sysml.xpect.tests/library.systems/Requirements.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Requirements.sysml
@@ -24,14 +24,14 @@ standard library package Requirements {
 		 * then all the required constraints must be true.
 		 */
 	
-		ref constraint assumptions[0..*] :> constraintChecks {
+		constraint assumptions[0..*] :> constraintChecks, subperformances {
 			doc
 			/*
 			 * Assumptions that must hold for the required constraints to apply.
 			 */
 		}
 		
-		ref constraint constraints[0..*] :> constraintChecks {
+		constraint constraints[0..*] :> constraintChecks, subperformances {
 			doc
 			/*
 			 * The required constraints that are to be checked.
@@ -84,17 +84,17 @@ standard library package Requirements {
 		 * Note: assumptions and constraints are redefined here solely to simplify the
 		 * resolution of their qualified names as library elements.
 		 */
-		ref constraint assumptions :>> RequirementConstraintCheck::assumptions;
-		ref constraint constraints :>> RequirementConstraintCheck::constraints;
+		constraint assumptions :>> RequirementConstraintCheck::assumptions;
+		constraint constraints :>> RequirementConstraintCheck::constraints;
 		
-		abstract ref requirement subrequirements[0..*] :> requirementChecks, constraints {
+		abstract requirement subrequirements[0..*] :> requirementChecks, constraints {
 			doc
 			/*
 			 * Nested requirements, which are also required constraints.
 			 */
 		}
 		
-		abstract ref concern concerns[0..*] :> concernChecks, constraints {
+		abstract concern concerns[0..*] :> concernChecks, subrequirements {
 			doc
 			/*
 			 * The checks of any concerns being addressed (as required constraints).

--- a/org.omg.sysml.xpect.tests/library.systems/UseCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/UseCases.sysml
@@ -32,7 +32,7 @@ standard library package UseCases {
 			 */
 		}
 
-		abstract ref subUseCases : UseCase[0..*] :> subcases {
+		abstract subUseCases : UseCase[0..*] :> subcases {
 			doc
 			/*
 			 * Other UseCases carried out as part of the performance of this UseCase.

--- a/org.omg.sysml.xpect.tests/library.systems/VerificationCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/VerificationCases.sysml
@@ -24,7 +24,7 @@ standard library package VerificationCases {
 		objective obj :>> Case::obj {
 			subject subj = VerificationCase::subj;
 			
-			requirement requirementVerifications[0..*] {
+			requirement requirementVerifications : RequirementCheck[0..*] :> subrequirements {
 				doc
 				/*
 				 * A record of the evaluations of the RequirementChecks of requirements being verified.
@@ -32,14 +32,14 @@ standard library package VerificationCases {
 			}
 		}
 		
-		ref requirement requirementVerifications[0..*] = obj.requirementVerifications {
+		ref requirement requirementVerifications : RequirementCheck[0..*] = obj.requirementVerifications {
 			doc
 			/*
 			 * Checks on whether the verifiedRequirements of the VerificationCase have been satisfied.
 			 */
 		}
 		
-		abstract ref verification subVerificationCases : Case[0..*] :> verificationCases, subcases {
+		abstract verification subVerificationCases : Case[0..*] :> verificationCases, subcases {
 			doc
 			/*
 			 * The subcases of this VerificationCase that are VerificationCaseUsages.

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AnalysisCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AnalysisCaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -43,7 +43,8 @@ public class AnalysisCaseUsageAdapter extends CaseUsageAdapter {
 		
 	public boolean isSubAnalysisCase() {
 		Type owningType = getTarget().getOwningType();
-		return owningType instanceof AnalysisCaseDefinition || owningType instanceof AnalysisCaseUsage;
+		return isNonEntryExitComposite() &&
+			   (owningType instanceof AnalysisCaseDefinition || owningType instanceof AnalysisCaseUsage);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -46,7 +46,7 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 	public boolean isSubcalculation() {
 		CalculationUsage target = getTarget();
 		Type owningType = target.getOwningType();
-		return !isEntryExitAction() && target.isComposite() &&
+		return isNonEntryExitComposite() &&
 			   owningType instanceof CalculationDefinition || owningType instanceof CalculationUsage;
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -58,8 +58,10 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	}
 		
 	public boolean isSubcase() {
-		Type owningType = getTarget().getOwningType();
-		return owningType instanceof CaseDefinition || owningType instanceof CaseUsage;
+		CaseUsage target = getTarget();
+		Type owningType = target.getOwningType();
+		return isNonEntryExitComposite() &&
+			   (owningType instanceof CaseDefinition || owningType instanceof CaseUsage);
 	}
 	
 	// Transformation

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -36,11 +36,11 @@ public class ConcernUsageAdapter extends RequirementUsageAdapter {
 	}
 	
 	@Override
-	public void addRequirementSubsetting() {
-		if (UsageUtil.isAddressedConcern(getTarget())) {
+	public void addRequirementConstraintSubsetting() {
+		if (UsageUtil.isFramedConcern(getTarget())) {
 			addSubsetting(getDefaultSupertype("subrequirement"));
 		} else {
-			super.addRequirementSubsetting();
+			super.addRequirementConstraintSubsetting();
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +25,7 @@ import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.ItemDefinition;
 import org.omg.sysml.lang.sysml.ItemUsage;
+import org.omg.sysml.lang.sysml.RequirementConstraintKind;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
@@ -33,9 +34,6 @@ import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
 public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
-
-	public static final String CONSTRAINT_SUBSETTING_ASSUMPTION_FEATURE = "Requirements::RequirementCheck::assumptions";
-	public static final String CONSTRAINT_SUBSETTING_REQUIREMENT_FEATURE = "Requirements::RequirementCheck::constraints";
 
 	protected BindingConnector resultConnector = null;
 
@@ -73,22 +71,9 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 	
 	// Implicit Generalization
 	
-	protected void addAssumptionSubsetting() {
-		addSubsetting(CONSTRAINT_SUBSETTING_ASSUMPTION_FEATURE);
-	}
-	
-	protected void addRequirementSubsetting() {
-		addSubsetting(CONSTRAINT_SUBSETTING_REQUIREMENT_FEATURE);
-	}
-	
 	@Override
 	public void computeImplicitGeneralTypes() {
-		ConstraintUsage target = getTarget();
-		if (UsageUtil.isAssumptionConstraint(target)) {
-			addAssumptionSubsetting();
-		} else if (UsageUtil.isRequirementConstraint(target)){
-			addRequirementSubsetting();
-		}
+		addRequirementConstraintSubsetting();
 		super.computeImplicitGeneralTypes();
 		if (isCheckedConstraint()) {
 			addDefaultGeneralType("checkedConstraint");
@@ -101,6 +86,13 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 		}
 		if (isBehaviorOwned()) {
 			addDefaultGeneralType("enclosedPerformance");
+		}
+	}
+	
+	public void addRequirementConstraintSubsetting() {
+		RequirementConstraintKind kind = UsageUtil.getRequirementConstraintKindOf(getTarget());
+		if (kind != null) {
+			addDefaultGeneralType(kind.toString());
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -34,8 +34,6 @@ import org.omg.sysml.util.UsageUtil;
 
 public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	
-	public static final String REQUIREMENT_SUBSETTING_VERIFICATION_FEATURE = "Verifications::VerificationCase::obj::requirementVerifications";
-	
 	public RequirementUsageAdapter(RequirementUsage element) {
 		super(element);
 	}
@@ -53,7 +51,7 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	}
 	
 	// Implicit Generalization
-
+	
 	@Override
 	protected String getDefaultSupertype() {
 		return UsageUtil.isSubrequirement(getTarget())? 
@@ -62,11 +60,11 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	}
 	
 	@Override
-	public void addRequirementSubsetting() {
+	public void addRequirementConstraintSubsetting() {
 		if (UsageUtil.isVerifiedRequirement(getTarget())) {
-			addSubsetting(REQUIREMENT_SUBSETTING_VERIFICATION_FEATURE);
+			addDefaultGeneralType("verification");
 		} else {
-			super.addRequirementSubsetting();
+			super.addRequirementConstraintSubsetting();
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
@@ -51,7 +51,7 @@ public class StateUsageAdapter extends ActionUsageAdapter {
 		
 	public boolean isSubstate() {
 		Type owningType = getTarget().getOwningType();
-		return !isEntryExitAction() && 
+		return isNonEntryExitComposite() && 
 			   (owningType instanceof StateDefinition || owningType instanceof StateUsage);
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -67,6 +67,10 @@ public class UsageAdapter extends FeatureAdapter {
 		return false;
 	}
 	
+	public boolean isNonEntryExitComposite() {
+		return getTarget().isComposite() && !isEntryExitAction();
+	}
+	
 	public boolean isActionOwnedComposite() {
 		Usage target = getTarget();
 		Type owningType = target.getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -38,7 +38,8 @@ public class UseCaseUsageAdapter extends CaseUsageAdapter {
 		
 	public boolean isSubUseCase() {		
 		Type owningType = getTarget().getOwningType();
-		return owningType instanceof UseCaseDefinition || owningType instanceof UseCaseUsage;
+		return isNonEntryExitComposite() && 
+			   (owningType instanceof UseCaseDefinition || owningType instanceof UseCaseUsage);
 	}
 	
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/VerificationCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/VerificationCaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -43,7 +43,8 @@ public class VerificationCaseUsageAdapter extends CaseUsageAdapter {
 		
 	public boolean isSubVerificationCase() {
 		Type owningType = getTarget().getOwningType();
-		return owningType instanceof VerificationCaseDefinition || owningType instanceof VerificationCaseUsage;
+		return isNonEntryExitComposite() && 
+			   (owningType instanceof VerificationCaseDefinition || owningType instanceof VerificationCaseUsage);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -208,6 +208,8 @@ public class ImplicitGeneralizationMap {
 		put(ConstraintUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		put(ConstraintUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
 		put(ConstraintUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
+		put(ConstraintUsageImpl.class, "assumption", "Requirements::RequirementCheck::assumptions");
+		put(ConstraintUsageImpl.class, "requirement", "Requirements::RequirementCheck::constraints");
 		
 		put(DecisionNodeImpl.class, "subaction", "Actions::Action::decisions");
 		
@@ -283,6 +285,7 @@ public class ImplicitGeneralizationMap {
 		put(RequirementDefinitionImpl.class, "base", "Requirements::RequirementCheck");
 		put(RequirementUsageImpl.class, "base", "Requirements::requirementChecks");
 		put(RequirementUsageImpl.class, "subrequirement", "Requirements::RequirementCheck::subrequirements");
+		put(RequirementUsageImpl.class, "verification", "Verifications::VerificationCase::obj::requirementVerifications");
 		
 		put(SatisfyRequirementUsageImpl.class, "base", "Requirements::satisfiedRequirementChecks");
 		put(SatisfyRequirementUsageImpl.class, "negated", "Requirements::notSatisfiedRequirementChecks");

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -194,7 +194,7 @@ public class UsageUtil {
 		}
 	}
 	
-	public static boolean isAddressedConcern(ConcernUsage concern) {
+	public static boolean isFramedConcern(ConcernUsage concern) {
 		return concern.getOwningFeatureMembership() instanceof FramedConcernMembership;
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -168,7 +168,7 @@ public class UsageUtil {
 	
 	public static boolean isSubrequirement(RequirementUsage requirement) {
 		Type owningType = requirement.getOwningType();
-		return !isAssumptionConstraint(requirement) &&
+		return !isAssumptionConstraint(requirement) && requirement.isComposite() &&
 			   (owningType instanceof RequirementDefinition || 
 			    owningType instanceof RequirementUsage);
 	}

--- a/sysml.library/Systems Library/AnalysisCases.sysml
+++ b/sysml.library/Systems Library/AnalysisCases.sysml
@@ -22,7 +22,7 @@ standard library package AnalysisCases {
 		subject subj :>> Case::subj;
 		objective obj :>> Case::obj;
 		
-		abstract ref analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
+		abstract analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
 			doc
 			/*
 			 * Other AnalysisCases carried out as part of the performance of this AnalysisCase.

--- a/sysml.library/Systems Library/Cases.sysml
+++ b/sysml.library/Systems Library/Cases.sysml
@@ -53,7 +53,7 @@ standard library package Cases {
 			 */
 		}
 		
-		abstract ref case subcases : Case[0..*] :> cases, subcalculations {
+		abstract case subcases : Case[0..*] :> cases, subcalculations {
 			doc
 			/*
 			 * Other Cases carried out as part of the performance of this Case.

--- a/sysml.library/Systems Library/Requirements.sysml
+++ b/sysml.library/Systems Library/Requirements.sysml
@@ -24,14 +24,14 @@ standard library package Requirements {
 		 * then all the required constraints must be true.
 		 */
 	
-		ref constraint assumptions[0..*] :> constraintChecks {
+		constraint assumptions[0..*] :> constraintChecks, subperformances {
 			doc
 			/*
 			 * Assumptions that must hold for the required constraints to apply.
 			 */
 		}
 		
-		ref constraint constraints[0..*] :> constraintChecks {
+		constraint constraints[0..*] :> constraintChecks, subperformances {
 			doc
 			/*
 			 * The required constraints that are to be checked.
@@ -84,17 +84,17 @@ standard library package Requirements {
 		 * Note: assumptions and constraints are redefined here solely to simplify the
 		 * resolution of their qualified names as library elements.
 		 */
-		ref constraint assumptions :>> RequirementConstraintCheck::assumptions;
-		ref constraint constraints :>> RequirementConstraintCheck::constraints;
+		constraint assumptions :>> RequirementConstraintCheck::assumptions;
+		constraint constraints :>> RequirementConstraintCheck::constraints;
 		
-		abstract ref requirement subrequirements[0..*] :> requirementChecks, constraints {
+		abstract requirement subrequirements[0..*] :> requirementChecks, constraints {
 			doc
 			/*
 			 * Nested requirements, which are also required constraints.
 			 */
 		}
 		
-		abstract ref concern concerns[0..*] :> concernChecks, constraints {
+		abstract concern concerns[0..*] :> concernChecks, subrequirements {
 			doc
 			/*
 			 * The checks of any concerns being addressed (as required constraints).

--- a/sysml.library/Systems Library/UseCases.sysml
+++ b/sysml.library/Systems Library/UseCases.sysml
@@ -32,7 +32,7 @@ standard library package UseCases {
 			 */
 		}
 
-		abstract ref subUseCases : UseCase[0..*] :> subcases {
+		abstract subUseCases : UseCase[0..*] :> subcases {
 			doc
 			/*
 			 * Other UseCases carried out as part of the performance of this UseCase.

--- a/sysml.library/Systems Library/VerificationCases.sysml
+++ b/sysml.library/Systems Library/VerificationCases.sysml
@@ -24,7 +24,7 @@ standard library package VerificationCases {
 		objective obj :>> Case::obj {
 			subject subj = VerificationCase::subj;
 			
-			requirement requirementVerifications[0..*] {
+			requirement requirementVerifications : RequirementCheck[0..*] :> subrequirements {
 				doc
 				/*
 				 * A record of the evaluations of the RequirementChecks of requirements being verified.
@@ -32,14 +32,14 @@ standard library package VerificationCases {
 			}
 		}
 		
-		ref requirement requirementVerifications[0..*] = obj.requirementVerifications {
+		ref requirement requirementVerifications : RequirementCheck[0..*] = obj.requirementVerifications {
 			doc
 			/*
 			 * Checks on whether the verifiedRequirements of the VerificationCase have been satisfied.
 			 */
 		}
 		
-		abstract ref verification subVerificationCases : Case[0..*] :> verificationCases, subcases {
+		abstract verification subVerificationCases : Case[0..*] :> verificationCases, subcases {
 			doc
 			/*
 			 * The subcases of this VerificationCase that are VerificationCaseUsages.


### PR DESCRIPTION
1. Makes various features of `RequirementCheck` composite:
   - `assumptions` and `constraints`, since **`assume`** and **`require`** declarations parse as composite (also makes them subsets of `Performance::subperformances`).
   - `subrequirements`, since it subsets `constraints`.
   - `concerns`, since it subsets `constraints` (actually, makes it instead a subset of `subrequirements`, since concerns are requirements).
2. Makes `Cases::subcases`, `AnalysisCases::subAnalysisCases`, `VerificationCases::subVerificationCases` and `UseCases::subUseCases` all composite, since they indirectly subset `Actions::subactions`, which is composite.
3. Updates implicit specialization implementation as necessary for the above, and also adds entries to the `ImplicitGeneralizationMap` to support subsetting for requirement constraints.