### PR TITLE
ST6RI-685 Update KerML validation based on normative validation constraints

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_BadScopeWithOnlyTwoSingleDot.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_BadScopeWithOnlyTwoSingleDot.kerml.xt
@@ -24,7 +24,6 @@ package test{
 	}
 	classifier B{
 		//* XPECT errors ---
-        "Relationships must have at least two related elements" at ""
 		"no viable alternative at input '..'" at "test"
 		"no viable alternative at input '::'" at "::"
 		"no viable alternative at input 'A'" at "A"

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_BadScopeWithOnlyTwoSingleDotAtTheEnd.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_BadScopeWithOnlyTwoSingleDotAtTheEnd.kerml.xt
@@ -24,7 +24,6 @@ package test{
 	}
 	classifier B{
 		//* XPECT errors ---
-		"Relationships must have at least two related elements" at ""
 		"no viable alternative at input '..'" at ".."
 		"no viable alternative at input '..'" at "test"
 		"no viable alternative at input 'A'" at "A"

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/FeatureChain_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/FeatureChain_invalid.kerml.xt
@@ -62,7 +62,7 @@ package P {
     // XPECT errors ---> "Must be a valid feature" at "V"
     feature v2_V : Integer = V;
     
-    // XPECT errors ---> "Cannot have only one feature chaining" at "v1"
+    // XPECT errors ---> "Cannot have only one chaining feature" at "v1"
     feature v1_ chains v1;
  
     binding v1.n = v2.n;

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MembershipTests_Distinguishability.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MembershipTests_Distinguishability.kerml.xt
@@ -15,16 +15,16 @@ XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
 END_SETUP 
 */
 package test{
-	// XPECT warnings ---> "Duplicate of other element name" at "A"
+	// XPECT warnings ---> "Duplicate of other owned member name" at "A"
 	classifier A {}
-	// XPECT warnings ---> "Duplicate of other element name" at "A"
+	// XPECT warnings ---> "Duplicate of other owned member name" at "A"
 	package A{
 		classifier A {}
 		alias A_alias for A;
 	}
-	// XPECT warnings ---> "Duplicate of other element name" at "A"
+	// XPECT warnings ---> "Duplicate of other owned member name" at "A"
 	package A{}
-	// XPECT warnings ---> "Duplicate of other element name" at "A"
+	// XPECT warnings ---> "Duplicate of other owned member name" at "A"
 	feature A: A::A_alias;
 	feature B: A::A_alias;
 	

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MultiplicityRange_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MultiplicityRange_invalid.kerml.xt
@@ -1,0 +1,39 @@
+//* XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+        ResourceSet {
+                ThisFile {}
+                File {from ="/library/Base.kerml"}
+                File {from ="/library/Links.kerml"}
+                File {from ="/library/Occurrences.kerml"}
+                File {from ="/library/Objects.kerml"}
+				File {from ="/library/Performances.kerml"}
+				File {from ="/library/ScalarValues.kerml"}
+        }
+        Workspace {
+                JavaProject {
+                        SrcFolder {
+                                ThisFile {}
+                                File {from ="/library/Base.kerml"}
+                                File {from ="/library/Occurrences.kerml"}
+                 				File {from ="/library/Objects.kerml"}
+								File {from ="/library/Performances.kerml"}
+								File {from ="/library/ScalarValues.kerml"}
+                        }
+                }
+        }
+END_SETUP
+*/
+
+// XPECT noErrors ---> ""
+package MultiplicityRange {
+	// XPECT errors ---> "Must have a Natural value" at "false"
+	feature f [1..false];
+	
+	feature n = 0;
+	feature b = n > 3;
+	
+	// XPECT errors ---> "Must have a Natural value" at "b"
+	feature g [n..b];
+	
+	// XPECT errors ---> "Must have a Natural value" at ""x""
+	feature h ["x"..*];
+}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ShortNameTests_Distinguishibility1.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ShortNameTests_Distinguishibility1.kerml.xt
@@ -17,9 +17,9 @@ END_SETUP
 
 package Test {
 	 //short names are the same
-	 //XPECT warnings --> "Duplicate of other element name" at "one"
+	 //XPECT warnings --> "Duplicate of other owned member name" at "one"
 	 classifier <one> two;
-	 //XPECT warnings --> "Duplicate of other element name" at "one"
+	 //XPECT warnings --> "Duplicate of other owned member name" at "one"
 	 classifier <one> three;
 }
 

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ShortNameTests_Distinguishibility2.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ShortNameTests_Distinguishibility2.kerml.xt
@@ -17,8 +17,8 @@ END_SETUP
 
 package Test {
 	 //name and id are the same
-	 //XPECT warnings --> "Duplicate of other element name" at "two"
+	 //XPECT warnings --> "Duplicate of other owned member name" at "two"
 	 classifier <one> two;
-	  //XPECT warnings --> "Duplicate of other element name" at "two"
+	  //XPECT warnings --> "Duplicate of other owned member name" at "two"
 	 classifier <two> three;
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
@@ -1,0 +1,50 @@
+//*
+XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Objects.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Objects.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+package Specialization_invalid {
+	classifier A;
+	classifier B;
+	classifier C conjugates A;
+	
+	// XPECT errors--->"Conjugated type cannot be a specialized type" at "C"
+	subtype C specializes B;
+	
+	datatype D1;
+	//* XPECT errors ---
+	   "Cannot specialize class or association" at "C1"
+	   "Cannot specialize class or association" at "A1"
+	   ---
+	*/
+	datatype D2 specializes D1, C1, A1;
+	
+	class C1;
+	//* XPECT errors ---
+	   "Cannot specialize data type or association" at "D1"
+	   "Cannot specialize data type or association" at "A1"
+	   ---
+	*/
+	class C2 specializes C1, D1, A1;
+	
+	abstract assoc A1;
+	abstract assoc struct A2 specializes C2, A1;
+	abstract interaction A3 specializes C2, A1;
+}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/TypeRelationships_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/TypeRelationships_invalid.kerml.xt
@@ -28,7 +28,7 @@ package TypeRelationships {
 	
 	feature f;
 	
-    // XPECT errors ---> "Cannot have only one feature chaining" at "f"
+    // XPECT errors ---> "Cannot have only one chaining feature" at "f"
     feature g chains f;
 
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Type_Multiplicity_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Type_Multiplicity_invalid.kerml.xt
@@ -1,0 +1,23 @@
+//* XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+        ResourceSet {
+                ThisFile {}
+                File {from ="/library/Base.kerml"}
+        }
+        Workspace {
+                JavaProject {
+                        SrcFolder {
+                                ThisFile {}
+                                File {from ="/library/Base.kerml"}
+                        }
+                }
+        }
+END_SETUP
+*/
+package Type_Multiplicity {
+	classifier C {
+		multiplicity subsets Base::zeroOrOne;
+		
+		// XPECT errors--->"Only one multiplicity is allowed" at "multiplicity subsets Base::zeroToMany;"
+		multiplicity subsets Base::zeroToMany;
+	}
+}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Type_Relationships_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Type_Relationships_invalid.kerml.xt
@@ -26,9 +26,20 @@ package TypeRelationships {
 	*/
 	classifier X unions A intersects B differences C;
 	
-	feature f;
+	//* XPECT errors ---
+	   "Type cannot union with itself" at "Y"
+	   "Type cannot intersect with itself" at "Y"
+	   "Type cannot difference with itself" at "Y"
+	   ---
+	*/
+	classifier Y unions A, Y intersects B, Y differences C, Y;
+	
+	feature f {
+   		// XPECT errors ---> "Feature cannot have itself in a feature chain" at "h"
+		feature h chains f.h;
+	}
 	
     // XPECT errors ---> "Cannot have only one chaining feature" at "f"
     feature g chains f;
-
+    
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -71,7 +71,22 @@ import org.omg.sysml.lang.sysml.LibraryPackage
 import org.omg.sysml.lang.sysml.ItemFlowEnd
 import org.omg.sysml.lang.sysml.Namespace
 import org.omg.sysml.lang.sysml.Association
-import org.eclipse.emf.common.util.EList
+import org.omg.sysml.lang.sysml.Specialization
+import org.omg.sysml.lang.sysml.Conjugation
+import org.omg.sysml.lang.sysml.Relationship
+import org.omg.sysml.lang.sysml.DataType
+import org.omg.sysml.lang.sysml.AssociationStructure
+import org.omg.sysml.lang.sysml.Structure
+import org.omg.sysml.lang.sysml.ParameterMembership
+import org.omg.sysml.lang.sysml.Behavior
+import org.omg.sysml.lang.sysml.Step
+import org.omg.sysml.lang.sysml.ReturnParameterMembership
+import org.omg.sysml.lang.sysml.Function
+import org.omg.sysml.lang.sysml.ResultExpressionMembership
+import org.omg.sysml.lang.sysml.ItemFeature
+import org.eclipse.emf.ecore.EStructuralFeature
+import org.omg.sysml.lang.sysml.FeatureValue
+import org.omg.sysml.lang.sysml.MultiplicityRange
 
 /**
  * This class contains custom validation rules. 
@@ -93,27 +108,45 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	// CORE //
 	
-	public static val INVALID_TYPE_DIFFERENCING_TYPE_NOT_ONE = 'validateTypeDifferencingTypeNotOne'
-	public static val INVALID_TYPE_DIFFERENCING_TYPE_NOT_ONE_MSG = 'Cannot have only one differencing'
-	public static val INVALID_TYPE_INTERSECTING_TYPE_NOT_ONE = 'validateTypeIntersectingTypeNotOne'
-	public static val INVALID_TYPE_INTERSECTING_TYPE_NOT_ONE_MSG = 'Cannot have only one intersecting'
+	public static val INVALID_SPECIALIZATION_SPECIFIC_NOT_CONJUGATED = "validateSpecializationSpecificNotConjugated"
+	public static val INVALID_SPECIALIZATION_SPECIFIC_NOT_CONJUGATED_MSG = "Conjugated type cannot be a specialized type"	
+	
+	public static val INVALID_TYPE_AT_MOST_ONE_CONJUGATOR = "validateTypeAtMostOneConjugator"
+	public static val INVALID_TYPE_AT_MOST_ONE_CONJUGATOR_MSG = "Cannot have more than one conjugator"
+	public static val INVALID_TYPE_DIFFERENCING_TYPES_NOT_SELF = "validateTypeDifferencingTypesNotSelf"
+	public static val INVALID_TYPE_DIFFERENCING_TYPES_NOT_SELF_MSG = "Type cannot difference with itself"		
+	public static val INVALID_TYPE_INTERSECTING_TYPES_NOT_SELF = "validateTypeIntersectingTypesNotSelf"
+	public static val INVALID_TYPE_INTERSECTING_TYPES_NOT_SELF_MSG = "Type cannot intersect with itself"
+	public static val INVALID_TYPE_OWNED_DIFFERENCING_NOT_ONE = 'validateOwnedDifferencingNotOne'
+	public static val INVALID_TYPE_OWNED_DIFFERENCING_NOT_ONE_MSG = 'Cannot have only one differencing'
+	public static val INVALID_TYPE_OWNED_INTERSECTING_NOT_ONE = 'validateOwnedIntersectingNotOne'
+	public static val INVALID_TYPE_OWNED_INTERSECTING_NOT_ONE_MSG = 'Cannot have only one intersecting'
 	public static val INVALID_TYPE_OWNED_MULTIPLICITY = "validateTypeOwnedMultiplicity"
 	public static val INVALID_TYPE_OWNED_MULTIPLICITY_MSG = "Only one multiplicity is allowed"
-	public static val INVALID_TYPE_UNIONING_TYPE_NOT_ONE = 'validateTypeUnioningTypeNotOne'
-	public static val INVALID_TYPE_UNIONING_TYPE_NOT_ONE_MSG = 'Cannot have only one unioning'
-	
-	// Note: validateClassifierDefaultSupertype is not in the spec as a single constraint.
+	public static val INVALID_TYPE_OWNED_UNIONING_NOT_ONE = 'validateOwnedUnioningNotOne'
+	public static val INVALID_TYPE_OWNED_UNIONING_NOT_ONE_MSG = 'Cannot have only one unioning'
+	public static val INVALID_TYPE_UNIONING_TYPES_NOT_SELF = "validateTypeUnioningTypesNotSelf"
+	public static val INVALID_TYPE_UNIONING_TYPES_NOT_SELF_MSG = "Type cannot union with itself"	
+
+	// Note: validateClassifierDefaultSupertype is not in the spec, but it is implied by semantic constraints on classifiers.
 	public static val INVALID_CLASSIFIER_DEFAULT_SUPERTYPE = 'validateClassifierDefaultSupertype_'
 	public static val INVALID_CLASSIFIER_DEFAULT_SUPERTYPE_MSG = "Must directly or indirectly specialize {supertype}"
 
-	// Note: validateFeatureHasType is not in the spec, but it is implied by semantic constraints on features
+	public static val INVALID_CLASSIFIER_MULTIPLICITY_DOMAIN = "validateClassifierMultiplicityDomain"
+	public static val INVALID_CLASSIFIER_MULTIPLICITY_DOMAIN_MSG = "Multiplicity must not have a featuring type"
+
+	// Note: validateFeatureHasType is not in the spec, but it is implied by semantic constraints on features.
 	public static val INVALID_FEATURE_HAS_TYPE = 'validateFeatureHasType_'
 	public static val INVALID_FEATURE_HAS_TYPE_MSG = "Features must have at least one type"
 
-	public static val INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING = 'validateFeatureOwnedReferenceSubsetting'
-	public static val INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING_MSG = 'At most one reference subsetting is allowed'
-	public static val INVALID_FEATURE_FEATURE_CHAINING_NOT_ONE = 'validateFeatureFeatureChainingNotOne'
-	public static val INVALID_FEATURE_FEATURE_CHAINING_NOT_ONE_MSG = 'Cannot have only one feature chaining'
+	public static val INVALID_FEATURE_CHAINING_FEATURES_NOT_SELF = "validateFeatureChainingFeaturesNotSelf"
+	public static val INVALID_FEATURE_CHAINING_FEATURES_NOT_SELF_MSG = "Feature cannot have itself in a feature chain"
+	public static val INVALID_FEATURE_CHAINING_FEATURE_NOT_ONE = "validateFeatureChainingFeatureNotOne"
+	public static val INVALID_FEATURE_CHAINING_FEATURE_NOT_ONE_MSG = "Cannot have only one chaining feature"
+	public static val INVALID_FEATURE_MULTIPLICITY_DOMAIN = "validateFeatureMultiplicityDomain"
+	public static val INVALID_FEATURE_MULTIPLICITY_DOMAIN_MSG = "Multiplicity must have same featuring types as it feature"
+	public static val INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING = "validateFeatureOwnedReferenceSubsetting"
+	public static val INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING_MSG = "At most one reference subsetting is allowed"				
 
 	public static val INVALID_FEATURE_CHAINING_FEATURE_CONFORMANCE = "validatFeatureChainingFeatureConformance"
 	public static val INVALID_FEATURE_CHAINING__FEATURE_CONFORMANCE_MSG = "Must be a valid feature"
@@ -133,20 +166,49 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	// KERNEL //
 	
+	public static val INVALID_DATA_TYPE_SPECIALIZATION = "validateDataTypeSpecialization"
+	public static val INVALID_DATA_TYPE_SPECIALIZATION_MSG = "Cannot specialize class or association"    
+	
+	public static val INVALID_CLASS_SPECIALIZATION = "validateClassSpecialization"
+	public static val INVALID_CLASS_SPECIALIZATION_MSG = "Cannot specialize data type or association"    
+	
+	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION = "validateAssociationBinarySpecialization"
+	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG = "Cannot have more than two ends"
 	public static val INVALID_ASSOCIATION_RELATED_TYPES = "validateAssociationRelatedTypes"
 	public static val INVALID_ASSOCIATION_RELATED_TYPES_MSG = "Must have at least two related elements"
+	public static val INVALID_ASSOCIATION_STRUCTURE_INTERSECTION = "validateAssociationStructureIntersection"
+	public static val INVALID_ASSOCIATION_STRUCTURE_INTERSECTION_MSG = "Must be an association structure"
 		
 	public static val INVALID_BINDING_CONNECTOR_TYPE_CONFORMANCE = "validateBindingConnectorTypeConformance"
 	public static val INVALID_BINDING_CONNECTOR_TYPE_CONFORMANCE_MSG = "Bound features should have conforming types"
+	public static val INVALID_BINDING_CONNECTOR_IS_BINARY = "validateBindingConnectorIsBinary"
+	public static val INVALID_BINDING_CONNECTOR_IS_BINARY_MSG = "Binding connector must be binary"
 
 	// Note: This check is not currently implemented.
 	public static val INVALID_BINDING_CONNECTOR_ARGUMENT_TYPE_CONFORMANCE = "validateBindingConnectorArgumentTypeConformance"
 	public static val INVALID_BINDING_CONNECTOR_ARGUMENT_TYPE_CONFORMANCE_MSG = "Output feature must conform to input feature"
 
+	public static val INVALID_CONNECTOR_BINARY_SPECIALIZATION = "validateConnectorBinarySpecialization"
+	public static val INVALID_CONNECTOR_BINARY_SPECIALIZATION_MSG = "Cannot have more than two ends"
 	public static val INVALID_CONNECTOR_RELATED_FEATURES = "validateConnectorRelatedFeatures"
 	public static val INVALID_CONNECTOR_RELATED_FEATURES_MSG = "Must have at least two related elements"
 	public static val INVALID_CONNECTOR_TYPE_FEATURING = "validateConnectorTypeFeaturing"
 	public static val INVALID_CONNECTOR_TYPE_FEATURING_MSG = "Should be an accessible feature (use dot notation for nesting)"
+	
+	public static val INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE = "validateParameterMembershipOwningType"
+	public static val INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE_MSG = "Parameter membership not allowed"	
+		
+	public static val INVALID_EXPRESSION_RESULT_PARAMETER_MEMBERSHIP = "validateExpressionResultParameterMembership"
+	public static val INVALID_EXPRESSION_RESULT_PARAMETER_MEMBERSHIP_MSG = "Only one return parameter is allowed"	
+		
+	public static val INVALID_FUNCTION_RESULT_PARAMETER_MEMBERSHIP = "validateFunctionResultParameterMembership"
+	public static val INVALID_FUNCTION_RESULT_PARAMETER_MEMBERSHIP_MSG = "Only one return parameter is allowed"	
+		
+	public static val INVALID_RETURN_PARAMETER_MEMBERSHIP_OWNING_TYPE = "validateReturnParameterMembershipOwningType"
+	public static val INVALID_RETURN_PARAMETER_MEMBERSHIP_OWNING_TYPE_MSG = "Return parameter membership not allowed"	
+		
+	public static val INVALID_RESULT_EXPRESSION_MEMBERSHIP_OWNING_TYPE = "validateResultExpressionMembershipOwningType"
+	public static val INVALID_RESULT_EXPRESSION_MEMBERSHIP_OWNING_TYPE_MSG = "Result expression not allowed"	
 		
 	public static val INVALID_FEATURE_CHAIN_EXPRESSION_FEATURE_CONFORMANCE = "validateFeatureChainExpressionFeatureConformance"
 	public static val INVALID_FEATURE_CHAIN_EXPRESSION_FEATURE_CONFORMANCE_MSG = "Must be a valid feature"
@@ -166,11 +228,21 @@ class KerMLValidator extends AbstractKerMLValidator {
 	public static val INVALID_OPERATOR_EXPRESSION_BRACKET_OPERATOR = "validateOperatorExpressionBracketOperator_"
 	public static val INVALID_OPERATOR_EXPRESSION_BRACKET_OPERATOR_MSG = "Use #(...) for indexing"
 	
+	public static val INVALID_ITEM_FLOW_ITEM_FEATURE = "validateItemFlowItemFeature"
+	public static val INVALID_ITEM_FLOW_ITEM_FEATURE_MSG = "Only one item feature is allowed"	
+		
+	public static val INVALID_ITEM_FLOW_END_OWNING_TYPE = "validateItemFlowEndOwningType"
+	public static val INVALID_ITEM_FLOW_END_OWNING_TYPE_MSG = "Item flow end not allowed"
+	public static val INVALID_ITEM_FLOW_END_NESTED_FEATURE = "validateItemFlowEndNestedFeature"
+	public static val INVALID_ITEM_FLOW_END_NESTED_FEATURE_MSG = "Item flow end must have a nested input or output feature"
 	public static val INVALID_ITEM_FLOW_END_SUBSETTING = 'validateItemFlowEndSubsetting'
 	public static val INVALID_ITEM_FLOW_END_SUBSETTING_MSG = "Cannot identify item flow end (use dot notation)"
-	public static val INVALID_ITEM_FLOW_END_IMPLICIT_SUBSETTING = 'validateItemFlowEndImplicitSubsetting'
+	public static val INVALID_ITEM_FLOW_END_IMPLICIT_SUBSETTING = "validateItemFlowEndImplicitSubsetting"
 	public static val INVALID_ITEM_FLOW_END_IMPLICIT_SUBSETTING_MSG = "Flow ends should use dot notation"
 	
+	public static val INVALID_MULTIPLICITY_RANGE_BOUND_RESULT_TYPES = "validateMultiplicityRangeResultTypes"
+	public static val INVALID_MULTIPLICITY_RANGE_BOUND_RESULT_TYPES_MSG = "Must have a Natural value"
+
 	public static val INVALID_METADATA_FEATURE_ANNOTATED_ELEMENT = "validateMetadataFeatureAnnotatedElement"
 	public static val INVALID_METADATA_FEATURE_ANNOTATED_ELEMENT_MSG = "Cannot annotate {metaclass}"
 	public static val INVALID_METADATA_FEATURE_BODY = "invalidateMetadataFeatureBody"
@@ -201,7 +273,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 	}
 	
 	@Check
-	def checkNamespace(Namespace namesp){
+	def checkNamespace(Namespace namesp) {
 		// validateNamespaceDistinguishability
 		// Do not check distinguishability for automatically constructed expressions and binding connectors (to improve performance).
 		if (!(namesp instanceof InvocationExpression || namesp instanceof FeatureReferenceExpression || namesp instanceof LiteralExpression || 
@@ -250,29 +322,39 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	/* CORE */
 	
-	// TODO: validateSpecializationSpecificNotConjugated
+	@Check
+	def checkSpecialization(Specialization s) {
+		// validateSpecializationSpecificNotConjugated
+		if (s.specific.isConjugated) {
+			error(INVALID_SPECIALIZATION_SPECIFIC_NOT_CONJUGATED_MSG, s, SysMLPackage.eINSTANCE.specialization_Specific, INVALID_SPECIALIZATION_SPECIFIC_NOT_CONJUGATED)
+		}
+	}
 	
 	@Check
 	def checkType(Type t) {
-		// TODO: Check validateTypeAtMostOneConjugator
-		// TODO: Check validateTypeDifferencingTypesNotSelf
-		// TODO: Check validateTypeIntersectingTypesNotSelf
-		// TODO: Check validateTypeUnioningTypesNotSelf
+		// validateTypeAtMostOneConjugator
+		if (t.ownedRelationship.filter[r | r instanceof Conjugation].size() > 1) {
+			error(INVALID_TYPE_AT_MOST_ONE_CONJUGATOR_MSG, t, null, INVALID_TYPE_AT_MOST_ONE_CONJUGATOR)
+		}
 
-		// TODO: Add validateTypeUnioningTypeNotOne
-		checkNotOne(t.ownedUnioning, INVALID_TYPE_UNIONING_TYPE_NOT_ONE_MSG, INVALID_TYPE_UNIONING_TYPE_NOT_ONE)
-		// TODO: Add validateTypeIntersectingTypeNotOne
-		checkNotOne(t.ownedIntersecting, INVALID_TYPE_INTERSECTING_TYPE_NOT_ONE_MSG, INVALID_TYPE_INTERSECTING_TYPE_NOT_ONE)
-		// TODO: Add validateTypeDifferencingTypeNotOne
-		checkNotOne(t.ownedDifferencing, INVALID_TYPE_DIFFERENCING_TYPE_NOT_ONE_MSG, INVALID_TYPE_DIFFERENCING_TYPE_NOT_ONE)
+		// TODO: Add validateTypeOwnedDifferencingNotOne
+		checkNotOne(t.ownedDifferencing, INVALID_TYPE_OWNED_DIFFERENCING_NOT_ONE_MSG, INVALID_TYPE_OWNED_DIFFERENCING_NOT_ONE)
+		// validateDifferencingTypesNotSelf
+		checkTargetNotObject(t, t.ownedDifferencing, INVALID_TYPE_DIFFERENCING_TYPES_NOT_SELF_MSG, INVALID_TYPE_DIFFERENCING_TYPES_NOT_SELF)
+		
+		// TODO: Add validateTypeOwnedIntersectingNotOne
+		checkNotOne(t.ownedIntersecting, INVALID_TYPE_OWNED_INTERSECTING_NOT_ONE_MSG, INVALID_TYPE_OWNED_INTERSECTING_NOT_ONE)
+		// validateTypeIntersectingTypesNotSelf
+		checkTargetNotObject(t, t.ownedIntersecting, INVALID_TYPE_INTERSECTING_TYPES_NOT_SELF_MSG, INVALID_TYPE_INTERSECTING_TYPES_NOT_SELF)
+		
+		// TODO: Add validateTypeOwnedUnioningNotOne
+		checkNotOne(t.ownedUnioning, INVALID_TYPE_OWNED_UNIONING_NOT_ONE_MSG, INVALID_TYPE_OWNED_UNIONING_NOT_ONE)
+		// validateTypeUnioningTypesNotSelf
+		checkTargetNotObject(t, t.ownedUnioning, INVALID_TYPE_UNIONING_TYPES_NOT_SELF_MSG, INVALID_TYPE_UNIONING_TYPES_NOT_SELF)
 		
 		// validateTypeOwnedMultiplicity
 		var multiplicityMemberships = t.ownedMembership.filter[memberElement instanceof Multiplicity];
-		if (multiplicityMemberships.size > 1) {
-			for (var i = 1; i < multiplicityMemberships.size; i++) {
-				error(INVALID_TYPE_OWNED_MULTIPLICITY_MSG, multiplicityMemberships.get(i), SysMLPackage.eINSTANCE.membership_MemberElement, INVALID_TYPE_OWNED_MULTIPLICITY);			
-			}
-		}
+		checkAtMostOne(multiplicityMemberships, INVALID_TYPE_OWNED_MULTIPLICITY_MSG, SysMLPackage.eINSTANCE.membership_MemberElement, INVALID_TYPE_OWNED_MULTIPLICITY)
 	}
 	
 	
@@ -283,6 +365,12 @@ class KerMLValidator extends AbstractKerMLValidator {
 		val defaultSupertype = ImplicitGeneralizationMap.getDefaultSupertypeFor(c.getClass())
 		if (!TypeUtil.conforms(c, SysMLLibraryUtil.getLibraryType(c, defaultSupertype)))
 			error(INVALID_CLASSIFIER_DEFAULT_SUPERTYPE_MSG.replace("{supertype}", defaultSupertype), c, SysMLPackage.eINSTANCE.classifier_OwnedSubclassification, INVALID_CLASSIFIER_DEFAULT_SUPERTYPE)
+			
+		// validateClassifierMultiplicityDomain
+		val m = c.multiplicity;
+		if (m !== null && !m.multiplicity.featuringType.empty) {
+			error(INVALID_CLASSIFIER_MULTIPLICITY_DOMAIN_MSG, c, SysMLPackage.eINSTANCE.type_Multiplicity, INVALID_CLASSIFIER_MULTIPLICITY_DOMAIN)
+		}
 	}
 	
 	// @Check
@@ -292,12 +380,16 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	@Check
 	def checkFeature(Feature f){
-		val types = f.type;
-		
 		// TODO: Remove?
+		val types = f.type;
 		if (types !== null && types.isEmpty)
 			error(INVALID_FEATURE_HAS_TYPE_MSG, f, SysMLPackage.eINSTANCE.feature_Type, INVALID_FEATURE_HAS_TYPE)
 			
+		// validateFeatureChainingFeatureNotOne
+		checkNotOne(f.ownedFeatureChaining, INVALID_FEATURE_CHAINING_FEATURE_NOT_ONE_MSG, INVALID_FEATURE_CHAINING_FEATURE_NOT_ONE)
+		// validateFeatureChainingFeaturesNotSelf
+		checkTargetNotObject(f, f.ownedFeatureChaining, INVALID_FEATURE_CHAINING_FEATURES_NOT_SELF_MSG, INVALID_FEATURE_CHAINING_FEATURES_NOT_SELF)
+
 		// validateFeatureOwnedReferenceSubsetting
 		val refSubsettings = f.ownedRelationship.filter[r | r instanceof ReferenceSubsetting].toList
 		if (refSubsettings.size > 1) {
@@ -305,14 +397,15 @@ class KerMLValidator extends AbstractKerMLValidator {
 				error(INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING_MSG, refSubsettings.get(i), null, INVALID_FEATURE_OWNED_REFERENCE_SUBSETTING)
 		}
 		
-		// validateFeatureChainingFeatureNotOne
-		checkNotOne(f.ownedFeatureChaining, INVALID_FEATURE_FEATURE_CHAINING_NOT_ONE_MSG, INVALID_FEATURE_FEATURE_CHAINING_NOT_ONE)
+		// validateFeatureMultiplicityDomain
+		val m = f.multiplicity;
+		if (m !== null && f.featuringType.toSet != m.featuringType.toSet) {
+			error(INVALID_FEATURE_MULTIPLICITY_DOMAIN_MSG, f, SysMLPackage.eINSTANCE.type_Multiplicity, INVALID_FEATURE_MULTIPLICITY_DOMAIN)
+		}
 	}
 		
 	@Check
 	def checkFeatureChaining(FeatureChaining fc) {
-		// TODO: Check validateFeatureChainingFeaturesNotSelf
-		// TODO: Check validateFeatureMultiplicityDomain
 		// TODO: Add validateFeatureChainingFeatureConformance
 		val featureChainings = fc.featureChained.ownedFeatureChaining;
 		val i = featureChainings.indexOf(fc);
@@ -337,8 +430,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 			val redefinedFeaturingTypes = redefinedFeature.featuringType
 						
 			if (redefinedFeature.owningRelationship != redef &&
-				redefinedFeaturingTypes.containsAll(redefiningFeaturingTypes) && 
-				redefinedFeaturingTypes.size == redefiningFeaturingTypes.size){
+				redefinedFeaturingTypes.toSet == redefiningFeaturingTypes.toSet){
 				if (redefiningFeaturingTypes.isEmpty) {
 					warning(INVALID_REDEFINITION_FEATURING_TYPES_MSG_1, redef, 
 						SysMLPackage.eINSTANCE.redefinition_RedefinedFeature, INVALID_REDEFINITION_FEATURING_TYPES)
@@ -432,14 +524,36 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	/* KERNEL */
 	
-	// TODO: Check validateDataTypeSpecialization
+	@Check
+	def checkDataType(DataType d) {
+		// validateDataTypeSpecialization
+		for (s: d.ownedSpecialization) {
+			if (s.general instanceof org.omg.sysml.lang.sysml.Class || s.general instanceof Association) {
+				error(INVALID_DATA_TYPE_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_DATA_TYPE_SPECIALIZATION)
+			}
+		}
+	}
 	
-	// TODO: Check validateClassSpecialization
+	@Check
+	def checkClass(org.omg.sysml.lang.sysml.Class c) {
+		// validateClassSpecialization
+		// TODO: Update validateClassSpecification to allow Interactions to specialize Associations.
+		for (s: c.ownedSpecialization) {
+			if (s.general instanceof DataType || s.general instanceof Association && !(c instanceof Association)) {
+				error(INVALID_CLASS_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_CLASS_SPECIALIZATION)
+			}
+		}
+	}
 	
 	@Check
 	def checkAssociation(Association a){
-		// TODO: Check validateAssociationBinarySpecialization
-		// TODO: Check validateAssociationStructureIntersection
+		// validateAssociationBinarySpecialization
+		if (a.associationEnd.size() > 2) {
+			val binaryLinkType = SysMLLibraryUtil.getLibraryElement(a, "Links::BinaryLink") as Type
+			if (a.conformsTo(binaryLinkType)) {
+				error(INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG, a.associationEnd.get(2), null, INVALID_ASSOCIATION_BINARY_SPECIALIZATION)	
+			}
+		}
 
 		// validateAssociationRelatedTypes
 		if (!a.isAbstract) {
@@ -447,11 +561,18 @@ class KerMLValidator extends AbstractKerMLValidator {
 			if (relatedElements !== null && relatedElements.size < 2)
 				error(INVALID_ASSOCIATION_RELATED_TYPES_MSG, a, SysMLPackage.eINSTANCE.relationship_RelatedElement, INVALID_ASSOCIATION_RELATED_TYPES)	
 		}
+		
+		// validateAssociationStructureIntersection is automatically satisfied
 	}
 		
 	@Check
 	def checkBindingConnector(BindingConnector bc){
-		doCheckBindingConnector(bc, bc)
+		// validateBindingConnectorIsBinary
+		if (bc.relatedFeature.length != 2) {
+			error(INVALID_BINDING_CONNECTOR_IS_BINARY_MSG, bc, null, INVALID_BINDING_CONNECTOR_IS_BINARY)
+		} else {		
+			doCheckBindingConnector(bc, bc)
+		}
 	}
 	
 	@Check
@@ -460,17 +581,15 @@ class KerMLValidator extends AbstractKerMLValidator {
 			if (type instanceof FeatureReferenceExpression) {
 				connector.doCheckConnector(type, kind) 
 			}
-			connector.doCheckBindingConnector(type)
+			// Ignore ill-formed implicit binding connectors.
+			if (connector.relatedFeature.length >= 2) {
+				connector.doCheckBindingConnector(type)
+			}
 		])
 	}
 	
 	private def doCheckBindingConnector(BindingConnector bc, Element location) {
 		val rf = bc.relatedFeature
-		
-		// TODO: Check validateBindingConnectorIsBinary
-		if (rf.length !== 2) {
-			return //ignore binding connectors with invalid syntax
-		}
 		
 //		val inFeature = rf.map[owningFeatureMembership].filter[m|m !== null && m.direction == FeatureDirectionKind.IN].map[ownedMemberFeature_comp].findFirst[true]
 //		val outFeature = rf.map[owningFeatureMembership].filter[m|m !== null && m.direction == FeatureDirectionKind.OUT].map[ownedMemberFeature_comp].findFirst[true]
@@ -499,10 +618,19 @@ class KerMLValidator extends AbstractKerMLValidator {
 		// validateConnectorRelatedFeatures
 		if (!c.isAbstract) {
 			val relatedFeatures = c.getRelatedFeature
-			if (relatedFeatures !== null && relatedFeatures.size < 2)
-				error(INVALID_CONNECTOR_RELATED_FEATURES_MSG, c, SysMLPackage.eINSTANCE.relationship_RelatedElement, INVALID_CONNECTOR_RELATED_FEATURES)	
+			if (relatedFeatures !== null && relatedFeatures.size < 2) {
+				error(INVALID_CONNECTOR_RELATED_FEATURES_MSG, c, SysMLPackage.eINSTANCE.relationship_RelatedElement, INVALID_CONNECTOR_RELATED_FEATURES)
+			}
 		}		
 		
+		// validateConnectorBinarySpecialization
+		if (c.connectorEnd.size() > 2) {
+			val binaryLinkType = SysMLLibraryUtil.getLibraryElement(c, "Links::BinaryLink") as Type
+			if (c.conformsTo(binaryLinkType)) {
+				error(INVALID_CONNECTOR_BINARY_SPECIALIZATION_MSG, c.connectorEnd.get(2), null, INVALID_CONNECTOR_BINARY_SPECIALIZATION)	
+			}
+		}
+
 		doCheckConnector(c, c, null)
 	}
 	
@@ -514,8 +642,6 @@ class KerMLValidator extends AbstractKerMLValidator {
 			cFeaturingTypes.add(location);
 		}
 
-		// TODO: Check validateConnectorBinarySpecialization
-		
 		// checkConnectorTypeFeaturing
 		// TODO: Add validation for type featuring?
 		val relatedFeatures = c.relatedFeature				
@@ -535,14 +661,58 @@ class KerMLValidator extends AbstractKerMLValidator {
 		}
 	}
 	
-	// TODO: Check validateParameterMembershipOwningType
-	// validateParameterMembershipParameterHasDirection is automatically satisfied
+	@Check
+	def checkParameterMembership(ParameterMembership m) {
+		if (!(m instanceof ReturnParameterMembership)) {
+			// validateParameterMembershipOwningType
+			val owningType = m.owningType
+			if (!(owningType instanceof Behavior || owningType instanceof Step)) {
+				error(INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE_MSG, m, SysMLPackage.eINSTANCE.parameterMembership_OwnedMemberParameter, INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE)
+			}
+			
+			// validateParameterMembershipParameterHasDirection is automatically satisfied
+		}
+	}
 	
-	// TODO: Check validateExpressionResultParameterMembership
+	@Check
+	def checkExpression(Expression e) {
+		// validateExpressionResultParameterMembership
+		val mems = e.ownedFeatureMembership.filter[m | m instanceof ReturnParameterMembership]
+		checkAtMostOne(mems, INVALID_EXPRESSION_RESULT_PARAMETER_MEMBERSHIP_MSG, SysMLPackage.eINSTANCE.parameterMembership_OwnedMemberParameter, INVALID_EXPRESSION_RESULT_PARAMETER_MEMBERSHIP)
+		
+		// TODO: Add/check validateExpressionResultExpressionMembership
+	}
+		
+	@Check
+	def checkFunction(Function f) {
+		// validateFunctionResultParameterMembership
+		val mems = f.ownedFeatureMembership.filter[m | m instanceof ReturnParameterMembership]
+		checkAtMostOne(mems, INVALID_FUNCTION_RESULT_PARAMETER_MEMBERSHIP_MSG, SysMLPackage.eINSTANCE.parameterMembership_OwnedMemberParameter, INVALID_FUNCTION_RESULT_PARAMETER_MEMBERSHIP)
+		
+		// TODO: Add/check validateFunctionResultExpressionMembership
+	}
+		
+	@Check
+	def checkReturnParameterMembership(ReturnParameterMembership m) {
+		// validateReturnParameterMembershipOwningType
+		val owningType = m.owningType
+		if (!(owningType instanceof Function || owningType instanceof Expression)) {
+			error(INVALID_RETURN_PARAMETER_MEMBERSHIP_OWNING_TYPE_MSG, m, SysMLPackage.eINSTANCE.parameterMembership_OwnedMemberParameter, INVALID_RETURN_PARAMETER_MEMBERSHIP_OWNING_TYPE)
+		}
+		
+		// validateReturnParameterMembershipParameterHasDirectionOut is automatically satisfied
+	}
 	
-	// TODO: Check validateFunctionResultParameterMembership
-	
-	// TODO: Check validateResultExpressionMembershipOwningType
+	@Check
+	def checkResultExpressionMembership(ResultExpressionMembership m) {
+		// validateResultExpressionMembershipOwningType
+		val owningType = m.owningType
+		if (!(owningType instanceof Function || owningType instanceof Expression)) {
+			error(INVALID_RESULT_EXPRESSION_MEMBERSHIP_OWNING_TYPE_MSG, m, SysMLPackage.eINSTANCE.parameterMembership_OwnedMemberParameter, INVALID_RESULT_EXPRESSION_MEMBERSHIP_OWNING_TYPE)
+		}
+		
+		// validateReturnParameterMembershipParameterHasDirectionOut is automatically satisfied
+	}
 	
 	// @Check
 	// def checkReturnParameterMembership(ReturnParameterMembership m) {
@@ -625,17 +795,26 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	// TODO: Add validateSelectExpressionOperator	
 	
-	@Check 
+	@Check
 	def checkItemFlow(ItemFlow flow) {
-		// TODO: Check validateItemFlowItemFeature
+		// validateItemFlowItemFeature
+		val items = flow.ownedFeature.filter[f | f instanceof ItemFeature]
+		checkAtMostOne(items, INVALID_ITEM_FLOW_ITEM_FEATURE_MSG, null, INVALID_ITEM_FLOW_ITEM_FEATURE)
 	}
 	
 	@Check
 	def checkItemFlowEnd(ItemFlowEnd flowEnd) {
 		// validateItemFlowEndIsEnd is automatically satisfied
 		
-		// TODO: Check validateItemFlowEndNestedFeature
-		// TODO: Check validateItemFlowEndOwningType
+		// validateItemFlowEndNestedFeature
+		if (flowEnd.ownedFeature.size != 1) {
+			error(INVALID_ITEM_FLOW_END_NESTED_FEATURE_MSG, flowEnd, null, INVALID_ITEM_FLOW_END_NESTED_FEATURE)
+		}
+		
+		// validateItemFlowEndOwningType
+		if (!(flowEnd.owningType instanceof ItemFlow)) {
+			error(INVALID_ITEM_FLOW_END_OWNING_TYPE_MSG, flowEnd, null, INVALID_ITEM_FLOW_END_OWNING_TYPE)
+		}
 	
 		// TODO: Add validateItemFlowEndSubsetting? validateItemFlowEndImplicitSubsetting?
 		if (FeatureUtil.getSubsettedNotRedefinedFeaturesOf(flowEnd).isEmpty) {
@@ -648,9 +827,20 @@ class KerMLValidator extends AbstractKerMLValidator {
 		}
 	}
 	
-	// TODO: Add (and check) validateFeatureValueOverriding
+	@Check
+	def checkFeatureValue(FeatureValue fv) {
+		// TODO: Add/check validateFeatureValueOverriding
+	}
 	
-	// TODO: Check validateMultiplicityRangeBoundResultTypes (need type inference first?)
+	@Check
+	def checkMultiplicityRange(MultiplicityRange mult) {
+		// validateMultiplicityRangeBoundResultTypes
+		for (b: mult.bound) {
+			if (!b.isNatural) {
+				error(INVALID_MULTIPLICITY_RANGE_BOUND_RESULT_TYPES_MSG, b, null, INVALID_MULTIPLICITY_RANGE_BOUND_RESULT_TYPES)
+			}
+		}
+	}
 	
 	@Check
 	def checkMetadataFeature(MetadataFeature mf) {
@@ -744,9 +934,44 @@ class KerMLValidator extends AbstractKerMLValidator {
 		newArrayList("not", "xor", "&", "|").contains(operator)
 	}
 	
-	def checkNotOne( List<? extends EObject> list, String msg, String code) {
+	def boolean isNatural(Expression expr) {
+		expr instanceof LiteralInteger && (expr as LiteralInteger).value >= 0 ||
+		expr instanceof LiteralInfinity ||
+		// Allow expressions with Integer result, to allow referenced features not explicitly typed as Natural
+		TypeUtil.conforms(expr.result, getIntegerType(expr)) ||
+		// Arithmetic operations in DataFunctions actually have result DataValue.
+		// This infers that operations other than division are actually at least IntegerFunctions if their arguments are Natural.
+		expr instanceof OperatorExpression && 
+			(expr as OperatorExpression).operator.integerOperator && 
+			(expr as OperatorExpression).argument.forall[isNatural]
+	}
+	
+	def getIntegerType(Element context) {
+		SysMLLibraryUtil.getLibraryElement(context, "ScalarValues::Integer") as Type
+	}
+	
+	def isIntegerOperator(String operator) {
+		newArrayList("-", "+", "*", "%", "^", "**").contains(operator)
+	}
+	
+	def checkAtMostOne(Iterable<? extends EObject> list, String msg, EStructuralFeature feature, String code) {
+		if (list.size() > 1) {
+			for (var i = 1; i < list.size(); i++) {
+				error(msg, list.get(i), feature, code)
+			}
+		}
+	}
+
+	def checkNotOne(Iterable<? extends EObject> list, String msg, String code) {
 		if (list.size == 1) {
 			error(msg, list.get(0), null, code)
+		}
+	}
+	
+	def checkTargetNotObject(EObject obj, List<? extends Relationship> rels, String msg, String code) {
+		for (r: rels) {
+			if (r.target.contains(obj))
+				error(msg, r, null, code)
 		}
 	}
 	

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
@@ -3,6 +3,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 	ResourceSet {
 		ThisFile {}
 		File {from ="/library.kernel/Base.kerml"}
+		File {from ="/library.kernel/Links.kerml"}
 		File {from ="/library.kernel/Occurrences.kerml"}
        	File {from ="/library.kernel/Objects.kerml"}
        	File {from ="/library.kernel/Performances.kerml"}
@@ -17,6 +18,7 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 			SrcFolder {
 				ThisFile {}
 				File {from ="/library.kernel/Base.kerml"}
+				File {from ="/library.kernel/Links.kerml"}
 				File {from ="/library.kernel/Occurrences.kerml"}
        			File {from ="/library.kernel/Objects.kerml"}
        			File {from ="/library.kernel/Performances.kerml"}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CalculationUsage_Invalid2.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CalculationUsage_Invalid2.sysml.xt
@@ -40,18 +40,16 @@ package Test {
 	calc def C { return T; }
 	
 	calc def C1 {
-		// XPECT errors --> "Only one return parameter is allowed." at "return r1 : T;"
 		return r1 : T;
-		// XPECT errors --> "Only one return parameter is allowed." at "return r2 : T;"
+		// XPECT errors --> "Only one return parameter is allowed" at "return r2 : T;"
 		return r2 : T;
 	}
 	
 	calc c : C { return T; }
 	
 	calc c2 : C {
-		// XPECT errors --> "Only one return parameter is allowed." at "return r1 : T;"
 		return r1 : T;
-		// XPECT errors --> "Only one return parameter is allowed." at "return r2 : T;"
+		// XPECT errors --> "Only one return parameter is allowed" at "return r2 : T;"
 		return r2 : T;
 	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Relationship_invalid_relatedElement0.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Relationship_invalid_relatedElement0.sysml.xt
@@ -6,11 +6,9 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 		File {from ="/library.kernel/Links.kerml"}
        	File {from ="/library.kernel/Occurrences.kerml"}
        	File {from ="/library.kernel/Objects.kerml"}
-       	File {from ="/library.kernel/Performances.kerml"}
-		File {from ="/library.kernel/BaseFunctions.kerml"}
 		File {from ="/library.systems/Items.sysml"}
 		File {from ="/library.systems/Parts.sysml"}
-		File {from ="/library.systems/Ports.sysml"}
+		File {from ="/library.systems/Connections.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -20,39 +18,20 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.invalid.SysMLTests
 				File {from ="/library.kernel/Links.kerml"}
         		File {from ="/library.kernel/Occurrences.kerml"}
  		      	File {from ="/library.kernel/Objects.kerml"}
- 		      	File {from ="/library.kernel/Performances.kerml"}
-				File {from ="/library.kernel/BaseFunctions.kerml"}
-				File {from ="/library.systems/Items.sysml"}
+ 				File {from ="/library.systems/Items.sysml"}
 				File {from ="/library.systems/Parts.sysml"}
-				File {from ="/library.systems/Ports.sysml"}
+				File {from ="/library.systems/Connections.sysml"}
 			}
 		}
 	}
 END_SETUP 
 */
-package BindingConnectorExample {
-	part def B0;
-	part def B1; 
-	part def V;
-	part v : V {
-		// XPECT warnings --> "Duplicate of other element name" at "b0"
-		part b0 : B0 {
-			port p0 {
-				in ref myIn;
-			}
-		}
-		part b1 : B1 {
-			port p1 {
-				out ref myOut;
-			}
-		}
-		// XPECT warnings --> "Duplicate of other element name" at "b0"
-		//* XPECT errors --- 
-		"Relationships must have at least two related elements" at "bind b0.p0.myIn to"
-		"mismatched input 'to' expecting '='" at "to"
-		"no viable alternative at input '.'" at "."
-		"no viable alternative at input '.'" at "."
-		--- */
-		bind b0.p0.myIn to b0.p1.myOut;	
+package Relationship_invalid_relatedElement {
+	part v {
+		part b0;
+		// XPECT errors ---> "Must have at least two related elements" at "connection { end ::> b0; }"
+		connection { end ::> b0; }
+		
+		abstract connection { end ::> b0; }	
 	} 
 }

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -426,11 +426,6 @@ class SysMLValidator extends KerMLValidator {
 		checkAtMostOneFeature(ObjectiveMembership, mem, INVALID_OBJECTIVEMEMBERSHIP_MSG, INVALID_OBJECTIVEMEMBERSHIP)
 	}
 	
-	@Check // Must have at most one owned return parameter.
-	def checkReturnMembership(ReturnParameterMembership mem) {
-		checkAtMostOneFeature(ReturnParameterMembership, mem, INVALID_RETURNPARAMETERMEMBERSHIP_MSG, INVALID_RETURNPARAMETERMEMBERSHIP)
-	}
-	
 	@Check // Must be owned by objective of verification case.
 	def checkRequirementVerificationMembership(RequirementVerificationMembership mem) {
 		if (!UsageUtil.isLegalVerification(mem)) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
@@ -26,6 +26,7 @@ import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.OperatorExpression;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.ExpressionUtil;
 import org.omg.sysml.util.TypeUtil;
@@ -33,6 +34,7 @@ import org.omg.sysml.util.TypeUtil;
 public class OperatorExpressionAdapter extends InvocationExpressionAdapter {
 	
 	public static final String INDEXING_OPERATOR = "#";
+	public static final String ARRAY_TYPE = "Collections::Array";
 
 	public OperatorExpressionAdapter(OperatorExpression element) {
 		super(element);
@@ -51,11 +53,20 @@ public class OperatorExpressionAdapter extends InvocationExpressionAdapter {
 				Expression seqArgument = arguments.get(0);
 				ElementUtil.transform(seqArgument);
 				Feature seqResult = seqArgument.getResult();
-				Feature resultFeature = target.getResult();
-				if (resultFeature != null && seqResult != null)
-				TypeUtil.addImplicitGeneralTypeTo(resultFeature, SysMLPackage.eINSTANCE.getSubsetting(), seqResult);
+				if (!hasArrayType(seqResult)) {
+					Feature resultFeature = target.getResult();
+					if (resultFeature != null && seqResult != null) {
+						TypeUtil.addImplicitGeneralTypeTo(resultFeature, SysMLPackage.eINSTANCE.getSubsetting(), seqResult);
+					}
+				}
 			}
 		}		
+	}
+	
+	protected boolean hasArrayType(Feature feature) {
+		Type arrayType = getLibraryType(ARRAY_TYPE);
+		return arrayType != null && 
+			   feature.getType().stream().anyMatch(t->TypeUtil.conforms(t, arrayType));
 	}
 
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/lang/sysml/util/SysMLLibraryUtil.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/lang/sysml/util/SysMLLibraryUtil.xtend
@@ -45,20 +45,6 @@ class SysMLLibraryUtil {
 		modelLibraryPath
 	}
 	
-	@Deprecated
-	/**
-	 * @deprecated Use LibraryPackage::isStandard or ElementUtil::isStandardLibraryElement instead
-	 */
-	def static isModelLibrary(Resource resource) {
-		if (resource === null) {
-			return false;
-		} else {
-			val path = resource.URI.devicePath ?: resource.URI.path;
-			if (path === null) return false;
-			return path.contains(modelLibraryPath);
-		}
-	}
-	
 	def static IModelLibraryProvider getInstance(Resource resource) {
 		try {
 			IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(resource?.getURI)?.get(IModelLibraryProvider)

--- a/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
+++ b/sysml.library/Domain Libraries/Cause and Effect/CausationConnections.sysml
@@ -61,11 +61,11 @@ standard library package CausationConnections {
 		 * connections with multiple causes.)
 		 */
 		 
-		end occurrence theCause[*] :>> causes :> source {
+		end occurrence theCause[*] :>> causes :>> source {
 			doc /* The single causing occurrence. */
 		}
 		
-		end occurrence theEffect[*] :>> effects :> target {
+		end occurrence theEffect[*] :>> effects :>> target {
 			doc /* The single effect occurrence resulting from the cause. */
 		}
 	}

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -169,8 +169,11 @@ standard library package Transfers {
 	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore {
 		doc
 		/*
-		 * FlowTransferbefore is a FlowTransfer that is also a TransferBefore. 
+		 * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 
 		 */
+		 
+        end feature source: Occurrence[0..*] redefines Transfer::source, TransferBefore::source;
+        end feature target: Occurrence[0..*] redefines Transfer::target, TransferBefore::target;		 
 	}
 	
 	step transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {

--- a/sysml/src/examples/Simple Tests/ConjugationTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConjugationTest.sysml
@@ -22,13 +22,13 @@ package ConjugationTest {
 			port p2: ~P;		
 		}
 	
-		connection a: A connect p.p1 to p.p2 {
-			end port p3: P;
-			end port p4: ~P;
+		connection a: A {
+			end port p3: P ::> p.p1;
+			end port p4: ~P ::> p.p2;
 		}
-		interface i: I connect p.p1 to p.p2 {
-			end port p3: P;
-			end port p4: ~P;
+		interface i: I {
+			end port p3: P ::> p.p1;
+			end port p4: ~P ::> p.p2;
 		}
 	}
 	


### PR DESCRIPTION
This pull request implements validation constraints that are in the [KerML 1.0 Beta 1](https://www.omg.org/spec/KerML/1.0/Beta1/PDF) abstract syntax, but which were not previously implemented in the pilot implementation. In addition, the `org.omg.kerml.xtext.KerMLValidator.xtend` class has been reorganized so that there is one check method per metclass, with each validation constraint for the metaclass checked within that method. Further, the normative constraint names are now used as the error codes for the corresponding validation checks.

The following newly implemented constraints could potentially result in errors being flagged in models where they had not been before.

1. `validateSpecializationSpecificNotConjugated`
2. `validateTypeAtMostOneConjugator`
3. `validateTypeDifferencingTypesNotSelf`
4. `validateTypeIntersectingTypesNotSelf`
5. `validateTypeUnioningTypesNotSelf`
6. `validateFeatureChainingFeaturesNotSelf`
7. `validateDataTypeSpecialization`
8. `validateClassSpecialization`
9. `validateAssociationBinarySpecialization`
10. `validateBindingConnectorIsBinary`
11. `validateConnectorBinarySpecialization`
12. `validateExpressionResultParameterMembership`
13. `validateFunctionResultParameterMembership` 
14. `validateMultiplicityRangeBoundResultTypes`

The following constraints are automatically satisfied by models parsed from the textual notation. However, they have been implemented anyway, because it is possible that they might be violated due to modifications made directly on the abstract syntax representation of a model.

15. `validateElementIsImpliedIncluded`
16. `validateClassifierMultiplicityDomain`
17. `validateFeatureMultiplicityDomain`
18. `validateParameterMembershipOwningType`
19. `validateResultExpressionMembershipOwningType`
20. `validateReturnParameterMembershipOwningType`
21. `validateItemFlowItemFeature`
22. `validateItemFlowEndNestedFeature`
23. `validateItemFlowEndOwningType`

There are also validation checks that are implemented in the pilot implementation but are not currently in the Beta 1 specification. Certain of these have been proposed to the KerML Finalization Task Force for inclusion in the final specification (see [KERML-20](https://issues.omg.org/issues/task-force/KERML#issue-51021)). They are identified in the validator code with `TODO: Add...` comments (meaning to be "added" to the specification).