### PR TITLE
ST6RI-658 spaceTimeCoincidentOccurrences should subset timeCoincidentOccurrences

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -151,11 +151,12 @@ standard library package Occurrences {
 			 */
 
 			/* timeCoincidentOccurrences occurrences happen during each other. */
-			feature thisOccurrence: Occurrence[1] subsets that;
-			feature thatOccurrence: Occurrence[1] subsets self;
+			feature thatOccurrence: Occurrence[1] subsets longerOccurrence;
+			feature thisOccurrence: Occurrence[1] subsets shorterOccurrence;
+
 			connector :HappensDuring
-				from shorterOccurrence references thatOccurrence [1]
-				to longerOccurrence references thisOccurrence [1];
+				from shorterOccurrence references thisOccurrence [1]
+				to longerOccurrence references thatOccurrence [1];
 		}
 
 		feature spaceEnclosedOccurrences: Occurrence[1..*] subsets occurrences {
@@ -166,8 +167,8 @@ standard library package Occurrences {
 			 */
 
 			/* spaceEnclosedOccurrences is transitive. */
-			feature smallerSpace: Occurrence[1] subsets that;
-			feature largerSpace: Occurrence[1] subsets self;
+			feature largerSpace: Occurrence[1] subsets that;
+			feature smallerSpace: Occurrence[1] subsets self;
 			subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
 		}
 
@@ -189,12 +190,20 @@ standard library package Occurrences {
 			binding startShot[1] = endShot[1];
 		}
 
-		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets spaceTimeEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
 			 * and vice-versa, including this one.
 			 */
+
+			/* spaceTimeCoincidentOccurrences occurrences are inside of each other. */
+			feature redefines thatOccurrence subsets largerSpace;
+			feature redefines thisOccurrence subsets smallerSpace;
+
+			connector :InsideOf
+				from largerSpace references thatOccurrence [1]
+				to smallerSpace references thisOccurrence [1];
 		}
 
 		feature outsideOfOccurrences: Occurrence[0..*] subsets withoutOccurrences inverse of outsideOfOccurrences {
@@ -750,7 +759,7 @@ standard library package Occurrences {
 		end feature largerOccurrence: Occurrence[1..*] redefines longerOccurrence, largerSpace;
 	 }
 
-	assoc all WithinBoth specializes Within {
+	assoc all WithinBoth specializes Within, HappensWhile {
 		doc
 		/*
 		 * WithinBoth asserts that two occurrences are Within each other, that is, they occupy the
@@ -758,9 +767,9 @@ standard library package Occurrences {
 		 * itself and transitive.
 		 */
 
-		end feature thisOccurrence: Occurrence[1..*] redefines smallerOccurrence
+		end feature thisOccurrence redefines smallerOccurrence redefines HappensWhile::thisOccurrence
 		  subsets thatOccurrence.spaceTimeCoincidentOccurrences;
-		end feature thatOccurrence: Occurrence[1..*] redefines largerOccurrence
+		end feature thatOccurrence redefines largerOccurrence redefines HappensWhile::thatOccurrence 
 		  subsets thisOccurrence.spaceTimeCoincidentOccurrences;
 	}
 


### PR DESCRIPTION
Corrections to "concident" related elements in Occurrences.kerml.

In Occurrence::

- `spaceTimeCoincidentOccurrences`:
  - Changed subsets to `timeCoincidentOccurrences, spaceEnclosedOccurrences` (was `spaceTimeEnclosedOccurrences`, which subsets `timeEnclosedOccurrences, spaceEnclosedOccurrences`, but `timeCoincidentOccurrences` already subsets `timeEnclosedOccurrences`).
  - Added InsideOf connector to make it circular (space-coincident, there is no spaceCoincidentOccurrences, can move the connector to that if FTF adds it).

- `spaceEnclosedOccurrences`, reversed `smaller/largerSpace` (`that` should be the `largerSpace`, it was treating it as the `smallerSpace`).

- `timeCoincidentOccurrences`, subset `this`/`thatOccurrence` from the inherited `shorter`/`longerOccurrence` and reversed the names, to make it easier to understand (was subsetting `that`/`self` which `timeEnclosedOccurrences` was already doing).

In WithinBoth, added HappensWhile specialization and end feature redefinitions for it (reduces dependence on sufficiency to get `timeCoincidentOccurrences` constraints via `spaceTimeCoincidenceOccurrences`).
