### PR TITLE
ST6RI-686 Update SysML validation based on normative validation constraints

### DIFF
--- a/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/AnalysisCases.sysml
@@ -20,7 +20,10 @@ standard library package AnalysisCases {
 	
 		ref analysis self : AnalysisCase :>> Case::self;		
 		subject subj :>> Case::subj;
-		objective obj :>> Case::obj;
+		
+		objective obj :>> Case::obj {
+			subject subj = AnalysisCase::result;
+		}
 		
 		abstract analysis subAnalysisCases : AnalysisCase[0..*] :> analysisCases, subcases {
 			doc

--- a/org.omg.sysml.xpect.tests/library.systems/Cases.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Cases.sysml
@@ -43,7 +43,7 @@ standard library package Cases {
 			 * A check of whether the objective RequirementUsage was satisfied for this Case.
 			 */
 		
-			subject = Case::result;
+			subject subj default Case::result;
 		}
 		
 		return ref result[0..*] {

--- a/org.omg.sysml.xpect.tests/library.systems/Connections.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Connections.sysml
@@ -123,8 +123,8 @@ standard library package Connections {
 		 * messageConnections is the base feature of all FlowConnectionUsages.
 		 */
 	
-		end source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
-		end target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
+		end occurrence source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
+		end occurrence target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
 	}
 	
 	abstract message flowConnections: FlowConnection[0..*] nonunique :> messageConnections, flowTransfers {
@@ -134,8 +134,8 @@ standard library package Connections {
 		 * and target input.
 		 */
 	
-		end source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
-		end target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
+		end occurrence source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
+		end occurrence target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
 	}
 	
 	abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, flowTransfersBefore {
@@ -144,7 +144,7 @@ standard library package Connections {
 		 * successionFlowConnections is the base feature of all SuccessionFlowConnectionUsages.
 		 */
 	
-		end source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
-		end target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
+		end occurrence source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
+		end occurrence target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
 	}
 }

--- a/org.omg.sysml.xpect.tests/library.systems/Views.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Views.sysml
@@ -27,7 +27,7 @@ standard library package Views {
 			 */
 		}
 		
-		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] {
+		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] :>> viewpointChecks {
 		doc
 			/*
 			 * Checks that the View satisfies all required ViewpointUsages.

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
@@ -71,8 +71,8 @@ package ConnectionTest {
 		end end2 ::> d2;
 	}
 	flow def F {
-		end p : P;
-		end q;
+		end f_p : P;
+		end f_q;
 	}
 	
 	message : F from p to p;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ActionUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ActionUsage_invalid.sysml.xt
@@ -36,10 +36,17 @@ package pkg {
 	part def ABlock;
 	action def AnActivity;
 	action def B {
-		// XPECT errors -->   "An action must be typed by action definitions." at "action a: ABlock;"
+		// XPECT errors --> "An action must be typed by action definitions." at "action a: ABlock;"
 		action a: ABlock;
-		// XPECT errors -->   "An action must be typed by action definitions." at "action b: ABlock, AnActivity;"
+		// XPECT errors --> "An action must be typed by action definitions." at "action b: ABlock, AnActivity;"
 		action b: ABlock, AnActivity;
 	}
 	
+	ref b : B;
+	
+	// XPECT errors --> "Must reference an action." at "b"
+	perform b;
+	
+	// XPECT errors --> "An action must be typed by action definitions." at "perform b.a;"
+	perform b.a;
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseSubjectObjective_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseSubjectObjective_Invalid.sysml.xt
@@ -43,13 +43,11 @@ END_SETUP
 package 'Case Subjects and Objectives' {
 	
 	case def C {
-		// XPECT errors --> "Only one subject is allowed." at "subject s1;"
 		subject s1;
 		
 		// XPECT errors --> "Only one subject is allowed." at "subject s2;"
 		subject s2;
 
-		// XPECT errors --> "Only one objective is allowed." at "objective o1;"
 		objective o1;
 		
 		// XPECT errors --> "Only one objective is allowed." at "objective o2;"
@@ -57,13 +55,11 @@ package 'Case Subjects and Objectives' {
 	}
 	
 	case c: C {
-		// XPECT errors --> "Only one subject is allowed." at "subject s3;"
 		subject s3;
 		
 		// XPECT errors --> "Only one subject is allowed." at "subject s4;"
 		subject s4;
 
-		// XPECT errors --> "Only one objective is allowed." at "objective o3;"
 		objective o3;
 		
 		// XPECT errors --> "Only one objective is allowed." at "objective o4;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseSubjectObjective_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseSubjectObjective_Invalid.sysml.xt
@@ -66,9 +66,20 @@ package 'Case Subjects and Objectives' {
 		objective o4;
 	}
 	
-	case c1 : C {
-		subject s5; // Valid implicit redefinition.
+	case def C1 :> C {
+		in x;
+		
+		// XPECT errors --> "Subject must be first parameter." at "subject s5;"
+		subject s5;
+		
 		objective o5;
+	}
+	
+	case c1 : C1 {
+		in y;
+		
+		// XPECT errors --> "Subject must be first parameter." at "subject s6;"
+		subject s6;
 	}
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseUsage_Invalid.sysml.xt
@@ -56,27 +56,34 @@ package pkg {
 	
 	part def A;
 	part def B {
-		// XPECT errors --> "A case must be typed by one case definition." at "case c1: C1, C2;"
+		// XPECT errors ---> "A case must be typed by one case definition." at "case c1: C1, C2;"
 	 	case c1: C1, C2;
 	 	// XPECT errors ---> "A case must be typed by one case definition." at "case c2: A;"
     	case c2: A;
     	
- 	 	//* XPECT errors ---
- 	 	    "An analysis case must be typed by one analysis case definition." at "analysis ac1: C1;"
- 	 	--- */
+ 	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac1: C1;"
     	analysis ac1: C1;
  	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac2: AC1, AC2;"
     	analysis ac2: AC1, AC2;
  	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac3: B;"
     	analysis ac3: B;
     	
- 	 	//* XPECT errors ---
- 	 	    "A use case must be typed by one use case definition." at "use case uc1: C1;"
- 	 	--- */
+ 	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc1: C1;"
     	use case uc1: C1;
  	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc2: UC1, UC2;"
     	use case uc2: UC1, UC2;
  	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc3: B;"
     	use case uc3: B;
+   	}
+   	
+   	part b : B;
+   	ref u : UC1;
+   	
+   	use case uc4 {
+   		// XPECT errors ---> "Must reference a use case." at "u"
+   		include u;
+   		
+   		// XPECT errors ---> "A use case must be typed by one use case definition." at "include b.uc1;"
+   		include b.uc1;
    	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/IndividualUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/IndividualUsage_Invalid.sysml.xt
@@ -43,7 +43,7 @@ package 'Individuals and Roles' {
 	}
 	individual def B_1 :> B;
 	
-	// XPECT errors --> "An individual must be typed by one individual definition." at "individual two_types : A_1, B_1;"
+	// XPECT errors --> "At most one individual definition is allowed." at "individual two_types : A_1, B_1;"
 	individual two_types : A_1, B_1;
 
 	// XPECT errors -->"An individual must be typed by one individual definition." at "individual snapshot b_1_1 : B;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
@@ -47,4 +47,11 @@ package pkg {
 	attribute aValue: Real;
 	part def PartDef;
 	part aPart: PartDef;	
+	ref a : A;
+
+	// XPECT errors --> "Must reference an occurrence." at "a"
+	event a;
+
+	// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "event a.areal;"
+	event a.areal;	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PartUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PartUsage_invalid.sysml.xt
@@ -37,22 +37,22 @@ END_SETUP
 package pkg {
 	import ScalarValues::*;
 	part def A {
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p1: Real;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p1: Real;"
 		part p1: Real;
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p2: att;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p2: att;"
 		part p2: att;
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p3: act;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p3: act;"
 		part p3: act;
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p4: AttDef;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p4: AttDef;"
 		part p4: AttDef;
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p5: PartDef::aPort;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p5: PartDef::aPort;"
 		part p5: PartDef::aPort;
 		/* XPECT errors ---
-		 "A part must be typed by item definitions and at least one part definition." at "part p6: PartDef::aPart;"
+		 "A part must be typed by item definitions." at "part p6: PartDef::aPart;"
 		 "Features must have at least one type" at "part p6: PartDef::aPart;"
 		--- */
 		part p6: PartDef::aPart;
-		// XPECT errors --> "A part must be typed by item definitions and at least one part definition." at "part p7: PartDef, AttDef;"
+		// XPECT errors --> "A part must be typed by item definitions." at "part p7: PartDef, AttDef;"
 		part p7: PartDef, AttDef;
 	}
 	attribute def AttDef;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PortUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PortUsage_Invalid.sysml.xt
@@ -29,7 +29,12 @@ END_SETUP
 package 'Port Example' {
 	attribute def Vt;
 	part def B;
-	port def pd1;
+	port def pd1 {
+		port p1 : pd1;
+		ref b1 : B;
+		// XPECT errors --> "Owned usages of a port definition (other than ports) must be referential." at "part b2 : B;"
+		part b2 : B;		
+	}
 	port def pd2;
 	part def FA {
 		// XPECT errors --> "A port must be typed by port definitions." at "port p1 : B;"
@@ -37,7 +42,12 @@ package 'Port Example' {
 		// XPECT errors --> "A port must be typed by port definitions." at "port p2 : Vt;"
 		port p2 : Vt;
 
-		port two_port_def_types: pd1, pd2;
+		port two_port_def_types: pd1, pd2 {
+			port p2 : pd2;
+			ref b3 : B;		
+			// XPECT errors --> "Nested usages of a port usage (other than ports) must be referential." at "part b4 : B;"
+			part b4 : B;		
+		}
 	}
 	part tank: FA {
 		// XPECT errors --> "A port must be typed by port definitions." at "port pp redefines p1;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementSubject_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementSubject_Invalid.sysml.xt
@@ -53,7 +53,6 @@ END_SETUP
 package 'Requirement Subjects' {
 	
 	requirement def R {
-		// XPECT errors --> "Only one subject is allowed." at "subject s1;"
 		subject s1;
 		
 		// XPECT errors --> "Only one subject is allowed." at "subject s2;"
@@ -61,7 +60,6 @@ package 'Requirement Subjects' {
 	}
 	
 	requirement r: R {
-		// XPECT errors --> "Only one subject is allowed." at "subject s3;"
 		subject s3;
 		
 		// XPECT errors --> "Only one subject is allowed." at "subject s4;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementSubject_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementSubject_Invalid.sysml.xt
@@ -66,8 +66,18 @@ package 'Requirement Subjects' {
 		subject s4;
 	}
 	
-	requirement r1 : R {
-		subject s5; // Valid implicit redefinition.
+	requirement def R1 :> R {
+		in x;
+		
+		// XPECT errors --> "Subject must be first parameter." at "subject s5;"
+		subject s5;
+	}
+	
+	requirement r1 : R1 {
+		in y;
+		
+		// XPECT errors --> "Subject must be first parameter." at "subject s6;"
+		subject s6;		
 	}
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
@@ -62,6 +62,17 @@ package StateUsage_invalid {
   		exit action c1;
 		//XPECT errors --> "A state may have at most one exit action." at "exit action c2;"
   		exit action c2;
+  		
+		//XPECT errors --> "A state must be typed by state definitions." at "state sa : A;"
+		state sa : A;
 	}
+	
+	ref s :> s4;
+	
+	//XPECT errors --> "Must reference a state." at "s"
+	exhibit s;
+	
+	//XPECT errors --> "A state must be typed by state definitions." at "exhibit s.sa;"
+	exhibit s.sa;
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/TransitionUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/TransitionUsage_invalid.sysml.xt
@@ -40,35 +40,27 @@ END_SETUP
 */
 package TransitionUsage_invalid {
 	
-	state def S1;
-	
-	state def S2 parallel {
+	state def S1 parallel {
+		state S1_1;
+		// XPECT errors ---> "A parallel state cannot have successions or transitions." at "then S1_2;"
+		then S1_2;
+		state S1_2;
+	}
+
+	state def S2 {
 		state S2_1;
-		// XPECT errors ---> "A parallel state cannot have successions or transitions." at "then S2_2;"
-		then S2_2;
+		transition
+			first S2_1
+			// XPECT errors ---> "Must be a Boolean expression." at "if \"test\""
+			if "test"
+			then S2_2;
 		state S2_2;
 	}
-
-	state def S3 {
-		state S3_1;
-		state S3_2;
-	}
 	
-	state s1;
-	
-	state s2 parallel {
-		state s2_1;
-		// XPECT errors ---> "A parallel state cannot have successions or transitions." at "then s2_2;"
-		then s2_2;
-		state s2_2;
+	state s1 parallel {
+		state s1_1;
+		// XPECT errors ---> "A parallel state cannot have successions or transitions." at "then s1_2;"
+		then s1_2;
+		state s1_2;
 	}
-
-	state s3 {
-		state s3_1;
-		state s3_2 {
-			state s3_2_1;
-			state s3_2_2;
-		}
-	}
-	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Variability_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Variability_invalid.sysml.xt
@@ -48,6 +48,9 @@ package VariabilityModel {
     	attribute a2;
     }
 
+    // XPECT errors --> "A variation must not specialize another variation." at "AttributeChoices"
+    variation attribute def AttributeChoices1 :> AttributeChoices;
+    
     part def PartChoices :> B {
 		// XPECT errors --> "A variant must be an owned member of a variation." at "variant b1;"
         variant b1;
@@ -70,6 +73,10 @@ package VariabilityModel {
 			// XPECT errors --> "A variant must be an owned member of a variation." at "variant action f1;"
         	variant action f1;
         	action f2;
-        }       
+        }
+        
+        // XPECT errors --> "A variation must not specialize another variation." at "d"
+    	variation part e :> d;
+              
     }
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Variability_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Variability_invalid.sysml.xt
@@ -44,14 +44,14 @@ package VariabilityModel {
 
     variation attribute def AttributeChoices {
     	variant attribute a1;
-		// XPECT errors --> "A variation must only have variant owned members." at "attribute a2;"
+		// XPECT errors --> "An owned usage of a variation must be a variant." at "attribute a2;"
     	attribute a2;
     }
 
     part def PartChoices :> B {
-		// XPECT errors --> "A variant must be an owned member of a variation." at "b1;"
+		// XPECT errors --> "A variant must be an owned member of a variation." at "variant b1;"
         variant b1;
-		// XPECT errors --> "A variant must be an owned member of a variation." at "b2;"
+		// XPECT errors --> "A variant must be an owned member of a variation." at "variant b2;"
         variant b2;
     }
     
@@ -61,13 +61,13 @@ package VariabilityModel {
 
     part c {
         variation part d : D {
-			// XPECT errors --> "A variation must only have variant owned members." at "part d1;"
+			// XPECT errors --> "An owned usage of a variation must be a variant." at "part d1;"
         	part d1;
         	variant part d2;
         }
         
         action f {
-			// XPECT errors --> "A variant must be an owned member of a variation." at "action f1;"
+			// XPECT errors --> "A variant must be an owned member of a variation." at "variant action f1;"
         	variant action f1;
         	action f2;
         }       

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -422,11 +422,11 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkDefinition(Definition definition) {		
 		if (!definition.isVariation) {
-			// validateDefinitionNonVariationMembership is redundant with validateVariantMembershipOwningNamespace
-			// validateDefinitionNonVariationMembership
-//			for (mem: definition.variantMembership) {
-//				error(INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP)
-//			}
+			// validateDefinitionNonVariationMembership is redundant with validateVariantMembershipOwningNamespace. (See SYSML2-300.)
+			// TODO: Check validateDefinitionNonVariationMembership
+			// for (mem: definition.variantMembership) {
+			//	error(INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP)
+			// }
 		} else {
 			// validateDefinitionVariationMembership
 			for (ownedUsage: definition.ownedUsage) {
@@ -456,11 +456,11 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkUsage(Usage usage) {
 		if (!usage.isVariation) {
-			// validateUsageNonVariationMembership is redundant with validateVariantMembershipOwningNamespace
-			// validateUsageNonVariationMembership
-//			for (mem: usage.variantMembership) {
-//				error(INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_NON_VARIATION_MEMBERSHIP)
-//			}
+			// validateUsageNonVariationMembership is redundant with validateVariantMembershipOwningNamespace. (See SYSML2-300.)
+			// TODO: Check validateUsageNonVariationMembership
+			// for (mem: usage.variantMembership) {
+			// 	error(INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_NON_VARIATION_MEMBERSHIP)
+			// }
 		} else {
 			// validateUsageVariationMembership
 			for (nestedUsage: usage.nestedUsage) {
@@ -504,7 +504,7 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkAttributeDefinition(AttributeDefinition defn) {
 		// Not implemented for now, until resolution of KerML issues on composite semantics. (See KERML-4.)
-		// TODO: validateAttributeDefinitionFeatures
+		// TODO: Check validateAttributeDefinitionFeatures
 		// NOTE: Only check owned features, for efficiency and to avoid redundancy.
 		// (This should be sufficient, unless a composite feature is inherited from a KerML data type.)
 		// checkAllNotComposite(defn.ownedFeature, INVALID_ATTRIBUTE_DEFINITION_FEATURES_MSG, INVALID_ATTRIBUTE_DEFINITION_FEATURES)
@@ -525,7 +525,7 @@ class SysMLValidator extends KerMLValidator {
 		// validateAttributeUsageIsReference is satisfied automatically			
 		
 		// Not implemented for now, until resolution of KerML issues on composite semantics. (See KerML-4.)
-		// TODO: validateAttributeUsageFeatures
+		// TODO: Check validateAttributeUsageFeatures
 		// NOTE: Only check owned features, for efficiency and to avoid redundancy.
 		// (This should be sufficient, unless a composite feature is inherited from a KerML data type.)
 		// checkAllNotComposite(usg.ownedFeature, INVALID_ATTRIBUTE_USAGE_FEATURES_MSG, INVALID_ATTRIBUTE_USAGE_FEATURES)
@@ -735,7 +735,7 @@ class SysMLValidator extends KerMLValidator {
 		// TODO: Check validateControlNodeIncomingSuccessions (?)
 		// TODO: Check validateControlNodeOutgoingSuccessions (?)
 		
-		// TODO: Check validateControlNodeOwningType
+		// validateControlNodeOwningType
 		val owningType = node.owningType
 		if (!(owningType !== null && (owningType instanceof ActionUsage || owningType instanceof ActionDefinition))) {
 			error(INVALID_CONTROL_NODE_OWNING_TYPE_MSG, node, null, INVALID_CONTROL_NODE_OWNING_TYPE)
@@ -796,14 +796,14 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkExhibitStateUsage(ExhibitStateUsage usg) {
-		// validateExhibitStateUsageReference
+		// TODO: Add validateExhibitStateUsageReference
 		checkReferenceType(usg, StateUsage, INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG, INVALID_EXHIBIT_STATE_USAGE_REFERENCE)
 	}
 		
 	@Check
 	def checkStateDefinition(StateDefinition defn) {
 		// Not implemented pending further review. (See SYSML2-306.)
-		// TODO: validateStateDefinitionParallelGeneralization
+		// TODO: Check validateStateDefinitionIsParallelGeneralization
 		// checkAllParallelSpecialization(defn, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_1, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_2, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION)
 		
 		// validateStateDefinitionParallelSubactions is checked by checkTransitionUsage and checkSuccession
@@ -827,7 +827,7 @@ class SysMLValidator extends KerMLValidator {
 		checkAllTypes(usg, Behavior, INVALID_STATE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.stateUsage_StateDefinition, INVALID_STATE_USAGE_TYPE)
 
 		// Not implemented pending further review. (See SYSML2-306.)
-		// TODO: validateStateUsageIsParallelGeneralization
+		// TODO: Check validateStateUsageIsParallelGeneralization
 		// checkAllParallelSpecialization(usg, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_1, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_2, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION)
 		
 		// validateStateUsageParallelSubactions is checked by checkTransitionUsage and checkSuccession
@@ -1088,7 +1088,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkIncludeUseCaseUsage(IncludeUseCaseUsage usg) {
-		// validateIncludeUseCaseUsageReference
+		// TODO: Add validateIncludeUseCaseUsageReference
 		checkReferenceType(usg, UseCaseUsage, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE)
 	}
 	

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -123,6 +123,13 @@ import org.omg.sysml.lang.sysml.IncludeUseCaseUsage
 import org.omg.sysml.lang.sysml.Expose
 import org.omg.sysml.lang.sysml.ViewRenderingMembership
 import org.omg.sysml.lang.sysml.AttributeDefinition
+import org.omg.sysml.lang.sysml.Namespace
+import org.omg.sysml.lang.sysml.LifeClass
+import org.omg.sysml.lang.sysml.ActionDefinition
+import org.eclipse.emf.ecore.EObject
+import org.omg.sysml.lang.sysml.TransitionFeatureKind
+import org.omg.sysml.lang.sysml.ActorMembership
+import org.omg.sysml.lang.sysml.RequirementConstraintKind
 
 /**
  * This class contains custom validation rules. 
@@ -140,17 +147,21 @@ class SysMLValidator extends KerMLValidator {
 	
 	public static val INVALID_USAGE_NON_VARIATION_MEMBERSHIP = "validateUsageNonVariationMembership"
 	public static val INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG = "A variant must be an owned member of a variation."
+	public static val INVALID_USAGE_OWNING_TYPE = "validateUsageOwningType"
+	public static val INVALID_USAGE_OWNING_TYPE_MSG = "A usage can only be featured by a definition or usage."
 	public static val INVALID_USAGE_VARIATION_MEMBERSHIP = "validateUsageVariationMembership"
-	public static val INVALID_USAGE_VARIATION_MSG = "An owned usage of a variation must be a variant."
+	public static val INVALID_USAGE_VARIATION_MEMBERSHIP_MSG = "An owned usage of a variation must be a variant."
 	public static val INVALID_USAGE_VARIATION_SPECIALIZATION = "validateUsageVariationSpecialization"
 	public static val INVALID_USAGE_VARIATION_SPECIALIZATION_MSG = "A variation must not specialize another variation."
 	
-	public static val INVALID_VARIATION_MEMBERSHIP_OWNING_NAMESPACE = "validateVariationMembershipOwningNamespace"
-	public static val INVALID_VARIATION_MEMBERSHIP_OWNING_NAMESPACE_MSG = "Variant membership not allowed."
+	public static val INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE = "validateVariationMembershipOwningNamespace"
+	public static val INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE_MSG = "A variant must be an owned member of a variation."
 	
 	public static val INVALID_ATTRIBUTE_DEFINITION_FEATURES = "validateAttributeDefinitionFeatures"
 	public static val INVALID_ATTRIBUTE_DEFINITION_FEATURES_MSG = "Features of an attribute definition must be referential."
-	
+	public static val INVALID_ATTRIBUTE_DEFINITION_SPECIALIZATION = "validateDataTypeSpecialization"
+	public static val INVALID_ATTRIBUTE_DEFINITION_SPECIALIZATION_MSG = "Cannot specialize item definition"    
+		
 	public static val INVALID_ATTRIBUTE_USAGE_FEATURES = "validateAttributeUsageFeatures"
 	public static val INVALID_ATTRIBUTE_USAGE_FEATURES_MSG = "Features of an attribute usage must be referential."
 	public static val INVALID_ATTRIBUTE_USAGE_TYPE = "validateAttributeUsageType_"
@@ -165,20 +176,24 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_EVENT_OCCURRENCE_USAGE_REFERENCE_MSG = "Must reference an occurrence."
 	
 	public static val INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS = "validateOccurrenceDefinitionLifeClass"
-	public static val INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS_MSG = "Must have a LifeClass."
+	public static val INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS_MSG_1 = "Must have exactly one LifeClass."
+	public static val INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS_MSG_2 = "Must not have a LifeClass."
 	
 	public static val INVALID_OCCURRENCE_USAGE_TYPE = "validateOccurrenceUsageType_"
 	public static val INVALID_OCCURRENCE_USAGE_TYPE_MSG = "An occurrence must be typed by occurrence definitions."
 	public static val INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION = "validateOccurrenceUsageIndividualDefinition"
-	public static val INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG = "Only one individual definition is allowed."
+	public static val INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG = "At most one individual definition is allowed."
 	public static val INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE = "validateOccurrenceUsageIndividualUsage"
 	public static val INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE_MSG = "An individual must be typed by one individual definition."	
 	
+	public static val INVALID_ITEM_DEFINITION_SPECIALIZATION = "validateClassSpecialization"
+	public static val INVALID_ITEM_DEFINITION_SPECIALIZATION_MSG = "Cannot specialize attribute definition"    	
+
 	public static val INVALID_ITEM_USAGE_TYPE = "validateItemUsageType_"
 	public static val INVALID_ITEM_USAGE_TYPE_MSG = "An item must be typed by item definitions."
 	
 	public static val INVALID_PART_USAGE_TYPE = "validatePartUsageType_"
-	public static val INVALID_PART_USAGE_TYPE_MSG = "A part must be typed by item definitions and at least one part definition."
+	public static val INVALID_PART_USAGE_TYPE_MSG = "A part must be typed by item definitions."
 	public static val INVALID_PART_USAGE_PART_DEFINITION = "validatePartUsagePartDefinition"
 	public static val INVALID_PART_USAGE_PART_DEFINITION_MSG = "A part must be typed by at least one part definition."
 	
@@ -227,6 +242,8 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_CONTROL_NODE_INCOMING_SUCCESSIONS_MSG = "Incoming successions must have target multiplicity 1."
 	public static val INVALID_CONTROL_NODE_OUTGOING_SUCCESSIONS = "validateControlNodeOutgoingSuccessions"
 	public static val INVALID_CONTROL_NODE_OUTGOING_SUCCESSIONS_MSG = "Outgoing successions must have source multiplicity 1."
+	public static val INVALID_CONTROL_NODE_OWNING_TYPE = "validateControlNodeOwningType"
+	public static val INVALID_CONTROL_NODE_OWNING_TYPE_MSG = "A control node must be owned by an action definition or usage."
 	
 	public static val INVALID_DECISION_NODE_INCOMING_SUCCESSIONS = "validateDecisionNodeIncomingSuccessions"
 	public static val INVALID_DECISION_NODE_INCOMING_SUCCESSIONS_MSG = "Must have at most one incoming succession."
@@ -245,7 +262,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_MERGE_NODE_OUTGOING_SUCCESSIONS_MSG = "Must have at most one outgoing succession."
 	
 	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE = "validatePerformActionUsageReference"
-	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG = "Must reference an occurrence"
+	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG = "Must reference an action"
 	
 	public static val INVALID_SEND_ACTION_USAGE_PARAMETERS = "validateSendActionUsageParameter"
 	public static val INVALID_SEND_ACTION_USAGE_PARAMETERS_MSG = "A send action usage must have three input parameters."
@@ -253,14 +270,17 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_SEND_ACTION_USAGE_RECEIVER_MSG = 'Sending to a port should generally use "via" instead of "to".'
 	public static val INVALID_SEND_ACTION_USAGE_PAYLOAD = "validateSendActionPayload_"
 	public static val INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG = 'A send action must have a payload.'
+	
+	public static val INVALID_EXHIBIT_STATE_USAGE_REFERENCE = "validateExhibitStateUsageReference"
+	public static val INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG = "Must reference a state"
 		
 	public static val INVALID_STATE_SUBACTION_KIND_ENTRY_MSG = "A state may have at most one entry action."
 	public static val INVALID_STATE_SUBACTION_KIND_DO_MSG = "A state may have at most one do action."
 	public static val INVALID_STATE_SUBACTION_KIND_EXIT_MSG = "A state may have at most one exit action."
 	
 	public static val INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION = "validateStateDefinitionParallelGeneralization"
-	public static val INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_1 = "Parallel state must have parallel state generalizations."
-	public static val INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_2 = "Non-parallel state must not have parallel state generalizations."
+	public static val INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_1 = "Parallel state definition must specialize only parallel state definitions."
+	public static val INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_2 = "Non-parallel state definition must not specialize parallel state definitions."
 	public static val INVALID_STATE_DEFINITION_PARALLEL_SUBACTIONS = "validateStateDefinitionParallelSubactions"
 	public static val INVALID_STATE_DEFINITION_PARALLEL_SUBACTIONS_MSG = "A parallel state cannot have successions or transitions."
 	public static val INVALID_STATE_DEFINITION_SUBACTION_KIND = "validateStateDefinitionSubactionKind"
@@ -268,8 +288,14 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_STATE_DEFINITION_SUBACTION_KIND_MSG_2 = INVALID_STATE_SUBACTION_KIND_DO_MSG
 	public static val INVALID_STATE_DEFINITION_SUBACTION_KIND_MSG_3 = INVALID_STATE_SUBACTION_KIND_EXIT_MSG
 	
+	public static val INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE = "validateStateSubactionMembershioOwningType"
+	public static val INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE_MSG = "Only a state can have an entry, do or exit action."
+	
 	public static val INVALID_STATE_USAGE_TYPE = "validateStateUsageType_"
 	public static val INVALID_STATE_USAGE_TYPE_MSG = "A state must be typed by state definitions."
+	public static val INVALID_STATE_USAGE_PARALLEL_GENERALIZATION = "validateStateDefinitionParallelGeneralization"
+	public static val INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_1 = "Parallel state must specialize only parallel states."
+	public static val INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_2 = "Non-parallel state must not specialize parallel states."
 	public static val INVALID_STATE_USAGE_PARALLEL_SUBACTIONS = "validateStateUsageParallelSubactions"
 	public static val INVALID_STATE_USAGE_PARALLEL_SUBACTIONS_MSG = "A parallel state cannot have successions or transitions."
 	public static val INVALID_STATE_USAGE_SUBACTION_KIND = "validateStateUsageSubactionKind"
@@ -286,9 +312,9 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_TRANSITION_FEATURE_MEMBERSHIP_TRIGGER_ACTION = "validateTransitionFeatureMembershipTriggerAction"
 	public static val INVALID_TRANSITION_FEATURE_MEMBERSHIP_TRIGGER_ACTION_MSG = "Must be an accept action."
 	
-	public static val INVALID_TRANSITION_USAGE_PARMETERS = "validateTransitionUsageParameters"
-	public static val INVALID_TRANSITION_USAGE_PARMETERS_MSG_1 = "Must have an input parameter."
-	public static val INVALID_TRANSITION_USAGE_PARMETERS_MSG_2 = "Must have two input parameters."
+	public static val INVALID_TRANSITION_USAGE_PARAMETERS = "validateTransitionUsageParameters"
+	public static val INVALID_TRANSITION_USAGE_PARAMETERS_MSG_1 = "Must have an input parameter."
+	public static val INVALID_TRANSITION_USAGE_PARAMETERS_MSG_2 = "Must have two input parameters."
 	public static val INVALID_TRANSITION_USAGE_SUCCESSION = "validateTransitionUsageSuccession"
 	public static val INVALID_TRANSITION_USAGE_SUCCESSION_MSG = "A transition must own a succession to its target."
 	
@@ -300,6 +326,9 @@ class SysMLValidator extends KerMLValidator {
 	
 	public static val INVALID_ACTOR_MEMBERSHIP_OWNING_TYPE = "validateActorMembershipOwningType"
 	public static val INVALID_ACTOR_MEMBERSHIP_OWNING_TYPE_MSG = "Only requirements and cases can have actors."
+	
+	public static val INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND = "validateFramedConcernMembershipConstraintKind"
+	public static val INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND_MSG = "A framed concern must be a required constraint."
 	
 	public static val INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE = "validateRequirementConstraintMembershipIsComposite"
 	public static val INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE_MSG = "A requirement constraint must be composite."
@@ -353,9 +382,12 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_OWNING_TYPE = "validateRequirementVerificationMembershipOwningType"
 	public static val INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_OWNING_TYPE_MSG = "A requirement verification must be in the objective of a verification case."
 	
-	public static val INVALID_VERIFICATIONCASE_USAGE_TYPE = "validateVerificationCaseUsageType_"
-	public static val INVALID_VERIFICATIONCASE_USAGE_TYPE_MSG = "A verification case must be typed by one verification case definition."
+	public static val INVALID_VERIFICATION_CASE_USAGE_TYPE = "validateVerificationCaseUsageType_"
+	public static val INVALID_VERIFICATION_CASE_USAGE_TYPE_MSG = "A verification case must be typed by one verification case definition."
 	
+	public static val INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE = "validateIncludeUseCaseUsageReference"
+	public static val INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG = "Must reference a use case"
+		
 	public static val INVALID_USE_CASE_USAGE_TYPE = "validateUseCaseUsageType_"
 	public static val INVALID_USE_CASE_USAGE_TYPE_MSG = "A use case must be typed by one use case definition."
 	
@@ -390,21 +422,28 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkDefinition(Definition definition) {		
 		if (!definition.isVariation) {
+			// validateDefinitionNonVariationMembership is redundant with validateVariantMembershipOwningNamespace
 			// validateDefinitionNonVariationMembership
-			for (mem: definition.variantMembership) {
-				error(INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_NON_VARIATION_MEMBERSHIP)
-			}
+//			for (mem: definition.variantMembership) {
+//				error(INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_DEFINITION_NON_VARIATION_MEMBERSHIP)
+//			}
 		} else {
 			// validateDefinitionVariationMembership
 			for (ownedUsage: definition.ownedUsage) {
-				// TODO: Allow parameters and objectives in variations in spec? Or is that just due to implementation here?
+				// NOTE: Need to allow parameters and objectives because they are currently physically inserted by transform implementation.
+				// TODO: Add allowance of parameters and objectives in variations to spec? Or remove when possible?
 				val mem = ownedUsage.owningFeatureMembership
 				if (!(mem instanceof ParameterMembership || mem instanceof ObjectiveMembership)) {
-					error(INVALID_USAGE_VARIATION_MSG, mem, null, INVALID_USAGE_VARIATION_MEMBERSHIP)							
+					error(INVALID_DEFINITION_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_DEFINITION_VARIATION_MEMBERSHIP)							
 				}
 			}
 			
-			// TODO: Check validateDefinitionVariationSpecialization
+			// NEW: validateDefinitionVariationSpecialization
+			for (ownedSpec: definition.ownedSpecialization) {
+				if (ownedSpec.general.isVariation) {
+					error(INVALID_DEFINITION_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_Specific, INVALID_DEFINITION_VARIATION_SPECIALIZATION)
+				}
+			}
 		}	
 	}
 	
@@ -417,34 +456,58 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkUsage(Usage usage) {
 		if (!usage.isVariation) {
+			// validateUsageNonVariationMembership is redundant with validateVariantMembershipOwningNamespace
 			// validateUsageNonVariationMembership
-			for (mem: usage.variantMembership) {
-				error(INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_NON_VARIATION_MEMBERSHIP)
-			}
+//			for (mem: usage.variantMembership) {
+//				error(INVALID_USAGE_NON_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_NON_VARIATION_MEMBERSHIP)
+//			}
 		} else {
 			// validateUsageVariationMembership
 			for (nestedUsage: usage.nestedUsage) {
-				// TODO: Allow parameters and objectives in variations in spec? Or is that just due to implementation here?
+				// NOTE: Need to allow parameters and objectives because they are currently physically inserted by transform implementation.
+				// TODO: Add allowance of parameters and objectives in variations to spec? Or remove when possible?
 				val mem = nestedUsage.owningFeatureMembership
 				if (!(mem instanceof ParameterMembership || mem instanceof ObjectiveMembership)) {
-					error(INVALID_USAGE_VARIATION_MSG, mem, null, INVALID_USAGE_VARIATION_MEMBERSHIP)							
+					error(INVALID_USAGE_VARIATION_MEMBERSHIP_MSG, mem, null, INVALID_USAGE_VARIATION_MEMBERSHIP)							
 				}
 			}
 			
-			// TODO: Check validateUsageVariationSpecialization
+			// NEW: validateUsageVariationSpecialization
+			for (ownedSpec: usage.ownedSpecialization) {
+				if (ownedSpec.general.isVariation) {
+					error(INVALID_USAGE_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_Specific, INVALID_USAGE_VARIATION_SPECIALIZATION)
+				}
+			}
 		}
 		
-		// TODO: Check validateUsageOwningType	
+		// validateUsageOwningType is too restrictive. (See SYSML2-301.)
+		// TODO: Check validateUsageOwningType
+		// val owningType = usage.owningType
+		// if (!(owningType === null || owningType instanceof Definition || owningType instanceof Usage)) {
+		//		error(INVALID_USAGE_OWNING_TYPE_MSG, usage, null, INVALID_USAGE_OWNING_TYPE)
+		// }
+	}
+	
+	protected def boolean isVariation(Namespace namespace) {
+		namespace instanceof Definition && (namespace as Definition).isVariation ||
+		namespace instanceof Usage && (namespace as Usage).isVariation
 	}
 	
 	@Check
 	def checkVariantMembership(VariantMembership mem) {
-	  // TODO: Check validateVariantMembershipOwningNamespace		
+		// validateVariantMembershipOwningNamespace
+		if (!mem.membershipOwningNamespace.isVariation) {
+			error(INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE_MSG, mem, null, INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE)
+		}	
 	}
 
 	@Check
 	def checkAttributeDefinition(AttributeDefinition defn) {
-		// TODO: Check validateAttributeDefinitionFeatures
+		// Not implemented for now, until resolution of KerML issues on composite semantics. (See KERML-4.)
+		// TODO: validateAttributeDefinitionFeatures
+		// NOTE: Only check owned features, for efficiency and to avoid redundancy.
+		// (This should be sufficient, unless a composite feature is inherited from a KerML data type.)
+		// checkAllNotComposite(defn.ownedFeature, INVALID_ATTRIBUTE_DEFINITION_FEATURES_MSG, INVALID_ATTRIBUTE_DEFINITION_FEATURES)
 	}
 	
 	@Check 
@@ -461,7 +524,11 @@ class SysMLValidator extends KerMLValidator {
 		
 		// validateAttributeUsageIsReference is satisfied automatically			
 		
-		// TODO: Check validateAttributeUsageFeatures
+		// Not implemented for now, until resolution of KerML issues on composite semantics. (See KerML-4.)
+		// TODO: validateAttributeUsageFeatures
+		// NOTE: Only check owned features, for efficiency and to avoid redundancy.
+		// (This should be sufficient, unless a composite feature is inherited from a KerML data type.)
+		// checkAllNotComposite(usg.ownedFeature, INVALID_ATTRIBUTE_USAGE_FEATURES_MSG, INVALID_ATTRIBUTE_USAGE_FEATURES)
 	}
 	
 //	@Check
@@ -478,7 +545,11 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkEventOccurrenceUsage(EventOccurrenceUsage usg) {
 		// validateEventOccurrenceUsageIsReference is satisfied automatically
-		// TODO: Check validateEventOccurrenceUsageReference
+		
+		// NEW: validateEventOccurrenceUsageReference
+		if (!(usg instanceof PerformActionUsage || usg instanceof IncludeUseCaseUsage)) {
+			checkReferenceType(usg, OccurrenceUsage, INVALID_EVENT_OCCURRENCE_USAGE_REFERENCE_MSG, INVALID_EVENT_OCCURRENCE_USAGE_REFERENCE)
+		}
 	}
 	
 //	@Check
@@ -489,7 +560,17 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkOccurrenceDefinition(OccurrenceDefinition defn) {
-		// TODO: Check validateOccurrenceDefinitionLifeClass
+		// NEW: validateOccurrenceDefinitionLifeClass
+		val n = defn.ownedMember.filter[m | m instanceof LifeClass].size
+		if (defn.isIndividual) {
+			if (n != 1) {
+				error(INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS_MSG_1, defn, null, INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS)
+			}
+		} else {
+			if (n > 0) {
+				error(INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS_MSG_2, defn, null, INVALID_OCCURRENCE_DEFINITION_LIFE_CLASS)
+			}			
+		}
 	}
 	
 	@Check 
@@ -498,11 +579,16 @@ class SysMLValidator extends KerMLValidator {
 		if (!(usg instanceof ItemUsage || usg instanceof PortUsage || usg instanceof Step))	
 			checkAllTypes(usg, org.omg.sysml.lang.sysml.Class, INVALID_OCCURRENCE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, INVALID_OCCURRENCE_USAGE_TYPE)
 
-		// TODO: Check validateOccurrenceUsageIndividualDefinition
+		// NEW: validateOccurrenceUsageIndividualDefinition
+		var nIndividualDefs = usg.occurrenceDefinition.filter[d | d instanceof OccurrenceDefinition && (d as OccurrenceDefinition).isIndividual].size
+		if (nIndividualDefs > 1) {
+			error(INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG, usg, null, INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG)
 
 		// validateOccurrenceUsageIndividualUsage
-		if (usg.isIndividual && usg.occurrenceDefinition.filter[t | t instanceof OccurrenceDefinition && (t as OccurrenceDefinition).isIndividual].size() != 1)
-			error (INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE)	
+		} else if (usg.isIndividual && nIndividualDefs != 1) {
+			error (INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, INVALID_OCCURRENCE_USAGE_INDIVIDUAL_USAGE)
+		}
+
 	}
 	
 	@Check 
@@ -514,22 +600,39 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkPartUsage(PartUsage pu){
-		// validatePartUsagePartDefinition
 		if (!(pu instanceof ConnectionUsage))
 			if (checkAllTypes(pu, Structure, INVALID_PART_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.itemUsage_ItemDefinition, INVALID_PART_USAGE_TYPE))
-				checkAtLeastOneType(pu, PartDefinition, INVALID_PART_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.partUsage_PartDefinition, INVALID_PART_USAGE_TYPE)
+				// validatePartUsagePartDefinition
+				checkAtLeastOneType(pu, PartDefinition, INVALID_PART_USAGE_PART_DEFINITION_MSG, SysMLPackage.eINSTANCE.partUsage_PartDefinition, INVALID_PART_USAGE_PART_DEFINITION)
 	}
 	
 	@Check
 	def checkConjugatedPortDefinition(ConjugatedPortDefinition cpd) {
-		// TODO: Check validateConjugatedPortDefinitionConjugatedPortDefinition
-		// TODO: Check validateConjugatedPortDefinitionOriginalPortDefinition
+		// NEW: validateConjugatedPortDefinitionConjugatedPortDefinition
+		if (cpd.conjugatedPortDefinition !== null) {
+			error(INVALID_CONJUGATED_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION_MSG, cpd, null, INVALID_CONJUGATED_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION)
+		}
+		
+		// NEW: validateConjugatedPortDefinitionOriginalPortDefinition
+		val portConjugator = cpd.ownedPortConjugator
+		if (portConjugator !== null && portConjugator.originalPortDefinition !== cpd.originalPortDefinition) {
+			error(INVALID_CONJUGATED_PORT_DEFINITION_ORIGINAL_PORT_DEFINITION_MSG, cpd, null, INVALID_CONJUGATED_PORT_DEFINITION_ORIGINAL_PORT_DEFINITION)
+		}
 	}
 	
 	@Check
 	def checkPortDefinition(PortDefinition pd) {
-		// TODO: Check validatePortDefinitionConjugatedPortDefinition
-		// TODO: Check validatePortDefinitionOwnedUsagesNotComposite
+		// NEW: Check validatePortDefinitionConjugatedPortDefinition
+		if (!(pd instanceof ConjugatedPortDefinition)) {
+			val n = pd.ownedMember.filter[m | m instanceof ConjugatedPortDefinition].size()
+			if (n != 1) {
+				error(INVALID_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION_MSG, pd, null, INVALID_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION)
+			}
+		}
+		
+		// NEW: validatePortDefinitionOwnedUsagesNotComposite
+		val usages = pd.ownedUsage.filter[u | !(u instanceof PortUsage)]
+		checkAllNotComposite(usages, INVALID_PORT_DEFINITION_OWNED_USAGES_NOT_COMPOSITE_MSG, INVALID_PORT_DEFINITION_OWNED_USAGES_NOT_COMPOSITE)
 	}
 	
 	@Check
@@ -538,7 +641,10 @@ class SysMLValidator extends KerMLValidator {
 		checkAllTypes(usg, PortDefinition, INVALID_PORT_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.portUsage_PortDefinition, INVALID_PORT_USAGE_TYPE)
 
 		// validatePortUsageIsReference is satisfied automatically
-		// TODO: Check validatePortUsageNestedUsagesNotComposite
+
+		// NEW: validatePortUsageNestedUsagesNotComposite
+		val usages = usg.nestedUsage.filter[u | !(u instanceof PortUsage)]
+		checkAllNotComposite(usages, INVALID_PORT_USAGE_NESTED_USAGES_NOT_COMPOSITE_MSG, INVALID_PORT_USAGE_NESTED_USAGES_NOT_COMPOSITE)
 	}
 
 	@Check
@@ -599,7 +705,10 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkAcceptActionUsage(AcceptActionUsage usg) {
-		// TODO: Check validateAcceptActionUsageParameters
+		// NEW: validateAcceptActionUsageParameters
+		if (usg.inputParameters.size < 2) {
+			error(INVALID_ACCEPT_ACTION_USAGE_PARAMETERS_MSG, usg, null, INVALID_ACCEPT_ACTION_USAGE_PARAMETERS)
+		}
 	}
 	
 	@Check
@@ -626,7 +735,12 @@ class SysMLValidator extends KerMLValidator {
 	def checkControlNode(ControlNode node) {
 		// TODO: Check validateControlNodeIncomingSuccessions (?)
 		// TODO: Check validateControlNodeOutgoingSuccessions (?)
+		
 		// TODO: Check validateControlNodeOwningType
+		val owningType = node.owningType
+		if (!(owningType !== null && (owningType instanceof ActionUsage || owningType instanceof ActionDefinition))) {
+			error(INVALID_CONTROL_NODE_OWNING_TYPE_MSG, node, null, INVALID_CONTROL_NODE_OWNING_TYPE)
+		}
 	}
 	
 	@Check
@@ -636,25 +750,29 @@ class SysMLValidator extends KerMLValidator {
 	}
 	
 	@Check
-	def checkForkNodeIncomingSuccessions(ForkNode node) {
-		// TODO: Check validateForkNodeIncomingSuccessions
+	def checkForkNode(ForkNode node) {
+		// TODO: Check validateForkNodeIncomingSuccessions (?)
 	}
 	
-	def checkJoinNodeIncomingSuccessions(JoinNode node) {
-		// TODO: Check validateJoinNodeOutgoingSuccessions
+	def checkJoinNode(JoinNode node) {
+		// TODO: Check validateJoinNodeOutgoingSuccessions (?)
 	}
 	
-	def checkMergeNodeIncomingSuccessions(MergeNode node) {	
-		// TODO: Check validateMergeNodeIncomingSuccessions
-		// TODO: Check validateMergeNodeOutgoingSucessions
+	def checkMergeNode(MergeNode node) {	
+		// TODO: Check validateMergeNodeIncomingSuccessions (?)
+		// TODO: Check validateMergeNodeOutgoingSucessions (?)
 	}
 	
 	def checkPerformActionUsage(PerformActionUsage usg) {
-		// TODO: Check validatePerformActionUsageReference
+		// NEW: validatePerformActionUsageReference
+		if (!(usg instanceof ExhibitStateUsage)) {
+			checkReferenceType(usg, ActionUsage, INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG, INVALID_PERFORM_ACTION_USAGE_REFERENCE)
+		}
 	}
 	
 	@Check
 	def checkSendActionUsage(SendActionUsage usg) {
+		// Warn if sending "to" a port, rather than "via"
 		val receiverArgument = usg.receiverArgument
 		if (receiverArgument instanceof FeatureReferenceExpression && 
 				(receiverArgument as FeatureReferenceExpression).referent instanceof PortUsage ||
@@ -668,23 +786,36 @@ class SysMLValidator extends KerMLValidator {
 			error(INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG, usg, null, INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG)
 		} 
 
-		// TODO: Check validateSendActionParameters
+		// NEW: validateSendActionParameters
+		if (usg.inputParameters.size < 3) {
+			error(INVALID_SEND_ACTION_USAGE_PARAMETERS_MSG, usg, null, INVALID_SEND_ACTION_USAGE_PARAMETERS)
+		}
 	}	
 	
 	def checkExhibitStateUsage(ExhibitStateUsage usg) {
-		// TODO: Add validateExhibitStateUsageReference
+		// NEW: validateExhibitStateUsageReference
+		checkReferenceType(usg, StateUsage, INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG, INVALID_EXHIBIT_STATE_USAGE_REFERENCE)
 	}
 		
 	@Check
 	def checkStateDefinition(StateDefinition defn) {
-		// TODO: CHeck validateStateDefinitionParallelGeneralization
+		// Not implemented pending further review. (See SYSML2-306.)
+		// TODO: validateStateDefinitionParallelGeneralization
+		// checkAllParallelSpecialization(defn, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_1, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION_MSG_2, INVALID_STATE_DEFINITION_PARALLEL_GENERALIZATION)
+		
+		// validateStateDefinitionParallelSubactions is checked by checkTransitionUsage and checkSuccession
+		
 		// validateStateDefinitionStateSubactionKind
 		checkStateSubactions(defn);
 	}
 	
 	@Check
-	def checkStateSubactionMembership(StateSubactionMembership defn) {
-		// TODO: Check validateStateSubactionMembershipOwningType
+	def checkStateSubactionMembership(StateSubactionMembership mem) {
+		// NEW: validateStateSubactionMembershipOwningType
+		val owningType = mem.owningType;
+		if (!(owningType instanceof StateUsage || owningType instanceof StateDefinition)) {
+			error(INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 		
 	@Check
@@ -692,7 +823,11 @@ class SysMLValidator extends KerMLValidator {
 		// All types must be Behaviors
 		checkAllTypes(usg, Behavior, INVALID_STATE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.stateUsage_StateDefinition, INVALID_STATE_USAGE_TYPE)
 
-		// TODO: Check validateStateUsageIsParallelGeneralization
+		// Not implemented pending further review. (See SYSML2-306.)
+		// TODO: validateStateUsageIsParallelGeneralization
+		// checkAllParallelSpecialization(usg, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_1, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION_MSG_2, INVALID_STATE_USAGE_PARALLEL_GENERALIZATION)
+		
+		// validateStateUsageParallelSubactions is checked by checkTransitionUsage and checkSuccession
 
 //		val owningType = usg.owningType
 //		if (owningType !== null && !owningType.isAbstract && usg.isComposite && 
@@ -714,10 +849,29 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkTransitionFeatureMembership(TransitionFeatureMembership mem) {
-		// TODO: Check validateTransitionFeatureMembershipEffectAction
-		// TODO: Check validateTransitionFeatureMembershipGuardAction
-		// TODO: Check validateTransitionFeatureMembershipOwningType
-		// TODO: Check validateTransitionFeatureMembershipTriggerAction
+		val kind = mem.kind
+		if (kind == TransitionFeatureKind.EFFECT) {
+			// NEW: validateTransitionFeatureMembershipEffectAction
+			if (!(mem.transitionFeature instanceof ActionUsage)) {
+				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
+			}
+		} else if (kind == TransitionFeatureKind.GUARD) {
+			// NEW: Check validateTransitionFeatureMembershipGuardAction
+			val transitionFeature = mem.transitionFeature
+			if (!(transitionFeature instanceof Expression && (transitionFeature as Expression).isBoolean)) {
+				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
+			}
+		} if (kind == TransitionFeatureKind.TRIGGER) {
+			// NEW: validateTransitionFeatureMembershipTriggerAction
+			if (!(mem.transitionFeature instanceof AcceptActionUsage)) {
+				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
+			}
+		}
+		
+		// NEW: validateTransitionFeatureMembershipOwningType
+		if (!(mem.owningType instanceof TransitionUsage)) {
+			error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 	
 	@Check
@@ -725,11 +879,30 @@ class SysMLValidator extends KerMLValidator {
 		// validateStateDefinitionParallelSubactions
 		// validateStateUsageParallelSubactions
 		if (UsageUtil.isParallelState(usg.owningType)) {
-			error(INVALID_STATE_USAGE_PARALLEL_SUBACTIONS_MSG, usg, null, INVALID_STATE_USAGE_PARALLEL_SUBACTIONS_MSG)
+			if (usg.owningType instanceof Definition) {
+				error(INVALID_STATE_DEFINITION_PARALLEL_SUBACTIONS_MSG, usg, null, INVALID_STATE_DEFINITION_PARALLEL_SUBACTIONS_MSG)
+			} else {
+				error(INVALID_STATE_USAGE_PARALLEL_SUBACTIONS_MSG, usg, null, INVALID_STATE_USAGE_PARALLEL_SUBACTIONS_MSG)
+			}
 		}
 		
-		// TODO: Check validateTransitionUsageParameters
-		// TODO: Check validateTransitionUsageSuccession	
+		// NEW: validateTransitionUsageParameters
+		val n = usg.inputParameters.size
+		if (usg.triggerAction.isEmpty) {
+			if (n < 1) {
+				error(INVALID_TRANSITION_USAGE_PARAMETERS_MSG_1, usg, null, INVALID_TRANSITION_USAGE_PARAMETERS)
+			}
+		} else {
+			if (n < 2) {
+				error(INVALID_TRANSITION_USAGE_PARAMETERS_MSG_2, usg, null, INVALID_TRANSITION_USAGE_PARAMETERS)
+			}
+		}
+		
+		// NEW: validateTransitionUsageSuccession	
+		val successions = usg.ownedMember.filter[m | m instanceof Succession]
+		if (successions.empty || !(successions.get(0) as Succession).targetFeature.forall[f | FeatureUtil.getBasicFeatureOf(f) instanceof ActionUsage]) {
+			error(INVALID_TRANSITION_USAGE_SUCCESSION_MSG, usg, null, INVALID_TRANSITION_USAGE_SUCCESSION)
+		}
 	}
 	
 	@Check
@@ -750,7 +923,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkAssertConstraintUsage(AssertConstraintUsage usg) {
-		// TODO: Add validateAssertConstraintUsageReference
+		// TODO: Add/check validateAssertConstraintUsageReference
 	}
 
 	@Check 
@@ -761,19 +934,36 @@ class SysMLValidator extends KerMLValidator {
 	}
 	
 	@Check
-	def checkActorMembership(ConstraintUsage usg) {
-		// TODO: Check validateActorMembershipOwningType
+	def checkActorMembership(ActorMembership mem) {
+		// NEW: validateActorMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage ||
+			  owningType instanceof CaseDefinition || owningType instanceof CaseUsage)) {
+			error(INVALID_ACTOR_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_ACTOR_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 	
 	@Check
 	def checkFramedConcernUsage(FramedConcernMembership mem) {
-		// TODO: Check validateFramedConcernMembershipConstraintKind
+		// NEW: validateFramedConcernMembershipConstraintKind
+		if (mem.kind != RequirementConstraintKind::REQUIREMENT) {
+			error(INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND_MSG, mem, null, INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND)
+		}
 	}
 	
 	@Check
 	def checkRequirementConstraintMembership(RequirementConstraintMembership mem) {
-		// TODO: Check validateRequirementConstraintMembershipIsComposite
-		// TODO: Check validateRequirementConstraintMembershipOwningType
+		// NEW: validateRequirementConstraintMembershipIsComposite
+		val ownedConstraint = mem.ownedConstraint
+		if (ownedConstraint !== null && !ownedConstraint.isComposite) {
+			error(INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE_MSG, mem, null, INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE)
+		}
+		
+		// NEW: validateRequirementConstraintMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage)) {
+			error(INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 	
 	@Check
@@ -781,7 +971,8 @@ class SysMLValidator extends KerMLValidator {
 		// validateRequirementDefinitionOnlyOneSubject
 		checkAtMostOneFeature(defn, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// TODO: Check validateRequirementDefinitionSubjectParameterPosition
+		// NEW: validateRequirementDefinitionSubjectParameterPosition
+		checkSubjectParameter(defn, defn.subjectParameter, defn.input, INVALID_REQUIREMENT_DEFINITION_SUBJECT_PARAMETER_POSITION_MSG, INVALID_REQUIREMENT_DEFINITION_SUBJECT_PARAMETER_POSITION)
 	}	
 	
 	@Check 
@@ -792,22 +983,35 @@ class SysMLValidator extends KerMLValidator {
 		// validateRequirementUsageOnlyOneSubject
 		checkAtMostOneFeature(usg, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// TODO: Check validateRequirementUsageSubjectParameterPosition
+		// NEW: validateRequirementUsageSubjectParameterPosition
+		checkSubjectParameter(usg, usg.subjectParameter, usg.input, INVALID_REQUIREMENT_USAGE_SUBJECT_PARAMETER_POSITION_MSG, INVALID_REQUIREMENT_USAGE_SUBJECT_PARAMETER_POSITION)
 	}
 	
 	@Check
 	def checkSatisfyRequirementUsage(SatisfyRequirementUsage usg) {
-		// TODO: Add validateSatisfyRequirementUsageReference
+		// TODO: Add/check validateSatisfyRequirementUsageReference
 	}
 	
 	@Check
 	def checkStakeholderMembership(StakeholderMembership mem) {
-		// TODO: Check validateStakeholderMembershipOwningType
+		// NEW: validateStakeholderMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage)) {
+			error(INVALID_STAKEHOLDER_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_STAKEHOLDER_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 	
 	@Check
 	def checkSubjectMembership(SubjectMembership mem) {
-		// TODO: Check validateSubjectMembershipOwningType
+		// NEW: validateSubjectMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage ||
+			  owningType instanceof CaseDefinition || owningType instanceof CaseUsage ||
+			  // NOTE: Temporarily allow requirement constraint features to have subject memberships
+			  // TODO: Remove this once implicit subjects are no longer being physically inserted
+			  owningType !== null && owningType.owningMembership instanceof RequirementConstraintMembership)) {
+			error(INVALID_SUBJECT_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_SUBJECT_MEMBERSHIP_OWNING_TYPE)
+		}
 	}
 	
 	
@@ -819,7 +1023,8 @@ class SysMLValidator extends KerMLValidator {
 		// validateCaseDefinitionOnlyOneSubject is checked in checkSubjectMembership
 		checkAtMostOneFeature(defn, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// TODO: Check validateCaseDefinitionSubjectParameterPosition
+		// NEW: validateCaseDefinitionSubjectParameterPosition
+		checkSubjectParameter(defn, defn.subjectParameter, defn.input, INVALID_CASE_DEFINITION_SUBJECT_PARAMETER_POSITION_MSG, INVALID_CASE_DEFINITION_SUBJECT_PARAMETER_POSITION)
 	}
 
 	@Check 
@@ -834,13 +1039,23 @@ class SysMLValidator extends KerMLValidator {
 		// validateCaseDefinitionOnlyOneSubject is checked in checkSubjectMembership
 		checkAtMostOneFeature(usg, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// TODO: Check validateCaseUsageSubjectParameterPosition
+		// NEW: validateCaseUsageSubjectParameterPosition
+		checkSubjectParameter(usg, usg.subjectParameter, usg.input, INVALID_CASE_USAGE_SUBJECT_PARAMETER_POSITION_MSG, INVALID_CASE_USAGE_SUBJECT_PARAMETER_POSITION)
 	}
 	
 	@Check
 	def checkObjectiveMembership(ObjectiveMembership mem) {
-		// TODO: Check validateObjectiveMembershipIsComposite
-		// TODO: Check validateObjectiveMembershipOwningType
+		// NEW: validateObjectiveMembershipIsComposite
+		val ownedObjectiveRequirement = mem.ownedObjectiveRequirement
+		if (ownedObjectiveRequirement !== null && !ownedObjectiveRequirement.isComposite) {
+			error(INVALID_OBJECTIVE_MEMBERSHIP_IS_COMPOSITE_MSG, mem, null, INVALID_OBJECTIVE_MEMBERSHIP_IS_COMPOSITE)
+		}
+		
+		// NEW: validateObjectiveMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof CaseDefinition || owningType instanceof CaseUsage)) {
+			error(INVALID_OBJECTIVE_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_OBJECTIVE_MEMBERSHIP_OWNING_TYPE)
+		}
 	}	
 	
 	@Check 
@@ -851,7 +1066,10 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkRequirementVerificationMembership(RequirementVerificationMembership mem) {
-		// TODO: Check validateRequirementVerificationMembershipKind
+		// NEW: validateRequirementVerificationMembershipKind
+		if (mem.kind != RequirementConstraintKind::REQUIREMENT) {
+			error(INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_KIND_MSG, mem, null, INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_KIND)
+		}
 
 		// validateRequirementVerificationMembershipOwningType
 		if (!UsageUtil.isLegalVerification(mem)) {
@@ -862,12 +1080,13 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkVerificationCaseUsage(VerificationCaseUsage usg) {
 		// Must have exactly one type, which is a VerificationCaseDefinition
-		checkOneType(usg, VerificationCaseDefinition, INVALID_VERIFICATIONCASE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.verificationCaseUsage_VerificationCaseDefinition, INVALID_VERIFICATIONCASE_USAGE_TYPE)
+		checkOneType(usg, VerificationCaseDefinition, INVALID_VERIFICATION_CASE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.verificationCaseUsage_VerificationCaseDefinition, INVALID_VERIFICATION_CASE_USAGE_TYPE)
 	}
 	
 	@Check
 	def checkIncludeUseCaseUsage(IncludeUseCaseUsage usg) {
-		// TODO: Add validateIncludeUseCaseUsageReference
+		// NEW: validateIncludeUseCaseUsageReference
+		checkReferenceType(usg, UseCaseUsage, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE)
 	}
 	
 	@Check 
@@ -879,7 +1098,11 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkExpose(Expose exp) {
 		// validateExposeIsImportAll is automatically satisfied
-		// TODO: Check validateExposeOwningNamespace
+		
+		// NEW: validateExposeOwningNamespace
+		if (!(exp.importOwningNamespace instanceof ViewUsage)) {
+			error(INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE_MSG, exp, null, INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE)
+		}	
 	}
 	
 	@Check
@@ -890,13 +1113,17 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkViewDefinition(ViewDefinition viewDef) {
-		// validateViewDefinitionOnlyOneRendering
+		// validateViewDefinitionOnlyOneViewRendering
 		checkAtMostOneElement(viewDef.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING_MSG, INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING)
 	}
 	
 	@Check
 	def checkViewRenderingMembership(ViewRenderingMembership mem) {
-		// TODO: Check validateViewRenderingMembershipOwningType
+		// NEW: validateViewRenderingMembershipOwningType
+		val owningType = mem.owningType
+		if (!(owningType instanceof ViewDefinition || owningType instanceof ViewUsage)) {
+			error(INVALID_VIEW_RENDERING_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_VIEW_RENDERING_MEMBERSHIP_OWNING_TYPE)
+		}		
 	}
 	
 	@Check
@@ -921,6 +1148,28 @@ class SysMLValidator extends KerMLValidator {
 	}
 	
 	/* Overrides */
+	
+	@Check
+	override checkDataType(DataType d) {
+		// validateDataTypeSpecialization
+		// Overridden to tailor error message for SysML.
+		for (s: d.ownedSpecialization) {
+			if (s.general instanceof org.omg.sysml.lang.sysml.Class || s.general instanceof Association) {
+				error(INVALID_ATTRIBUTE_DEFINITION_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_ATTRIBUTE_DEFINITION_SPECIALIZATION)
+			}
+		}
+	}
+	
+	@Check
+	override checkClass(org.omg.sysml.lang.sysml.Class c) {
+		// validateClassSpecialization
+		// Overridden to tailor error message for SysML.
+		for (s: c.ownedSpecialization) {
+			if (s.general instanceof DataType || s.general instanceof Association && !(c instanceof Association)) {
+				error(INVALID_ITEM_DEFINITION_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_ITEM_DEFINITION_SPECIALIZATION)
+			}
+		}
+	}
 	
 	@Check
 	override checkOperatorExpression(OperatorExpression e) {
@@ -958,6 +1207,15 @@ class SysMLValidator extends KerMLValidator {
 	
 	/* Utility Methods */
 	
+	protected def boolean checkNotAny(Iterable<? extends EObject> list, String msg, EStructuralFeature eFeature, String eId) {
+		var check = true
+		for (obj: list) {
+			error(msg, obj, eFeature, eId)
+			check = false
+		}
+		return check
+	}
+	
 	protected def boolean checkAtMostOneFeature(Type owningType, Class<? extends FeatureMembership> kind, String msg, String eId) {
 		var mems = owningType.ownedFeatureMembership.filter[m | kind.isInstance(m)]
 		checkAtMostOneElement(mems, msg, eId);
@@ -994,6 +1252,53 @@ class SysMLValidator extends KerMLValidator {
 		if (!check)
 			error (msg, ref, eId)
 		return check
+	}
+	
+	protected def boolean checkAllNotComposite(Iterable<? extends Feature> list, String msg, String eId) {
+		var check = true
+		for (feature: list) {
+			if (feature.isComposite) {
+				error(msg, feature, null, eId)
+				check = false
+			}
+		}
+		return check
+	}
+	
+	protected def boolean checkReferenceType(Feature feature, Class<?> type, String msg, String eId) {
+		val subsetting = feature.ownedReferenceSubsetting
+		
+		// NOTE: This is implemented using getBasicFeatureOf to account for feature chaining. (See SYSML2-307.)
+		if (subsetting !== null && !type.isInstance(FeatureUtil.getBasicFeatureOf(subsetting.referencedFeature))) {
+			error(msg, subsetting, null, eId)
+			return false
+		}
+		
+		return true
+	}
+	
+	protected def boolean checkSubjectParameter(Type type, Feature subjectParameter, Iterable<Feature> inputs, String msg, String eId) {
+		if (subjectParameter !== null && (inputs.empty || inputs.get(0) !== subjectParameter)) {
+			if (subjectParameter.owningType === type) {
+				error(msg, subjectParameter, null, eId)
+			} else {
+				error(msg, type, null, eId)
+			}
+			return false
+		}
+		return true
+	}
+	
+	protected def boolean checkAllParallelSpecialization(Type type, String msg1, String msg2, String eId) {
+		val isParallel = type.isParallel
+		val badGen = type.ownedSpecialization.filter[s | s.general.isParallel != isParallel]
+		checkNotAny(badGen, isParallel? msg1: msg2, SysMLPackage.eINSTANCE.specialization_General, eId)
+	}
+	
+	protected def boolean isParallel(Type type) {
+		if (type instanceof StateDefinition) type.isParallel
+		else if (type instanceof StateUsage) type.isParallel
+		else false
 	}
 	
 }

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -262,7 +262,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_MERGE_NODE_OUTGOING_SUCCESSIONS_MSG = "Must have at most one outgoing succession."
 	
 	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE = "validatePerformActionUsageReference"
-	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG = "Must reference an action"
+	public static val INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG = "Must reference an action."
 	
 	public static val INVALID_SEND_ACTION_USAGE_PARAMETERS = "validateSendActionUsageParameter"
 	public static val INVALID_SEND_ACTION_USAGE_PARAMETERS_MSG = "A send action usage must have three input parameters."
@@ -272,7 +272,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG = 'A send action must have a payload.'
 	
 	public static val INVALID_EXHIBIT_STATE_USAGE_REFERENCE = "validateExhibitStateUsageReference"
-	public static val INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG = "Must reference a state"
+	public static val INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG = "Must reference a state."
 		
 	public static val INVALID_STATE_SUBACTION_KIND_ENTRY_MSG = "A state may have at most one entry action."
 	public static val INVALID_STATE_SUBACTION_KIND_DO_MSG = "A state may have at most one do action."
@@ -386,7 +386,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_VERIFICATION_CASE_USAGE_TYPE_MSG = "A verification case must be typed by one verification case definition."
 	
 	public static val INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE = "validateIncludeUseCaseUsageReference"
-	public static val INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG = "Must reference a use case"
+	public static val INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG = "Must reference a use case."
 		
 	public static val INVALID_USE_CASE_USAGE_TYPE = "validateUseCaseUsageType_"
 	public static val INVALID_USE_CASE_USAGE_TYPE_MSG = "A use case must be typed by one use case definition."
@@ -438,10 +438,10 @@ class SysMLValidator extends KerMLValidator {
 				}
 			}
 			
-			// NEW: validateDefinitionVariationSpecialization
+			// validateDefinitionVariationSpecialization
 			for (ownedSpec: definition.ownedSpecialization) {
 				if (ownedSpec.general.isVariation) {
-					error(INVALID_DEFINITION_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_Specific, INVALID_DEFINITION_VARIATION_SPECIALIZATION)
+					error(INVALID_DEFINITION_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_General, INVALID_DEFINITION_VARIATION_SPECIALIZATION)
 				}
 			}
 		}	
@@ -472,10 +472,10 @@ class SysMLValidator extends KerMLValidator {
 				}
 			}
 			
-			// NEW: validateUsageVariationSpecialization
+			// validateUsageVariationSpecialization
 			for (ownedSpec: usage.ownedSpecialization) {
 				if (ownedSpec.general.isVariation) {
-					error(INVALID_USAGE_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_Specific, INVALID_USAGE_VARIATION_SPECIALIZATION)
+					error(INVALID_USAGE_VARIATION_SPECIALIZATION_MSG, ownedSpec, SysMLPackage.eINSTANCE.specialization_General, INVALID_USAGE_VARIATION_SPECIALIZATION)
 				}
 			}
 		}
@@ -546,7 +546,7 @@ class SysMLValidator extends KerMLValidator {
 	def checkEventOccurrenceUsage(EventOccurrenceUsage usg) {
 		// validateEventOccurrenceUsageIsReference is satisfied automatically
 		
-		// NEW: validateEventOccurrenceUsageReference
+		// validateEventOccurrenceUsageReference
 		if (!(usg instanceof PerformActionUsage || usg instanceof IncludeUseCaseUsage)) {
 			checkReferenceType(usg, OccurrenceUsage, INVALID_EVENT_OCCURRENCE_USAGE_REFERENCE_MSG, INVALID_EVENT_OCCURRENCE_USAGE_REFERENCE)
 		}
@@ -559,7 +559,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkOccurrenceDefinition(OccurrenceDefinition defn) {
-		// NEW: validateOccurrenceDefinitionLifeClass
+		// validateOccurrenceDefinitionLifeClass
 		val n = defn.ownedMember.filter[m | m instanceof LifeClass].size
 		if (defn.isIndividual) {
 			if (n != 1) {
@@ -578,7 +578,7 @@ class SysMLValidator extends KerMLValidator {
 		if (!(usg instanceof ItemUsage || usg instanceof PortUsage || usg instanceof Step))	
 			checkAllTypes(usg, org.omg.sysml.lang.sysml.Class, INVALID_OCCURRENCE_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, INVALID_OCCURRENCE_USAGE_TYPE)
 
-		// NEW: validateOccurrenceUsageIndividualDefinition
+		// validateOccurrenceUsageIndividualDefinition
 		var nIndividualDefs = usg.occurrenceDefinition.filter[d | d instanceof OccurrenceDefinition && (d as OccurrenceDefinition).isIndividual].size
 		if (nIndividualDefs > 1) {
 			error(INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG, usg, null, INVALID_OCCURRENCE_USAGE_INDIVIDUAL_DEFINITION_MSG)
@@ -607,12 +607,12 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkConjugatedPortDefinition(ConjugatedPortDefinition cpd) {
-		// NEW: validateConjugatedPortDefinitionConjugatedPortDefinition
+		// validateConjugatedPortDefinitionConjugatedPortDefinition
 		if (cpd.conjugatedPortDefinition !== null) {
 			error(INVALID_CONJUGATED_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION_MSG, cpd, null, INVALID_CONJUGATED_PORT_DEFINITION_CONJUGATED_PORT_DEFINITION)
 		}
 		
-		// NEW: validateConjugatedPortDefinitionOriginalPortDefinition
+		// validateConjugatedPortDefinitionOriginalPortDefinition
 		val portConjugator = cpd.ownedPortConjugator
 		if (portConjugator !== null && portConjugator.originalPortDefinition !== cpd.originalPortDefinition) {
 			error(INVALID_CONJUGATED_PORT_DEFINITION_ORIGINAL_PORT_DEFINITION_MSG, cpd, null, INVALID_CONJUGATED_PORT_DEFINITION_ORIGINAL_PORT_DEFINITION)
@@ -621,7 +621,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkPortDefinition(PortDefinition pd) {
-		// NEW: Check validatePortDefinitionConjugatedPortDefinition
+		// Check validatePortDefinitionConjugatedPortDefinition
 		if (!(pd instanceof ConjugatedPortDefinition)) {
 			val n = pd.ownedMember.filter[m | m instanceof ConjugatedPortDefinition].size()
 			if (n != 1) {
@@ -629,7 +629,7 @@ class SysMLValidator extends KerMLValidator {
 			}
 		}
 		
-		// NEW: validatePortDefinitionOwnedUsagesNotComposite
+		// validatePortDefinitionOwnedUsagesNotComposite
 		val usages = pd.ownedUsage.filter[u | !(u instanceof PortUsage)]
 		checkAllNotComposite(usages, INVALID_PORT_DEFINITION_OWNED_USAGES_NOT_COMPOSITE_MSG, INVALID_PORT_DEFINITION_OWNED_USAGES_NOT_COMPOSITE)
 	}
@@ -641,7 +641,7 @@ class SysMLValidator extends KerMLValidator {
 
 		// validatePortUsageIsReference is satisfied automatically
 
-		// NEW: validatePortUsageNestedUsagesNotComposite
+		// validatePortUsageNestedUsagesNotComposite
 		val usages = usg.nestedUsage.filter[u | !(u instanceof PortUsage)]
 		checkAllNotComposite(usages, INVALID_PORT_USAGE_NESTED_USAGES_NOT_COMPOSITE_MSG, INVALID_PORT_USAGE_NESTED_USAGES_NOT_COMPOSITE)
 	}
@@ -704,7 +704,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkAcceptActionUsage(AcceptActionUsage usg) {
-		// NEW: validateAcceptActionUsageParameters
+		// validateAcceptActionUsageParameters
 		if (usg.inputParameters.size < 2) {
 			error(INVALID_ACCEPT_ACTION_USAGE_PARAMETERS_MSG, usg, null, INVALID_ACCEPT_ACTION_USAGE_PARAMETERS)
 		}
@@ -753,18 +753,21 @@ class SysMLValidator extends KerMLValidator {
 		// TODO: Check validateForkNodeIncomingSuccessions (?)
 	}
 	
+	@Check
 	def checkJoinNode(JoinNode node) {
 		// TODO: Check validateJoinNodeOutgoingSuccessions (?)
 	}
 	
+	@Check
 	def checkMergeNode(MergeNode node) {	
 		// TODO: Check validateMergeNodeIncomingSuccessions (?)
 		// TODO: Check validateMergeNodeOutgoingSucessions (?)
 	}
 	
+	@Check
 	def checkPerformActionUsage(PerformActionUsage usg) {
-		// NEW: validatePerformActionUsageReference
-		if (!(usg instanceof ExhibitStateUsage)) {
+		// validatePerformActionUsageReference
+		if (!(usg instanceof ExhibitStateUsage || usg instanceof IncludeUseCaseUsage)) {
 			checkReferenceType(usg, ActionUsage, INVALID_PERFORM_ACTION_USAGE_REFERENCE_MSG, INVALID_PERFORM_ACTION_USAGE_REFERENCE)
 		}
 	}
@@ -785,14 +788,15 @@ class SysMLValidator extends KerMLValidator {
 			error(INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG, usg, null, INVALID_SEND_ACTION_USAGE_PAYLOAD_MSG)
 		} 
 
-		// NEW: validateSendActionParameters
+		// validateSendActionParameters
 		if (usg.inputParameters.size < 3) {
 			error(INVALID_SEND_ACTION_USAGE_PARAMETERS_MSG, usg, null, INVALID_SEND_ACTION_USAGE_PARAMETERS)
 		}
 	}	
 	
+	@Check
 	def checkExhibitStateUsage(ExhibitStateUsage usg) {
-		// NEW: validateExhibitStateUsageReference
+		// validateExhibitStateUsageReference
 		checkReferenceType(usg, StateUsage, INVALID_EXHIBIT_STATE_USAGE_REFERENCE_MSG, INVALID_EXHIBIT_STATE_USAGE_REFERENCE)
 	}
 		
@@ -810,7 +814,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkStateSubactionMembership(StateSubactionMembership mem) {
-		// NEW: validateStateSubactionMembershipOwningType
+		// validateStateSubactionMembershipOwningType
 		val owningType = mem.owningType;
 		if (!(owningType instanceof StateUsage || owningType instanceof StateDefinition)) {
 			error(INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_STATE_SUBACTION_MEMBERSHIP_OWNING_TYPE)
@@ -850,24 +854,24 @@ class SysMLValidator extends KerMLValidator {
 	def checkTransitionFeatureMembership(TransitionFeatureMembership mem) {
 		val kind = mem.kind
 		if (kind == TransitionFeatureKind.EFFECT) {
-			// NEW: validateTransitionFeatureMembershipEffectAction
+			// validateTransitionFeatureMembershipEffectAction
 			if (!(mem.transitionFeature instanceof ActionUsage)) {
 				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
 			}
 		} else if (kind == TransitionFeatureKind.GUARD) {
-			// NEW: Check validateTransitionFeatureMembershipGuardAction
+			// Check validateTransitionFeatureMembershipGuardExpression
 			val transitionFeature = mem.transitionFeature
 			if (!(transitionFeature instanceof Expression && (transitionFeature as Expression).isBoolean)) {
-				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
+				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_GUARD_EXPRESSION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_GUARD_EXPRESSION)
 			}
 		} if (kind == TransitionFeatureKind.TRIGGER) {
-			// NEW: validateTransitionFeatureMembershipTriggerAction
+			// validateTransitionFeatureMembershipTriggerAction
 			if (!(mem.transitionFeature instanceof AcceptActionUsage)) {
-				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_EFFECT_ACTION)
+				error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_TRIGGER_ACTION_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_TRIGGER_ACTION)
 			}
 		}
 		
-		// NEW: validateTransitionFeatureMembershipOwningType
+		// validateTransitionFeatureMembershipOwningType
 		if (!(mem.owningType instanceof TransitionUsage)) {
 			error(INVALID_TRANSITION_FEATURE_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_TRANSITION_FEATURE_MEMBERSHIP_OWNING_TYPE)
 		}
@@ -885,7 +889,7 @@ class SysMLValidator extends KerMLValidator {
 			}
 		}
 		
-		// NEW: validateTransitionUsageParameters
+		// validateTransitionUsageParameters
 		val n = usg.inputParameters.size
 		if (usg.triggerAction.isEmpty) {
 			if (n < 1) {
@@ -897,7 +901,7 @@ class SysMLValidator extends KerMLValidator {
 			}
 		}
 		
-		// NEW: validateTransitionUsageSuccession	
+		// validateTransitionUsageSuccession	
 		val successions = usg.ownedMember.filter[m | m instanceof Succession]
 		if (successions.empty || !(successions.get(0) as Succession).targetFeature.forall[f | FeatureUtil.getBasicFeatureOf(f) instanceof ActionUsage]) {
 			error(INVALID_TRANSITION_USAGE_SUCCESSION_MSG, usg, null, INVALID_TRANSITION_USAGE_SUCCESSION)
@@ -934,7 +938,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkActorMembership(ActorMembership mem) {
-		// NEW: validateActorMembershipOwningType
+		// validateActorMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage ||
 			  owningType instanceof CaseDefinition || owningType instanceof CaseUsage)) {
@@ -944,7 +948,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkFramedConcernUsage(FramedConcernMembership mem) {
-		// NEW: validateFramedConcernMembershipConstraintKind
+		// validateFramedConcernMembershipConstraintKind
 		if (mem.kind != RequirementConstraintKind::REQUIREMENT) {
 			error(INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND_MSG, mem, null, INVALID_FRAMED_CONCERN_MEMBERSHIP_CONSTRAINT_KIND)
 		}
@@ -952,13 +956,13 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkRequirementConstraintMembership(RequirementConstraintMembership mem) {
-		// NEW: validateRequirementConstraintMembershipIsComposite
+		// validateRequirementConstraintMembershipIsComposite
 		val ownedConstraint = mem.ownedConstraint
 		if (ownedConstraint !== null && !ownedConstraint.isComposite) {
 			error(INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE_MSG, mem, null, INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_IS_COMPOSITE)
 		}
 		
-		// NEW: validateRequirementConstraintMembershipOwningType
+		// validateRequirementConstraintMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage)) {
 			error(INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_REQUIREMENT_CONSTRAINT_MEMBERSHIP_OWNING_TYPE)
@@ -970,7 +974,7 @@ class SysMLValidator extends KerMLValidator {
 		// validateRequirementDefinitionOnlyOneSubject
 		checkAtMostOneFeature(defn, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// NEW: validateRequirementDefinitionSubjectParameterPosition
+		// validateRequirementDefinitionSubjectParameterPosition
 		checkSubjectParameter(defn, defn.subjectParameter, defn.input, INVALID_REQUIREMENT_DEFINITION_SUBJECT_PARAMETER_POSITION_MSG, INVALID_REQUIREMENT_DEFINITION_SUBJECT_PARAMETER_POSITION)
 	}	
 	
@@ -982,7 +986,7 @@ class SysMLValidator extends KerMLValidator {
 		// validateRequirementUsageOnlyOneSubject
 		checkAtMostOneFeature(usg, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// NEW: validateRequirementUsageSubjectParameterPosition
+		// validateRequirementUsageSubjectParameterPosition
 		checkSubjectParameter(usg, usg.subjectParameter, usg.input, INVALID_REQUIREMENT_USAGE_SUBJECT_PARAMETER_POSITION_MSG, INVALID_REQUIREMENT_USAGE_SUBJECT_PARAMETER_POSITION)
 	}
 	
@@ -993,7 +997,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkStakeholderMembership(StakeholderMembership mem) {
-		// NEW: validateStakeholderMembershipOwningType
+		// validateStakeholderMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage)) {
 			error(INVALID_STAKEHOLDER_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_STAKEHOLDER_MEMBERSHIP_OWNING_TYPE)
@@ -1002,7 +1006,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkSubjectMembership(SubjectMembership mem) {
-		// NEW: validateSubjectMembershipOwningType
+		// validateSubjectMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof RequirementDefinition || owningType instanceof RequirementUsage ||
 			  owningType instanceof CaseDefinition || owningType instanceof CaseUsage ||
@@ -1022,7 +1026,7 @@ class SysMLValidator extends KerMLValidator {
 		// validateCaseDefinitionOnlyOneSubject is checked in checkSubjectMembership
 		checkAtMostOneFeature(defn, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// NEW: validateCaseDefinitionSubjectParameterPosition
+		// validateCaseDefinitionSubjectParameterPosition
 		checkSubjectParameter(defn, defn.subjectParameter, defn.input, INVALID_CASE_DEFINITION_SUBJECT_PARAMETER_POSITION_MSG, INVALID_CASE_DEFINITION_SUBJECT_PARAMETER_POSITION)
 	}
 
@@ -1038,19 +1042,19 @@ class SysMLValidator extends KerMLValidator {
 		// validateCaseDefinitionOnlyOneSubject is checked in checkSubjectMembership
 		checkAtMostOneFeature(usg, SubjectMembership, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT_MSG, INVALID_REQUIREMENT_USAGE_ONLY_ONE_SUBJECT)
 		
-		// NEW: validateCaseUsageSubjectParameterPosition
+		// validateCaseUsageSubjectParameterPosition
 		checkSubjectParameter(usg, usg.subjectParameter, usg.input, INVALID_CASE_USAGE_SUBJECT_PARAMETER_POSITION_MSG, INVALID_CASE_USAGE_SUBJECT_PARAMETER_POSITION)
 	}
 	
 	@Check
 	def checkObjectiveMembership(ObjectiveMembership mem) {
-		// NEW: validateObjectiveMembershipIsComposite
+		// validateObjectiveMembershipIsComposite
 		val ownedObjectiveRequirement = mem.ownedObjectiveRequirement
 		if (ownedObjectiveRequirement !== null && !ownedObjectiveRequirement.isComposite) {
 			error(INVALID_OBJECTIVE_MEMBERSHIP_IS_COMPOSITE_MSG, mem, null, INVALID_OBJECTIVE_MEMBERSHIP_IS_COMPOSITE)
 		}
 		
-		// NEW: validateObjectiveMembershipOwningType
+		// validateObjectiveMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof CaseDefinition || owningType instanceof CaseUsage)) {
 			error(INVALID_OBJECTIVE_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_OBJECTIVE_MEMBERSHIP_OWNING_TYPE)
@@ -1065,7 +1069,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkRequirementVerificationMembership(RequirementVerificationMembership mem) {
-		// NEW: validateRequirementVerificationMembershipKind
+		// validateRequirementVerificationMembershipKind
 		if (mem.kind != RequirementConstraintKind::REQUIREMENT) {
 			error(INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_KIND_MSG, mem, null, INVALID_REQUIREMENT_VERIFICATION_MEMBERSHIP_KIND)
 		}
@@ -1084,7 +1088,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkIncludeUseCaseUsage(IncludeUseCaseUsage usg) {
-		// NEW: validateIncludeUseCaseUsageReference
+		// validateIncludeUseCaseUsageReference
 		checkReferenceType(usg, UseCaseUsage, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE_MSG, INVALID_INCLUDE_USE_CASE_USAGE_REFERENCE)
 	}
 	
@@ -1098,7 +1102,7 @@ class SysMLValidator extends KerMLValidator {
 	def checkExpose(Expose exp) {
 		// validateExposeIsImportAll is automatically satisfied
 		
-		// NEW: validateExposeOwningNamespace
+		// validateExposeOwningNamespace
 		if (!(exp.importOwningNamespace instanceof ViewUsage)) {
 			error(INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE_MSG, exp, null, INVALID_VARIANT_MEMBERSHIP_OWNING_NAMESPACE)
 		}	
@@ -1118,7 +1122,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	@Check
 	def checkViewRenderingMembership(ViewRenderingMembership mem) {
-		// NEW: validateViewRenderingMembershipOwningType
+		// validateViewRenderingMembershipOwningType
 		val owningType = mem.owningType
 		if (!(owningType instanceof ViewDefinition || owningType instanceof ViewUsage)) {
 			error(INVALID_VIEW_RENDERING_MEMBERSHIP_OWNING_TYPE_MSG, mem, null, INVALID_VIEW_RENDERING_MEMBERSHIP_OWNING_TYPE)

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -208,6 +208,41 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_SENDACTIONUSAGE_NO_ARGS = 'Invalid SendActionUsage - No arguments'
 	public static val INVALID_SENDACTIONUSAGE_NO_ARGS_MSG = 'A send action must have at least one of "via" or "to".'
 	
+	// TODO: Check validateDefinitionVariationMembership
+	// TODO: Check validateDefinitionVariationSpecialization
+	
+	// validateReferenceUsageIsReferential is satisfied automatically
+	
+	// TODO: Check validateUsageVariationSpecialization
+	
+	@Check
+	def checkUsage(Usage usage) {
+		val owningMembership = usage.owningMembership;
+		val owningNamespace = owningMembership?.membershipOwningNamespace;
+		
+		if (owningMembership instanceof VariantMembership) {
+			// validateDefinitionNonVariationMembership
+			// validateUsageNonVariationMembership
+			// A variant Usage must be owned by a variation
+			if (!owningNamespace.isVariation) {
+				error(SysMLValidator.INVALID_USAGE_VARIANT_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIANT)				
+			}
+		// validateDefniitionVariationMembership
+		// validateUsageVariationMembership
+		// TODO: Allow parameters and objectives in variations? Or is that just due to implementation here?
+		// A variation must not own non-variant Usages (except for parameters)
+		} else if (owningNamespace.isVariation && !(owningMembership instanceof ParameterMembership) && !(owningMembership instanceof ObjectiveMembership)) {
+				error(INVALID_USAGE_VARIATION_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIATION)							
+		}
+	}
+	
+	def boolean isVariation(Namespace namespace) {
+		if (namespace instanceof Definition) namespace.isVariation
+		else if (namespace instanceof Usage) namespace.isVariation
+		else false
+	}
+
+	// TODO: Check validateVariantMembershipOwningNamespace
 
 	@Check
 	override checkOperatorExpression(OperatorExpression e) {
@@ -227,7 +262,7 @@ class SysMLValidator extends KerMLValidator {
 	
 	/**
 	 * Check if the result of the given Expression conforms to the given Type, or, alternatively, if the 
-	 * Expression is an OpeartorExpression with a result that has a type to which the given Type conforms, 
+	 * Expression is an OperatorExpression with a result that has a type to which the given Type conforms, 
 	 * check whether at least one of the argument Expression results conforms to the given Type in a similar way.
 	 * (This works, for example, for nested OperatorExpressions with arithmetic operations that return the same
 	 * result Type as one of their arguments, such as for MeasurementReference operations.)
@@ -243,28 +278,11 @@ class SysMLValidator extends KerMLValidator {
 		}
 	}
 	
-	@Check
-	def checkUsage(Usage usage) {
-		val owningMembership = usage.owningMembership;
-		val owningNamespace = owningMembership?.membershipOwningNamespace;
-		
-		if (owningMembership instanceof VariantMembership) {
-			// A variant Usage must be owned by a variation
-			if (!owningNamespace.isVariation) {
-				error(SysMLValidator.INVALID_USAGE_VARIANT_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIANT)				
-			}
-		// A variation must not own non-variant Usages (except for parameters)
-		} else if (owningNamespace.isVariation && !(owningMembership instanceof ParameterMembership) && !(owningMembership instanceof ObjectiveMembership)) {
-				error(INVALID_USAGE_VARIATION_MSG, SysMLPackage.eINSTANCE.element_OwningMembership, SysMLValidator.INVALID_USAGE_VARIATION)							
-		}
-	}
+	// TODO: Check validateAttributeDefinitionFeatures
 	
-	def boolean isVariation(Namespace namespace) {
-		if (namespace instanceof Definition) namespace.isVariation
-		else if (namespace instanceof Usage) namespace.isVariation
-		else false
-	}
-
+	// TODO: Check validateAttributeUsageFeatures
+	// validateAttributeUsageIsReference is satisfied automatically
+	
 	@Check //All types must be DataTypes.
 	def checkAttributeUsageTypes(AttributeUsage usg){
 		checkAllTypes(usg, DataType, SysMLValidator.INVALID_ATTRIBUTEUSAGE_MSG, SysMLPackage.eINSTANCE.attributeUsage_AttributeDefinition, SysMLValidator.INVALID_ATTRIBUTEUSAGE)
@@ -275,117 +293,68 @@ class SysMLValidator extends KerMLValidator {
 			}
 		}
 	}
+	
+	// validateEnumerationDefinitionIsVariation is satisfied automatically
+	
 	@Check // Must have exactly one type, which is an EnumerationDefinition
 	def checkEnumerationUsageTypes(EnumerationUsage usg){
 		checkOneType(usg, EnumerationDefinition, INVALID_ENUMERATIONUSAGE_MSG, SysMLPackage.eINSTANCE.enumerationUsage_EnumerationDefinition, INVALID_ENUMERATIONUSAGE)
 	}
+	
+	// validateOccurrenceUsageIsReference is satisfied automatically
+	// TODO: Check validateEventOccurrenceUsageReference
+	
+	// TODO: Update LifeClass so isSufficient = true
+	
+	// TODO: Check validateOccurrenceDefinitionLifeClass
+	
 	@Check //All types must be Classes. 
-	def checkOccurreceUsageTypes(OccurrenceUsage ou){
+	def checkOccurrenceUsageTypes(OccurrenceUsage ou){
 		if (!(ou instanceof ItemUsage || ou instanceof PortUsage || ou instanceof Step))	
 			checkAllTypes(ou, org.omg.sysml.lang.sysml.Class, SysMLValidator.INVALID_OCCURRENCEUSAGE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, SysMLValidator.INVALID_OCCURRENCEUSAGE)
 	}
+	
+	// TODO: Check validateOccurrenceUsageIndividualDefinition
+	
+	// validateOccurrenceUsageIndividualUsage
+	@Check //Must have one occurrenceDefinition that is an individual.
+	def checkIndividualUsageTypes(OccurrenceUsage usg){
+		if (usg.isIndividual && usg.occurrenceDefinition.filter[t | t instanceof OccurrenceDefinition && (t as OccurrenceDefinition).isIndividual].size() != 1)
+			error (SysMLValidator.INVALID_INDIVIDUALUSAGE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, SysMLValidator.INVALID_INDIVIDUALUSAGE)	
+	}
+	
 	@Check //All types must be Structures. 
 	def checkItemUsageTypes(ItemUsage iu){
 		if (!(iu instanceof PartUsage || iu instanceof PortUsage || iu instanceof MetadataUsage))	
 			checkAllTypes(iu, Structure, SysMLValidator.INVALID_ITEMUSAGE_MSG, SysMLPackage.eINSTANCE.itemUsage_ItemDefinition, SysMLValidator.INVALID_ITEMUSAGE)
 	}
+	
+	// validatePartUsagePartDefinition
 	@Check //All types must be Structures, at least one must be a PartDefinition. 
 	def checkPartUsageTypes(PartUsage pu){
 		if (!(pu instanceof ConnectionUsage))
 			if (checkAllTypes(pu, Structure, SysMLValidator.INVALID_PARTUSAGE_MSG, SysMLPackage.eINSTANCE.itemUsage_ItemDefinition, SysMLValidator.INVALID_PARTUSAGE))
 				checkAtLeastOneType(pu, PartDefinition, SysMLValidator.INVALID_PARTUSAGE_MSG, SysMLPackage.eINSTANCE.partUsage_PartDefinition, SysMLValidator.INVALID_PARTUSAGE)
 	}
-	@Check //All types must be Behaviors
-	def checkActionUsageTypes(ActionUsage usg){
-		if (!(usg instanceof StateUsage || usg instanceof CalculationUsage || usg instanceof FlowConnectionUsage) )
-			checkAllTypes(usg, Behavior, SysMLValidator.INVALID_ACTIONUSAGE_MSG, SysMLPackage.eINSTANCE.actionUsage_ActionDefinition, SysMLValidator.INVALID_ACTIONUSAGE)
-	}	
-	@Check //Must have exactly one type, which is a Predicate.
-	def checkConstraintUsageTypes(ConstraintUsage usg){
-		if (!(usg instanceof RequirementUsage))
-			checkOneType(usg, Predicate, SysMLValidator.INVALID_CONSTRAINTUSAGE_MSG, SysMLPackage.eINSTANCE.constraintUsage_ConstraintDefinition, SysMLValidator.INVALID_CONSTRAINTUSAGE)
-	}
-	@Check //Must have exactly one type, which is a Function.
-	def checkCalculationUsageTypes(CalculationUsage usg){
-		if (!(usg instanceof CaseUsage))
-			checkOneType(usg, Function, SysMLValidator.INVALID_CALCULATIONUSAGE_MSG, SysMLPackage.eINSTANCE.calculationUsage_CalculationDefinition, SysMLValidator.INVALID_CALCULATIONUSAGE)
-	}
-	@Check //Must have exactly one type, which is a CaseDefinition.
-	def checkCaseUsageTypes(CaseUsage usg){
-		if (!(usg instanceof AnalysisCaseUsage || usg instanceof VerificationCaseUsage || usg instanceof UseCaseUsage))
-			checkOneType(usg, CaseDefinition, SysMLValidator.INVALID_CASEUSAGE_MSG, SysMLPackage.eINSTANCE.caseUsage_CaseDefinition, SysMLValidator.INVALID_CASEUSAGE)
-	}
-	@Check //Must have exactly one type, which is an AnalysisCaseDefinition.
-	def checkAnalysisCaseUsageTypes(AnalysisCaseUsage usg){
-		checkOneType(usg, AnalysisCaseDefinition, SysMLValidator.INVALID_ANALYSISCASEUSAGE_MSG, SysMLPackage.eINSTANCE.analysisCaseUsage_AnalysisCaseDefinition, SysMLValidator.INVALID_ANALYSISCASEUSAGE)
-	}
-	@Check //Must have exactly one type, which is a VerificationCaseDefinition.
-	def checkVerificationCaseUsageTypes(VerificationCaseUsage usg){
-		checkOneType(usg, VerificationCaseDefinition, SysMLValidator.INVALID_VERIFICATIONCASEUSAGE_MSG, SysMLPackage.eINSTANCE.verificationCaseUsage_VerificationCaseDefinition, SysMLValidator.INVALID_VERIFICATIONCASEUSAGE)
-	}
-	@Check //Must have exactly one type, which is a UseCaseDefinition.
-	def checkUseCaseUsageTypes(UseCaseUsage usg){
-		checkOneType(usg, UseCaseDefinition, SysMLValidator.INVALID_USECASEUSAGE_MSG, SysMLPackage.eINSTANCE.useCaseUsage_UseCaseDefinition, SysMLValidator.INVALID_USECASEUSAGE)
-	}
-	@Check //Must have one occurrenceDefinition that is an individual.
-	def checkIndividualUsageTypes(OccurrenceUsage usg){
-		if (usg.isIndividual && usg.occurrenceDefinition.filter[t | t instanceof OccurrenceDefinition && (t as OccurrenceDefinition).isIndividual].size() != 1)
-			error (SysMLValidator.INVALID_INDIVIDUALUSAGE_MSG, SysMLPackage.eINSTANCE.occurrenceUsage_OccurrenceDefinition, SysMLValidator.INVALID_INDIVIDUALUSAGE)	
-	}
-	@Check //All types must be Associations.
-	def checkConnectionUsageTypes(ConnectionUsage usg){
-		if (!(usg instanceof FlowConnectionUsage || usg instanceof InterfaceUsage || usg instanceof AllocationUsage))	
-			checkAllTypes(usg, Association, SysMLValidator.INVALID_CONNECTIONUSAGE_MSG, SysMLPackage.eINSTANCE.connectionUsage_ConnectionDefinition, SysMLValidator.INVALID_CONNECTIONUSAGE)
-	}
-	@Check //All types must be Interactions.
-	def checkFlowConnectionUsageTypes(FlowConnectionUsage usg){
-		checkAllTypes(usg, Interaction, SysMLValidator.INVALID_FLOWCONNECTIONUSAGE_MSG, SysMLPackage.eINSTANCE.flowConnectionUsage_FlowConnectionDefinition, SysMLValidator.INVALID_FLOWCONNECTIONUSAGE)
-	}
-	@Check //All types must be InterfaceDefinitions.
-	def checkInterfaceUsageTypes(InterfaceUsage usg){
-		checkAllTypes(usg, InterfaceDefinition, SysMLValidator.INVALID_INTERFACEUSAGE_MSG, SysMLPackage.eINSTANCE.interfaceUsage_InterfaceDefinition, SysMLValidator.INVALID_INTERFACEUSAGE)
-	}
-	@Check //All types must be AllocationDefinitions.
-	def checkAllocationUsageTypes(AllocationUsage usg){
-		checkAllTypes(usg, AllocationDefinition, SysMLValidator.INVALID_ALLOCATIONUSAGE_MSG, SysMLPackage.eINSTANCE.allocationUsage_AllocationDefinition, SysMLValidator.INVALID_ALLOCATIONUSAGE)
-	}
+	
+	// TODO: Check validateConjugatedPortDefinitionConjugatedPortDefinition
+	// TODO: Check validateConjugatedPortDefinitionOriginalPortDefinition
+	
+	// TODO: Check validatePortDefinitionConjugatedPortDefinition
+	// TODO: Check validatePortDefinitionOwnedUsagesNotComposite
+	
+	// validatePortUsageIsReference is satisfied automatically
+	// TODO: Check validatePortUsageNestedUsagesNotComposite
+	
 	@Check //All types must be PortDefinitions. 
 	def checkPortUsageTypes(PortUsage usg){
 		checkAllTypes(usg, PortDefinition, SysMLValidator.INVALID_PORTUSAGE_MSG, SysMLPackage.eINSTANCE.portUsage_PortDefinition, SysMLValidator.INVALID_PORTUSAGE)
 	}
-	@Check  //Must have exactly one type, which is a RequirementDefinition. 
-	def checkRequirementUsageTypes(RequirementUsage usg){
-		checkOneType(usg, RequirementDefinition, SysMLValidator.INVALID_REQUIREMENTUSAGE_MSG, SysMLPackage.eINSTANCE.requirementUsage_RequirementDefinition, SysMLValidator.INVALID_REQUIREMENTUSAGE)
-	}
-	@Check //All types must be Behaviors.
-	def checkStateUsageTypes(StateUsage usg){
-		checkAllTypes(usg, Behavior, SysMLValidator.INVALID_STATEUSAGE_MSG, SysMLPackage.eINSTANCE.stateUsage_StateDefinition, SysMLValidator.INVALID_STATEUSAGE)
-	}
-	@Check //Must have exactly one type, which is a ViewDefinition.
-	def checkViewUsageTypes(ViewUsage usg){
-		checkOneType(usg, ViewDefinition, SysMLValidator.INVALID_VIEWUSAGE_MSG, SysMLPackage.eINSTANCE.viewUsage_ViewDefinition, SysMLValidator.INVALID_VIEWUSAGE)
-	}
-	@Check //Must have exactly one type, which is a ViewpointDefinition. 
-	def checkViewpointUsageTypes(ViewpointUsage usg){
-		checkOneType(usg, ViewpointDefinition, SysMLValidator.INVALID_VIEWPOINTUSAGE_MSG, SysMLPackage.eINSTANCE.viewpointUsage_ViewpointDefinition, SysMLValidator.INVALID_VIEWPOINTUSAGE)
-	}
-	@Check //Must have exactly one type, which is a RenderingDefinition. 
-	def checkRenderingUsageTypes(RenderingUsage usg){
-		checkOneType(usg, RenderingDefinition, SysMLValidator.INVALID_RENDERINGUSAGE_MSG, SysMLPackage.eINSTANCE.renderingUsage_RenderingDefinition, SysMLValidator.INVALID_RENDERINGUSAGE)
-	}
-	
-	@Check //Must have at most one rendering.
-	def checkViewDefinitionRender(ViewDefinition viewDef){
-		checkAtMostOneElement(viewDef.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEWDEFINITION_RENDER_MSG, INVALID_VIEWDEFINITION_RENDER)
-	}
-	@Check //Must have at most one rendering.
-	def checkViewUsageRender(ViewUsage viewUsg){
-		checkAtMostOneElement(viewUsg.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEWUSAGE_RENDER_MSG, INVALID_VIEWUSAGE_RENDER)
-	}
-	
-	@Check //Must have exactly one type, which is a Metaclass. 
-	def checkMetadataUsageTypes(MetadataUsage usg){
-		checkOneType(usg, Metaclass, SysMLValidator.INVALID_METADATAUSAGE_MSG, SysMLPackage.eINSTANCE.metadataUsage_MetadataDefinition, SysMLValidator.INVALID_METADATAUSAGE)
+
+	@Check //All types must be Associations.
+	def checkConnectionUsageTypes(ConnectionUsage usg){
+		if (!(usg instanceof FlowConnectionUsage || usg instanceof InterfaceUsage || usg instanceof AllocationUsage))	
+			checkAllTypes(usg, Association, SysMLValidator.INVALID_CONNECTIONUSAGE_MSG, SysMLPackage.eINSTANCE.connectionUsage_ConnectionDefinition, SysMLValidator.INVALID_CONNECTIONUSAGE)
 	}
 	
 	@Check //At most two owned ends
@@ -396,6 +365,11 @@ class SysMLValidator extends KerMLValidator {
 				error(INVALID_FLOWCONNECTIONDEFINITION_END_MSG, ends.get(i), null, INVALID_FLOWCONNECTIONDEFINITION_END)
 			}
 		}
+	}
+
+	@Check //All types must be Interactions.
+	def checkFlowConnectionUsageTypes(FlowConnectionUsage usg){
+		checkAllTypes(usg, Interaction, SysMLValidator.INVALID_FLOWCONNECTIONUSAGE_MSG, SysMLPackage.eINSTANCE.flowConnectionUsage_FlowConnectionDefinition, SysMLValidator.INVALID_FLOWCONNECTIONUSAGE)
 	}
 
 	@Check //Ends must be ports
@@ -416,6 +390,238 @@ class SysMLValidator extends KerMLValidator {
 		}
 	}
 	
+	@Check //All types must be InterfaceDefinitions.
+	def checkInterfaceUsageTypes(InterfaceUsage usg){
+		checkAllTypes(usg, InterfaceDefinition, SysMLValidator.INVALID_INTERFACEUSAGE_MSG, SysMLPackage.eINSTANCE.interfaceUsage_InterfaceDefinition, SysMLValidator.INVALID_INTERFACEUSAGE)
+	}
+
+	@Check //All types must be AllocationDefinitions.
+	def checkAllocationUsageTypes(AllocationUsage usg){
+		checkAllTypes(usg, AllocationDefinition, SysMLValidator.INVALID_ALLOCATIONUSAGE_MSG, SysMLPackage.eINSTANCE.allocationUsage_AllocationDefinition, SysMLValidator.INVALID_ALLOCATIONUSAGE)
+	}
+	
+	// TODO: Check validateAcceptActionUsageParameters
+	
+	@Check //All types must be Behaviors
+	def checkActionUsageTypes(ActionUsage usg){
+		if (!(usg instanceof StateUsage || usg instanceof CalculationUsage || usg instanceof FlowConnectionUsage) )
+			checkAllTypes(usg, Behavior, SysMLValidator.INVALID_ACTIONUSAGE_MSG, SysMLPackage.eINSTANCE.actionUsage_ActionDefinition, SysMLValidator.INVALID_ACTIONUSAGE)
+	}
+	
+	// TODO: Add/check validateAssignmentActionUsageArguments
+	// TODO: Add/check validateAssignmentActionUsageReferent
+	
+	// TODO: Add/check validate TriggerInvocationExpressionAfterArgument
+	// TODO: Add/check validate TriggerInvocationExpressionAtArgument
+	// TODO: Add/check validate TriggerInvocationExpressionWhenArgument
+	
+	// TODO: Check validateControlNodeIncomingSuccessions (?)
+	// TODO: Check validateControlNoteOutgoingSuccessions (?)
+	// TODO: Check validateControlNodeOwningType
+	
+	// TODO: Check validateDecisionNodeIncomingSuccessions (?)
+	// TODO: Check validateDecisionNodeOutgoingSuccessions (?)
+	
+	// TODO: Check validateForkNodeIncomingSuccessions
+	
+	// TODO: Check validateJoinNodeOutgoingSuccessions
+	
+	// TODO: Check validateMergeNodeIncomingSuccessions
+	// TODO: Check validateMergeNodeOutgoingSucessions
+	
+	// TODO: Check validatePerformActionUsageReference
+	
+	// TODO: Check validateSendActionParameters
+	@Check
+	def checkSendActionUsage(SendActionUsage usg) {
+		val senderArgument = usg.senderArgument
+		val receiverArgument = usg.receiverArgument
+		// TODO: Change SendActionUsage argument check to payloadArgument === null
+		if (senderArgument === null && receiverArgument === null) {
+			error(INVALID_SENDACTIONUSAGE_NO_ARGS_MSG, usg, null, INVALID_SENDACTIONUSAGE_NO_ARGS_MSG)
+		} else if (receiverArgument instanceof FeatureReferenceExpression && 
+				(receiverArgument as FeatureReferenceExpression).referent instanceof PortUsage ||
+			receiverArgument instanceof FeatureChainExpression &&
+				FeatureUtil.getBasicFeatureOf((receiverArgument as FeatureChainExpression).targetFeature) instanceof PortUsage) {
+			warning(INVALID_SENDACTIONUSAGE_RECEIVER_MSG, receiverArgument, null, INVALID_SENDACTIONUSAGE_RECEIVER)
+		}
+	}	
+	
+	// TODO: Add validateExhibitStateUsageReference
+	
+	// TODO: CHeck validateStateDefinitionParallelGeneralization
+	
+	@Check
+	def checkStateDefinition(StateDefinition defn) {
+		// validateStateDefinitionStateSubactionKind
+		checkStateSubactions(defn);
+	}
+	
+	// TODO: Check validateStateSubactionMembershipOwningType
+	
+	// TODO: Check validateStateUsageIsParallelGeneralization
+	
+	@Check //All types must be Behaviors.
+	def checkStateUsageTypes(StateUsage usg){
+		checkAllTypes(usg, Behavior, SysMLValidator.INVALID_STATEUSAGE_MSG, SysMLPackage.eINSTANCE.stateUsage_StateDefinition, SysMLValidator.INVALID_STATEUSAGE)
+	}
+
+	@Check
+	def checkStateUsage(StateUsage usg) {
+//		val owningType = usg.owningType
+//		if (owningType !== null && !owningType.isAbstract && usg.isComposite && 
+//			UsageUtil.isNonParallelState(owningType) && !UsageUtil.hasIncomingTransitions(usg)
+//		) {
+//			warning(INVALID_STATEUSAGE_TRANSITIONS_MSG, usg, null, INVALID_STATEUSAGE_TRANSITIONS)
+//		}
+		// validateStateUsageStateSubactionKind
+		checkStateSubactions(usg)
+	}
+	
+	protected def checkStateSubactions(Type type) {
+		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.ENTRY), INVALID_STATE_SUBACTION_MEMBERSHIP_ENTRY_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_ENTRY);
+		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.DO), INVALID_STATE_SUBACTION_MEMBERSHIP_DO_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_DO);
+		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.EXIT), INVALID_STATE_SUBACTION_MEMBERSHIP_EXIT_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_EXIT);
+	}
+	
+	// TODO: Check validateTransitionFeatureMembershipEffectAction
+	// TODO: Check validateTransitionFeatureMembershipGuardAction
+	// TODO: Check validateTransitionFeatureMembershipOwningType
+	// TODO: Check validateTransitionFeatureMembershipTriggerAction
+	
+	// TODO: Check validateTransitionUsageParameters
+	// TODO: Check validateTransitionUsageSuccession
+	
+	// validateStateDefinitionParallelSubactions
+	// validateStateUsageParallelSubactions
+	@Check
+	def checkTransitionUsage(TransitionUsage usg) {
+		if (UsageUtil.isParallelState(usg.owningType)) {
+			error(INVALID_TRANSITIONUSAGE_MSG, usg, null, INVALID_TRANSITIONUSAGE)
+		}
+	}
+	
+	// validateStateDefinitionParallelSubactions
+	// validateStateUsageParallelSubactions
+	@Check
+	def checkSuccession(Succession usg) {
+		if (UsageUtil.isParallelState(usg.owningType)) {
+			error(INVALID_TRANSITIONUSAGE_MSG, usg, null, INVALID_TRANSITIONUSAGE)
+		}
+	}
+	
+	@Check //Must have exactly one type, which is a Function.
+	def checkCalculationUsageTypes(CalculationUsage usg){
+		if (!(usg instanceof CaseUsage))
+			checkOneType(usg, Function, SysMLValidator.INVALID_CALCULATIONUSAGE_MSG, SysMLPackage.eINSTANCE.calculationUsage_CalculationDefinition, SysMLValidator.INVALID_CALCULATIONUSAGE)
+	}
+	
+	// TODO: Add validateAssertConstraintUsageReference
+
+	@Check //Must have exactly one type, which is a Predicate.
+	def checkConstraintUsageTypes(ConstraintUsage usg){
+		if (!(usg instanceof RequirementUsage))
+			checkOneType(usg, Predicate, SysMLValidator.INVALID_CONSTRAINTUSAGE_MSG, SysMLPackage.eINSTANCE.constraintUsage_ConstraintDefinition, SysMLValidator.INVALID_CONSTRAINTUSAGE)
+	}
+	
+	// TODO: Check validateActorMembershipOwningType
+	
+	// TODO: Check validateFramedConcernUsageConstraintKind
+	
+	// TODO: Check validateRequirementConstraintMembershipIsComposite
+	// TODO: Check validateRequirementConstraintMembershipOwningType
+	
+	// TODO: Check validateRequirementDefinitionOnlyOneSubject
+	// TODO: Check validateRequirementDefinitionSubjectParameterPosition
+	
+	// TODO: Check validateRequirementUsageOnlyOneSubject
+	// TODO: Check validateRequirementUsageSubjectParameterPosition
+	
+	@Check  //Must have exactly one type, which is a RequirementDefinition. 
+	def checkRequirementUsageTypes(RequirementUsage usg){
+		checkOneType(usg, RequirementDefinition, SysMLValidator.INVALID_REQUIREMENTUSAGE_MSG, SysMLPackage.eINSTANCE.requirementUsage_RequirementDefinition, SysMLValidator.INVALID_REQUIREMENTUSAGE)
+	}
+	
+	// TODO: Add validateSatisfyRequirementUsageReference
+	
+	// TODO: Check validateStakeholderMembershipOwningType
+	
+	// TODO: Check validateSubjectMembershipOwningType
+	
+	// TODO: Check validateCaseDefinitionOnlyOneObjective
+	// TODO: Check validateCaseDefinitionOnlyOneSubject
+	// TODO: Check validateCaseDefinitionSubjectParameterPosition
+
+	// TODO: Check validateCaseUsageOnlyOneObjective
+	// TODO: Check validateCaseUsageOnlyOneSubject
+	// TODO: Check validateCaseUsageSubjectParameterPosition
+
+	@Check //Must have exactly one type, which is a CaseDefinition.
+	def checkCaseUsageTypes(CaseUsage usg){
+		if (!(usg instanceof AnalysisCaseUsage || usg instanceof VerificationCaseUsage || usg instanceof UseCaseUsage))
+			checkOneType(usg, CaseDefinition, SysMLValidator.INVALID_CASEUSAGE_MSG, SysMLPackage.eINSTANCE.caseUsage_CaseDefinition, SysMLValidator.INVALID_CASEUSAGE)
+	}
+	
+	// TODO: Check validateObjectiveMembershipIsComposite
+	// TODO: Check validateObjectiveMembershipOwningType
+	
+	@Check //Must have exactly one type, which is an AnalysisCaseDefinition.
+	def checkAnalysisCaseUsageTypes(AnalysisCaseUsage usg){
+		checkOneType(usg, AnalysisCaseDefinition, SysMLValidator.INVALID_ANALYSISCASEUSAGE_MSG, SysMLPackage.eINSTANCE.analysisCaseUsage_AnalysisCaseDefinition, SysMLValidator.INVALID_ANALYSISCASEUSAGE)
+	}
+	
+	// TODO: Check validateRequirementVerificationMembershipKind
+	// TODO: Check validateRequirementVerificationMembershipOwningType
+	
+	@Check //Must have exactly one type, which is a VerificationCaseDefinition.
+	def checkVerificationCaseUsageTypes(VerificationCaseUsage usg){
+		checkOneType(usg, VerificationCaseDefinition, SysMLValidator.INVALID_VERIFICATIONCASEUSAGE_MSG, SysMLPackage.eINSTANCE.verificationCaseUsage_VerificationCaseDefinition, SysMLValidator.INVALID_VERIFICATIONCASEUSAGE)
+	}
+	
+	// TODO: Add validateIncludeUseCaseUsageReference
+	
+	@Check //Must have exactly one type, which is a UseCaseDefinition.
+	def checkUseCaseUsageTypes(UseCaseUsage usg){
+		checkOneType(usg, UseCaseDefinition, SysMLValidator.INVALID_USECASEUSAGE_MSG, SysMLPackage.eINSTANCE.useCaseUsage_UseCaseDefinition, SysMLValidator.INVALID_USECASEUSAGE)
+	}
+	
+	// validateExposeIsImportAll is automatically satisfied
+	// TODO: Check validateExposeOwningNamespace
+	
+	@Check //Must have exactly one type, which is a RenderingDefinition. 
+	def checkRenderingUsageTypes(RenderingUsage usg){
+		checkOneType(usg, RenderingDefinition, SysMLValidator.INVALID_RENDERINGUSAGE_MSG, SysMLPackage.eINSTANCE.renderingUsage_RenderingDefinition, SysMLValidator.INVALID_RENDERINGUSAGE)
+	}
+	
+	// validateViewDefinitionOnlyOneRendering
+	@Check //Must have at most one rendering.
+	def checkViewDefinitionRender(ViewDefinition viewDef){
+		checkAtMostOneElement(viewDef.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEWDEFINITION_RENDER_MSG, INVALID_VIEWDEFINITION_RENDER)
+	}
+	
+	// TODO: Check validateViewRenderingMembershipOwningType
+	
+	@Check //Must have exactly one type, which is a ViewpointDefinition. 
+	def checkViewpointUsageTypes(ViewpointUsage usg){
+		checkOneType(usg, ViewpointDefinition, SysMLValidator.INVALID_VIEWPOINTUSAGE_MSG, SysMLPackage.eINSTANCE.viewpointUsage_ViewpointDefinition, SysMLValidator.INVALID_VIEWPOINTUSAGE)
+	}
+	
+	@Check //Must have exactly one type, which is a ViewDefinition.
+	def checkViewUsageTypes(ViewUsage usg){
+		checkOneType(usg, ViewDefinition, SysMLValidator.INVALID_VIEWUSAGE_MSG, SysMLPackage.eINSTANCE.viewUsage_ViewDefinition, SysMLValidator.INVALID_VIEWUSAGE)
+	}
+	
+	// validateViewUsageOnlyOneRendering	
+	@Check //Must have at most one rendering.
+	def checkViewUsageRender(ViewUsage viewUsg){
+		checkAtMostOneElement(viewUsg.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEWUSAGE_RENDER_MSG, INVALID_VIEWUSAGE_RENDER)
+	}
+	
+	@Check //Must have exactly one type, which is a Metaclass. 
+	def checkMetadataUsageTypes(MetadataUsage usg){
+		checkOneType(usg, Metaclass, SysMLValidator.INVALID_METADATAUSAGE_MSG, SysMLPackage.eINSTANCE.metadataUsage_MetadataDefinition, SysMLValidator.INVALID_METADATAUSAGE)
+	}
+	
 	@Check //Must have at most one subject membership.
 	def checkSubjectMembership(SubjectMembership mem) {
 		checkAtMostOneFeature(SubjectMembership, mem, INVALID_SUBJECTMEMBERSHIP_MSG, INVALID_SUBJECTMEMBERSHIP)
@@ -430,56 +636,6 @@ class SysMLValidator extends KerMLValidator {
 	def checkRequirementVerificationMembership(RequirementVerificationMembership mem) {
 		if (!UsageUtil.isLegalVerification(mem)) {
 			error(INVALID_REQUIREMENTVERIFICATIONMEMBERSHIP_MSG, null, INVALID_REQUIREMENTVERIFICATIONMEMBERSHIP)
-		}
-	}
-	
-	@Check
-	def checkSendActionUsage(SendActionUsage usg) {
-		val senderArgument = usg.senderArgument
-		val receiverArgument = usg.receiverArgument
-		if (senderArgument === null && receiverArgument === null) {
-			error(INVALID_SENDACTIONUSAGE_NO_ARGS_MSG, usg, null, INVALID_SENDACTIONUSAGE_NO_ARGS_MSG)
-		} else if (receiverArgument instanceof FeatureReferenceExpression && 
-				(receiverArgument as FeatureReferenceExpression).referent instanceof PortUsage ||
-			receiverArgument instanceof FeatureChainExpression &&
-				FeatureUtil.getBasicFeatureOf((receiverArgument as FeatureChainExpression).targetFeature) instanceof PortUsage) {
-			warning(INVALID_SENDACTIONUSAGE_RECEIVER_MSG, receiverArgument, null, INVALID_SENDACTIONUSAGE_RECEIVER)
-		}
-	}
-	
-	@Check
-	def checkStateDefinition(StateDefinition defn) {
-		checkStateSubactions(defn);
-	}
-	
-	@Check
-	def checkStateUsage(StateUsage usg) {
-//		val owningType = usg.owningType
-//		if (owningType !== null && !owningType.isAbstract && usg.isComposite && 
-//			UsageUtil.isNonParallelState(owningType) && !UsageUtil.hasIncomingTransitions(usg)
-//		) {
-//			warning(INVALID_STATEUSAGE_TRANSITIONS_MSG, usg, null, INVALID_STATEUSAGE_TRANSITIONS)
-//		}
-		checkStateSubactions(usg)
-	}
-	
-	protected def checkStateSubactions(Type type) {
-		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.ENTRY), INVALID_STATE_SUBACTION_MEMBERSHIP_ENTRY_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_ENTRY);
-		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.DO), INVALID_STATE_SUBACTION_MEMBERSHIP_DO_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_DO);
-		checkAtMostOneElement(UsageUtil.getStateSubactionMembershipsOf(type, StateSubactionKind.EXIT), INVALID_STATE_SUBACTION_MEMBERSHIP_EXIT_MSG, INVALID_STATE_SUBACTION_MEMBERSHIP_EXIT);
-	}
-	
-	@Check
-	def checkSuccession(Succession usg) {
-		if (UsageUtil.isParallelState(usg.owningType)) {
-			error(INVALID_TRANSITIONUSAGE_MSG, usg, null, INVALID_TRANSITIONUSAGE)
-		}
-	}
-	
-	@Check
-	def checkTransitionUsage(TransitionUsage usg) {
-		if (UsageUtil.isParallelState(usg.owningType)) {
-			error(INVALID_TRANSITIONUSAGE_MSG, usg, null, INVALID_TRANSITIONUSAGE)
 		}
 	}
 	

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -555,7 +555,6 @@ class SysMLValidator extends KerMLValidator {
 //	@Check
 //	def checkLifeClass(LifeClass cls) {}
 //		// validateLifeClassIsSufficient is satisfied automatically
-//		// TODO: Update LifeClass so isSufficient = true
 //	}
 	
 	@Check

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -186,7 +186,7 @@ public class UsageAdapter extends FeatureAdapter {
 			Usage parameter = SysMLFactory.eINSTANCE.createReferenceUsage();
 			SubjectMembership membership = SysMLFactory.eINSTANCE.createSubjectMembership();
 			membership.setOwnedSubjectParameter(parameter);
-			type.getOwnedRelationship().add(membership);
+			type.getOwnedRelationship().add(0, membership);
 		}
 	}
 	

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LifeClassImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LifeClassImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -52,6 +52,13 @@ public class LifeClassImpl extends ClassImpl implements LifeClass {
 	@Override
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.LIFE_CLASS;
+	}
+	
+	// Other overrides
+	
+	@Override
+	public boolean isSufficient() {
+		return true;
 	}
 	
 } //LifeClassImpl

--- a/sysml.library/Systems Library/Connections.sysml
+++ b/sysml.library/Systems Library/Connections.sysml
@@ -123,8 +123,8 @@ standard library package Connections {
 		 * messageConnections is the base feature of all FlowConnectionUsages.
 		 */
 	
-		end source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
-		end target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
+		end occurrence source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
+		end occurrence target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
 	}
 	
 	abstract message flowConnections: FlowConnection[0..*] nonunique :> messageConnections, flowTransfers {
@@ -134,8 +134,8 @@ standard library package Connections {
 		 * and target input.
 		 */
 	
-		end source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
-		end target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
+		end occurrence source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
+		end occurrence target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
 	}
 	
 	abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, flowTransfersBefore {
@@ -144,7 +144,7 @@ standard library package Connections {
 		 * successionFlowConnections is the base feature of all SuccessionFlowConnectionUsages.
 		 */
 	
-		end source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
-		end target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
+		end occurrence source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
+		end occurrence target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
 	}
 }

--- a/sysml/src/examples/Arrowhead Framework Example/AHFNorwayTopics.sysml
+++ b/sysml/src/examples/Arrowhead Framework Example/AHFNorwayTopics.sysml
@@ -19,13 +19,13 @@ package AHFNorway {
 	#servicedd port def APIS_DD :> APISService {
 		doc /* Service design description with nested protocol-specific ports */	
 
-		#idd APIS_HTTP {
+		#idd port APIS_HTTP {
 			// the asynch implementation of synchronous remote calls
 			out cll:CallGiveItems;
 			in retrn:ResultGiveItems;
 		}
 		
-		#idd APIS_MQTT  {
+		#idd port APIS_MQTT  {
 			// GetAllItems functionality
 			out pub:Publish;
 			out retall:Return_AllItems;
@@ -57,7 +57,7 @@ package AHFNorway {
 			// Call apisp::APIS_HTTP::giveItems(in allitems: String = "All the items", out ackback:Boolean);
 			
 			state TellUbehavior{
-				entry send CallGiveItems("All the items") to apisp.APIS_HTTP;
+				entry send CallGiveItems("All the items") via apisp.APIS_HTTP;
 				then Wait;
 				state Wait;
 					accept rs:ResultGiveItems
@@ -81,13 +81,13 @@ package AHFNorway {
 			 {  in itms:String; out ack:Boolean;
 			 	/* Forward itms and return an ack */
 			 	first start;
-			 	then send Return_AllItems(itms) to apisc.APIS_MQTT;
+			 	then send Return_AllItems(itms) via apisc.APIS_MQTT;
 			 	success = true;
 			 	bind ack = success;
 			 }
 			
 			state APISPbehavior{
-				entry send Publish("Return_AllItems") to apisc.APIS_MQTT;
+				entry send Publish("Return_AllItems") via apisc.APIS_MQTT;
 				then WaitOnData; 
 				
 				state WaitOnData;
@@ -95,7 +95,7 @@ package AHFNorway {
 					do action {
 						first start;
 						then action giveItems{ in itms=cl.itms; out ack=x; }
-						then send ResultGiveItems(x) to tellu.APIS_HTTP;
+						then send ResultGiveItems(x) via tellu.APIS_HTTP;
 					}
 				then WaitOnData;				
 			}
@@ -110,7 +110,7 @@ package AHFNorway {
 			
 			// Now sending signal to the remote behavior through the port functionality
 			state MQTT_APISP {
-				entry send Subscribe("Return_AllItems") to apisp.APIS_MQTT; 
+				entry send Subscribe("Return_AllItems") via apisp.APIS_MQTT; 
 				then Idle;		
 				state Idle;
 					accept Return_AllItems via apisp.APIS_MQTT
@@ -138,7 +138,7 @@ package AHFNorway {
  				
  				state Idle;
  					accept retrnall:Return_AllItems via getTopic.APIS_MQTT
- 					do send retrnall to giveTopic.APIS_MQTT
+ 					do send retrnall via giveTopic.APIS_MQTT
  				then Idle;
  			} 			
  		}

--- a/sysml/src/examples/Simple Tests/ConnectionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConnectionTest.sysml
@@ -38,8 +38,8 @@ package ConnectionTest {
 	}
 	
 	flow def F {
-		end p : P;
-		end q;
+		end f_p : P;
+		end f_q;
 	}
 	
 	message : F from p to p;

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
@@ -1501,10 +1501,10 @@ package SimpleVehicleModel{
                         }
                     }
                 }
-                // varaition point based on variation of part definition
-                variation part transmissionChoices:TransmissionChoices;
+                // variation point based on variation of part definition
+                part transmissionChoices:TransmissionChoices;
                 // optional variation point
-                variation part sunroof:Sunroof;
+                part sunroof:Sunroof[0..1];
                 // selection constraint
                 assert constraint selectionConstraint{
                     (engine==engine::engine4Cyl and transmissionChoices==TransmissionChoices::transmissionManual) xor

--- a/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
+++ b/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
@@ -162,23 +162,23 @@ package '14c-Language-Extensions' {
 
 			#prevention connect 'battery depleted' to req1;
 			
-			#cause 'battery depleted' {
+			#cause occurrence 'battery depleted' {
 				:>> occurs = 0.005;
 			}
 			
 			#causation first 'battery depleted' then 'battery cannot be charged';
 			
-			#failure 'battery cannot be charged' {
+			#failure occurrence 'battery cannot be charged' {
 				:>> detected = 0.013;
 			}
 			
 			#causation first 'battery cannot be charged' then 'glucose level undetected';
 			
-			#effect 'glucose level undetected';
+			#effect occurrence 'glucose level undetected';
 			
 			#causation first 'glucose level undetected' then 'therapy delay';
 			
-			#effect 'therapy delay' {
+			#effect occurrence 'therapy delay' {
 				:>> severity = "High";
 			}
 


### PR DESCRIPTION
This pull request implements validation constraints that are in the [SysML 2.0 Beta 1](https://www.omg.org/spec/SysML/2.0/Beta1/Language/PDF) abstract syntax, but which were not previously implemented in the pilot implementation. In addition, the `org.omg.sysml.xtext.SysMLValidator.xtend` class has been reorganized so that there is one check method per metclass, with each validation constraint for the metaclass checked within that method. Further, the normative constraint names are now used as the error codes for the corresponding validation checks.

The following newly implemented constraints could potentially result in errors being flagged in models where they had not been before.

1. `validateDefinitionVariationSpecialization`
2. `validateUsageVariationSpecialization`
3. `validateEventOccurrenceUsageReference`
4. `validateOccurrenceUsageIndividualDefinition`
5. `validatePortDefinitionOwnedUsagesNotComposite`
6. `validatePortUsageNestedUsagesNotComposite`
7. `validatePerformActionUsageReference`
8. `validateTransitionFeatureMembershipGuardExpression`
9. `validateRequirementDefinitionSubjectParameterPosition`
10. `validateRequirementUsageSubjectParameterPosition`
11. `validateCaseDefinitionSubjectParameterPosition`
12. `validateCaseUsageSubjectParameterPosition`

The following constraints are automatically satisfied by models parsed from the textual notation. However, they have been implemented anyway, because it is possible that they might be violated due to modifications made directly on the abstract syntax representation of a model.

13. `validateOccurrenceDefinitionLifeClass`
14. `validatePortDefinitionConjugatedPortDefinition`
15. `validateConjugatedPortDefinitionConjugatedPortDefinition`
16. `validateConjugatedPortDefinitionOriginalPortDefinition`
17. `validateAcceptActionUsageParameters`
18. `validateControlNodeOwningType`
19. `validateSendActionUsageParameters`
20. `validateStateSubactionMembershipOwningType`
21. `validateTransitionFeatureMembershipEffectAction`
22. `validateTransitionFeatureMembershipTriggerAction`
23. `validateTransitionFeatureMembershipOwningType`
24. `validateTransitionUsageParameters`
25. `validateTransitionUsageSuccession`
26. `validateActorMembershipOwningType`
27. `validateFramedConcernMembershipConstraintKind`
28. `validateRequirementConstraintMembershipIsComposite`
29. `validateRequirementConstraintMembershipOwningType`
30. `validateSubjectMembershipOwningType`
31. `validateObjectiveIsComposite`
32. `validateObjectiveMembershipOwningType`
33. `validateRequirementVerificationMembershipOwningType`
34. `validateExposeOwningNamespace`
35. `validateViewRenderingMembershipOwningType`

The following constraints have _not_ been implemented, either for implementation reasons or because there are outstanding specification issues related to them.

36. `validateDefinitionNonVariationMembership` (see [SYSML2-300](https://issues.omg.org/issues/task-force/SYSML2#issue-51636))
37. `validateUsageNonVariationMembership` (see [SYSML2-300](https://issues.omg.org/issues/task-force/SYSML2#issue-51636))
38. `validateUsageOwningType` (see [SYSML2-301)](https://issues.omg.org/issues/task-force/SYSML2#issue-51637)
39. `validateAttributeDefinitionFeatures` (pending [KERML-4](https://issues.omg.org/issues/task-force/KERML#issue-50970))
40. `validateAttributeUsageFeatures` (pending [KERML-4](https://issues.omg.org/issues/task-force/KERML#issue-50970))
41. `validateControlNodeIncomingSuccessions`
42. `validateControlNodeOutgoingSuccessions`
43. `validateDecisionNodeIncomingSuccessions`
44. `validateDecisionNodeOutgoingSuccessions`
45. `validateForkNodeIncomingSuccessions`
46. `validateJoinNodeOutgoingSuccessions`
47. `validateMergeNodeIncomingSuccessions`
48. `validateMergeNodeOutgoingSuccessions`
49. `validateStateDefinitionIsParallelGeneralization` (see [SYSML2-306](https://issues.omg.org/issues/task-force/SYSML2#issue-51654))
50. `validateStateUsageIsParallelGeneralization` (see [SYSML2-306](https://issues.omg.org/issues/task-force/SYSML2#issue-51654))

There are also validation checks that are implemented in the pilot implementation but are not currently in the Beta 1 specification. Certain of these have been proposed to the SysML v2 Finalization Task Force for inclusion in the final specification (see [SYSML2-28](https://issues.omg.org/issues/task-force/SYSML2#issue-51047)). They are identified in the validator code with `TODO: Add...` comments (meaning to be "added" to the specification).

The PR also includes the following changes necessary to avoid problems with the new validations:

1. Updated `LifeClassImpl` so `isSufficient()` always returns true.
2. Updated `UsageAdapter` to add a subject parameter as the first, rather than last, parameter.
3. In the standard library model `Connections`, updated the end features of `MessageConnection`, `FlowConnection` and `SuccessionFlowConnection` to be occurrence usages (see also [SYSML2-305](https://issues.omg.org/issues/task-force/SYSML2#issue-51653)).