### PR TITLE
ST6RI-657 Occurrence::self should subset spaceTimeCoincidentOccurrences

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -34,7 +34,7 @@ standard library package Occurrences {
 
 		feature portionOfLife: Life[1] subsets portionOf;
 
-		feature self: Occurrence[1] redefines Anything::self subsets timeSlices, spaceSlices, sameLifeOccurrences;
+		feature self: Occurrence[1] redefines Anything::self subsets timeSlices, spaceSlices, spaceTimeCoincidentOccurrences, sameLifeOccurrences;
 		feature sameLifeOccurrences: Occurrence[1..*] subsets things;
 
 		feature this : Occurrence[1] default self {


### PR DESCRIPTION
Subset Occurrence::`self `from `spaceTimeCoincidentOccurrences` (was added in PR #442 for [ST6RI-633](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/pull/442)), because the existing subsets from `time`/`spaceSlices` don't imply coincidence.