### PR TITLE
ST6RI-482: Render <<perform>> and <<exhibit>> for just `perform` and `exhibit` instead of <<perform action>> and <<exhibit state>>

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -500,13 +500,6 @@ public class SysML2PlantUMLStyle {
     }
 
     public static class StyleStereotypeDefaultSwitch extends StyleStereotypeSwitch {
-        private static boolean hasRefSubsettingWithoutDeclaredName(Feature f) {
-            if (f.getOwnedReferenceSubsetting() == null) return false;
-            if (f.getDeclaredName() != null) return false;
-            if (f.getDeclaredShortName() != null) return false;
-            return f.getOwnedRedefinition().isEmpty();
-        }
-
 		@Override
 		public String caseClass(Class object) {
             if (SysMLPackage.Literals.CLASS.equals(object.eClass())) return " ";
@@ -515,7 +508,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseExhibitStateUsage(ExhibitStateUsage esu) {
-            if (hasRefSubsettingWithoutDeclaredName(esu)) {
+            if (VStructure.hasRefSubsettingWithoutDeclaredName(esu)) {
                 return " exhibit>> ";
             } else {
                 return " exhibit state>> ";
@@ -534,7 +527,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String casePerformActionUsage(PerformActionUsage pau) {
-            if (hasRefSubsettingWithoutDeclaredName(pau)) {
+            if (VStructure.hasRefSubsettingWithoutDeclaredName(pau)) {
                 return " perform>> ";
             } else {
                 return " perform action>> ";

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -508,7 +508,11 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseExhibitStateUsage(ExhibitStateUsage esu) {
-            return "<<exhibit state>> ";
+            if (esu.getOwnedReferenceSubsetting() != null) {
+                return " exhibit>> ";
+            } else {
+                return " exhibit state>> ";
+            }
 		}
 
 		@Override
@@ -523,7 +527,11 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String casePerformActionUsage(PerformActionUsage pau) {
-            return " perform action>> ";
+            if (pau.getOwnedReferenceSubsetting() != null) {
+                return " perform>> ";
+            } else {
+                return " perform action>> ";
+            }
 		}
 
 		@Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -500,6 +500,13 @@ public class SysML2PlantUMLStyle {
     }
 
     public static class StyleStereotypeDefaultSwitch extends StyleStereotypeSwitch {
+        private static boolean hasRefSubsettingWithoutDeclaredName(Feature f) {
+            if (f.getOwnedReferenceSubsetting() == null) return false;
+            if (f.getDeclaredName() != null) return false;
+            if (f.getDeclaredShortName() != null) return false;
+            return f.getOwnedRedefinition().isEmpty();
+        }
+
 		@Override
 		public String caseClass(Class object) {
             if (SysMLPackage.Literals.CLASS.equals(object.eClass())) return " ";
@@ -508,7 +515,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseExhibitStateUsage(ExhibitStateUsage esu) {
-            if (esu.getOwnedReferenceSubsetting() != null) {
+            if (hasRefSubsettingWithoutDeclaredName(esu)) {
                 return " exhibit>> ";
             } else {
                 return " exhibit state>> ";
@@ -527,7 +534,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String casePerformActionUsage(PerformActionUsage pau) {
-            if (pau.getOwnedReferenceSubsetting() != null) {
+            if (hasRefSubsettingWithoutDeclaredName(pau)) {
                 return " perform>> ";
             } else {
                 return " perform action>> ";

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2023 Mgnite Inc.
  * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020 Mgnite Inc.
+ * Copyright (c) 2020-2023 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
@@ -55,8 +55,9 @@ public class VAction extends VDefault {
     }
 
     private void addAction(Type typ) {
-        if (addRecLine(typ, true) < 0) return;
-        // addGeneralizations(typ);
+        int id = addRecLine(typ, true);
+        if (id < 0) return;
+        addSpecializations(id, typ);
         VActionMembers v = new VActionMembers(this);
         v.startAction(typ);
         append("\n");

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -473,7 +473,7 @@ public class VCompartment extends VStructure {
         } else if (getFeatureName(ce.f) == null) {
             addAnonymouseFeatureText(ce.f);
         } else {
-            return addFeatureText(ce.f, false);
+            return addFeatureText(ce.f, ce.isInherited);
         }
         return true;
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2023 Mgnite Inc.
  * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
@@ -30,6 +30,8 @@ import org.omg.sysml.lang.sysml.StateUsage;
 import org.omg.sysml.lang.sysml.Type;
 
 public class VStateMachine extends VDefault {
+    private final boolean showStereotype;
+
     private void addState(Type typ, boolean isParallel, boolean withStyle) {
         String name = getNameAnyway(typ);
         if (isParallel) {
@@ -44,7 +46,7 @@ public class VStateMachine extends VDefault {
 
     @Override
     public String caseStateUsage(StateUsage su) {
-        addState(su, su.isParallel(), false);
+        addState(su, su.isParallel(), showStereotype);
         return getString();
     }
     
@@ -64,9 +66,11 @@ public class VStateMachine extends VDefault {
     public VStateMachine(Visitor prev) {
     	super(prev);
         setShowsMultiplicity(false);
+        this.showStereotype = true;
     }
 
     public VStateMachine() {
         setShowsMultiplicity(false);
+        this.showStereotype = false;
     }
 }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMembers.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020 Mgnite Inc.
+ * Copyright (c) 2020-2023 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -245,10 +245,11 @@ public abstract class VStructure extends VDefault {
             Feature f = (Feature) e;
             boolean added = appendFeatureType(sb, ": ", f);
             sb.append(' ');
+            added = appendSubsettings(sb, f) || added;
             if (!hasRefSubsettingWithoutDeclaredName(f)) {
+                sb.append(' ');
                 added = appendReferenceSubsetting(sb, f) || added;
             }
-            added = appendSubsettings(sb, f) || added;
             sb.insert(0, name);
             /*
               if (f instanceof Usage) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2023 Mgnite Inc.
  * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -230,6 +230,13 @@ public abstract class VStructure extends VDefault {
         }
     }
 
+    public static boolean hasRefSubsettingWithoutDeclaredName(Feature f) {
+        if (f.getOwnedReferenceSubsetting() == null) return false;
+        if (f.getDeclaredName() != null) return false;
+        if (f.getDeclaredShortName() != null) return false;
+        return f.getOwnedRedefinition().isEmpty();
+    }
+
     protected String extractTitleName(Element e) {
         String name = getNameAnyway(e);
         StringBuilder sb = new StringBuilder();
@@ -238,7 +245,10 @@ public abstract class VStructure extends VDefault {
             Feature f = (Feature) e;
             boolean added = appendFeatureType(sb, ": ", f);
             sb.append(' ');
-            added = appendSubsettingFeature(sb, ":> ", f) || added;
+            if (!hasRefSubsettingWithoutDeclaredName(f)) {
+                added = appendReferenceSubsetting(sb, f) || added;
+            }
+            added = appendSubsettings(sb, f) || added;
             sb.insert(0, name);
             /*
               if (f instanceof Usage) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -234,7 +234,7 @@ public abstract class VStructure extends VDefault {
         if (f.getOwnedReferenceSubsetting() == null) return false;
         if (f.getDeclaredName() != null) return false;
         if (f.getDeclaredShortName() != null) return false;
-        return f.getOwnedRedefinition().isEmpty();
+        return true;
     }
 
     protected String extractTitleName(Element e) {


### PR DESCRIPTION
So far the visualizer did not distinguish `perform action` and `perform` or `exhibit state` and `exhibit`.  So it visualize actions and states with `<<perform action>>` and `<<exhibit state>>` for both cases.  This PR renders such `perform` and `exhibit` with `<<perform>>` or `<<exhibit>>`

This PR also fixes the following issues:

- `^` was not shown in compartments.
-  specializations are not shown in the action view.
-  `<<state>>` stereotype is not shown in the mixed view.
