### PR TITLE
ST6RI-699 End features inherited via feature chains are not redefined

### DIFF
--- a/kerml/src/examples/Simple Tests/Connectors.kerml
+++ b/kerml/src/examples/Simple Tests/Connectors.kerml
@@ -4,8 +4,8 @@ package Connectors {
 		feature a : A;
 		feature b : A;
 		
-		connector from a to b;
-		connector {
+		connector c1 from a to b;
+		connector c2 {
 			end feature references a;
 			end feature references b;
 		}
@@ -23,5 +23,10 @@ package Connectors {
 			end feature references a;
 			end feature references b;
 		}
+	}
+	
+	class B {
+	    feature a : A;	    
+	    connector :> a.c1 from a.a to a.b;
 	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_NestedConnectorConnectingEndsGoodCase.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ConnectorTest_NestedConnectorConnectingEndsGoodCase.kerml.xt
@@ -28,8 +28,11 @@ package test{
 			feature z;
 		}
 		
-		connector from end1 to f.z;
+		connector c from end1 to f.z;
 	}
 	
-	connector c:A from x to y;
+	connector a:A from x to y;
+	
+	// Checks that ends from connector c are redefined.
+	connector :> a.c from a.end1 to a.f.z;
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -157,7 +157,7 @@ public class TypeUtil {
 		visited.add(type);
 		List<Feature> ends = getOwnedEndFeaturesOf(type);
 		int n = ends.size();
-		for (Type general: getSupertypesOf(type)) {
+		for (Type general: getGeneralTypesOf(type)) {
 			if (general != null && !visited.contains(general)) {
 				List<Feature> inheritedEnds = getAllEndFeaturesOf(general, visited);
 				if (inheritedEnds.size() > n) {

--- a/sysml/src/examples/Flashlight Example/Flashlight Example.sysml
+++ b/sysml/src/examples/Flashlight Example/Flashlight Example.sysml
@@ -20,8 +20,8 @@ package 'Flashlight Example' {
 		}
 		
 		interface userToFlashlight connect user.onOffCmdPort to flashlight.onOffCmdPort {
-			ref flow :> illuminateRegion.onOffCmdFlow
-				from source.onOffCmd to target.onOffCmd;
+			ref flow references illuminateRegion.onOffCmdFlow
+				from source.onOffCmd to target.onOffCmd; 
 		}
 		
 		part flashlight {


### PR DESCRIPTION
The `TypeUtil::getAllEndFeaturesOf` method is used to get the owned and inherited end features of a type without processing the entire set of inherited features of the type. It used the `getSupertypesOf` method to get the supertypes of the give type, in order to recurse up the specialization tree. However, this does not account for the possibility that the given type is a feature with a feature chain, in which case ends features can be effectively inherited from the final feature in the chain. This pull request fixes the bug by changing the call of `getSupertypesOf` in `getAllEndFeaturesOf` to a call to `getGeneralTypesOf`, which treats the final feature of a feature chain as an effective general type.