### PR TITLE
ST6RI-721 Implementation of Type::directionOf is incorrect for conjugation

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/delegate/Type_input_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/Type_input_SettingDelegate.java
@@ -50,14 +50,14 @@ public class Type_input_SettingDelegate extends BasicDerivedListSettingDelegate 
 	
 	public static void addInputsOf(Type type, EList<Feature> inputs, Set<Type> visited) {
 		visited.add(type);
+		type.getOwnedFeature().stream().filter(feature->
+			FeatureDirectionKind.IN.equals(feature.getDirection()) ||
+			FeatureDirectionKind.INOUT.equals(feature.getDirection())).
+				forEachOrdered(inputs::add);
 		Conjugation conjugator = type.getOwnedConjugator();
 		if (conjugator != null) {
 			Type_output_SettingDelegate.addOutputsOf(conjugator.getOriginalType(), inputs, visited);
 		} else {
-			type.getOwnedFeature().stream().filter(feature->
-					FeatureDirectionKind.IN.equals(feature.getDirection()) ||
-					FeatureDirectionKind.INOUT.equals(feature.getDirection())).
-				forEachOrdered(inputs::add);
 			type.getOwnedSpecialization().stream().
 				map(Specialization::getGeneral).
 				filter(g->!visited.contains(g)).

--- a/org.omg.sysml/src/org/omg/sysml/delegate/Type_output_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/Type_output_SettingDelegate.java
@@ -50,14 +50,14 @@ public class Type_output_SettingDelegate extends BasicDerivedListSettingDelegate
 
 	public static void addOutputsOf(Type type, EList<Feature> outputs, Set<Type> visited) {
 		visited.add(type);
+		type.getOwnedFeature().stream().filter(feature->
+			FeatureDirectionKind.OUT.equals(feature.getDirection()) ||
+			FeatureDirectionKind.INOUT.equals(feature.getDirection())).
+				forEachOrdered(outputs::add);
 		Conjugation conjugator = type.getOwnedConjugator();
 		if (conjugator != null) {
 			Type_input_SettingDelegate.addInputsOf(conjugator.getOriginalType(), outputs, visited);
 		} else {
-			type.getOwnedFeature().stream().filter(feature->
-					FeatureDirectionKind.OUT.equals(feature.getDirection()) ||
-					FeatureDirectionKind.INOUT.equals(feature.getDirection())).
-				forEachOrdered(outputs::add);
 			type.getOwnedSpecialization().stream().
 				map(Specialization::getGeneral).
 				filter(g->!visited.contains(g)).

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -18,7 +18,6 @@
  * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
  *  
  *******************************************************************************/
-
 
 package org.omg.sysml.lang.sysml.impl;
 
@@ -903,7 +902,7 @@ public class TypeImpl extends NamespaceImpl implements Type {
 				FeatureDirectionKind originalDirection = directionOf(feature, originalType, visited);
 				return originalDirection == FeatureDirectionKind.IN? FeatureDirectionKind.OUT:
 					   originalDirection == FeatureDirectionKind.OUT? FeatureDirectionKind.IN:
-					   FeatureDirectionKind.INOUT;
+					   originalDirection;
 			}
 		} else {
 			for (Specialization specialization: type.getOwnedSpecialization()) {


### PR DESCRIPTION
1. Previously, `TypeImpl::directionOf` was implemented to return `FeatureDirectionKind::INOUT` in the case that the `Type` was conjugated and the `originalDirection` of the given `feature` was not `IN` or `OUT`. This has been corrected so that the method returns the `originalDirection` in this case (that is, it returns `null` if the `originalDirection` is `null` and `INOUT` if the `originalDirection` is INOUT).
2. Updated `Type_input_SettingDelegate` and `Type_output_SettingDelegate` so that `ownedFeatures` with the relevant `direction` are returned, even if the `Type` is conjugated.