### PR TITLE
ST6RI-680 An unnecessary `=` is rendered when we use `:=` in feature values. 

### DIFF
--- a/org.omg.sysml.jupyter.jupyterlab/package.json
+++ b/org.omg.sysml.jupyter.jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@systems-modeling/jupyterlab-sysml",
-  "version": "0.33.0-SNAPSHOT",
+  "version": "0.34.0-SNAPSHOT",
   "description": "A JupyterLab extension for system modeling using SysML",
   "repository": "github:Systems-Modeling/SysML-v2-Pilot-Implementation",
   "author": "SysML v2 Submission Team",

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -112,7 +112,7 @@ public abstract class VStructure extends VDefault {
         return true;
     }
 
-    private static Pattern patEqFeatureValue = Pattern.compile("^\\s*=");
+    private static Pattern patEqFeatureValue = Pattern.compile("^\\s*:?=");
 
     protected boolean appendFeatureValue(FeatureValue fv) {
         Expression ex = fv.getValue();


### PR DESCRIPTION
I thought it had been fixed but maybe due to some merge, this issue again appeared.  The fix is just correcting the regular expression pattern.