### PR TITLE
ST6RI 690/692/694 Various derivation implementations are incorrect

### DIFF
--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -461,7 +461,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 		}
 
 		val relatedFeatures = c.relatedFeature				
-		val connectorEnds = c.connectorEnd
+		val connectorEnds = TypeUtil.getOwnedEndFeaturesOf(c)
 		for (var i = 0; i < relatedFeatures.size; i++) {
 			val relatedFeature = relatedFeatures.get(i)
 			if (!(relatedFeature.featuringType.empty || 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
  * Copyright (c) 2020-2023 Mgnite Inc.
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -68,6 +68,7 @@ import org.omg.sysml.lang.sysml.TransitionUsage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.lang.sysml.VariantMembership;
+import org.omg.sysml.util.TypeUtil;
 
 public class VCompartment extends VStructure {
     private List<VTree> subtrees = new ArrayList<VTree>();
@@ -373,7 +374,7 @@ public class VCompartment extends VStructure {
     private void addConnectorText(Connector c, boolean isInherited) {
         boolean hasPrefix = false;
         hasPrefix = addFeatureText(c, isInherited);
-        List<Feature> ends = c.getConnectorEnd();
+        List<Feature> ends = TypeUtil.getOwnedEndFeaturesOf(c);
         if (ends.size() == 2) {
             Feature f1 = ends.get(0);
             Feature f2 = ends.get(1);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
@@ -1,6 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
  * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,6 +20,7 @@
  * 
  * Contributors:
  *  Hisashi Miyashita, Mgnite Inc.
+ *  Ed Seidewitz, MDS
  * 
  *****************************************************************************/
 
@@ -40,6 +42,7 @@ import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.plantuml.SysML2PlantUMLStyle.StyleStereotypeSwitch;
 import org.omg.sysml.plantuml.SysML2PlantUMLStyle.StyleSwitch;
+import org.omg.sysml.util.TypeUtil;
 
 public class VComposite extends VMixed {
     private static final SysML2PlantUMLStyle style
@@ -118,7 +121,7 @@ public class VComposite extends VMixed {
             Type t = f.getOwningType();
             if (t instanceof Connector) {
                 Connector c = (Connector) t;
-                List<Feature> fs = c.getConnectorEnd();
+                List<Feature> fs = TypeUtil.getOwnedEndFeaturesOf(c);
                 /* 
                    Currently we regard the first connector end as a source end, but it might be changed.
                    We can check it by extracting the sources of the relationship, but it does not work with ItemFlowEnd

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
  * Copyright (c) 2020-2022 Mgnite Inc.
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -56,6 +56,7 @@ import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.util.TypeUtil;
 
 public class VDefault extends VTraverser {
     protected Element getEnd(Feature f) {
@@ -78,7 +79,7 @@ public class VDefault extends VTraverser {
     }
 
     private void addConnector(Connector c, String desc) {
-        List<Feature> ends = c.getConnectorEnd();
+        List<Feature> ends = TypeUtil.getOwnedEndFeaturesOf(c);
         int size = ends.size();
         if (size >= 2) {
             Element end1 = getEnd(ends.get(0));

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -48,6 +48,7 @@ import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.TypeUtil;
 
 public class VPath extends VTraverser {
     private boolean initialized;
@@ -605,7 +606,7 @@ public class VPath extends VTraverser {
     public String caseConnector(Connector c) {
         /* VTraverser.traverse() do not duplicatedly traverse features already visited.
            Thus VPath visits ends without counting on traverse(). */
-        for (Feature f: c.getConnectorEnd()) {
+        for (Feature f: TypeUtil.getOwnedEndFeaturesOf(c)) {
             visit(f);
         }
         return "";

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
@@ -23,6 +23,7 @@ package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.util.ConnectorUtil;
+import org.omg.sysml.util.TypeUtil;
 
 public class ConnectionUsageAdapter extends PartUsageAdapter {
 
@@ -37,7 +38,8 @@ public class ConnectionUsageAdapter extends PartUsageAdapter {
 
 	@Override
 	protected String getDefaultSupertype() {
-		return getTarget().getConnectorEnd().size() != 2? 
+		int numEnds = TypeUtil.getOwnedEndFeaturesOf(getTarget()).size();
+		return numEnds != 2? 
 				getDefaultSupertype("base"):
 				getDefaultSupertype("binary");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectorAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectorAdapter.java
@@ -43,11 +43,12 @@ public class ConnectorAdapter extends FeatureAdapter {
 	@Override
 	protected String getDefaultSupertype() {
 		Connector target = getTarget();
+		int numEnds = TypeUtil.getOwnedEndFeaturesOf(target).size();
 		return hasStructureType()?
-				target.getConnectorEnd().size() != 2? 
+				numEnds != 2? 
 					getDefaultSupertype("object"):
 					getDefaultSupertype("binaryObject"):
-				target.getConnectorEnd().size() != 2? 
+				numEnds != 2? 
 					getDefaultSupertype("base"):
 					getDefaultSupertype("binary");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/delegate/AssignmentActionUsage_referent_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/AssignmentActionUsage_referent_SettingDelegate.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -27,7 +28,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Membership;
-import org.omg.sysml.util.FeatureUtil;
+import org.omg.sysml.lang.sysml.OwningMembership;
 
 public class AssignmentActionUsage_referent_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -38,8 +39,9 @@ public class AssignmentActionUsage_referent_SettingDelegate extends BasicDerived
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
 		return (Feature) ((AssignmentActionUsage)owner).getOwnedMembership().stream().
+				filter(m->!(m instanceof OwningMembership)).
 				map(Membership::getMemberElement).
-				filter(e->e instanceof Feature && !FeatureUtil.isParameter((Feature)e)).
+				filter(Feature.class::isInstance).
 				findFirst().orElse(null);
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/Connector_connectorEnd_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/Connector_connectorEnd_SettingDelegate.java
@@ -22,24 +22,12 @@
 
 package org.omg.sysml.delegate;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.Connector;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.util.NonNotifyingEObjectEList;
 
-public class Connector_connectorEnd_SettingDelegate extends BasicDerivedListSettingDelegate {
+public class Connector_connectorEnd_SettingDelegate extends Type_endFeature_SettingDelegate {
 
 	public Connector_connectorEnd_SettingDelegate(EStructuralFeature eStructuralFeature) {
 		super(eStructuralFeature);
-	}
-
-	@Override
-	protected EList<? extends Feature> basicGet(InternalEObject owner) {
-		EList<Feature> connectorEnds = new NonNotifyingEObjectEList<>(Feature.class, owner, eStructuralFeature.getFeatureID());
-		((Connector)owner).getOwnedFeature().stream().filter(Feature::isEnd).forEachOrdered(connectorEnds::add);
-		return connectorEnds;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/IfActionUsage_ifArgument_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/IfActionUsage_ifArgument_SettingDelegate.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,15 +22,12 @@
 
 package org.omg.sysml.delegate;
 
-import java.util.List;
-
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.IfActionUsage;
-import org.omg.sysml.util.FeatureUtil;
-import org.omg.sysml.util.TypeUtil;
 
 public class IfActionUsage_ifArgument_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -39,8 +37,8 @@ public class IfActionUsage_ifArgument_SettingDelegate extends BasicDerivedObject
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		List<Feature> parameters = TypeUtil.getOwnedParametersOf((IfActionUsage)owner);
-		return parameters.isEmpty()? null: FeatureUtil.getValueExpressionFor(parameters.get(0));
+		Feature parameter = ((IfActionUsage)owner).inputParameter(1);
+		return parameter != null && parameter instanceof Expression? (Expression)parameter: null;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
@@ -122,15 +122,13 @@ public class ConnectorUtil {
 	
 	public static Feature getSourceFeatureOf(Connector connector) {
 		EList<Feature> relatedFeatures = connector.getRelatedFeature();
-		return relatedFeatures.size() == 2? relatedFeatures.get(0): null;
+		return relatedFeatures.isEmpty()? null: relatedFeatures.get(0);
 	}
 
 	public static void addTargetFeatures(Connector connector, EList<Feature> targetFeatures) {
 		EList<Feature> relatedFeatures = connector.getRelatedFeature();
-		if (relatedFeatures.size() == 2) {
-			targetFeatures.add(relatedFeatures.get(1));
-		} else {
-			targetFeatures.addAll(relatedFeatures);
+		if (relatedFeatures.size() >= 2) {
+			targetFeatures.addAll(relatedFeatures.subList(1, relatedFeatures.size()));
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -458,16 +458,14 @@ public class TypeUtil {
 	// Associations
 
 	public static Type getSourceTypeOf(Association association) {
-		EList<Type> relatedType = association.getRelatedType();
-		return relatedType.size() == 2? relatedType.get(0): null;
+		EList<Type> relatedTypes = association.getRelatedType();
+		return relatedTypes.isEmpty()? null: relatedTypes.get(0);
 	}
 
 	public static void addTargetTypes(Association association, EList<Type> targetTypes) {
 		EList<Type> relatedTypes = association.getRelatedType();
-		if (relatedTypes.size() == 2) {
-			targetTypes.add(relatedTypes.get(1));
-		} else {
-			targetTypes.addAll(relatedTypes);
+		if (relatedTypes.size() >= 2) {
+			targetTypes.addAll(relatedTypes.subList(1, relatedTypes.size()));
 		}
 	}
 	


### PR DESCRIPTION
This pull request fixes bugs in the implementation of several derived property computations.

1. _ST6RI-690 Connector::connectorEnd implementation is incorrect._ The KerML specification defines the derivation for `Type::endFeature` to be all `features` of a `Type` that have `isEnd = true`. The property `Connector::connectorEnd` redefines `endFeature` and inherits the same derivation. This was implemented correctly in `Type_endFeature_SettingDelegate`, but `Connector_connectorEnd_SettingDelegate` had a separate derivation that only returned owned end features.
2. _ST6RI-692 AssignmentActionUsage_referent_SettingDelegate is incorrect._ The implementation in this setting delegate presumed that the `referent` of an `AssignmentActionUsage` would be the first non-parameter member of the action. This is different than the definition in the SysML specifiation (which is that the `referent` is the first `Feature` that is the `memberElement` of an `ownedMembership` that is not an `OwningMembership`), and it did not work properly when the `referent` was a parameter of a containing action rather than the `AssignmentActionUsage` itself.
3. _ST6RI-694 Derivations of sourceType, targetType, sourceFeature and targetFeature are incorrect.` The utility methods `TypeUtil::getSourceTypeOf`, `TypeUtil::addTargetTypes`, `ConnectorUtil::getSourceFeatureOf` and `ConnectorUtil::addTargetFeatures` did not correctly implement the derivations in the specification of `Association::sourceType/targetType` and `Connector::sourceFeature/targetFeature`.

The PR also changes existing calls in the code of `Connector::getConnectorEnd` to `TypeUtil::getOwnedEndFeatureOf`, so that they produce functionally the same result as before the change to `getConnectorEnd` as described in item 1 above.