### PR TITLE
ST6RI-699 Problem with the setting of the source feature of the transitionLink of a TransitionUsage

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowConnectionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowConnectionUsageAdapter.java
@@ -27,6 +27,7 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FlowConnectionUsage;
 import org.omg.sysml.util.ConnectorUtil;
 import org.omg.sysml.util.TypeUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class FlowConnectionUsageAdapter extends ConnectionUsageAdapter {
 
@@ -58,7 +59,7 @@ public class FlowConnectionUsageAdapter extends ConnectionUsageAdapter {
 	
 	@Override
 	protected String getDefaultSupertype() {
-		return getTarget().getOwnedFeature().stream().noneMatch(Feature::isEnd)?
+		return UsageUtil.isMessageConnection(getTarget())?
 				getDefaultSupertype("message"):
 				getDefaultSupertype("base");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -32,7 +32,6 @@ import org.omg.sysml.lang.sysml.Succession;
 import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.TransitionUsage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.util.ElementUtil;
 import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
@@ -79,11 +78,10 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 			transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
 			TypeUtil.addOwnedFeatureTo(transition, transitionLinkFeature);			
 			Succession succession = transition.getSuccession();
-			ElementUtil.transform(succession);
 			addBindingConnector(succession, transitionLinkFeature);			
 			List<Feature> parameters = TypeUtil.getOwnedParametersOf(transition);
 			if (!parameters.isEmpty()) {
-				Feature source = succession.getSourceFeature();
+				Feature source = transition.getSource();
 				if (source != null) {
 					addBindingConnector(source, parameters.get(0));
 				}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -26,6 +26,8 @@ import java.util.List;
 import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.StateDefinition;
 import org.omg.sysml.lang.sysml.StateUsage;
 import org.omg.sysml.lang.sysml.Succession;
@@ -71,6 +73,17 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	
 	// Transformation
 	
+	protected void computeSource() {
+		TransitionUsage target = getTarget();
+		List<Membership> ownedMemberships = target.getOwnedMembership();
+		if (ownedMemberships.isEmpty() || ownedMemberships.get(0) instanceof OwningMembership) {
+			Feature source = UsageUtil.getPreviousFeature(target);
+			Membership membership = SysMLFactory.eINSTANCE.createMembership();
+			membership.setMemberElement(source);
+			target.getOwnedRelationship().add(0, membership);
+		}
+	}
+	
 	protected Feature computeTransitionLinkConnectors() {
 		TransitionUsage transition = getTarget();
 		Feature transitionLinkFeature = UsageUtil.getTransitionLinkFeatureOf(transition);
@@ -92,7 +105,9 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	
 	@Override
 	public void doTransform() {
-		// Note: Needs to come first, before clearing and recomputation of inheritance cache.
+		// Note: Needs to come before computeTransitionLinkConnectors.
+		computeSource();
+		// Note: Needs to come before clearing and recomputation of inheritance cache.
 		computeTransitionLinkConnectors();		
 		super.doTransform();
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -224,7 +224,7 @@ public class TypeAdapter extends NamespaceAdapter {
 		}
 		
 		// Disallow adding more implicit general types once unnecessary ones have been removed.
-		isAddImplicitGeneralTypes = false;
+		setIsAddImplicitGeneralTypes(false);
 	}
 	
 	// Implicit Specialization Computation

--- a/org.omg.sysml/src/org/omg/sysml/delegate/TransitionUsage_source_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/TransitionUsage_source_SettingDelegate.java
@@ -29,9 +29,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Membership;
-import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.TransitionUsage;
-import org.omg.sysml.util.UsageUtil;
 
 public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -45,13 +43,8 @@ public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSe
 		if (ownedMemberships.isEmpty()) {
 			return null;
 		} else {
-			Membership membership = ownedMemberships.get(0);
-			if (membership instanceof OwningMembership) {
-				return UsageUtil.getPreviousFeature((TransitionUsage)owner);
-			} else {
-				Element member = membership.getMemberElement();
-				return member instanceof ActionUsage? (ActionUsage)member: null;
-			}
+			Element member = ownedMemberships.get(0).getMemberElement();
+			return member instanceof ActionUsage? (ActionUsage)member: null;
 		}
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/TransitionUsage_source_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/TransitionUsage_source_SettingDelegate.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
+ * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,9 +27,11 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.ActionUsage;
-import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.TransitionUsage;
-import org.omg.sysml.util.FeatureUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -38,12 +41,17 @@ public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSe
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		EList<Feature> relatedFeatures = ((TransitionUsage)owner).getSuccession().getRelatedFeature();
-		if (relatedFeatures.isEmpty()) {
+		EList<Membership> ownedMemberships = ((TransitionUsage)owner).getOwnedMembership();
+		if (ownedMemberships.isEmpty()) {
 			return null;
 		} else {
-			Feature source = FeatureUtil.getBasicFeatureOf(relatedFeatures.get(0));
-			return source instanceof ActionUsage? (ActionUsage)source: null;
+			Membership membership = ownedMemberships.get(0);
+			if (membership instanceof OwningMembership) {
+				return UsageUtil.getPreviousFeature((TransitionUsage)owner);
+			} else {
+				Element member = membership.getMemberElement();
+				return member instanceof ActionUsage? (ActionUsage)member: null;
+			}
 		}
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -94,7 +94,7 @@ public class FeatureUtil {
 		} else {
 			return feature.directionFor(owningType);
 		}
-	}
+	}	
 	
 	// Typing
 	


### PR DESCRIPTION
This pull request includes the following changes:

1. Revises the computation of `TransitionUsage::source` to be consistent with the specification: "The <code>source</code> of a <code>TransitionUsage</code> is given by the <code>memberElement</code> of its first <code>ownedMembership</code>, which must be an <code>ActionUsage</code>." (Previously it had been implemented as the `sourceFeature` of the `succession` of the `TransitionUsage`.)
2. Revises `SuccessionAsUsageAdapter::addSourceEnd` to always set the `sourceFeature` of the `succession` of a `TransitionUsage` to the `source` of the `TransitionUsage`.
3. Adds a `computeSource` transformation to `TransitionUsageAdapter`, which physically adds an alias `Membership` to the "previous feature" of a `TransitionUsage`, so that this becomes its `source` if one has not been parsed explicitly.
4. Moves the `getPreviousFeature` method to `UsageUtil` and:
    * simplifies it to only search within the immediately owning `Namespace`
    * removes the allowance for a non-action `ItemFlow` as a previous feature
    * allows a `FlowConnectionUsage` that is a message connection to be a previous feature

As a result, warnings are no longer generated when the **`then`** succession shorthand is used on a message connection or when a "conditional succession" (parsed as a `TransitionUsage`) is used between message connections.