### PR TITLE
ST6RI-681 Add %help command to Jupyter

### DIFF
--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractive.java
@@ -222,6 +222,24 @@ public class SysMLInteractive extends SysMLUtil {
 		}
 	}
 	
+	public String help(String command, List<String> help) {
+		this.counter++;
+		if (Strings.isNullOrEmpty(command)) {
+			return help.isEmpty()? SysMLInteractiveHelp.getGeneralHelp(): SysMLInteractiveHelp.getHelpHelp();
+		}
+		if (!command.startsWith("%")) {
+			command = "%" + command;
+		}
+		String helpString = SysMLInteractiveHelp.getHelpString(command);
+		return helpString == null? SysMLInteractiveHelp.getGeneralHelp(): helpString;
+	}
+	
+	public String help(String command) {
+		return "-h".equals(command)? 
+				help(null, Collections.singletonList("true")):
+				help(command, Collections.emptyList());
+	}
+	
 	public String eval(String input, String targetName, List<String> help) {
 		if (Strings.isNullOrEmpty(input)) {
 			this.counter++;
@@ -562,6 +580,8 @@ public class SysMLInteractive extends SysMLUtil {
 							
 							if ("%exit".equals(command)) {
 								break;
+							} else if ("%help".equals(command)) {
+								System.out.print(this.help(argument));
 							} else if ("%list".equals(command)) {
 								System.out.print(this.list(argument));
 							} else if ("%show".equals(command)) {

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveHelp.java
@@ -28,14 +28,34 @@
 
 package org.omg.sysml.interactive;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.omg.sysml.plantuml.SysML2PlantUMLStyle;
 
 public class SysMLInteractiveHelp {
 	
+	private static final String GENERAL_HELP_STRING =
+			  "The following SysML v2 magic commands are available.\n"
+			+ "For help on a specific command, use \"%help <COMMAND>\" or \"%<cmd> -h\".\n\n"
+			+ "%eval\t\tEvaluate a given expression.\n"
+			+ "%export\t\tSave a file of the JSON representation of the abstract syntax tree rooted in the named element.\n"
+			+ "%help\t\tGet a list of available commands or help on a specific command\n"
+			+ "%list\t\tList loaded library packages or the results of a given query\n"
+			+ "%show\t\tPrint the abstract syntax tree rooted in a named element\n"
+			+ "%publish\tPublish to the repository the modele elements rooted in a named element\n"
+			+ "%view\t\tRender the view specified by the named view usage\n"
+			+ "%viz\t\tVisualize the name model elements\n";
+	
+	private static final String HELP_HELP_STRING =
+			  "Usage: %help [<COMMAND>]\n\n"
+			+ "Print help information on the named SysML v2 magic <COMMAND>.\n"
+			+ "If no <COMMAND> is given, then list the available commands.\n";
+	
 	private static final String EVAL_HELP_STRING =
 			  "Usage: %eval [--target=<NAME>] <EXPR>\n\n"
 			+ "Print the results of evaluating <EXPR> on the target given by <NAME>, which must be fully qualified.\n"
-			+ "If a target is not given, then evaluate <EXPR> in global scope.";
+			+ "If a target is not given, then evaluate <EXPR> in global scope.\n";
 
 	private static final String LIST_HELP_STRING =
 			  "Usage: %list [<QUERY>]\n\n"
@@ -96,6 +116,14 @@ public class SysMLInteractiveHelp {
 			+ "Save a file containing the complete JSON representation of the abstract syntax tree rooted in <NAME>.\n"
 		    + "<NAME> must be fully qualified.\n";
  
+	public static String getGeneralHelp() {
+		return GENERAL_HELP_STRING;
+	}
+ 
+	public static String getHelpHelp() {
+		return HELP_HELP_STRING;
+	}
+ 
 	public static String getEvalHelp() {
 		return EVAL_HELP_STRING;
 	}
@@ -122,6 +150,25 @@ public class SysMLInteractiveHelp {
     
     public static String getExportHelp() {
     	return EXPORT_HELP_STRING;
+    }
+    
+    private static Map<String, String> commandHelpMap = createCommandHelpMap();
+    
+    private static Map<String, String> createCommandHelpMap() {
+    	Map<String, String> map = new HashMap<>();
+    	map.put("%help", HELP_HELP_STRING);    	
+    	map.put("%eval", EVAL_HELP_STRING);    	
+    	map.put("%list", LIST_HELP_STRING);    	
+    	map.put("%show", SHOW_HELP_STRING);    	
+    	map.put("%publish", PUBLISH_HELP_STRING);    	
+    	map.put("%viz", VIZ_HELP_STRING);    	
+    	map.put("%view", VIEW_HELP_STRING);    	
+    	map.put("%export", EXPORT_HELP_STRING);    	
+    	return map;
+    }
+    
+    public static String getHelpString(String command) {
+    	return commandHelpMap.get(command);
     }
 	
 }

--- a/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/SysMLKernel.java
+++ b/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/SysMLKernel.java
@@ -72,6 +72,7 @@ public class SysMLKernel extends BaseKernel {
         Optional.ofNullable(System.getenv(ISysML.GRAPHVIZ_PATH_KEY)).ifPresent(interactive::setGraphVizPath);
 
         this.magics = new Magics();
+        this.magics.registerMagics(Help.class);
         this.magics.registerMagics(Eval.class);
         this.magics.registerMagics(Listing.class);
         this.magics.registerMagics(Show.class);

--- a/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/magic/Help.java
+++ b/org.omg.sysml.jupyter.kernel/src/main/java/org/omg/sysml/jupyter/kernel/magic/Help.java
@@ -1,0 +1,43 @@
+/*
+ * SysML 2 Pilot Implementation
+ * Copyright (C) 2023 Model Driven Solutions, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ */
+
+package org.omg.sysml.jupyter.kernel.magic;
+
+import io.github.spencerpark.jupyter.kernel.magic.registry.LineMagic;
+import io.github.spencerpark.jupyter.kernel.magic.registry.MagicsArgs;
+import org.omg.sysml.jupyter.kernel.ISysML;
+
+import java.util.List;
+import java.util.Map;
+
+public class Help {
+    private static final MagicsArgs SHOW_ARGS = MagicsArgs.builder().onlyKnownKeywords().onlyKnownFlags()
+    		.optional("command")
+            .flag("help", 'h', "true")
+    		.build();
+
+    @LineMagic
+    public static String help(List<String> args) {
+        Map<String, List<String>> vals = SHOW_ARGS.parse(args);
+        List<String> names = vals.get("command");
+        String name = names.isEmpty()? null: names.get(0);
+        List<String> help = vals.get("help");
+        return ISysML.getKernelInstance().getInteractive().help(name, help);
+    }
+}


### PR DESCRIPTION
This pull request adds a new `%help` command to the Jupyter SysML v2 kernel. Without an argument, this command prints a list of all available magic commands (this its particularly useful new capability). If given a command name (with or without the initial `%`) as its argument, it prints the help information for that command (i.e., `%help`_`cmd`_ produces the same result as _`%cmd`_` -h`.