### PR TITLE
ST6RI-714 PortUsage::isComposite is implemented incorrectly

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/PortUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/PortUsageImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.omg.sysml.lang.sysml.PortDefinition;
 import org.omg.sysml.lang.sysml.PortUsage;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
 
 /**
  * <!-- begin-user-doc -->
@@ -118,7 +119,11 @@ public class PortUsageImpl extends OccurrenceUsageImpl implements PortUsage {
 	
 	@Override
 	public boolean isComposite() {
-		return false;
+		Type owningType = getOwningType();
+		return owningType != null &&
+			   (owningType instanceof PortDefinition ||
+			    owningType instanceof PortUsage) &&
+			   super.isComposite();
 	}
 	
 	//

--- a/sysml/src/examples/Simple Tests/PartTest.sysml
+++ b/sysml/src/examples/Simple Tests/PartTest.sysml
@@ -14,7 +14,10 @@ package PartTest {
 		public abstract part a: A[1..2];
 		public abstract part b subsets a;
 		public abstract part c[0..1] subsets a;
-		port x: ~C;
+		port x: ~C {
+		    port p;
+		    ref port q;
+		}
 		package P { }
 		
 		action a1;
@@ -28,6 +31,8 @@ package PartTest {
 		private in ref y: A, B;
 		alias z1 for y;
 		alias z2 for y;
+		port c1 : C;
+		ref port c2 : C;
 	}
 	
     part p1 :> p2;


### PR DESCRIPTION
In the SysML v2 Specification, the `validatePortUsageIsReference` constraint only requires a `PortUsage` to be referential if it is not a feature of a `PortDefinition` or `PortUsage`. This PR corrects the implementation of `PortUsageImpl::isComposite` which previously always returned `false`, even if the port was a feature of a port definition or usage. With this correction, a `PortUsage` nested in a `PortDefinition` or `PortUsage` is composite by default and only referential if declared with the **`ref`** keyword.