### PR TITLE
ST6RI-712 Implicit specialization of non-framed concern usages is wrong

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
@@ -36,9 +36,21 @@ public class ConcernUsageAdapter extends RequirementUsageAdapter {
 	}
 	
 	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (UsageUtil.isSubrequirement(getTarget())) {
+			addDefaultGeneralType("subrequirement");
+		}
+	}
+	
+	@Override
+	protected String getDefaultSupertype() {
+		return getDefaultSupertype("base");
+	}
+	@Override
 	public void addRequirementConstraintSubsetting() {
 		if (UsageUtil.isFramedConcern(getTarget())) {
-			addSubsetting(getDefaultSupertype("subrequirement"));
+			addSubsetting(getDefaultSupertype("concern"));
 		} else {
 			super.addRequirementConstraintSubsetting();
 		}

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -195,7 +195,7 @@ public class ImplicitGeneralizationMap {
 		
 		put(ConcernDefinitionImpl.class, "base", "Requirements::ConcernCheck");
 		put(ConcernUsageImpl.class, "base", "Requirements::concernChecks");
-		put(ConcernUsageImpl.class, "subrequirement", "Requirements::RequirementCheck::concerns");
+		put(ConcernUsageImpl.class, "concern", "Requirements::RequirementCheck::concerns");
 		
 		put(ConnectionDefinitionImpl.class, "base", "Connections::Connection");
 		put(ConnectionDefinitionImpl.class, "binary", "Connections::BinaryConnection");


### PR DESCRIPTION
1. The semantic constraint `checkConcernUsageFramedConcernSpecialization` in the SysML v2 Specification only requires that framed concerns (i.e., concern usages owned by a requirement definition or usage via a framed concern membership) specialize `Requirements::RequirementsCheck::concerns`. This PR corrects a bug that previously resulted in all concern usages nested in requirement definitions or usages, not just framed concerns, implicitly specializing `Requirements::RequirementsCheck::concerns`. 
2. The PR also corrects a bug in `TypeAdapter::removeUnnecessaryImplicitGeneralTypes` that prevented the removal of some unnecessary implicit specializations.