### PR TITLE
ST6RI-669 Resolved outstanding TODOs in SysML validation cases and examples

### DIFF
--- a/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
+++ b/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
@@ -48,15 +48,13 @@ package VehicleGeometryAndCoordinateFrames {
 		 * As an example of a more involved placement of composite parts, constrain the positions of the coordinate frame origins 
 		 * of the lugbolts to a circle with radius lbpr distributed evenly over 360°.
 		 * 		
-		 * Currently casting (lugBolts[i] as LugBolt) is needed to resolve coordinateFrame
-		 * TODO: When origin position is available as position3dVector rather than Point, use SpatialItem::PositionOf to reformulate 
-		 * the constraint in terms of the origin postion of each of lugbolts.
+		 * Casting (lugBolts#[i] as LugBolt) is needed to resolve coordinateFrame
 		 */
         attribute <lbpr> lugBoltPlacementRadius :>> radius default 60 [mm];
 		private attribute lugBoltDistributionAngle :>> planeAngle = 360/numberOfBolts ['°'];
         private attribute lbda : Real = lugBoltDistributionAngle.num * (pi/180); // lugBoltDistributionAngle in radian
 		assert constraint {
-			1..numberOfBolts->forAll { 
+			1..numberOfBolts->forAll {
 				in i : Natural;
 				private attribute lbcf = (lugBolts#(i) as LugBolt).coordinateFrame;
 				private attribute trs : TranslationRotationSequence {

--- a/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
+++ b/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
@@ -47,16 +47,14 @@ package VehicleGeometryAndCoordinateFrames {
 		/* 
 		 * As an example of a more involved placement of composite parts, constrain the positions of the coordinate frame origins 
 		 * of the lugbolts to a circle with radius lbpr distributed evenly over 360°.
-		 * 		
-		 * Casting (lugBolts#[i] as LugBolt) is needed to resolve coordinateFrame
 		 */
         attribute <lbpr> lugBoltPlacementRadius :>> radius default 60 [mm];
 		private attribute lugBoltDistributionAngle :>> planeAngle = 360/numberOfBolts ['°'];
         private attribute lbda : Real = lugBoltDistributionAngle.num * (pi/180); // lugBoltDistributionAngle in radian
 		assert constraint {
-			1..numberOfBolts->forAll {
+			(1..numberOfBolts)->forAll {
 				in i : Natural;
-				private attribute lbcf = (lugBolts#(i) as LugBolt).coordinateFrame;
+				private attribute lbcf : CoordinateFrame = lugBolts#(i).coordinateFrame; 
 				private attribute trs : TranslationRotationSequence {
 					:>> source = wcf;
 					:>> target = lbcf;

--- a/sysml/src/validation/03-Function-based Behavior/3c-Function-based Behavior-structure mod-1.sysml
+++ b/sysml/src/validation/03-Function-based Behavior/3c-Function-based Behavior-structure mod-1.sysml
@@ -31,14 +31,19 @@ package '3c-Function-based Behavior-structure mod-1' {
 			}
 		}
 		
-		perform action {
+		action {
 			// Create a link and assign it as the TrailerHitch connection.
 			// Link participants are determined from inherited ends.
 			action 'connect trailer to vehicle'
 				assign 'vehicle-trailer system'.trailerHitch := TrailerHitch();
 				
+			// Destroy the link object.
+			then action 'destroy connection of trailer to vehicle' : 
+				OccurrenceFunctions::destroy {
+				:>> occ = 'vehicle-trailer system'.trailerHitch;
+			}
+				
 			// Remove the link from the TrailerHitch connection.
-			// TODO: Destroy the link object.
 			then action 'disconnect trailer from vehicle'
 				assign 'vehicle-trailer system'.trailerHitch := null;
 		}	

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_01-Constants.sysml
@@ -3,9 +3,6 @@ package '15_01-Constants' {
     import SI::*;
     import RealFunctions::*;
 
-    /* TODO: Move mathematical and fundamental physical constants to model library package(s) */
-    /* TODO: Add concept of precision for Real values */
-    
     /* Note: Value properties that are bound to specific values are constants and have the specified
      * values in all contexts. It is not legal to redefine them.
      */    
@@ -36,7 +33,6 @@ package '15_01-Constants' {
 	     * Standard fundamental physical constants
 	     * 
 	     * Physical constants have a standard measured attribute to a finite precision.
-	     * TODO: Represent physical constant attribute error bounds.
 	     *
 	     * The reference source is:
 	     * CODATA - Task Group on Fundamental Physical Constants (TGFC) - 2018 CODATA recommended values

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_03-Value Expression.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_03-Value Expression.sysml
@@ -23,8 +23,8 @@ package '15_03-Value Expression' {
     }
     
     part def Tire {
-    	attribute profileDepth: LengthValue = 6.0 [mm];
-    	/* TODO: Change profileDepth by adding tolerance: profileDepth: LengthValue = @i{6.0 ± 0.5} [mm]; */
+    	attribute profileDepth: LengthValue default 6.0 [mm];
+        constraint hasLegalProfileDepth {profileDepth >= 3.5 [mm]}
     	attribute height: LengthValue = 45 [mm];
     }
 }

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_06-System of Quantities.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_06-System of Quantities.sysml
@@ -26,8 +26,15 @@ package '15_06-System of Quantities' {
 	 */
 	 
 	 /*
-	  * TODO: Support definition of a System Of Quantities package with additional information that records its provenance.
-	  * TODO: Support explicit identification of the base quantities.
-	  * TODO: Add integrated support for vectors, matrices, nth-order tensors in general (prototypes exist).
+	  * Above capabilities were implemented in:
+      * - standard library Quantities:
+      *   TensorQuantityValue, VectorQuantityValue, ScalarQuantityValue,
+      *   tensorQuantities, vectorQuantities, scalarQuantities, 
+      *   SystemOfQuantities
+	  * - standard library MeasurementReferences:
+	  *   TensorMeasurementReference, VectorMeasurementReference, ScalarMeasurementReference,
+      *   SystemOfUnits
+	  * - standard library ISQBase:
+	  *   attribute <isq> 'International System of Quantities': SystemOfQuantities in ISQBase
 	  */
 }

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_07-System of Units and Scales.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_07-System of Units and Scales.sysml
@@ -32,7 +32,15 @@ package '15_07-System of Units and Scales' {
 	 */
 	 
 	 /*
-	  * TODO: Allow annotation of a System Of Units and Scales package with additional information that records its provenance.
-	  * TODO: Support explicit identification of the base units.
+	  * Above capabilities were implemented in:
+	  * - standard library MeasurementReferences:
+      *   TensorMeasurementReference, VectorMeasurementReference, ScalarMeasurementReference,
+      *   MeasurementUnit, OrdinalScale, IntervalScale, CyclicRatioScale, LogarithmicScale, 
+      *   SystemOfUnits
+	  * - standard library SI:
+	  *   attribute <si> 'ISO/IEC 80000 International System of Units' : SystemOfUnits
+      *     :>> systemOfQuantities = isq;
+      *     :>> baseUnits = (m, kg, s, A, K, mol, cd);
+      *   }
 	  */
 }

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_08-Range Restriction.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_08-Range Restriction.sysml
@@ -1,16 +1,10 @@
 package '15_08-Range Restriction' {
-	import MeasurementReferences::*;
+	import ISQ::*;
 	import SI::*;
 	import '15_01-Constants'::'Mathematical Constants'::pi;
 	
 	part def HeadLightsTiltKnob {
 		attribute headLightsTile : LightBeamTiltAngleValue[1];
-	}
-	
-	/* TODO: Define a model library for angular units. */
-	attribute def PlaneAngleValue :> DimensionOneValue;
-	attribute deg: DimensionOneUnit {
-		attribute :>> unitConversion: ConversionByConvention { :>> referenceUnit = one; :>> conversionFactor = pi/180.0; }
 	}
 	
 	attribute def LightBeamTiltAngleValue :> PlaneAngleValue {
@@ -20,6 +14,6 @@ package '15_08-Range Restriction' {
 			 * Tilt angle shall be limited to the range between 50 and 80 degrees (inclusive).
 			 */
 		}
-		assert constraint { angle >= 50 [deg] and angle <= 80 [deg] }
+		assert constraint { angle >= 50 ['°'] and angle <= 80 ['°'] }
 	}
 }

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_10-Primitive Data Types.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_10-Primitive Data Types.sysml
@@ -26,9 +26,8 @@ package '15.10-Primitive Data Types' {
 	
 	attribute def UnsignedReal :> Real {
 		doc
-		/* TODO: Move this to the model library.
-		 * (To be discussed whether Unsigned attribute defs should really be part of the primitive 
-		 * data / attribute defs. These are more a computer data type concern.)
+		/*
+		 * Example of restriction of the base Real datatype.
 		 */
 		attribute x: Real :>> self;
 		assert constraint { x >= 0.0 }
@@ -38,7 +37,6 @@ package '15.10-Primitive Data Types' {
 		doc
 		/*
 		 * String attributes are sequences of characters.
-		 * TODO: Specify any requirements on character encoding.
 		 */
 	}
 	
@@ -49,7 +47,6 @@ package '15.10-Primitive Data Types' {
 		 */
 	}
 	
-	/* TODO: Specify standardized string encodings. */
 	import Time::DateTime;
 	
 	enum def ConditionColor {

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_11-Variable Length Collection Types.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_11-Variable Length Collection Types.sysml
@@ -5,7 +5,7 @@ package '15_11-Variable Length Collection Types' {
 	part def SparePart;
 	part def Person;
 	
-	/* TODO: Define syntactic sugar for instantiating collection types. */
+	/* Examples of declaring syntactic sugar-like names for instantiating collection types. */
 	
 	attribute def 'Bag<SparePart>' :> Bag {
 		ref part :>> elements: SparePart;

--- a/sysml/src/validation/15-Properties-Values-Expressions/15_19a-Materials with Properties.sysml
+++ b/sysml/src/validation/15-Properties-Values-Expressions/15_19a-Materials with Properties.sysml
@@ -6,7 +6,8 @@ package '15_19a-Materials with Properties' {
 	
     attribute def AtomicMassValue :> MassValue;
     
-	// TODO: Move definition of tensile strength and N/mm² to SI
+	/* Example declarations of a quantity and unit that are not specified in ISQ and SI */
+
 	attribute def TensileStrengthUnit :> DerivedUnit {
         private attribute lengthPF: QuantityPowerFactor[1] { :>> quantity = isq.L; :>> exponent = -1; }
         private attribute massPF: QuantityPowerFactor[1] { :>> quantity = isq.M; :>> exponent = 1; }


### PR DESCRIPTION
This PR resolves the following left-over TODOs in various SysML validation case and example files were resolved.

1. `3c-Function-based Behavior-structure mod-1`
    - `TODO: Destroy the link object.`
       <br/>Added action to destroy the connection using `OccurrenceFunctions::destroy`.

2. `15_03-Value Expression`
   - `TODO: Change profileDepth by adding tolerance: profileDepth: LengthValue = @i{6.0 ± 0.5} [mm];`
      <br/>Instead of specifying a tolerance the following constraint was added:    
      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`constraint hasLegalProfileDepth {profileDepth >= 3.5 [mm]}`
      and the `profileDepth` value was changed from binding to default:
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`attribute profileDepth: LengthValue default 6.0 [mm];`

3. `15_06-System of Quantities`
   - `TODO: Support definition of a System Of Quantities package with additional information that records its provenance.`
   - `TODO: Support explicit identification of the base quantities.`
   - `TODO: Add integrated support for vectors, matrices, nth-order tensors in general (prototypes exist).`
      <br/>Replaced TODOs with comments that explain the actual implementation in standard libraries.

4. `15_07-System of Units and Scales`
   - `TODO: Allow annotation of a System Of Units and Scales package with additional information that records its provenance.`
   - `TODO: Support explicit identification of the base units.`
      <br/>Replaced TODOs with annotations that explain the actual implementation in standard libraries.

5. `15_08-Range Restriction`
   - `TODO: Define a model library for angular units.`
      <br/>Resolved TODO by importing `ISQ` and `SI`, and using standard `ISQ::PlaneAngleValue` and `SI::'°'`.
      Deleted redundant declarations.

6. `15_10-Primitive Data Types`
   - `TODO: Move this to the model library.`
      <br/>Removed TODO on `UnsignedReal`, and updated documentation

7. 15_10-Primitive Data Types`
   - `TODO: Specify any requirements on character encoding.`
      <br/>Removed TODO, as character encoding for `String` is specified in the KerML specification.

8. `15_10-Primitive Data Types`
   - `TODO: Specify standardized string encodings.`
      <br/>Removed TODO, as string encoding for `DateTime` values is specified in the `Time` package.

9. `15_11-Variable Length Collection Types`
   - `TODO: Define syntactic sugar for instantiating collection types.`
      <br/>Replaced TODO with comment 
      `/* Examples of declaring syntactic sugar-like names for instantiating collection types. */`

10. `15_19a-Materials with Properties`
   - `TODO: Move definition of tensile strength and N/mm² to SI`
      <br/>Replaced TODO with comment:
      `/* Example declarations of a quantity and unit that are not specified in ISQ and SI */`

The following TODOs were removed and recorded as issues for possible future resolution:

1. `VehicleGeometryAndCoordinateFrames`
   - `TODO: When origin position is available as position3dVector rather than Point, use SpatialItem::PositionOf to reformulate`

2. `15_01-Constants.sysml`
   - `TODO: Move mathematical and fundamental physical constants to model library package(s)`
   - `TODO: Add concept of precision for Real values`
   - `TODO: Represent physical constant attribute error bounds.`
