### PR TITLE
ST6RI-711 Example models from KerML Spec Annex A

### DIFF
--- a/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
@@ -10,4 +10,5 @@ package Atoms {
 	classifier Atom;
 	 	metaclass <atom> AtomMetadata specializes Metaobject {
 			baseType = Atom meta KerML::Classifier;
+	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
@@ -1,0 +1,13 @@
+package Atoms {
+	doc
+	/* This package defines a keyword (atom) for classifiers with
+	 * exactly one instance and are disjoint from any others
+	 * marked with this keyword.
+	 */
+
+	private import Metaobjects::Metaobject;
+	
+	classifier Atom;
+	 	metaclass <atom> AtomMetadata specializes Metaobject {
+			baseType = Atom meta KerML::Classifier;
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-2-Atoms.kerml
@@ -8,7 +8,7 @@ package Atoms {
 	private import Metaobjects::Metaobject;
 	
 	classifier Atom;
-	 	metaclass <atom> AtomMetadata specializes Metaobject {
-			baseType = Atom meta KerML::Classifier;
+	metaclass <atom> AtomMetadata specializes Metaobject {
+		baseType = Atom meta KerML::Classifier;
 	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-2-ModelingInstances.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-2-ModelingInstances.kerml
@@ -14,7 +14,7 @@ package ModelingInstancesWithAtoms {
 	/* 
 	 */
 
-	import Atoms::Atom;
+	import Atoms::atom;
 
 	classifier Vehicle;
 	classifier Bicycle specializes Vehicle;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-2-ModelingInstances.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-2-ModelingInstances.kerml
@@ -1,0 +1,38 @@
+package ModelingInstances {
+	doc
+	/* 
+	 */
+
+	classifier Vehicle;
+	classifier Bicycle specializes Vehicle;
+	classifier MyBike [1] specializes Bicycle;
+	classifier YourBike [1] specializes Bicycle disjoint from MyBike;
+}
+
+package ModelingInstancesWithAtoms {
+	doc
+	/* 
+	 */
+
+	import Atoms::Atom;
+
+	classifier Vehicle;
+	classifier Bicycle specializes Vehicle;
+
+	#atom
+	classifier MyBike specializes Bicycle;
+	#atom
+	classifier YourBike specializes Bicycle;
+
+	/* Assigning feature values. */
+
+	classifier Garage {
+		feature stores : Bicycle [*];
+	}
+	classifier OurBicycle unions MyBike, YourBike;
+
+	#atom
+	classifier OurGarage specializes Garage {
+		feature redefines stores : OurBicycle [2];
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-2-WithoutConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-2-WithoutConnectors.kerml
@@ -1,0 +1,39 @@
+
+package WithoutConnectorsModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+	classifier Bicycle {
+		feature rollsOn : Wheel [2];
+		feature holdsWheel : BikeFork [*];
+	}
+	classifier Wheel;
+	classifier BikeFork;
+}
+
+package WithoutConnectorsExecution {
+	doc
+	/* 
+	 */
+
+	import WithoutConnectorsModelToBeExecuted::*;
+	import Atoms::*;
+
+	#atom
+	classifier MyBike specializes Bicycle;
+	#atom
+	classifier MyWheel1 specializes Wheel;
+	#atom
+	classifier MyWheel2 specializes Wheel;
+
+	classifier MyWheel unions MyWheel1, MyWheel2;
+
+	#atom
+	classifier MyBike specializes Bicycle {
+		feature redefines rollsOn : MyWheel;
+	}
+}
+
+
+

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-2-WithoutConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-2-WithoutConnectors.kerml
@@ -17,11 +17,9 @@ package WithoutConnectorsExecution {
 	/* 
 	 */
 
-	import WithoutConnectorsModelToBeExecuted::*;
 	import Atoms::*;
+	import WithoutConnectorsModelToBeExecuted::*;
 
-	#atom
-	classifier MyBike specializes Bicycle;
 	#atom
 	classifier MyWheel1 specializes Wheel;
 	#atom

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-3-OneToOneConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-3-OneToOneConnectors.kerml
@@ -1,0 +1,63 @@
+
+package OneToOneConnectorsModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+        import WithoutConnectorsModelToBeExecuted::Wheel;
+        import WithoutConnectorsModelToBeExecuted::BikeFork;
+
+	classifier Bicycle {
+		feature rollsOn : Wheel [2];
+		feature holdsWheel : BikeFork [*];
+		connector fixWheel : BikeWheelFixed from rollsOn [1] to holdsWheel [1];
+	}
+	assoc BikeWheelFixed {
+		end feature wheel : Wheel;  //[What do end mults default to? Assume *]
+		end feature fixedTo : BikeFork;
+	}
+}
+
+package OneToOneConnectorsExecution {
+	doc
+	/* 
+	 */
+
+	import OneToOneConnectorsModelToBeExecuted::*;
+	import Atoms::*;
+	import WithoutConnectorsExecution::MyWheel1;
+	import WithoutConnectorsExecution::MyWheel2;
+	import WithoutConnectorsExecution::MyWheel;
+
+	#atom
+	classifier MyBikeFork1 specializes BikeFork;
+	#atom
+	classifier MyBikeFork2 specializes BikeFork;
+
+	classifier MyBikeFork unions MyBikeFork1, MyBikeFork2;
+
+	#atom
+	classifier MyBike specializes Bicycle {
+		feature redefines rollsOn : MyWheel;
+		feature redefines holdsWheel : MyBikeFork;
+	}
+	#atom
+ 	assoc MyBikeWheel1_Fork1_BWF_Link specializes BikeWheelFixed {
+		end feature redefines wheel : MyWheel1;
+		end feature redefines fixedTo : MyBikeFork1;
+	}
+	#atom
+	assoc MyBikeWheel2_Fork2_BWF_Link specializes BikeWheelFixed {
+		end feature redefines wheel : MyWheel2;
+		end feature redefines fixedTo : MyBikeFork2;
+	}
+
+	classifier MyBikeWheel_Fork_BWF_Link unions MyBikeWheel1_Fork1_BWF_Link, MyBikeWheel2_Fork2_BWF_Link;
+
+	#atom
+	classifier MyBike specializes Bicycle {
+		feature redefines rollsOn : MyWheel;
+		feature redefines holdsWheel : MyBikeFork;
+		connector redefines fixWheel : MyBikeWheel_Fork_BWF_Link [2] from rollsOn [1] to holdsWheel [1];
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-3-OneToOneConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-3-OneToOneConnectors.kerml
@@ -13,7 +13,7 @@ package OneToOneConnectorsModelToBeExecuted {
 		connector fixWheel : BikeWheelFixed from rollsOn [1] to holdsWheel [1];
 	}
 	assoc BikeWheelFixed {
-		end feature wheel : Wheel;  //[What do end mults default to? Assume *]
+		end feature wheel : Wheel;
 		end feature fixedTo : BikeFork;
 	}
 }
@@ -23,8 +23,8 @@ package OneToOneConnectorsExecution {
 	/* 
 	 */
 
-	import OneToOneConnectorsModelToBeExecuted::*;
 	import Atoms::*;
+	import OneToOneConnectorsModelToBeExecuted::*;
 	import WithoutConnectorsExecution::MyWheel1;
 	import WithoutConnectorsExecution::MyWheel2;
 	import WithoutConnectorsExecution::MyWheel;
@@ -36,11 +36,6 @@ package OneToOneConnectorsExecution {
 
 	classifier MyBikeFork unions MyBikeFork1, MyBikeFork2;
 
-	#atom
-	classifier MyBike specializes Bicycle {
-		feature redefines rollsOn : MyWheel;
-		feature redefines holdsWheel : MyBikeFork;
-	}
 	#atom
  	assoc MyBikeWheel1_Fork1_BWF_Link specializes BikeWheelFixed {
 		end feature redefines wheel : MyWheel1;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
@@ -53,7 +53,7 @@ package OneToUnrestrictedConnectorsExecution {
 		end feature redefines fixedTo : MyBikeFork1;
 	}
 
-	classifier MyBikeBasket_Fork_BBF_Link unions MyBikeFork1_Basket1_BBF_Link, MyBikeFork1_Basket2_BBF_Link;
+	classifier MyBikeBasket_Fork_BBF_Link unions MyBikeBasket1_Fork1_BBF_Link, MyBasket2_BikeFork1_BBF_Link;
 
 	#atom
 	classifier MyBike specializes Bicycle {

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
@@ -1,0 +1,63 @@
+
+package OneToUnrestrictedConnectorsModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+	import WithoutConnectorsModelToBeExecuted::BikeFork;
+
+	classifier Bicycle {
+		feature carrier : BikeBasket [*];
+		feature holdsWheel : BikeFork [*];
+		connector carrierFixed : BikeBasketFixed from carrier [1] to holdsWheel [*];
+	}
+	classifier BikeBasket;
+
+	assoc BikeBasketFixed {
+		end feature basket : BikeBasket;
+		end feature fixedTo : BikeFork;
+	}
+}
+
+package OneToUnrestrictedConnectorsExecution {
+	doc
+	/* 
+	 */
+
+	import OneToUnrestrictedConnectorsModelToBeExecuted::*;
+	import OneToOneConnectorsExecution::MyBikeFork1;
+	import OneToOneConnectorsExecution::MyBikeFork2;
+	import OneToOneConnectorsExecution::MyBikeFork;
+	import Atoms::*;
+
+	#atom
+	classifier MyBikeBasket1 specializes BikeBasket;
+	#atom
+	classifier MyBikeBasket2 specializes BikeBasket;
+
+	classifier MyBikeBasket unions MyBikeBasket1, MyBikeBasket2;
+
+	#atom
+	classifier MyBike specializes Bicycle {
+		feature redefines carrier : MyBikeBasket [2];
+		feature redefines holdsWheel : MyBikeFork [2];
+	}
+	#atom
+	assoc MyBikeBasket1_Fork1_BBF_Link specializes BikeBasketFixed {
+		end feature redefines basket : MyBikeBasket1;
+		end feature redefines fixedTo : MyBikeFork1;
+	}
+	#atom
+	assoc MyBasket2_BikeFork1_BBF_Link specializes BikeBasketFixed {
+		end feature redefines basket : MyBikeBasket2;
+		end feature redefines fixedTo : MyBikeFork1;
+	}
+
+	classifier MyBikeBasket_Fork_BBF_Link unions MyBikeFork1_Basket1_BBF_Link, MyBikeFork1_Basket2_BBF_Link;
+
+	#atom
+	classifier MyBike specializes Bicycle {
+		feature redefines carrier : MyBikeBasket [2];
+		connector redefines carrierFixed : MyBikeBasket_Fork_BBF_Link [2] from carrier [*] to holdsWheel [1];
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-4-OneToUnrestrictedConnectors.kerml
@@ -9,7 +9,7 @@ package OneToUnrestrictedConnectorsModelToBeExecuted {
 	classifier Bicycle {
 		feature carrier : BikeBasket [*];
 		feature holdsWheel : BikeFork [*];
-		connector carrierFixed : BikeBasketFixed from carrier [1] to holdsWheel [*];
+		connector carrierFixed : BikeBasketFixed from carrier [*] to holdsWheel [1];
 	}
 	classifier BikeBasket;
 
@@ -24,11 +24,11 @@ package OneToUnrestrictedConnectorsExecution {
 	/* 
 	 */
 
+	import Atoms::*;
 	import OneToUnrestrictedConnectorsModelToBeExecuted::*;
 	import OneToOneConnectorsExecution::MyBikeFork1;
 	import OneToOneConnectorsExecution::MyBikeFork2;
 	import OneToOneConnectorsExecution::MyBikeFork;
-	import Atoms::*;
 
 	#atom
 	classifier MyBikeBasket1 specializes BikeBasket;
@@ -38,26 +38,22 @@ package OneToUnrestrictedConnectorsExecution {
 	classifier MyBikeBasket unions MyBikeBasket1, MyBikeBasket2;
 
 	#atom
-	classifier MyBike specializes Bicycle {
-		feature redefines carrier : MyBikeBasket [2];
-		feature redefines holdsWheel : MyBikeFork [2];
-	}
-	#atom
 	assoc MyBikeBasket1_Fork1_BBF_Link specializes BikeBasketFixed {
 		end feature redefines basket : MyBikeBasket1;
 		end feature redefines fixedTo : MyBikeFork1;
 	}
 	#atom
-	assoc MyBasket2_BikeFork1_BBF_Link specializes BikeBasketFixed {
+	assoc MyBikeBasket2_Fork1_BBF_Link specializes BikeBasketFixed {
 		end feature redefines basket : MyBikeBasket2;
 		end feature redefines fixedTo : MyBikeFork1;
 	}
 
-	classifier MyBikeBasket_Fork_BBF_Link unions MyBikeBasket1_Fork1_BBF_Link, MyBasket2_BikeFork1_BBF_Link;
+	classifier MyBikeBasket_Fork_BBF_Link unions MyBikeBasket1_Fork1_BBF_Link, MyBikeBasket2_Fork1_BBF_Link;
 
 	#atom
 	classifier MyBike specializes Bicycle {
 		feature redefines carrier : MyBikeBasket [2];
+		feature redefines holdsWheel : MyBikeFork [2];
 		connector redefines carrierFixed : MyBikeBasket_Fork_BBF_Link [2] from carrier [*] to holdsWheel [1];
 	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
@@ -59,7 +59,7 @@ package TimingForStructuresExecution2 {
 	 */
 
 	import TimingForStructuresModelToBeExecuted2::*;
-	import Occurrences::Occurrence::HappensDuring;
+	import Occurrences::HappensDuring;
 	import OneToOneConnectorsExecution::MyWheel1;
 	import OneToOneConnectorsExecution::MyWheel2;
 	import OneToOneConnectorsExecution::MyWheel;
@@ -166,29 +166,29 @@ package TimingForStructuresExecution3 {
 
 	  /* HappensWhile atoms */
 	#atom
-	assoc MyBikeEnd_While_Wheel1End_Link specializes HappensDuring {
+	assoc MyBikeEnd_While_Wheel1End_Link specializes HappensWhile {
 		end feature redefines thisOccurrence : MyBikeEnd;
 		end feature redefines thatOccurrence : MyWheel1End;
 	}
 	#atom
-	assoc MyBikeEnd_While_Wheel2End_Link specializes HappensDuring {
+	assoc MyBikeEnd_While_Wheel2End_Link specializes HappensWhile {
 		end feature redefines thisOccurrence : MyBikeEnd;
 		end feature redefines thatOccurrence : MyWheel2End;
 	}
 	#atom
-	assoc MyBikeEnd_While_Fork1End_Link specializes HappensDuring {
+	assoc MyBikeEnd_While_Fork1End_Link specializes HappensWhile {
 		end feature redefines thisOccurrence : MyBikeEnd;
 		end feature redefines thatOccurrence : MyBikeFork1End;
 	}
 	#atom
-	assoc MyBikeEnd_While_Fork2End_Link specializes HappensDuring {
+	assoc MyBikeEnd_While_Fork2End_Link specializes HappensWhile {
 		end feature redefines thisOccurrence : MyBikeEnd;
 		end feature redefines thatOccurrence : MyBikeFork2End;
 	}
 
 	assoc MyBikeEnd_While_PartsEnd_Link  specializes HappensWhile
 		unions MyBikeEnd_While_Wheel1End_Link, MyBikeEnd_While_Fork1End_Link,
-		       MyBikeEnd_While_Wheel2End_Link, MyBike_While_Fork2End_Link;
+		       MyBikeEnd_While_Wheel2End_Link, MyBikeEnd_While_Fork2End_Link;
 
 	#atom
 	struct MyBike specializes Bicycle {

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
@@ -19,16 +19,17 @@ package TimingForStructuresExecution1 {
 	/* 
 	 */
 
+	import Atoms::*;
 	import TimingForStructuresModelToBeExecuted1::*;
 	import OneToOneConnectorsExecution::MyWheel;
 	import OneToOneConnectorsExecution::MyBikeFork;
-	import Atoms::*;
 
-	struct MyBikeParts unions MyWheel, MyBikeFork;
+	struct MyBikeTimeCoincident unions MyWheel, MyBikeFork, MyBike;
 
 	#atom
 	struct MyBike specializes Bicycle {
-		feature redefines timeCoincidentOccurrences : MyBikeParts [4];
+		feature redefines self : MyBike;
+		feature redefines timeCoincidentOccurrences : MyBikeTimeCoincident [5];
 		feature redefines rollsOn : MyWheel;
 		feature redefines holdsWheel : MyBikeFork;
 	}
@@ -58,6 +59,7 @@ package TimingForStructuresExecution2 {
 	/* 
 	 */
 
+	import Atoms::*;
 	import TimingForStructuresModelToBeExecuted2::*;
 	import Occurrences::HappensDuring;
 	import OneToOneConnectorsExecution::MyWheel1;
@@ -66,7 +68,6 @@ package TimingForStructuresExecution2 {
 	import OneToOneConnectorsExecution::MyBikeFork1;
 	import OneToOneConnectorsExecution::MyBikeFork2;
 	import OneToOneConnectorsExecution::MyBikeFork;
-	import Atoms::*;
 
 	#atom
 	assoc MyBike_During_Wheel1_Link specializes HappensDuring {
@@ -103,7 +104,7 @@ package TimingForStructuresExecution2 {
 
 		feature redefines self : MyBike;
 		connector redefines b_during_ap : MyBike_During_Parts_Link [4]
-			from self [1] to allParts [4];
+			from self [1] to allParts [*];
 	}
 }
 
@@ -131,35 +132,35 @@ package TimingForStructuresExecution3 {
 	/* 
 	 */
 
+	import Atoms::*;
 	import TimingForStructuresModelToBeExecuted3::*;
 	import Occurrences::Occurrence;
 	import Occurrences::HappensWhile;
 	import WithoutConnectorsModelToBeExecuted::Wheel;
 	import WithoutConnectorsModelToBeExecuted::BikeFork;
-	import Atoms::*;
 
 	  /* End atoms */
 	#atom
 	struct MyWheel1End specializes Wheel;
 	#atom
 	struct MyWheel1 specializes Wheel {
-		redefines endShot : MyWheel1End;
+		feature redefines endShot : MyWheel1End;
 	}
 	#atom
 	struct MyWheel2End specializes Wheel;
 	#atom
 	struct MyWheel2 specializes Wheel {
-		redefines endShot : MyWheel2End;
+		feature redefines endShot : MyWheel2End;
 	}
 	struct MyBikeFork1End specializes BikeFork;
 	#atom
 	struct MyBikeFork1 specializes BikeFork {
-		redefines endShot : MyBikeFork1End;
+		feature redefines endShot : MyBikeFork1End;
 	}
 	struct MyBikeFork2End specializes BikeFork;
 	#atom
 	struct MyBikeFork2 specializes BikeFork {
-		redefines endShot : MyBikeFork2End;
+		feature redefines endShot : MyBikeFork2End;
 	}
 	#atom
 	struct MyBikeEnd specializes Bicycle;
@@ -186,14 +187,14 @@ package TimingForStructuresExecution3 {
 		end feature redefines thatOccurrence : MyBikeFork2End;
 	}
 
-	assoc MyBikeEnd_While_PartsEnd_Link  specializes HappensWhile
+	assoc MyBikeEnd_While_PartsEnd_Link specializes HappensWhile
 		unions MyBikeEnd_While_Wheel1End_Link, MyBikeEnd_While_Fork1End_Link,
 		       MyBikeEnd_While_Wheel2End_Link, MyBikeEnd_While_Fork2End_Link;
 
 	#atom
 	struct MyBike specializes Bicycle {
-		redefines endShot : MyBikeEnd;
-		connector redefines be_while_pe : HappensWhile [4]
+		feature redefines endShot : MyBikeEnd;
+		connector redefines be_while_pe : MyBikeEnd_While_PartsEnd_Link [4]
 			from endShot [1] to endShot.allParts.endShot[*];  
 	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
@@ -1,0 +1,199 @@
+
+package TimingForStructuresModelToBeExecuted1 {
+	doc
+	/* 
+	 */
+
+	import WithoutConnectorsModelToBeExecuted::Wheel;
+	import WithoutConnectorsModelToBeExecuted::BikeFork;
+	import Occurrences::Occurrence;
+
+	struct Bicycle {
+		feature rollsOn : Wheel [2] subsets timeCoincidentOccurrences;
+		feature holdsWheel : BikeFork [2] subsets timeCoincidentOccurrences;
+	}
+}
+
+package TimingForStructuresExecution1 {
+	doc
+	/* 
+	 */
+
+	import TimingForStructuresModelToBeExecuted1::*;
+	import OneToOneConnectorsExecution::MyWheel;
+	import OneToOneConnectorsExecution::MyBikeFork;
+	import Atoms::*;
+
+	struct MyBikeParts unions MyWheel, MyBikeFork;
+
+	#atom
+	struct MyBike specializes Bicycle {
+		feature redefines timeCoincidentOccurrences : MyBikeParts [4];
+		feature redefines rollsOn : MyWheel;
+		feature redefines holdsWheel : MyBikeFork;
+	}
+}
+
+
+package TimingForStructuresModelToBeExecuted2 {
+	doc
+	/* 
+	 */
+
+	import WithoutConnectorsModelToBeExecuted::Wheel;
+	import WithoutConnectorsModelToBeExecuted::BikeFork;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensDuring;
+
+	struct Bicycle {
+		feature rollsOn : Wheel [2];
+		feature holdsWheel : BikeFork [2];
+		feature allParts : Occurrence unions rollsOn, holdsWheel;
+		connector b_during_ap : HappensDuring from self [1] to allParts [*];
+	}
+}
+
+package TimingForStructuresExecution2 {
+	doc
+	/* 
+	 */
+
+	import TimingForStructuresModelToBeExecuted2::*;
+	import Occurrences::Occurrence::HappensDuring;
+	import OneToOneConnectorsExecution::MyWheel1;
+	import OneToOneConnectorsExecution::MyWheel2;
+	import OneToOneConnectorsExecution::MyWheel;
+	import OneToOneConnectorsExecution::MyBikeFork1;
+	import OneToOneConnectorsExecution::MyBikeFork2;
+	import OneToOneConnectorsExecution::MyBikeFork;
+	import Atoms::*;
+
+	#atom
+	assoc MyBike_During_Wheel1_Link specializes HappensDuring {
+		end feature redefines shorterOccurrence : MyBike;
+		end feature redefines longerOccurrence : MyWheel1;
+	}
+	#atom
+	assoc MyBike_During_Wheel2_Link specializes HappensDuring {
+		end feature redefines shorterOccurrence : MyBike;
+		end feature redefines longerOccurrence : MyWheel2;
+	}
+	#atom
+	assoc MyBike_During_Fork1_Link specializes HappensDuring {
+		end feature redefines shorterOccurrence : MyBike;
+		end feature redefines longerOccurrence : MyBikeFork1;
+	}
+	#atom
+	assoc MyBike_During_Fork2_Link specializes HappensDuring {
+		end feature redefines shorterOccurrence : MyBike;
+		end feature redefines longerOccurrence : MyBikeFork2;
+	}
+
+	assoc MyBike_During_Parts_Link specializes HappensDuring
+		unions MyBike_During_Wheel1_Link, MyBike_During_Fork1_Link,
+		       MyBike_During_Wheel2_Link, MyBike_During_Fork2_Link;
+
+	struct MyBikeParts unions MyWheel, MyBikeFork;
+
+	#atom
+	struct MyBike specializes Bicycle {
+		feature redefines rollsOn : MyWheel;
+		feature redefines holdsWheel : MyBikeFork;
+		feature redefines allParts : MyBikeParts [4];
+
+		feature redefines self : MyBike;
+		connector redefines b_during_ap : MyBike_During_Parts_Link [4]
+			from self [1] to allParts [4];
+	}
+}
+
+package TimingForStructuresModelToBeExecuted3 {
+	doc
+	/* 
+	 */
+
+	import WithoutConnectorsModelToBeExecuted::Wheel;
+	import WithoutConnectorsModelToBeExecuted::BikeFork;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensWhile;
+
+	struct Bicycle {
+		feature rollsOn : Wheel [2];
+		feature holdsWheel : BikeFork [2];
+		feature allParts : Occurrence unions rollsOn, holdsWheel;
+		feature redefines endShot : Bicycle;
+		connector be_while_pe : HappensWhile from endShot [1] to endShot.allParts.endShot[*];
+	}
+}
+
+package TimingForStructuresExecution3 {
+	doc
+	/* 
+	 */
+
+	import TimingForStructuresModelToBeExecuted3::*;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensWhile;
+	import WithoutConnectorsModelToBeExecuted::Wheel;
+	import WithoutConnectorsModelToBeExecuted::BikeFork;
+	import Atoms::*;
+
+	  /* End atoms */
+	#atom
+	struct MyWheel1End specializes Wheel;
+	#atom
+	struct MyWheel1 specializes Wheel {
+		redefines endShot : MyWheel1End;
+	}
+	#atom
+	struct MyWheel2End specializes Wheel;
+	#atom
+	struct MyWheel2 specializes Wheel {
+		redefines endShot : MyWheel2End;
+	}
+	struct MyBikeFork1End specializes BikeFork;
+	#atom
+	struct MyBikeFork1 specializes BikeFork {
+		redefines endShot : MyBikeFork1End;
+	}
+	struct MyBikeFork2End specializes BikeFork;
+	#atom
+	struct MyBikeFork2 specializes BikeFork {
+		redefines endShot : MyBikeFork2End;
+	}
+	#atom
+	struct MyBikeEnd specializes Bicycle;
+
+	  /* HappensWhile atoms */
+	#atom
+	assoc MyBikeEnd_While_Wheel1End_Link specializes HappensDuring {
+		end feature redefines thisOccurrence : MyBikeEnd;
+		end feature redefines thatOccurrence : MyWheel1End;
+	}
+	#atom
+	assoc MyBikeEnd_While_Wheel2End_Link specializes HappensDuring {
+		end feature redefines thisOccurrence : MyBikeEnd;
+		end feature redefines thatOccurrence : MyWheel2End;
+	}
+	#atom
+	assoc MyBikeEnd_While_Fork1End_Link specializes HappensDuring {
+		end feature redefines thisOccurrence : MyBikeEnd;
+		end feature redefines thatOccurrence : MyBikeFork1End;
+	}
+	#atom
+	assoc MyBikeEnd_While_Fork2End_Link specializes HappensDuring {
+		end feature redefines thisOccurrence : MyBikeEnd;
+		end feature redefines thatOccurrence : MyBikeFork2End;
+	}
+
+	assoc MyBikeEnd_While_PartsEnd_Link  specializes HappensWhile
+		unions MyBikeEnd_While_Wheel1End_Link, MyBikeEnd_While_Fork1End_Link,
+		       MyBikeEnd_While_Wheel2End_Link, MyBike_While_Fork2End_Link;
+
+	#atom
+	struct MyBike specializes Bicycle {
+		redefines endShot : MyBikeEnd;
+		connector redefines be_while_pe : HappensWhile [4]
+			from endShot [1] to endShot.allParts.endShot[*];  
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
@@ -7,9 +7,9 @@ package SequencesModelToBeExecuted {
 	behavior Manufacture {
 		step paint : Paint [1];
 		step dry : Dry [*];
-		succession p_before_d from paint [1] to dry [1];
+		succession p_before_d first paint [1] then dry [1];
 		step ship : Ship [*];
-		succession d_before_s from dry [1] to ship [1];
+		succession d_before_s first dry [1] then ship [1];
 	}
 	behavior Paint;
 	behavior Dry;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
@@ -21,20 +21,13 @@ package SequencesExecution {
 	/* 
 	 */
 
+	import Atoms::*;
 	import SequencesModelToBeExecuted::*;
 	import Occurrences::Occurrence;
 	import Occurrences::HappensBefore;
-	import Atoms::*;
 
 	#atom
-	behavior MyManufacture specializes Manufacture;
-	#atom
 	behavior MyPaint specializes Paint;
-	#atom
-	behavior MyManufacture specializes Manufacture {
-		feature redefines timeEnclosedOccurrences : MyPaint [1];
-		step redefines paint : MyPaint;
-	}
 	#atom
 	behavior MyDry specializes Dry;
 
@@ -46,13 +39,6 @@ package SequencesExecution {
 
 	behavior MyManufactureStepsPD unions MyPaint, MyDry;
 
-	#atom
-	behavior MyManufacture specializes Manufacture {
-		feature redefines timeEnclosedOccurrences : MyManufactureStepsPD [2];
-		step redefines paint : MyPaint;
-		step redefines dry : MyDry [1];
-		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
-	}
 	#atom
 	behavior MyShip specializes Ship;
 
@@ -70,7 +56,7 @@ package SequencesExecution {
 		step redefines paint : MyPaint;
 		step redefines dry : MyDry [1];
 		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
-		step redefines dry : MyShip [1];
+		step redefines ship : MyShip [1];
 		succession redefines d_before_s : MyDry_Before_Ship_Link [1] first dry then ship;
 	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-6-Sequences.kerml
@@ -1,0 +1,76 @@
+
+package SequencesModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+	behavior Manufacture {
+		step paint : Paint [1];
+		step dry : Dry [*];
+		succession p_before_d from paint [1] to dry [1];
+		step ship : Ship [*];
+		succession d_before_s from dry [1] to ship [1];
+	}
+	behavior Paint;
+	behavior Dry;
+	behavior Ship;
+}
+
+package SequencesExecution {
+	doc
+	/* 
+	 */
+
+	import SequencesModelToBeExecuted::*;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensBefore;
+	import Atoms::*;
+
+	#atom
+	behavior MyManufacture specializes Manufacture;
+	#atom
+	behavior MyPaint specializes Paint;
+	#atom
+	behavior MyManufacture specializes Manufacture {
+		feature redefines timeEnclosedOccurrences : MyPaint [1];
+		step redefines paint : MyPaint;
+	}
+	#atom
+	behavior MyDry specializes Dry;
+
+	#atom
+	assoc MyPaint_Before_Dry_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyPaint;
+		end feature redefines laterOccurrence : MyDry;
+	}
+
+	behavior MyManufactureStepsPD unions MyPaint, MyDry;
+
+	#atom
+	behavior MyManufacture specializes Manufacture {
+		feature redefines timeEnclosedOccurrences : MyManufactureStepsPD [2];
+		step redefines paint : MyPaint;
+		step redefines dry : MyDry [1];
+		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
+	}
+	#atom
+	behavior MyShip specializes Ship;
+
+	#atom
+	assoc MyDry_Before_Ship_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyDry;
+		end feature redefines laterOccurrence : MyShip;
+	}
+
+	behavior MyManufactureStepsPDS unions MyManufactureStepsPD, MyShip;
+
+	#atom
+	behavior MyManufacture specializes Manufacture {
+		feature redefines timeEnclosedOccurrences : MyManufactureStepsPDS [3];
+		step redefines paint : MyPaint;
+		step redefines dry : MyDry [1];
+		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
+		step redefines dry : MyShip [1];
+		succession redefines d_before_s : MyDry_Before_Ship_Link [1] first dry then ship;
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-7-DecisionsAndMerges.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-7-DecisionsAndMerges.kerml
@@ -34,7 +34,7 @@ package DecisionsAndMergesModelToBeExecuted {
 		succession ms_before_s first mShip [1] then ship [1];
 		step ship : Ship [*];
 
-		  /* Decision and merge timing constraints. */  
+		  /* Decision and merge timing constraints. */
 		feature inspectOutgoingHBLinks : HappensBefore [*] unions i_before_f, i_before_r;
 		connector bindIOHBL : SelfLink from inspectOutgoingHBLinks [1] to inspect.outgoingHBLink [1];
 		feature mShipIncomingHBLinks : HappensBefore [*] unions f_before_ms, r_before_ms;
@@ -51,10 +51,10 @@ package DecisionsAndMergesExecution {
 	/* 
 	 */
 
+	import Atoms::*;
 	import DecisionsAndMergesModelToBeExecuted::*;
 	import Occurrences::Occurrence;
 	import Occurrences::HappensBefore;
-	import Atoms::*;
 
 	  /* Before decision. */
 	#atom
@@ -62,7 +62,7 @@ package DecisionsAndMergesExecution {
 
 	  /* Decision. */
 	#atom
-	behavior MyInspect specializes DecisionPerformance; //must use behavior keyword?
+	behavior MyInspect specializes DecisionPerformance;
 	#atom
 	assoc MyAdmit_Before_Inspect_Link specializes HappensBefore {
 		end feature redefines earlierOccurrence : MyAdmit;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-7-DecisionsAndMerges.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-7-DecisionsAndMerges.kerml
@@ -1,0 +1,130 @@
+
+package DecisionsAndMergesModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+	import ControlPerformances::DecisionPerformance;
+	import ControlPerformances::MergePerformance;
+	import Occurrences::HappensBefore;
+	import Links::SelfLink;
+
+	behavior Manufacture {
+		  /* Before decision. */
+		step admit : Admit [1];
+		succession a_before_i first admit [1] then inspect [1];
+
+		  /* Decision. */
+		step inspect : DecisionPerformance [*];
+
+		  /* Two decision branches. */
+		succession i_before_f first inspect [1] then finish [0..1];
+		step finish : Touchup [*];
+		succession i_before_r first inspect [1] then recycle [0..1];
+		step recycle : MarkForRecycling [*];
+
+		  /* Two merge branches. */
+		succession f_before_ms first finish [0..1] then mShip [1];
+		succession r_before_ms first recycle [0..1] then mShip [1];
+
+		  /* Merge */
+		step mShip : MergePerformance [*];
+
+		  /* After merge */
+		succession ms_before_s first mShip [1] then ship [1];
+		step ship : Ship [*];
+
+		  /* Decision and merge timing constraints. */  
+		feature inspectOutgoingHBLinks : HappensBefore [*] unions i_before_f, i_before_r;
+		connector bindIOHBL : SelfLink from inspectOutgoingHBLinks [1] to inspect.outgoingHBLink [1];
+		feature mShipIncomingHBLinks : HappensBefore [*] unions f_before_ms, r_before_ms;
+		connector bindmSIHBL : SelfLink from mShipIncomingHBLinks [1] to mShip.incomingHBLink [1];
+	}
+	behavior Admit;
+	behavior Touchup;
+	behavior MarkForRecycling;
+	behavior Ship;
+}
+
+package DecisionsAndMergesExecution {
+	doc
+	/* 
+	 */
+
+	import DecisionsAndMergesModelToBeExecuted::*;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensBefore;
+	import Atoms::*;
+
+	  /* Before decision. */
+	#atom
+	behavior MyAdmit specializes Admit;
+
+	  /* Decision. */
+	#atom
+	behavior MyInspect specializes DecisionPerformance; //must use behavior keyword?
+	#atom
+	assoc MyAdmit_Before_Inspect_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyAdmit;
+		end feature redefines laterOccurrence : MyInspect;
+	}
+
+	  /* One decision branch taken. */
+	#atom
+	behavior MyTouchup specializes Touchup;
+	#atom
+	assoc MyInspect_Before_Touchup_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyInspect;
+		end feature redefines laterOccurrence : MyTouchup;
+	}
+
+	  /* One merge branch taken. Merge. */
+	#atom
+	behavior MyMergeToShip specializes MergePerformance;
+	#atom
+	assoc MyTouchup_Before_Merge_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyTouchup;
+		end feature redefines laterOccurrence : MyMergeToShip;
+	}
+
+	  /* After merge. */
+	#atom
+	behavior MyShip specializes Ship;
+	#atom
+	assoc MyMerge_Before_Ship_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyMergeToShip;
+		end feature redefines laterOccurrence : Ship;
+	}
+
+	behavior MyManufactureSteps unions MyAdmit, MyInspect, MyTouchup, MyMergeToShip, MyShip;
+
+	#atom
+	behavior MyManufacture specializes Manufacture {
+		feature redefines timeEnclosedOccurrences : MyManufactureSteps [5];
+
+	  	    /* Before decision. */
+		step redefines admit : MyAdmit [1];
+
+		  /* Decision. */
+		step redefines inspect : MyInspect [1];
+		succession redefines a_before_i : MyAdmit_Before_Inspect_Link [1] first admit then inspect;
+
+		  /* One decision branch taken. */
+		step redefines finish : MyTouchup [1];
+		succession redefines i_before_f : MyInspect_Before_Touchup_Link [1] first inspect then finish;
+
+		  /* One merge branch taken. */
+		succession redefines f_before_ms : MyTouchup_Before_Merge_Link [1] first finish then mShip;
+
+		  /* Merge. */        
+		step redefines mShip: MyMergeToShip [1];
+
+		   /* After merge */
+		step redefines ship : MyShip [1];
+		succession redefines ms_before_s : MyMerge_Before_Ship_Link [1] first mShip then ship;
+
+		  /* Decision and merge timing constraints. */  
+		feature redefines inspectOutgoingHBLinks : MyInspect_Before_Touchup_Link;
+		feature redefines mShipIncomingHBLinks : MyTouchup_Before_Merge_Link;
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -9,14 +9,14 @@ package ChangingFeatureValuesModelToBeExecuted {
 
 	behavior Manufacture {
 		feature objectToFinish : Product [1];
-		step paint : Paint [1]{
+		step paint : Paint [1] {
 			redefines objectToPaint = objectToFinish;
 		}
-		step dry : Dry [*]  {
+		step dry : Dry [*] {
 			redefines objectToDry = objectToFinish;
 		}
 		succession p_before_d first paint [1] then dry [1];
-		step ship : Ship [*]	{
+		step ship : Ship [*] {
 			redefines objectToShip = objectToFinish;
 		}
 		succession d_before_s first dry [1] then ship [1];
@@ -29,7 +29,7 @@ package ChangingFeatureValuesModelToBeExecuted {
 	}
 
 	behavior Paint {
-		feature objectToPaint: Product [1];
+		feature objectToPaint : Product [1];
 
 		step painting : FeatureWritePerformance [1] {
 			redefines onOccurrence : Product = objectToPaint {
@@ -43,7 +43,7 @@ package ChangingFeatureValuesModelToBeExecuted {
 			redefines onOccurrence : Product = objectToPaint {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isPainted; } }
-						redefines replacementValues = true;
+			redefines replacementValues = true;
 		}
 	}
 
@@ -53,17 +53,17 @@ package ChangingFeatureValuesModelToBeExecuted {
 			redefines onOccurrence : Product = objectToDry {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isDry; } }
-						redefines replacementValues = true;
+			redefines replacementValues = true;
 		}
 	}
 
 	behavior Ship {
-		feature objectToShip: Product [1];  
+		feature objectToShip : Product [1];  
 		step shipped : FeatureWritePerformance [1] {
 			redefines onOccurrence : Product = objectToShip {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isShipped; } }
-						redefines replacementValues = true;
+			redefines replacementValues = true;
 		}
 	}
 }
@@ -73,10 +73,10 @@ package ChangingFeatureValuesExecution {
 	/* 
 	 */
 
+	import Atoms::*;
 	import ChangingFeatureValuesModelToBeExecuted::*;
 	import Occurrences::Occurrence;
 	import Occurrences::HappensBefore;
-	import Atoms::*;
 
 	struct ProductTimeSlice specializes Product {
 		readonly feature redefines isPainted;
@@ -111,7 +111,7 @@ package ChangingFeatureValuesExecution {
 		feature redefines objectToPaint : MyProduct;
 		step redefines painting : PaintingMyProductFeatureWrite;
 		step redefines painted : PaintedMyProductFeatureWrite;
-		succession redefines p_before_p : MyPaintingFW_Before_PaintFW_Link [1] first painting then painted;
+		succession redefines p_before_p : MyPaintingFW_Before_PaintFW_Link first painting then painted;
 	}
 
 	#atom
@@ -148,11 +148,11 @@ package ChangingFeatureValuesExecution {
 				objectToFinish.whilePainting.startShot.timeCoincidentOccurrences
 			chains paint.painting.endShot;
 		feature owPiP chains objectToFinish.whilePainting.isPainted = false;
-		feature owPiD chains objectToFinish.whilePainting.isDry = false;  
+		feature owPiD chains objectToFinish.whilePainting.isDry = false;
 		feature owPiS chains objectToFinish.whilePainting.isShipped = false;
 
 
-		feature subsets objectToFinish.whilePainting.immediateSuccessors,		
+		feature subsets objectToFinish.whilePainting.immediateSuccessors,
 				objectToFinish.afterPaint.startShot.timeCoincidentOccurrences
 			chains paint.painted.endShot;
 		feature oaPiP chains objectToFinish.afterPaint.isPainted = true;
@@ -166,8 +166,8 @@ package ChangingFeatureValuesExecution {
 				objectToFinish.afterDry.startShot.timeCoincidentOccurrences
 			chains dry.dried.endShot;
 		feature oaDiP chains objectToFinish.afterDry.isPainted = true;
-		feature oaDiD chains objectToFinish.afterDry.isDry = true;  
-		feature oaDiF chains objectToFinish.afterDry.isShipped = false;
+		feature oaDiD chains objectToFinish.afterDry.isDry = true;
+		feature oaDiS chains objectToFinish.afterDry.isShipped = false;
 
 
 		step redefines ship : MyShip;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -32,38 +32,38 @@ package ChangingFeatureValuesModelToBeExecuted {
 		feature objectToPaint : Product [1];
 
 		step painting : FeatureWritePerformance [1] {
-			redefines onOccurrence : Product = objectToPaint {
+			in onOccurrence : Product = objectToPaint {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isDry; } }
-			redefines replacementValues = false;
+			in replacementValues = false;
 		}
 
 		succession p_before_p first painting [1] then painted [1];
 		step painted : FeatureWritePerformance [*] {
-			redefines onOccurrence : Product = objectToPaint {
+			in onOccurrence : Product = objectToPaint {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isPainted; } }
-			redefines replacementValues = true;
+			in replacementValues = true;
 		}
 	}
 
 	behavior Dry {
 		feature objectToDry : Product [1];
 		step dried : FeatureWritePerformance [1] {
-			redefines onOccurrence : Product = objectToDry {
+			in onOccurrence : Product = objectToDry {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isDry; } }
-			redefines replacementValues = true;
+			in replacementValues = true;
 		}
 	}
 
 	behavior Ship {
 		feature objectToShip : Product [1];  
 		step shipped : FeatureWritePerformance [1] {
-			redefines onOccurrence : Product = objectToShip {
+			in onOccurrence : Product = objectToShip {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isShipped; } }
-			redefines replacementValues = true;
+			in replacementValues = true;
 		}
 	}
 }

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -94,7 +94,7 @@ package ChangingFeatureValuesExecution {
 	}
 
 	behavior MyProductFeatureWrite specializes FeatureWritePerformance {
-		feature redefines onOccurrence : MyProduct;
+		in redefines onOccurrence : MyProduct;
 	}
 
 	#atom

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -137,7 +137,7 @@ package ChangingFeatureValuesExecution {
 	#atom
 	behavior MyManufacture specializes Manufacture {
 		feature redefines objectToFinish : MyProduct;
-		feature startShot subsets objectToFinish.beforePaint.startShot.timeCoincidentOccurrences;
+		feature redefines startShot subsets objectToFinish.beforePaint.startShot.timeCoincidentOccurrences;
 		feature obPiP chains objectToFinish.beforePaint.isPainted = false;
 		feature obPiD chains objectToFinish.beforePaint.isDry = true;
 		feature obPiS chains objectToFinish.beforePaint.isShipped = false;

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -1,0 +1,183 @@
+
+package ChangingFeatureValuesModelToBeExecuted {
+	doc
+	/* 
+	 */
+
+	import ScalarValues::Boolean;
+	import FeatureReferencingPerformances::FeatureWritePerformance;
+
+	behavior Manufacture {
+		feature objectToFinish : Product [1];
+		step paint : Paint [1]{
+			redefines objectToPaint = objectToFinish;
+		}
+		step dry : Dry [*]  {
+			redefines objectToDry = objectToFinish;
+		}
+		succession p_before_d first paint [1] then dry [1];
+		step ship : Ship [*]	{
+			redefines objectToShip = objectToFinish;
+		}
+		succession d_before_s first dry [1] then ship [1];
+	}
+
+	struct Product {
+		feature isPainted : Boolean [1] := false;
+		feature isDry : Boolean [1] := true;
+		feature isShipped : Boolean [1] := false;
+	}
+
+	behavior Paint {
+		feature objectToPaint: Product [1];
+
+		step painting : FeatureWritePerformance [1] {
+			redefines onOccurrence : Product = objectToPaint {
+				redefines startingAt : Product {
+					redefines accessedFeature : Boolean [1] subsets isDry; } }
+			redefines replacementValues = false;
+		}
+
+		succession p_before_p first painting [1] then painted [1];
+		step painted : FeatureWritePerformance [*] {
+			redefines onOccurrence : Product = objectToPaint {
+				redefines startingAt : Product {
+					redefines accessedFeature : Boolean [1] subsets isPainted; } }
+						redefines replacementValues = true;
+		}
+	}
+
+	behavior Dry {
+		feature objectToDry : Product [1];
+		step dried : FeatureWritePerformance [1] {
+			redefines onOccurrence : Product = objectToDry {
+				redefines startingAt : Product {
+					redefines accessedFeature : Boolean [1] subsets isDry; } }
+						redefines replacementValues = true;
+		}
+	}
+
+	behavior Ship {
+		feature objectToShip: Product [1];  
+		step shipped : FeatureWritePerformance [1] {
+			redefines onOccurrence : Product = objectToShip {
+				redefines startingAt : Product {
+					redefines accessedFeature : Boolean [1] subsets isShipped; } }
+						redefines replacementValues = true;
+		}
+	}
+}
+
+package ChangingFeatureValuesExecution {
+	doc
+	/* 
+	 */
+
+	import ChangingFeatureValuesModelToBeExecuted::*;
+	import Occurrences::Occurrence;
+	import Occurrences::HappensBefore;
+	import Atoms::*;
+
+	struct ProductTimeSlice specializes Product {
+		readonly feature redefines isPainted;
+		readonly feature redefines isDry;
+		readonly feature redefines isShipped;
+	}
+
+	#atom
+	struct MyProduct specializes Product {
+		feature beforePaint : ProductTimeSlice [1] subsets timeSlices;
+		feature whilePainting : ProductTimeSlice [1] subsets timeSlices;
+		feature afterPaint : ProductTimeSlice [1] subsets timeSlices;
+		feature afterDry : ProductTimeSlice [1] subsets timeSlices;
+		feature afterShip : ProductTimeSlice [1] subsets timeSlices;  
+	}
+
+	behavior MyProductFeatureWrite specializes FeatureWritePerformance {
+		feature redefines onOccurrence : MyProduct;
+	}
+
+	#atom
+	behavior PaintingMyProductFeatureWrite specializes MyProductFeatureWrite;
+	#atom
+	behavior PaintedMyProductFeatureWrite specializes MyProductFeatureWrite;
+	#atom
+	assoc MyPaintingFW_Before_PaintFW_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : PaintingMyProductFeatureWrite;
+		end feature redefines laterOccurrence : PaintedMyProductFeatureWrite;
+	}
+	#atom
+	behavior MyPaint specializes Paint {
+		feature redefines objectToPaint : MyProduct;
+		step redefines painting : PaintingMyProductFeatureWrite;
+		step redefines painted : PaintedMyProductFeatureWrite;
+		succession redefines p_before_p : MyPaintingFW_Before_PaintFW_Link [1] first painting then painted;
+	}
+
+	#atom
+	behavior MyDry specializes Dry {
+		feature redefines objectToDry : MyProduct;
+		step redefines dried : MyProductFeatureWrite;  
+	}
+	#atom
+	assoc MyPaint_Before_Dry_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyPaint;
+		end feature redefines laterOccurrence : MyDry;
+	}
+	#atom
+	behavior MyShip specializes Ship {
+		feature redefines objectToShip : MyProduct;
+		step redefines shipped : MyProductFeatureWrite;  
+	}
+	#atom
+	assoc MyDry_Before_Ship_Link specializes HappensBefore {
+		end feature redefines earlierOccurrence : MyDry;
+		end feature redefines laterOccurrence : MyShip;
+	}
+	#atom
+	behavior MyManufacture specializes Manufacture {
+		feature redefines objectToFinish : MyProduct;
+		feature startShot subsets objectToFinish.beforePaint.startShot.timeCoincidentOccurrences;
+		feature obPiP chains objectToFinish.beforePaint.isPainted = false;
+		feature obPiD chains objectToFinish.beforePaint.isDry = true;
+		feature obPiS chains objectToFinish.beforePaint.isShipped = false;
+
+
+		step redefines paint : MyPaint;
+		feature subsets objectToFinish.beforePaint.immediateSuccessors,
+				objectToFinish.whilePainting.startShot.timeCoincidentOccurrences
+			chains paint.painting.endShot;
+		feature owPiP chains objectToFinish.whilePainting.isPainted = false;
+		feature owPiD chains objectToFinish.whilePainting.isDry = false;  
+		feature owPiS chains objectToFinish.whilePainting.isShipped = false;
+
+
+		feature subsets objectToFinish.whilePainting.immediateSuccessors,		
+				objectToFinish.afterPaint.startShot.timeCoincidentOccurrences
+			chains paint.painted.endShot;
+		feature oaPiP chains objectToFinish.afterPaint.isPainted = true;
+		feature oaPiD chains objectToFinish.afterPaint.isDry = false;
+		feature oaPiS chains objectToFinish.afterPaint.isShipped = false;
+
+
+		step redefines dry : MyDry;
+		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
+		feature subsets objectToFinish.afterPaint.immediateSuccessors,
+				objectToFinish.afterDry.startShot.timeCoincidentOccurrences
+			chains dry.dried.endShot;
+		feature oaDiP chains objectToFinish.afterDry.isPainted = true;
+		feature oaDiD chains objectToFinish.afterDry.isDry = true;  
+		feature oaDiF chains objectToFinish.afterDry.isShipped = false;
+
+
+		step redefines ship : MyShip;
+		succession redefines d_before_s : MyDry_Before_Ship_Link [1] first dry then ship;
+		feature subsets objectToFinish.afterDry.immediateSuccessors,
+				objectToFinish.afterShip.startShot.timeCoincidentOccurrences
+			chains ship.shipped.endShot;
+		feature redefines endShot subsets objectToFinish.afterShip.timeCoincidentOccurrences;
+		feature oaSiP chains objectToFinish.afterShip.isPainted = true;
+		feature oaSiD chains objectToFinish.afterShip.isDry = true;
+		feature oaSiS chains objectToFinish.afterShip.isShipped = true;
+	}
+}

--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -32,38 +32,38 @@ package ChangingFeatureValuesModelToBeExecuted {
 		feature objectToPaint : Product [1];
 
 		step painting : FeatureWritePerformance [1] {
-			in onOccurrence : Product = objectToPaint {
+			in redefines onOccurrence : Product = objectToPaint {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isDry; } }
-			in replacementValues = false;
+			in redefines replacementValues = false;
 		}
 
 		succession p_before_p first painting [1] then painted [1];
 		step painted : FeatureWritePerformance [*] {
-			in onOccurrence : Product = objectToPaint {
+			in redefines onOccurrence : Product = objectToPaint {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isPainted; } }
-			in replacementValues = true;
+			in redefines replacementValues = true;
 		}
 	}
 
 	behavior Dry {
 		feature objectToDry : Product [1];
 		step dried : FeatureWritePerformance [1] {
-			in onOccurrence : Product = objectToDry {
+			in redefines onOccurrence : Product = objectToDry {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isDry; } }
-			in replacementValues = true;
+			in redefines replacementValues = true;
 		}
 	}
 
 	behavior Ship {
 		feature objectToShip : Product [1];  
 		step shipped : FeatureWritePerformance [1] {
-			in onOccurrence : Product = objectToShip {
+			in redefines onOccurrence : Product = objectToShip {
 				redefines startingAt : Product {
 					redefines accessedFeature : Boolean [1] subsets isShipped; } }
-			in replacementValues = true;
+			in redefines replacementValues = true;
 		}
 	}
 }


### PR DESCRIPTION
This pull request adds, under `kerml/examples/KerML Annex A Examples`, models used as examples in Annex A: Model Execution of the KerML Specification:

- `A-2-Atoms.kerml`
- `A-2-ModelingInstances.kerml`
- `A-3-2-WithoutConnectors.kerml`
- `A-3-3-OneToOneConnectors.kerml`
- `A-3-4-OneToUnrestrictedConnectors.kerml`
- `A-3-5-TimingForStructures.kerml`
- `A-3-6-Sequences.kerml`
- `A-3-7-DecisionsAndMerges.kerml`
- `A-3-8-ChangingFeatureValues.kerml`

It is expected that these models will be included as informative artifacts with the finalized 1.0 specification.