### PR TITLE
ST6RI-676 Feature chain expression result typing can fail when used with indexing

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Indexing.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Indexing.kerml.xt
@@ -1,0 +1,49 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Performances.kerml"}
+		File {from ="/library/ScalarValues.kerml"}
+		File {from ="/library/Collections.kerml"}
+		File {from ="/library/BaseFunctions.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Performances.kerml"}
+				File {from ="/library/ScalarValues.kerml"}
+				File {from ="/library/Collections.kerml"}
+				File {from ="/library/BaseFunctions.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+// XPECT noErrors ---> ""
+package Indexing {
+	classifier A {
+	  feature b : B;
+	}
+	classifier B {
+	  feature c;
+	}
+	feature a : A[*];
+	feature b = a#(1).b;
+	feature c = b.c;
+	
+	feature arr : Collections::Array {
+	  :>> dimensions = (2, 3);
+	  :>> elements = ("a", "b", "c",
+	                  "x", "y", "z");
+	}
+	feature arr13 = arr#(1,3);
+	feature arr22 = arr#(2,2);
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -453,6 +453,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 	}
 	
 	private def doCheckConnector(Connector c, Type location, EClass kind) {
+		ElementUtil.transform(c)
 		val cFeaturingTypes = c.featuringType
 		
 		if (kind == SysMLPackage.Literals.FEATURE_MEMBERSHIP) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
@@ -26,6 +26,7 @@ import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.OperatorExpression;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.ExpressionUtil;
 import org.omg.sysml.util.TypeUtil;
 
@@ -47,8 +48,10 @@ public class OperatorExpressionAdapter extends InvocationExpressionAdapter {
 		if (INDEXING_OPERATOR.equals(target.getOperator())) {
 			EList<Expression> arguments = target.getArgument();
 			if (!arguments.isEmpty()) {
+				Expression seqArgument = arguments.get(0);
+				ElementUtil.transform(seqArgument);
+				Feature seqResult = seqArgument.getResult();
 				Feature resultFeature = target.getResult();
-				Feature seqResult = arguments.get(0).getResult();
 				if (resultFeature != null && seqResult != null)
 				TypeUtil.addImplicitGeneralTypeTo(resultFeature, SysMLPackage.eINSTANCE.getSubsetting(), seqResult);
 			}

--- a/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
+++ b/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
@@ -54,7 +54,7 @@ package VehicleGeometryAndCoordinateFrames {
 		assert constraint {
 			(1..numberOfBolts)->forAll {
 				in i : Natural;
-				private attribute lbcf : CoordinateFrame = lugBolts#(i).coordinateFrame; 
+				private attribute lbcf = lugBolts#(i).coordinateFrame; 
 				private attribute trs : TranslationRotationSequence {
 					:>> source = wcf;
 					:>> target = lbcf;


### PR DESCRIPTION
Updates `OperatorExpressionAdapter::addIndexingResultSubsetting` to ensure that the `seq` argument is transformed before trying to use its result parameter as the target of the implicit subsetting of the result parameter of an index expression. This subsetting not being set correctly was the underlying cause of the bug being fixed.