### PR TITLE
ST6RI-667 Empty subjects are not hidden in Jupyter visualization (PlantUML)

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
@@ -82,8 +82,8 @@ public class ElementAdapter extends AdapterImpl {
 	
 	public void transform() {
 		if (!isTransformed) {
-			doTransform();
 			isTransformed = true;
+			doTransform();
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -443,6 +443,7 @@ public class TypeUtil {
 	}
 
 	public static Usage basicGetSubjectParameterOf(Type type) {
+		ElementUtil.transform(type);
 		return (Usage)getOwnedFeatureByMembershipIn(type, SubjectMembership.class);
 	}
 	


### PR DESCRIPTION
After PR #440 (ST6RI-631), empty subjects of requirements and cases are no longer shown when visualized using PlantUML within Eclipse. This PR corrects a bug that caused empty subjects to sometimes still be shown when visualized in Juptyer Lab.

The cause of the bug was that the effective name of an "empty" subject of a requirement usage was not being returned correctly in the Jupyter environment. The underlying reason for this was due to the transformation that adds an implicit subject to the base requirement usage `requirementChecks` being run automatically when the `Requirements` library model is loaded into memory in the Eclipse environment, but not in the Jupyter environment. This PR updates the utility method for getting the subject of a requirement or case to ensure that this transformation is run (if it hasn't been already) before the subject parameter is retrieved, so that `requirementChecks` has a subject that is properly linked to the subject of the base definition `RequirementCheck`.