### PR TITLE
ST6RI-726 validateRedefinitionDirectionConformance not checked for implicit Redefinitions

### DIFF
--- a/kerml/src/examples/Simple Tests/Behaviors.kerml
+++ b/kerml/src/examples/Simple Tests/Behaviors.kerml
@@ -1,0 +1,13 @@
+package Behaviors {
+    behavior A {
+        in x;
+        out y = b.y1;
+        composite step b : B {
+            in x1 = A::x;
+        }
+    }
+    behavior B specializes A {
+        in x1;
+        out y1;
+    }
+}

--- a/kerml/src/examples/Simple Tests/Expressions.kerml
+++ b/kerml/src/examples/Simple Tests/Expressions.kerml
@@ -17,21 +17,24 @@ package Expressions {
 	d1 = x.?{in xx; xx != null};
 	e = x->reduce {in s; in t; s + t}->reduce '+';
 	
-	behavior w specializes ControlPerformances::LoopPerformance { inout v: Integer;
-		in expr redefines whileTest {v > 3}
-		in step redefines body : Performances::Performance {
-			step decrement {
-				out v_decr : Integer = v - 1;			
-			}
-			succession decrement then update;
-			step update : FeatureReferencingPerformances::FeatureWritePerformance {
-				in redefines onOccurrence = w::self {
-					feature redefines startingAt : w {
-						inout feature redefines accessedFeature redefines v;
-					}
-				}
-				inout replacementValues = decrement.v_decr;
-			}
+	behavior w { inout v : Integer;
+	    step : ControlPerformances::LoopPerformance {
+    		in expr whileTest {v > 3}
+    		in expr untilTest;
+    		in step body {
+    			step decrement {
+    				out v_decr : Integer = v - 1;			
+    			}
+    			succession decrement then update;
+    			step update : FeatureReferencingPerformances::FeatureWritePerformance {
+    				in redefines onOccurrence = w::self {
+    					feature redefines startingAt : w {
+    						inout feature redefines accessedFeature redefines v;
+    					}
+    				}
+    				inout replacementValues = decrement.v_decr;
+    			}
+    		}
 		}
 	}
 	

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Behaviors.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Behaviors.kerml.xt
@@ -1,0 +1,37 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Performances.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+// XPECT noErrors ---> ""
+package Behaviors {
+    behavior A {
+        in x;
+        out y = b.y1;
+        composite step b : B {
+            in x1 = A::x;
+        }
+    }
+    behavior B specializes A {
+        in x1;
+        out y1;
+    }
+}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Expressions.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Expressions.kerml.xt
@@ -57,22 +57,25 @@ package Expressions {
 	d1 = x.?{in xx; xx != null};
 	e = x->reduce {in s; in t; s + t}->reduce '+';
 	
-	behavior w specializes ControlPerformances::LoopPerformance {
-		inout v: Integer;
-		in expr redefines whileTest {v > 3}
-		in step redefines body : Performances::Performance {
-			step decrement {
-				out v_decr : Integer = v - 1;			
-			}
-			succession decrement then update;
-			step update : FeatureReferencingPerformances::FeatureWritePerformance {
-				in redefines onOccurrence : w = w::self {
-					feature redefines startingAt {
-						feature redefines accessedFeature redefines v;
-					}
-				}
-				inout redefines replacementValues = decrement.v_decr;
-			}
+	behavior w { 
+		inout v : Integer;
+	    step : ControlPerformances::LoopPerformance {
+    		in expr whileTest {v > 3}
+    		in expr untilTest;
+    		in step body {
+    			step decrement {
+    				out v_decr : Integer = v - 1;			
+    			}
+    			succession decrement then update;
+    			step update : FeatureReferencingPerformances::FeatureWritePerformance {
+    				in redefines onOccurrence = w::self {
+    					feature redefines startingAt : w {
+    						inout feature redefines accessedFeature redefines v;
+    					}
+    				}
+    				inout replacementValues = decrement.v_decr;
+    			}
+    		}
 		}
 	}
 	

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_DirectionConformance_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_DirectionConformance_invalid.kerml.xt
@@ -1,0 +1,54 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Performances.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+
+package Redefinition_DirectionConformance {
+    behavior A {
+        in x;
+        inout y;
+        composite step b : B {
+        	// XPECT errors ---> "Redefining feature must have a compatible direction" at "in x1;"
+            in x1;
+        }
+    }
+    behavior B specializes A {
+    	// XPECT errors ---> "Redefining feature must have a compatible direction" at "out x1;"
+        out x1;
+        out y1;
+    }
+    class C {
+    	in z;
+    }
+    class D specializes C {
+    	// XPECT errors ---> "Redefining feature must have a compatible direction" at "z"
+    	out :>> z;
+    }
+    feature d : D {
+    	// XPECT errors ---> "Redefining feature must have a compatible direction" at "z"
+    	in :>> z;
+    }
+    class C1 conjugates C;
+    class D1 specializes C1 {
+    	// XPECT errors ---> "Redefining feature must have a compatible direction" at "z"
+    	in :>> z;
+    }
+}


### PR DESCRIPTION
This PR corrects `KerMLValidator` so that the`validateRedefinitionDirectionConformance` constraint is checked on implicit as well as explicit redefinitions. In particular, it will be checked for implicit redefinitions of parameters which will, for example, catch the following validation error that was not caught before:
```
behavior A {
  in x;
}
behavior B {
  out y; // Fails validation
}
```