### PR TITLE
ST6RI-707 Defaults are wrong for various "kind" properties

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FramedConcernMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FramedConcernMembershipImpl.java
@@ -24,6 +24,7 @@ package org.omg.sysml.lang.sysml.impl;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.omg.sysml.lang.sysml.FramedConcernMembership;
+import org.omg.sysml.lang.sysml.RequirementConstraintKind;
 import org.omg.sysml.lang.sysml.ConcernUsage;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -157,6 +158,26 @@ public class FramedConcernMembershipImpl extends RequirementConstraintMembership
 		return basicGetReferencedConcern() != null;
 	}
 
+	// Additional Overrides
+	
+	@Override
+	public RequirementConstraintKind getKind() {
+		return RequirementConstraintKind.REQUIREMENT;
+	}
+	
+	/**
+	 * <!-- begin-user-doc -->
+	 * Consider the "kind" property to never be explicitly "set". 
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		return featureID != SysMLPackage.REQUIREMENT_CONSTRAINT_MEMBERSHIP__KIND && eIsSetGen(featureID);
+	}
+	
+	//
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -216,8 +237,7 @@ public class FramedConcernMembershipImpl extends RequirementConstraintMembership
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	@Override
-	public boolean eIsSet(int featureID) {
+	public boolean eIsSetGen(int featureID) {
 		switch (featureID) {
 			case SysMLPackage.FRAMED_CONCERN_MEMBERSHIP__OWNED_CONSTRAINT:
 				return isSetOwnedConstraint();

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RequirementConstraintMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RequirementConstraintMembershipImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -53,13 +53,14 @@ public class RequirementConstraintMembershipImpl extends FeatureMembershipImpl i
 	/**
 	 * The default value of the '{@link #getKind() <em>Kind</em>}' attribute.
 	 * <!-- begin-user-doc -->
+	 * Even though the "kind" property is mandatory, the abstract syntax does not specify a default for it.
 	 * <!-- end-user-doc -->
 	 * @see #getKind()
-	 * @generated
+	 * @generated NOT
 	 * @ordered
 	 */
-	protected static final RequirementConstraintKind KIND_EDEFAULT = RequirementConstraintKind.ASSUMPTION;
-
+	protected static final RequirementConstraintKind KIND_EDEFAULT = null;
+	
 	/**
 	 * The cached value of the '{@link #getKind() <em>Kind</em>}' attribute.
 	 * <!-- begin-user-doc -->

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RequirementVerificationMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RequirementVerificationMembershipImpl.java
@@ -25,6 +25,7 @@ package org.omg.sysml.lang.sysml.impl;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.omg.sysml.lang.sysml.ConstraintUsage;
+import org.omg.sysml.lang.sysml.RequirementConstraintKind;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.RequirementVerificationMembership;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -240,6 +241,26 @@ public class RequirementVerificationMembershipImpl extends RequirementConstraint
 	public boolean isSetReferencedConstraint() {
   		return false;
 	}
+	
+	// Additional Overrides
+	
+	@Override
+	public RequirementConstraintKind getKind() {
+		return RequirementConstraintKind.REQUIREMENT;
+	}
+	
+	/**
+	 * <!-- begin-user-doc -->
+	 * Consider the "kind" property to never be explicitly "set". 
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		return featureID != SysMLPackage.REQUIREMENT_CONSTRAINT_MEMBERSHIP__KIND && eIsSetGen(featureID);
+	}
+	
+	//
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -300,8 +321,7 @@ public class RequirementVerificationMembershipImpl extends RequirementConstraint
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	@Override
-	public boolean eIsSet(int featureID) {
+	public boolean eIsSetGen(int featureID) {
 		switch (featureID) {
 			case SysMLPackage.REQUIREMENT_VERIFICATION_MEMBERSHIP__OWNED_CONSTRAINT:
 				return isSetOwnedConstraint();

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/StateSubactionMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/StateSubactionMembershipImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -51,12 +51,13 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
 	/**
 	 * The default value of the '{@link #getKind() <em>Kind</em>}' attribute.
 	 * <!-- begin-user-doc -->
+	 * Even though the "kind" property is mandatory, the abstract syntax does not specify a default for it.
 	 * <!-- end-user-doc -->
 	 * @see #getKind()
-	 * @generated
+	 * @generated NOT
 	 * @ordered
 	 */
-	protected static final StateSubactionKind KIND_EDEFAULT = StateSubactionKind.ENTRY;
+	protected static final StateSubactionKind KIND_EDEFAULT = null;
 
 	/**
 	 * The cached value of the '{@link #getKind() <em>Kind</em>}' attribute.

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TransitionFeatureMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TransitionFeatureMembershipImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -50,12 +50,13 @@ public class TransitionFeatureMembershipImpl extends FeatureMembershipImpl imple
 	/**
 	 * The default value of the '{@link #getKind() <em>Kind</em>}' attribute.
 	 * <!-- begin-user-doc -->
+	 * Even though the "kind" property is mandatory, the abstract syntax does not specify a default for it.
 	 * <!-- end-user-doc -->
 	 * @see #getKind()
-	 * @generated
+	 * @generated NOT
 	 * @ordered
 	 */
-	protected static final TransitionFeatureKind KIND_EDEFAULT = TransitionFeatureKind.TRIGGER;
+	protected static final TransitionFeatureKind KIND_EDEFAULT = null;
 
 	/**
 	 * The cached value of the '{@link #getKind() <em>Kind</em>}' attribute.

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TriggerInvocationExpressionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TriggerInvocationExpressionImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -48,12 +48,13 @@ public class TriggerInvocationExpressionImpl extends InvocationExpressionImpl im
 	/**
 	 * The default value of the '{@link #getKind() <em>Kind</em>}' attribute.
 	 * <!-- begin-user-doc -->
+	 * Even though the "kind" property is mandatory, the abstract syntax does not specify a default for it.
 	 * <!-- end-user-doc -->
 	 * @see #getKind()
-	 * @generated
+	 * @generated NOT
 	 * @ordered
 	 */
-	protected static final TriggerKind KIND_EDEFAULT = TriggerKind.WHEN;
+	protected static final TriggerKind KIND_EDEFAULT = null;
 
 	/**
 	 * The cached value of the '{@link #getKind() <em>Kind</em>}' attribute.


### PR DESCRIPTION
1. The `kind` properties of the following metaclasses have enumeration types, but no default in the MOF abstract syntax model, even though they also have a multiplicity lower bound of 1:
    * `RequirementConstraintMembership`
    * `TriggerInvocationMembership`
    * `StateSubactionMembership`
    * `TransitionFeatureMembership`

   However Eclipse still normally generates a `KIND_EDEFAULT` constant for these properties in the corresponding implementation classes that is set to the first enumeration literal of the corresponding type. This means that the XMI generated for these relationships did not include a `kind` value in the case it was one of these defaults. This pull request updates these implementation classes so that `KIND_EDEFAULT` is set to `null`. As a result, `kind` is always serialized in XMI for these metaclasses (but see below).
2. The subclasses `FramedConcernMembership` and `RequirementVerificationMembership` of `RequirementConstraintMembership` redefine `kind` to give it the default `requirement`, which is actually the value that `kind` must _always_ have for these relationships. However, this redefinition is lost in the Ecore metamdeol, and the default from `RequirementConstraintMembershipImpl` is inherited by the implementations of the specialized relationships. 
   * This pull request updates the generated `eIsSet` method in the corresponding implementation classes so that `kind` is always considered "not set" for `FramedConcernMembership` and `RequirementVerificationMembership`, which means that `kind` is considered to always have its "default" value and is not serialized in XMI. 
   * The `getKind` method is also overridden to always return `requirement`.