### PR TITLE
ST6RI-697 Feature chains in Action or Interconnection views are not properly rendered

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
@@ -95,12 +95,12 @@ public abstract class VBehavior extends VDefault {
     }
 
     private Element nullizeStartOrEntryAction(Element e) {
-        if (!(e instanceof ActionUsage)) return null;
+        if (!(e instanceof ActionUsage)) return e;
         return nullizeStartOrEntryAction((ActionUsage) e);
     }
 
     private Element nullizeDoneOrExitAction(Element e) {
-        if (!(e instanceof ActionUsage)) return null;
+        if (!(e instanceof ActionUsage)) return e;
         return nullizeDoneOrExitAction((ActionUsage) e);
     }
 


### PR DESCRIPTION
The visualizer could not properly render feature chains in behavioural rendering, used by Action, State, Interconnection, Case views.  The example below

```
action a {
    action a1 {
        action a11;
    }
    action a12;
    first a1.a11 then a12;
}
```

is wrongly rendered as:
![Screenshot 2023-06-28 at 3 06 12 PM](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/assets/10537/bc6b43ad-c0a3-4b60-b9e2-2179fb120771)
