### PR TITLE
ST6RI-698 Implicit specializations not added when there are circular owned specializations

### DIFF
--- a/kerml/src/examples/Simple Tests/Circular.kerml
+++ b/kerml/src/examples/Simple Tests/Circular.kerml
@@ -5,4 +5,8 @@ package Circular {
 	package P {
 		import Circular::*;
 	}
+	
+	feature x :> z;
+	feature y :> x;
+	feature z :> y;
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_CircularReferences.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_CircularReferences.kerml.xt
@@ -26,10 +26,7 @@ package Test {
 			import Circular::*;
 		}
 		
-		// XPECT errors ---> "Must directly or indirectly specialize Base::Anything" at "classifier B :> B;"
-		classifier B :> B;
-		
-		// XPECT errors ---> "Features must have at least one type" at "feature b :> b;"
+		classifier B :> B;		
 		feature b :> b;
 		
 		// XPECT errors ---> "Must directly or indirectly specialize Base::Anything" at "classifier C ~ C;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
@@ -50,4 +50,10 @@ package PartTest {
 		alias z2 for y;
 	}
 	
+    part p1 :> p2;
+    part p2 :> p3; 
+    part p3 :> p1;
+    
+    part p4 :> p4;
+	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -25,8 +25,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -201,15 +203,20 @@ public class TypeAdapter extends NamespaceAdapter {
 	public void removeUnnecessaryImplicitGeneralTypes() {
 		Type target = getTarget();
 		List<Type> generals = target.getOwnedSpecialization().stream().
-				filter(spec->spec.getSpecific() == target).
+				filter(spec->spec.getSpecific() == target && spec.getGeneral() != target).
 				map(Specialization::getGeneral).
 				collect(Collectors.toList());
 		implicitGeneralTypes.values().forEach(generals::addAll);
+		Set<Type> visited = new HashSet<>();
+		visited.add(target);
 		for (Object eClass: implicitGeneralTypes.keySet().toArray()) {
 			if (eClass != SysMLPackage.eINSTANCE.getRedefinition()) {
 				List<Type> implicitGenerals = implicitGeneralTypes.get(eClass);
 				implicitGenerals.removeIf(gen->
-					generals.stream().anyMatch(type->type != gen && TypeUtil.conforms(type, gen)));
+					// NOTE: Treat target as already having been visited when checking conformance,
+					// to allow for the possibility of circular specialization. Otherwise, implicit
+					// specializations get removed from all types in the circle.
+					generals.stream().anyMatch(type->type != gen && TypeUtil.conforms(type, gen, visited)));
 				if (implicitGenerals.isEmpty()) {
 					implicitGeneralTypes.remove(eClass);
 				}

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -121,7 +121,7 @@ public class TypeUtil {
 	}
 	
 	// Note: Generalizations are allowed to be cyclic.
-	protected static boolean conforms(Type subtype, Type supertype, Set<Type> visited) {
+	public static boolean conforms(Type subtype, Type supertype, Set<Type> visited) {
 		if (subtype == supertype) {
 			return true;
 		} else if (subtype != null) {

--- a/sysml/src/examples/Simple Tests/PartTest.sysml
+++ b/sysml/src/examples/Simple Tests/PartTest.sysml
@@ -30,4 +30,10 @@ package PartTest {
 		alias z2 for y;
 	}
 	
+    part p1 :> p2;
+    part p2 :> p3; 
+    part p3 :> p1;
+    
+    part p4 :> p4;
+	
 }


### PR DESCRIPTION
Corrects the `TypeAdapter::removeUnnecessaryImplicitGeneralTypes` method so that it does not remove implicit specializations from types that are part of a chain of circular owned specializations. Declarations such as the following no longer produce errors:
```
part def A :> A;

part def B :> C;
part def C :> B;
```
In the case of a circle of two or more types, the implicit specialization is added to the lexically last one processed (e.g., `C` in the example above), though it would also have been legal to add the implicit specialization to any or all of the types in the circle.