### PR TITLE
ST6RI-671 Non-keyword highlighting does not work

### DIFF
--- a/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLAntlrTokenToAttributeIdMapper.xtend
+++ b/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLAntlrTokenToAttributeIdMapper.xtend
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * 
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Ed Seidewitz, MDS
+ * 
+ *****************************************************************************/
+package org.omg.kerml.xtext.ui;
+
+import org.eclipse.xtext.ide.editor.syntaxcoloring.HighlightingStyles;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultAntlrTokenToAttributeIdMapper;
+
+class KerMLAntlrTokenToAttributeIdMapper extends DefaultAntlrTokenToAttributeIdMapper {
+
+	protected override calculateId(String tokenName, int tokenType) {
+		if("RULE_STRING_VALUE".equals(tokenName))
+			HighlightingStyles.STRING_ID
+		else if ("RULE_DECIMAL_VALUE".equals(tokenName) || "RULE_EXP_VALUE".equals(tokenName))
+			HighlightingStyles.NUMBER_ID
+		else if("RULE_ML_NOTE".equals(tokenName) || "RULE_SL_NOTE".equals(tokenName))
+			HighlightingStyles.COMMENT_ID
+		else
+			super.calculateId(tokenName, tokenType);
+	}
+
+}

--- a/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLHighlightingConfiguration.xtend
+++ b/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLHighlightingConfiguration.xtend
@@ -1,0 +1,35 @@
+/*****************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * 
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ * 
+ * Contributors:
+ *  Ed Seidewitz, MDS
+ * 
+ *****************************************************************************/
+package org.omg.kerml.xtext.ui
+
+import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultHighlightingConfiguration
+import org.eclipse.xtext.ui.editor.utils.TextStyle
+
+class KerMLHighlightingConfiguration extends DefaultHighlightingConfiguration {
+	
+	override TextStyle numberTextStyle() {
+		defaultTextStyle().copy()
+	}
+
+}

--- a/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLUiModule.xtend
+++ b/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/KerMLUiModule.xtend
@@ -8,6 +8,8 @@ import org.eclipse.xtext.ui.shared.Access
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider
 import org.omg.kerml.xtext.ui.quickfix.KerMLQuickfixProvider
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.
@@ -16,11 +18,19 @@ import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculat
 class KerMLUiModule extends AbstractKerMLUiModule {
 
 	override Class<? extends IssueResolutionProvider> bindIssueResolutionProvider() {
-		return KerMLQuickfixProvider;
+		KerMLQuickfixProvider;
 	}
 	
 	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
-		return KerMLUserKeywordHighlightingCalculator
+		KerMLUserKeywordHighlightingCalculator
+	}
+	
+	def Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
+		KerMLHighlightingConfiguration
+	}
+	
+	def Class<? extends AbstractAntlrTokenToAttributeIdMapper> bindAbstractAntlrTokenToAttributeIdMapper() {
+		KerMLAntlrTokenToAttributeIdMapper
 	}
 	
 	override provideIAllContainersState() {

--- a/org.omg.kerml.xtext.ui/xtend-gen/org/omg/kerml/xtext/ui/.gitignore
+++ b/org.omg.kerml.xtext.ui/xtend-gen/org/omg/kerml/xtext/ui/.gitignore
@@ -4,3 +4,10 @@
 /.KerMLUserKeywordHighlightingCalculator.java._trace
 /KerMLUserKeywordHighlightingCalculator.java
 /.KerMLUserKeywordHighlightingCalculator.xtendbin
+/.KerMLAntlrTokenToAttributeIdMapper_.java._trace
+/.KerMLAntlrTokenToAttributeIdMapper.java._trace
+/.KerMLHighlightingConfiguration.java._trace
+/.KerMLAntlrTokenToAttributeIdMapper.xtendbin
+/.KerMLHighlightingConfiguration.xtendbin
+/KerMLAntlrTokenToAttributeIdMapper.java
+/KerMLHighlightingConfiguration.java

--- a/org.omg.sysml.xtext.ui/src/org/omg/sysml/xtext/ui/SysMLUiModule.xtend
+++ b/org.omg.sysml.xtext.ui/src/org/omg/sysml/xtext/ui/SysMLUiModule.xtend
@@ -9,6 +9,10 @@ import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider
 import org.omg.sysml.xtext.ui.quickfix.SysMLQuickfixProvider
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
 import org.omg.kerml.xtext.ui.KerMLUserKeywordHighlightingCalculator
+import org.omg.kerml.xtext.ui.KerMLAntlrTokenToAttributeIdMapper
+import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
+import org.omg.kerml.xtext.ui.KerMLHighlightingConfiguration
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.
@@ -22,6 +26,14 @@ class SysMLUiModule extends AbstractSysMLUiModule {
 	
 	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
 		return KerMLUserKeywordHighlightingCalculator
+	}
+	
+	def Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
+		KerMLHighlightingConfiguration
+	}
+	
+	def Class<? extends AbstractAntlrTokenToAttributeIdMapper> bindAbstractAntlrTokenToAttributeIdMapper() {
+		KerMLAntlrTokenToAttributeIdMapper
 	}
 	
 	override provideIAllContainersState() {


### PR DESCRIPTION
This PR adds the following to `org.omg.kerml.xtext.ui`:

1. `KerMLAntlrTokenToAttributeIdMapper` – This class extends the `DefaultAntlrTokenToAttributeIdMapper` to appropriately map tokens using the names of the lexical rules in the `KerMLExpressions` grammar (which is the base for the `KerML` and `SysML` grammars).
2. `KerMLHighlightingConfiguration` – This class extends the `DefaultHighlightingConfiguration` so that the default style for numbers is the same as the default text style, because the usual Xtext gray style looks strange for numbers used in multiplicities with `*`. (The `*` symbol is also used as the multiplication operator, so it can't be given a number style.)

The `org.omg.kerml.xtext.ui.KerMLUIModel` and `org.omg.sysml.xtext.ui.SysMLUiModel` classes have been updated with the appropriate bindings for the above.