### PR TITLE
ST6RI-719 View rendering redefinition is incorrect

### DIFF
--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ViewTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ViewTest.sysml.xt
@@ -88,6 +88,8 @@ package ViewTest {
 			expose P::*;
 			render r;
 			
+			rendering r2;
+			
 			alias vp1 for p1;
 			// Note: "expose" imports all.
 			alias vp2 for p2;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ViewRendering_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ViewRendering_invalid.sysml.xt
@@ -32,16 +32,18 @@ package ViewRendering_invalid {
 	rendering r;
 	
 	view def V {
-		rendering r1;
-		// XPECT errors ---> "A view definition may have at most one rendering." at "rendering r2;"
-		rendering r2;
+		render rendering r1;
+		// XPECT errors ---> "A view definition may have at most one view rendering." at "render rendering r2;"
+		render rendering r2;
+		rendering r3;
 	}
 
 	view v {
 		render r;
-		// XPECT errors ---> "A view may have at most one rendering." at "rendering r3;"
-		rendering r3;
-		// XPECT errors ---> "A view may have at most one rendering." at "rendering r4;"
-		rendering r4;
+		// XPECT errors ---> "A view may have at most one view rendering." at "render rendering r4;"
+		render rendering r4;
+		// XPECT errors ---> "A view may have at most one view rendering." at "render rendering r5;"
+		render rendering r5;
+		rendering r6;
 	}
 }

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -425,7 +425,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_RENDERING_USAGE_TYPE_MSG = "A rendering must be typed by one rendering definition."
 	
 	public static val INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING = "validateViewDefinitionOnlyOnvViewRendering"
-	public static val INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING_MSG = "A view definition may have at most one rendering."
+	public static val INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING_MSG = "A view definition may have at most one view rendering."
 	
 	public static val INVALID_VIEWPOINT_USAGE_TYPE = "validateViewpointUsageType_"
 	public static val INVALID_VIEWPOINT_USAGE_TYPE_MSG = "A viewpoint must be typed by one viewpoint definition."
@@ -436,7 +436,7 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_VIEW_USAGE_TYPE = "validateViewUsageType_"
 	public static val INVALID_VIEW_USAGE_TYPE_MSG = "A view must be typed by one view definition."
 	public static val INVALID_VIEW_USAGE_ONLY_ONE_RENDERING = "validateViewUsageOnlyOneRendering"
-	public static val INVALID_VIEW_USAGE_ONLY_ONE_RENDERING_MSG = "A view may have at most one rendering."
+	public static val INVALID_VIEW_USAGE_ONLY_ONE_RENDERING_MSG = "A view may have at most one view rendering."
 	
 	public static val INVALID_METADATA_USAGE_TYPE = "validateMetadataUsageType_"
 	public static val INVALID_METADATA_USAGE_TYPE_MSG = "A metadata usage must be typed by one metadata definition."
@@ -1201,7 +1201,7 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkViewDefinition(ViewDefinition viewDef) {
 		// validateViewDefinitionOnlyOneViewRendering
-		checkAtMostOneElement(viewDef.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING_MSG, INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING)
+		checkAtMostOneFeature(viewDef, ViewRenderingMembership, INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING_MSG, INVALID_VIEW_DEFINITION_ONLY_ONE_VIEW_RENDERING)
 	}
 	
 	@Check
@@ -1225,7 +1225,7 @@ class SysMLValidator extends KerMLValidator {
 		checkOneType(usg, ViewDefinition, INVALID_VIEW_USAGE_TYPE_MSG, SysMLPackage.eINSTANCE.viewUsage_ViewDefinition, INVALID_VIEW_USAGE_TYPE)
 
 		// validateViewUsageOnlyOneRendering	
-		checkAtMostOneElement(usg.ownedFeature.filter[f|f instanceof RenderingUsage], INVALID_VIEW_USAGE_ONLY_ONE_RENDERING_MSG, INVALID_VIEW_USAGE_ONLY_ONE_RENDERING)
+		checkAtMostOneFeature(usg, ViewRenderingMembership, INVALID_VIEW_USAGE_ONLY_ONE_RENDERING_MSG, INVALID_VIEW_USAGE_ONLY_ONE_RENDERING)
 	}
 	
 	@Check

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,17 +21,12 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.RenderingDefinition;
 import org.omg.sysml.lang.sysml.RenderingUsage;
+import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.ViewDefinition;
-import org.omg.sysml.lang.sysml.ViewUsage;
-import org.omg.sysml.util.FeatureUtil;
+import org.omg.sysml.lang.sysml.ViewRenderingMembership;
 
 public class RenderingUsageAdapter extends PartUsageAdapter {
 
@@ -43,6 +38,14 @@ public class RenderingUsageAdapter extends PartUsageAdapter {
 	public RenderingUsage getTarget() {
 		return (RenderingUsage)super.getTarget();
 	}
+	
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (isViewRendering()) {
+			addImplicitGeneralType(SysMLPackage.eINSTANCE.getRedefinition(), getLibraryType(getDefaultSupertype("viewRendering")));
+		}
+	}
 
 	@Override
 	protected String getDefaultSupertype() {
@@ -51,26 +54,14 @@ public class RenderingUsageAdapter extends PartUsageAdapter {
 					getDefaultSupertype("base");
 	}
 	
+	public boolean isViewRendering() {
+		FeatureMembership membership = getTarget().getOwningFeatureMembership();
+		return membership instanceof ViewRenderingMembership;
+	}
+	
 	public boolean isSubrendering() {
 		Type owningType = getTarget().getOwningType();
 		return owningType instanceof RenderingDefinition | owningType instanceof RenderingUsage;
-	}
-	
-	@Override
-	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
-		RenderingUsage target = getTarget();
-		return !FeatureUtil.isParameter(target) && !target.isEnd() && isRender(target)? getRenderFeatures(type):
-			   super.getRelevantFeatures(type, skip);
-	}
-	
-	protected List<? extends Feature> getRenderFeatures(Type type) {
-		List<Feature> features = type == getTarget().getOwningType()? type.getOwnedFeature(): type.getFeature();
-		return features.stream().filter(RenderingUsage.class::isInstance).collect(Collectors.toList());
-	}
-	
-	public static boolean isRender(RenderingUsage target) {
-		Type owningType = target.getOwningType();
-		return owningType instanceof ViewDefinition | owningType instanceof ViewUsage;
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,9 +26,6 @@ import org.omg.sysml.lang.sysml.ViewDefinition;
 import org.omg.sysml.lang.sysml.ViewUsage;
 
 public class ViewUsageAdapter extends PartUsageAdapter {
-
-	public static final String VIEW_SUBSETTING_BASE_DEFAULT = "Views::views";
-	public static final String VIEW_SUBSETTING_SUBVIEW_DEFAULT = "Views::View::subviews";
 
 	public ViewUsageAdapter(ViewUsage element) {
 		super(element);

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -281,6 +281,7 @@ public class ImplicitGeneralizationMap {
 		put(RenderingDefinitionImpl.class, "base", "Views::Rendering");
 		put(RenderingUsageImpl.class, "base", "Views::renderings");
 		put(RenderingUsageImpl.class, "subrendering", "Views::Rendering::subrenderings");
+		put(RenderingUsageImpl.class, "viewRendering", "Views::View::viewRendering");
 		
 		put(RequirementDefinitionImpl.class, "base", "Requirements::RequirementCheck");
 		put(RequirementUsageImpl.class, "base", "Requirements::requirementChecks");

--- a/sysml/src/examples/Simple Tests/ViewTest.sysml
+++ b/sysml/src/examples/Simple Tests/ViewTest.sysml
@@ -33,6 +33,8 @@ package ViewTest {
 			expose P::*;
 			render r;
 			
+			rendering r2;
+			
 			alias vp1 for p1;
 			// Note: "expose" imports all.
 			alias vp2 for p2;


### PR DESCRIPTION
1. This PR corrects the implicit redefinition of a `RenderingUsage` that is a view rendering of a `ViewDefinition` or `ViewUsage` (i.e., that is owned via a `ViewRenderingMembership`). Previously, the implemented gave a view rendering implicit redefinitions of the view renderings of any view definitions or usages specialized by the containing view definition or usage. This has now been changed to conform to the SysML v2 Specification, which requires that view rendering directly redefine `Views::View::viewRendering`.
2. The PR also corrects the checking of the `validateViewDefinitionOnlyOneViewRendering` and `validateViewUsageOnlyOneViewRendering`, so that a `ViewDefinition` or `ViewUsage` can have owned `RedefinitionUsages` other than its (at most) one view rendering.