### PR TITLE
ST6RI-663 Case::obj should not bind its subject to Case::result

### DIFF
--- a/sysml.library/Systems Library/AnalysisCases.sysml
+++ b/sysml.library/Systems Library/AnalysisCases.sysml
@@ -20,7 +20,10 @@ standard library package AnalysisCases {
 	
 		ref analysis self : AnalysisCase :>> Case::self;		
 		subject subj :>> Case::subj;
-		objective obj :>> Case::obj;
+		
+		objective obj :>> Case::obj {
+			subject subj = AnalysisCase::result;
+		}
 		
 		abstract analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
 			doc

--- a/sysml.library/Systems Library/Cases.sysml
+++ b/sysml.library/Systems Library/Cases.sysml
@@ -43,7 +43,7 @@ standard library package Cases {
 			 * A check of whether the objective RequirementUsage was satisfied for this Case.
 			 */
 		
-			subject = Case::result;
+			subject subj default Case::result;
 		}
 		
 		return ref result[0..*] {


### PR DESCRIPTION
This PR includes two changes to models in the Systems Model Library:

1. `Cases` – The binding of the subject of the objective of a `Case` to `Case::result` is changed to a default. The binding in `Case` conflicted with the binding of the subject of the objective of a `VerificationCase` to the `VerificationCase` subject, rather than the result. A default, on the other hand, can be overridden.
2. `AnalysisCases` – The default for the subject of the objective is overridden in `AnalysisCase` to be a mandatory binding to `AnalysisCase::result`. This is consistent with the specification documentation for `AnalysisCase`.

The above updates were included in the models in the Systems Model Library as delivered for the fourth revised submission to OMG.