### PR TITLE
ST6RI 695/696 Integer division and unary Real operator evaluation are implemented incorrectly

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -224,15 +224,18 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 	
 	@Test
 	public void testIntegerEvaluation() throws Exception {
-		assertEquals(5, evaluateIntegerValue(null, null, "2 + 3"));
+		assertEquals(2, evaluateIntegerValue(null, null, "+2"));
+		assertEquals(-2, evaluateIntegerValue(null, null, "-2"));
 		assertEquals(-1, evaluateIntegerValue(null, null, "2 - 3"));
 		assertEquals(6, evaluateIntegerValue(null, null, "2 * 3"));
-		assertEquals(0, evaluateIntegerValue(null, null, "2 / 3"));
-		assertEquals(2, evaluateIntegerValue(null, null, "2 % 3"));
+		assertEquals(2, evaluateIntegerValue(null, null, "2 % 3"));		
+		assertEquals(2.0/3.0d, evaluateRealValue(null, null, "2 / 3"), 0);
 	}
 	
 	@Test
 	public void testRealEvaluation() throws Exception {
+		assertEquals(2.0d, evaluateRealValue(null, null, "+2.0"), 0);
+		assertEquals(-2.0d, evaluateRealValue(null, null, "-2.0"), 0);
 		assertEquals(2.0d + 3.0d, evaluateRealValue(null, null, "2.0 + 3"), 0);
 		assertEquals(2.0d - 3.0d, evaluateRealValue(null, null, "2.0 - 3"), 0);
 		assertEquals(2.0d * 3.0d, evaluateRealValue(null, null, "2.0 * 3"), 0);

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ArithmeticFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ArithmeticFunction.java
@@ -60,7 +60,7 @@ public abstract class ArithmeticFunction implements LibraryFunction {
 		Object y = EvaluationUtil.valueOf(evaluator.argumentValue(invocation, 1, target));
 		return EvaluationUtil.numberOfArgs(invocation) == 1?
 					x instanceof Integer? unaryIntegerOp((Integer)x):
-					x instanceof Double? unaryRealOp((Integer)y):
+					x instanceof Double? unaryRealOp((Double)x):
 					EvaluationUtil.nullList():
 			   x instanceof Integer && y instanceof Integer? binaryIntegerOp((Integer)x, (Integer)y):
 			   x instanceof Double && y instanceof Integer? binaryRealOp((Double)x, (Integer)y):

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/DivideFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/DivideFunction.java
@@ -34,7 +34,7 @@ public class DivideFunction extends ArithmeticFunction {
 	
 	@Override
 	protected EList<Element> binaryIntegerOp(int x, int y) {
-		return y == 0? EvaluationUtil.nullList(): EvaluationUtil.integerResult(x / y);
+		return binaryRealOp(x, y);
 	}
 	
 	@Override


### PR DESCRIPTION
This pull request fixes two bugs in the evaluation of model-level evaluable expressions:

1. _ST6RI-695 Integer division is implemented incorrectly._ The `org.omg.sysml.expressions.functions.DivideFunction` class implemented the division of two integers using truncating Java integer division. However, the KerML `IntegerFunctions::'/'` function returns a `Rational` number is intended to not be truncating.
2. _ST6RI-696 Unary Real operator evaluation is implemented incorrectly._ The `org.omg.sysml.expressions.functions.ArithmeticFunction::invoke` made the call `unaryRealOp((Integer)y)` to evaluate a unary `Real` operator. This should instead have been `unaryRealOp((Double)x)`.