### PR TITLE
ST6RI-662 UseCase::includedUseCases should not subset subUseCases

### DIFF
--- a/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
@@ -52,24 +52,24 @@ standard library package AnalysisCases {
 	}
 	
 	abstract analysis analysisCases : AnalysisCase[0..*] nonunique :> cases {
-	doc
-	/*
-	 * analysisCases is the base feature of all AnalysisCaseUsages.
-	 */
+		doc
+		/*
+		 * analysisCases is the base feature of all AnalysisCaseUsages.
+		 */
 	}
 	
 	action def AnalysisAction {
-	doc
-	/*
-	 * An AnalysisAction is a specialized kind of Action intended to be used as a step in an AnalysisCase.
-	 */
+		doc
+		/*
+		 * An AnalysisAction is a specialized kind of Action intended to be used as a step in an AnalysisCase.
+		 */
 	}
 	
 	calc def AnalysisCalculation :> Calculation, AnalysisAction {
-	doc
-	/*
-	 * An AnalysisCalculation is a specialized kind of Calculation inteded to be used in a step of an AnalysisCase.
-	 */
+		doc
+		/*
+		 * An AnalysisCalculation is a specialized kind of Calculation inteded to be used in a step of an AnalysisCase.
+		 */
 	}
 	
 }

--- a/org.omg.sysml.xpect.tests/library.systems/UseCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/UseCases.sysml
@@ -39,7 +39,7 @@ standard library package UseCases {
 			 */
 		}
 		
-		abstract ref includedUseCases : UseCase[0..*] :> subUseCases {
+		abstract ref includedUseCases : UseCase[0..*] :> enclosedPerformances {
 			doc
 			/*
 			 * Other UseCases included by this UseCase (i.e., as modeled by an 

--- a/org.omg.sysml.xpect.tests/library.systems/Views.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Views.sysml
@@ -30,7 +30,7 @@ standard library package Views {
 		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] {
 		doc
 			/*
-			 * Checks that the View satisfies all required ViewpointsUsages.
+			 * Checks that the View satisfies all required ViewpointUsages.
 			 */
 		}
 		

--- a/sysml.library/Systems Library/AnalysisCases.sysml
+++ b/sysml.library/Systems Library/AnalysisCases.sysml
@@ -52,24 +52,24 @@ standard library package AnalysisCases {
 	}
 	
 	abstract analysis analysisCases : AnalysisCase[0..*] nonunique :> cases {
-	doc
-	/*
-	 * analysisCases is the base feature of all AnalysisCaseUsages.
-	 */
+		doc
+		/*
+		 * analysisCases is the base feature of all AnalysisCaseUsages.
+		 */
 	}
 	
 	action def AnalysisAction {
-	doc
-	/*
-	 * An AnalysisAction is a specialized kind of Action intended to be used as a step in an AnalysisCase.
-	 */
+		doc
+		/*
+		 * An AnalysisAction is a specialized kind of Action intended to be used as a step in an AnalysisCase.
+		 */
 	}
 	
 	calc def AnalysisCalculation :> Calculation, AnalysisAction {
-	doc
-	/*
-	 * An AnalysisCalculation is a specialized kind of Calculation inteded to be used in a step of an AnalysisCase.
-	 */
+		doc
+		/*
+		 * An AnalysisCalculation is a specialized kind of Calculation inteded to be used in a step of an AnalysisCase.
+		 */
 	}
 	
 }

--- a/sysml.library/Systems Library/UseCases.sysml
+++ b/sysml.library/Systems Library/UseCases.sysml
@@ -39,7 +39,7 @@ standard library package UseCases {
 			 */
 		}
 		
-		abstract ref includedUseCases : UseCase[0..*] :> subUseCases {
+		abstract ref includedUseCases : UseCase[0..*] :> enclosedPerformances {
 			doc
 			/*
 			 * Other UseCases included by this UseCase (i.e., as modeled by an 

--- a/sysml.library/Systems Library/Views.sysml
+++ b/sysml.library/Systems Library/Views.sysml
@@ -30,7 +30,7 @@ standard library package Views {
 		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] {
 		doc
 			/*
-			 * Checks that the View satisfies all required ViewpointsUsages.
+			 * Checks that the View satisfies all required ViewpointUsages.
 			 */
 		}
 		


### PR DESCRIPTION
Changed the subsetting of `UseCases::UseCase::includedUseCases` from `subUseCases` to `enclosedPerformances`. This was necessary because `includedUseCases` is referential (it is subsetted by `IncludeUseCaseUsages`, which are always referential) and `subUseCases` is composite.