### PR TITLE
ST6RI-722 Model library updates from KerML FTF Ballot #3

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Function Library/BaseFunctions.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/BaseFunctions.kerml
@@ -35,7 +35,7 @@ standard library package BaseFunctions {
 	abstract function '#'{ in seq: Anything[0..*] ordered nonunique; in index: Positive[1..*] ordered nonunique; 
 		return : Anything[0..1];
 	}
-	abstract function ','{ in seq1: Anything[0..*] ordered nonunique; seq2: Anything[0..*] ordered nonunique; 
+	abstract function ','{ in seq1: Anything[0..*] ordered nonunique; in seq2: Anything[0..*] ordered nonunique; 
 		return : Anything[0..*] ordered nonunique;
 	}
 	

--- a/sysml.library/Kernel Libraries/Kernel Function Library/DataFunctions.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/DataFunctions.kerml
@@ -36,8 +36,8 @@ standard library package DataFunctions {
 	abstract function '<=' { in x: DataValue[1]; in y: DataValue[1]; return : Boolean[1]; }
 	abstract function '>=' { in x: DataValue[1]; in y: DataValue[1]; return : Boolean[1]; }
 	
-	abstract function Max { in x: DataValue[1]; in y: DataValue[1]; return : DataValue[1]; }
-	abstract function Min { in x: DataValue[1]; in y: DataValue[1]; return : DataValue[1]; }
+	abstract function max { in x: DataValue[1]; in y: DataValue[1]; return : DataValue[1]; }
+	abstract function min { in x: DataValue[1]; in y: DataValue[1]; return : DataValue[1]; }
 	
 	abstract function '..' { in lower: DataValue[1]; in upper: DataValue[1]; return : DataValue[0..*] ordered; }	
 }

--- a/sysml.library/Kernel Libraries/Kernel Function Library/ScalarFunctions.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/ScalarFunctions.kerml
@@ -26,8 +26,8 @@ standard library package ScalarFunctions {
 	abstract function '<=' specializes DataFunctions::'<=' { in x: ScalarValue[1]; in y: ScalarValue[1]; return : Boolean[1]; }
 	abstract function '>=' specializes DataFunctions::'>=' { in x: ScalarValue[1]; in y: ScalarValue[1]; return : Boolean[1]; }
 	
-	abstract function max specializes DataFunctions::Max { in x: ScalarValue[1]; in y: ScalarValue[1]; return : ScalarValue[1]; }
-	abstract function min specializes DataFunctions::Min { in x: ScalarValue[1]; in y: ScalarValue[1]; return : ScalarValue[1]; }
+	abstract function max specializes DataFunctions::max { in x: ScalarValue[1]; in y: ScalarValue[1]; return : ScalarValue[1]; }
+	abstract function min specializes DataFunctions::min { in x: ScalarValue[1]; in y: ScalarValue[1]; return : ScalarValue[1]; }
 	
 	abstract function '..' specializes DataFunctions::'..' { in lower: ScalarValue[1]; in upper: ScalarValue[1]; return : ScalarValue[0..*]; }
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
@@ -8,9 +8,17 @@ standard library package Clocks {
 	private import ScalarValues::NumericalValue;
 	private import ScalarValues::Real;
 	private import Occurrences::Occurrence;
+	private import Occurrences::Life;
 	private import ControlFunctions::forAll;
 	
-	readonly feature universalClock : Clock[1] {
+	private struct UniversalClockLife[1] :> Clock, Life {
+	    doc
+	    /*
+	     * UniversalClockLife is the classifier of the singleton Life of the universalClock.
+	     */
+	}
+	
+	feature universalClock : UniversalClockLife[1] {
 		doc
 		/*
 		 * universalClock is a single Clock that can be used as a default universal

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
@@ -92,11 +92,18 @@ standard library package ControlPerformances {
 		inv { not ifTest() == elseClause->notEmpty() }
 	}
 	
-	behavior IfThenElsePerformance specializes IfThenPerformance, IfElsePerformance {
+	behavior IfThenElsePerformance specializes IfThenPerformance {
 		doc
 		/*
-		 * An IfThenElsePerformance is an IfThenPerformance and an IfElsePerformance.
+		 * An IfThenElsePerformance is an IfThenPerformance with an additional elseCaluse that
+		 * occurs after and only after the ifTest evaluation is false.
 		 */
+		 
+		in redefines ifTest;
+		in redefines thenClause;
+        in elseClause : Occurrence[0..1];
+        succession ifTest[1] then elseClause[0..1];
+        inv { not ifTest() == elseClause->notEmpty() }
 	}
 	
 	behavior LoopPerformance specializes Performance {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
@@ -95,7 +95,7 @@ standard library package ControlPerformances {
 	behavior IfThenElsePerformance specializes IfThenPerformance {
 		doc
 		/*
-		 * An IfThenElsePerformance is an IfThenPerformance with an additional elseCaluse that
+		 * An IfThenElsePerformance is an IfThenPerformance with an additional elseClause that
 		 * occurs after and only after the ifTest evaluation is false.
 		 */
 		 

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
@@ -1,67 +1,67 @@
 standard library package Links {
-	doc
-	/*
-	 * This package defines associations and features that are related to the typing of links.
-	 */
+    doc
+    /*
+     * This package defines associations and features that are related to the typing of links.
+     */
 
-	private import Base::Anything;
-	private import Base::things;
-	
-	abstract assoc Link specializes Anything {
-		doc
-		/*
-		 * Link is the most general association between two or more things.
-		 */
+    private import Base::Anything;
+    private import Base::things;
+    
+    abstract assoc Link specializes Anything {
+        doc
+        /*
+         * Link is the most general association between two or more things.
+         */
 
-		readonly feature participant: Anything[2..*] nonunique ordered;
-	}
-	
-	assoc all BinaryLink specializes Link {
-		doc
-		/*
-		 * BinaryLink is the most general binary association between exactly two things, 
-		 * nominally directed from source to target.
-		 */
-		 
-	    feature participant: Anything[2] nonunique ordered redefines Link::participant;
-		
-		readonly end feature source: Anything[0..*] nonunique subsets participant;
-	    readonly end feature target: Anything[0..*] nonunique subsets participant;
-	}
-	
-	assoc all SelfLink specializes BinaryLink {
-		doc
-		/*
-		 * SelfLink is a binary association in which the things at the two ends are asserted
-		 * to be the same.
-		 */
-		
-		end feature thisThing: Anything[1] redefines source subsets sameThing, sameThing.self;
-		end feature sameThing: Anything[1] redefines target subsets thisThing;
-	}
-		
-	abstract feature links: Link[0..*] nonunique subsets things {
-		doc
-		/*
-		 * links is the most general feature of links between individuals.
-		 */
-	}
-	
-	abstract feature binaryLinks: BinaryLink[0..*] nonunique subsets links {
-		doc
-		/*
-		 * binaryLinks is a specialization of links restricted to type BinaryLink.
-		 */
-	}
-	
-	abstract feature selfLinks: SelfLink[0..*] nonunique subsets binaryLinks {
-		doc
-		/*
-		 * selfLinks is a specialization of binaryLinks restricted to type SelfLink.
-		 */
+        readonly feature participant: Anything[2..*] nonunique ordered;
+    }
+    
+    assoc all BinaryLink specializes Link {
+        doc
+        /*
+         * BinaryLink is the most general binary association between exactly two things, 
+         * nominally directed from source to target.
+         */
+         
+        feature participant: Anything[2] nonunique ordered redefines Link::participant;
+        
+        readonly end feature source: Anything[0..*] nonunique subsets participant;
+        readonly end feature target: Anything[0..*] nonunique subsets participant;
+    }
+    
+    assoc all SelfLink specializes BinaryLink {
+        doc
+        /*
+         * SelfLink is a binary association in which the things at the two ends are asserted
+         * to be the same.
+         */
+        
+        end feature thisThing: Anything[1] redefines source subsets sameThing, sameThing.self;
+        end feature sameThing: Anything[1] redefines target subsets thisThing;
+    }
+        
+    abstract feature links: Link[0..*] nonunique subsets things {
+        doc
+        /*
+         * links is the most general feature of links between individuals.
+         */
+    }
+    
+    abstract feature binaryLinks: BinaryLink[0..*] nonunique subsets links {
+        doc
+        /*
+         * binaryLinks is a specialization of links restricted to type BinaryLink.
+         */
+    }
+    
+    abstract feature selfLinks: SelfLink[0..*] nonunique subsets binaryLinks {
+        doc
+        /*
+         * selfLinks is a specialization of binaryLinks restricted to type SelfLink.
+         */
 
-		end feature thisThing: Anything[1] redefines SelfLink::thisThing, binaryLinks::source;
-		end feature sameThing: Anything[1] redefines SelfLink::sameThing, binaryLinks::target;
-	}
-		
+        end feature thisThing: Anything[1] redefines SelfLink::thisThing, binaryLinks::source;
+        end feature sameThing: Anything[1] redefines SelfLink::sameThing, binaryLinks::target;
+    }
+
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Links.kerml
@@ -25,8 +25,8 @@ standard library package Links {
 		 
 	    feature participant: Anything[2] nonunique ordered redefines Link::participant;
 		
-		readonly end feature source: Anything[0..*] subsets participant;
-	    readonly end feature target: Anything[0..*] subsets participant;
+		readonly end feature source: Anything[0..*] nonunique subsets participant;
+	    readonly end feature target: Anything[0..*] nonunique subsets participant;
 	}
 	
 	assoc all SelfLink specializes BinaryLink {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
@@ -7,6 +7,7 @@ standard library package Observation {
 	 
 	private import ScalarValues::Boolean;
 	private import Occurrences::Occurrence;
+	private import Occurrences::Life;
 	private import SequenceFunctions::including;
 	private import SequenceFunctions::excluding;
 	private import ControlFunctions::select;
@@ -16,7 +17,14 @@ standard library package Observation {
 	private import FeatureReferencingPerformances::BooleanEvaluationResultToMonitorPerformance;
 	private import Transfers::TransferBefore;
 
-	readonly feature defaultMonitor[1] : ChangeMonitor {
+    private struct DefaultMonitorLife[1] :> ChangeMonitor, Life {
+        doc
+        /*
+         * DefaultMonitorLife is the classifier of the singleton Life of the defaultMonitor.
+         */
+    }
+    
+	feature defaultMonitor[1] : DefaultMonitorLife {
 		doc
 		/*
 		 * defaultMonitor is a single ChangeMonitor that can be used as a default.

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -20,16 +20,18 @@ standard library package Occurrences {
 	private import SequenceFunctions::includes;
 	private import SequenceFunctions::union;
 
-	/*
-	 * Occurrence is the most general classifier of entities that have identity and
-	 * occur over time and space.
-	 *
-	 * The features of Occurrence specify the semantics of associations between occurrences that
-	 * assert complete inclusion and exclusion in time or space, or both, which includes
-	 * portions of an occurrence (having the same identity).  Portions include slices and shots
-	 * over time and space.
-	 */
 	abstract class Occurrence specializes Anything disjoint from DataValue {
+        doc
+        /*
+         * Occurrence is the most general classifier of entities that have identity and
+         * occur over time and space.
+         *
+         * The features of Occurrence specify the semantics of associations between occurrences that
+         * assert complete inclusion and exclusion in time or space, or both, which includes
+         * portions of an occurrence (having the same identity).  Portions include slices and shots
+         * over time and space.
+         */
+        
 		private import SequenceFunctions::*;
 
 		feature portionOfLife: Life[1] subsets portionOf;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -29,7 +29,7 @@ standard library package Occurrences {
 	 * portions of an occurrence (having the same identity).  Portions include slices and shots
 	 * over time and space.
 	 */
-	abstract class Occurrence specializes Anything {
+	abstract class Occurrence specializes Anything disjoint from DataValue {
 		private import SequenceFunctions::*;
 
 		feature portionOfLife: Life[1] subsets portionOf;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
@@ -19,7 +19,7 @@ standard library package Performances {
 	private import ScalarValues::*;
 	private import SequenceFunctions::includes;
 	
-	abstract behavior Performance specializes Occurrence {
+	abstract behavior Performance specializes Occurrence disjoint from Object {
 		doc
 		/*
 		 * Performance is the most general class of behavioral Occurrences that may be performed over time.

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
@@ -1,196 +1,196 @@
 standard library package SpatialFrames {
-	doc
-	/*
-	 * This package models spatial frames of reference for quantifying the position of points 
-	 * in a three-dimensional space. 
-	 */
+    doc
+    /*
+     * This package models spatial frames of reference for quantifying the position of points 
+     * in a three-dimensional space. 
+     */
 
-	private import Clocks::*;
-	private import ScalarValues::NumericalValue;
-	private import VectorValues::ThreeVectorValue;
-	private import VectorValues::CartesianThreeVectorValue;
-	private import VectorFunctions::isZeroVector;
-	private import Occurrences::Life;
-	private import Objects::Body;
-	private import Objects::Point;
-	private import ControlFunctions::forAll;
-	private import SequenceFunctions::includes;
-	
-	private struct DefaultFrameLife[1] :> SpatialFrame, Life {
-	    doc
-	    /*
+    private import Clocks::*;
+    private import ScalarValues::NumericalValue;
+    private import VectorValues::ThreeVectorValue;
+    private import VectorValues::CartesianThreeVectorValue;
+    private import VectorFunctions::isZeroVector;
+    private import Occurrences::Life;
+    private import Objects::Body;
+    private import Objects::Point;
+    private import ControlFunctions::forAll;
+    private import SequenceFunctions::includes;
+    
+    private struct DefaultFrameLife[1] :> SpatialFrame, Life {
+        doc
+        /*
          * DefaultFrameLife is the classifier of the singleton Life of the defaultFrame.
-	     */
-	}
-	feature defaultFrame : DefaultFrameLife[1] {
-		doc
-		/*
-		 * defaultFrame is a fixed SpatialFrame used as a universal default.
-		 */
-	}
-	
-	abstract struct SpatialFrame specializes Body {
-		doc
-		/*
-		 * A SpatialFrame is a three-dimensional Body that provides a spatial extent that 
-		 * acts as a frame of reference for defining the physical position and displacement 
-		 * vectors of Points over time.
-		 */
-	}
-	
-	abstract function PositionOf {
-		doc
-		/*
-		 * The PositionOf a Point relative to a SpatialFrame, at a specific time relative to a given
-		 * Clock, as a positionVector that is a ThreeVectorValue.
-		 */
-	
-		in point : Point[1];
-		in time : NumericalValue[1];
-		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default frame.localClock;
-		return positionVector : ThreeVectorValue[1];
-		
-		inv positionTimePrecondition {
-			doc
-			/*
-			 * The given point must exist at the given time.
-			 */
-		
-			TimeOf(point.startShot) <= time and
-			time <= TimeOf(point.endShot)
-		}
-		
-		inv spacePositionConstraint {
-			doc
-			/*
-			 * The result positionVector is equal to the PositionOf the Point spaceShot of the
-			 * frame that encloses the given point, at the given time.
-			 */
-		
-			(frame.spaceShots as Point)->forAll{in p : Point;
-				p.spaceTimeEnclosedOccurrences->includes(point) implies
-					positionVector == PositionOf(p, time, frame)
-			}
-		}
-	}
-	
-	abstract function CurrentPositionOf {
-		doc
-		/*
-		 * The CurrentPositionOf a Point relative to a SpatialFrame and a Clock is the PositionOf
-		 * the Point relative to the SpatialFrame at the currentTime of the Clock.
-		 */
-	
-		in point : Point[1];
-		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default frame.localClock;
-		return positionVector : ThreeVectorValue[1] =
-			PositionOf(point, clock.currentTime, frame, clock);
-	}
-		
-	function DisplacementOf {
-		doc
-		/*
-		 * The DisplacementOf two Points relative to a SpatialFrame, at a specific time relative to a
-		 * given Clock, is the displacementVector computed as the difference between the PositionOf the 
-		 * first Point and PositionOf the second Point, relative to that SpatialFrame, at that time.
-		 */
-	
-		in point1 : Point[1];
-		in point2 : Point[1];
-		in time : NumericalValue;
-		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default frame.localClock;
-		return displacementVector : ThreeVectorValue[1] =
-			PositionOf(point2, time, frame, clock) - PositionOf(point1, time, frame, clock);
-			
-		inv zeroDisplacementConstraint {
-		doc
-		/*
-		 * If either point1 or point2 occurs within the other, then the displacementVector is
-		 * the zero vector.
-		 */
-		
-			(point1.spaceTimeEnclosedOccurrences->includes(point2) or
-			point2.spaceTimeEnclosedOccurrences->includes(point1)) implies
-				isZeroVector(displacementVector)
-		}
-	}
-	
-	function CurrentDisplacementOf {
-		doc
-		/*
-		 * The CurrentDisplacementOf two Points relative to a SpatialFrame and Clock is the DisplacementOf
-		 * the Points relative to the SpatialFrame at the currentTime of the Clock.
-		 */
-	
-		in point1 : Point[1];
-		in point2 : Point[1];
-		in frame : SpatialFrame[1] default defaultFrame;
-		in clock : Clock[1] default frame.localClock;
-		return displacementVector : ThreeVectorValue[1] =
-			DisplacementOf(point1, point2, clock.currentTime, frame, clock);
-	}
-	
-	abstract struct CartesianSpatialFrame :> SpatialFrame {
-		doc
-		/*
-		 * A CartesianSpatialFrame is a SpatialFrame relative to which all position and displacement
-		 * vectors can be represented as CartesianThreeVectorValues.
-		 */
-	}
-	
-	abstract function CartesianPositionOf :> PositionOf {
-		doc
-		/*
-		 * The PositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
-		 */
-	
-		in point : Point[1];
-		in time : NumericalValue[1];
-		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default frame.localClock;
-		return positionVector : CartesianThreeVectorValue[1];
-	}
-	
-	abstract function CartesianCurrentPositionOf :> CurrentPositionOf {
-		doc
-		/*
-		 * The CurrentPositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
-		 */
-	
-		in point : Point[1];
-		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default frame.localClock;
-		return positionVector : CartesianThreeVectorValue[1];
-	}
-	
-	function CartesianDisplacementOf :> DisplacementOf {
-		doc
-		/*
-		 * The DisplacementOf two Points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
-		 */
-	
-		in point1 : Point[1];
-		in point2 : Point[1];
-		in time : NumericalValue[1];
-		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default frame.localClock;
-		return displacementVector : CartesianThreeVectorValue[1];
-	}
-		
-	function CartesianCurrentDisplacementOf :> CurrentDisplacementOf {
-		doc
-		/*
-		 * The CurrentDisplacementOf two Points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
-		 */
-	
-		in point1 : Point[1];
-		in point2 : Point[1];
-		in frame : CartesianSpatialFrame[1];
-		in clock : Clock[1] default frame.localClock;
-		return displacementVector : CartesianThreeVectorValue[1];
-	}
-		
+         */
+    }
+    feature defaultFrame : DefaultFrameLife[1] {
+        doc
+        /*
+         * defaultFrame is a fixed SpatialFrame used as a universal default.
+         */
+    }
+    
+    abstract struct SpatialFrame specializes Body {
+        doc
+        /*
+         * A SpatialFrame is a three-dimensional Body that provides a spatial extent that 
+         * acts as a frame of reference for defining the physical position and displacement 
+         * vectors of Points over time.
+         */
+    }
+    
+    abstract function PositionOf {
+        doc
+        /*
+         * The PositionOf a Point relative to a SpatialFrame, at a specific time relative to a given
+         * Clock, as a positionVector that is a ThreeVectorValue.
+         */
+    
+        in point : Point[1];
+        in time : NumericalValue[1];
+        in frame : SpatialFrame[1] default defaultFrame;
+        in clock : Clock[1] default frame.localClock;
+        return positionVector : ThreeVectorValue[1];
+        
+        inv positionTimePrecondition {
+            doc
+            /*
+             * The given point must exist at the given time.
+             */
+        
+            TimeOf(point.startShot) <= time and
+            time <= TimeOf(point.endShot)
+        }
+        
+        inv spacePositionConstraint {
+            doc
+            /*
+             * The result positionVector is equal to the PositionOf the Point spaceShot of the
+             * frame that encloses the given point, at the given time.
+             */
+        
+            (frame.spaceShots as Point)->forAll{in p : Point;
+                p.spaceTimeEnclosedOccurrences->includes(point) implies
+                    positionVector == PositionOf(p, time, frame)
+            }
+        }
+    }
+    
+    abstract function CurrentPositionOf {
+        doc
+        /*
+         * The CurrentPositionOf a Point relative to a SpatialFrame and a Clock is the PositionOf
+         * the Point relative to the SpatialFrame at the currentTime of the Clock.
+         */
+    
+        in point : Point[1];
+        in frame : SpatialFrame[1] default defaultFrame;
+        in clock : Clock[1] default frame.localClock;
+        return positionVector : ThreeVectorValue[1] =
+            PositionOf(point, clock.currentTime, frame, clock);
+    }
+        
+    function DisplacementOf {
+        doc
+        /*
+         * The DisplacementOf two Points relative to a SpatialFrame, at a specific time relative to a
+         * given Clock, is the displacementVector computed as the difference between the PositionOf the 
+         * first Point and PositionOf the second Point, relative to that SpatialFrame, at that time.
+         */
+    
+        in point1 : Point[1];
+        in point2 : Point[1];
+        in time : NumericalValue;
+        in frame : SpatialFrame[1] default defaultFrame;
+        in clock : Clock[1] default frame.localClock;
+        return displacementVector : ThreeVectorValue[1] =
+            PositionOf(point2, time, frame, clock) - PositionOf(point1, time, frame, clock);
+            
+        inv zeroDisplacementConstraint {
+        doc
+        /*
+         * If either point1 or point2 occurs within the other, then the displacementVector is
+         * the zero vector.
+         */
+        
+            (point1.spaceTimeEnclosedOccurrences->includes(point2) or
+            point2.spaceTimeEnclosedOccurrences->includes(point1)) implies
+                isZeroVector(displacementVector)
+        }
+    }
+    
+    function CurrentDisplacementOf {
+        doc
+        /*
+         * The CurrentDisplacementOf two Points relative to a SpatialFrame and Clock is the DisplacementOf
+         * the Points relative to the SpatialFrame at the currentTime of the Clock.
+         */
+    
+        in point1 : Point[1];
+        in point2 : Point[1];
+        in frame : SpatialFrame[1] default defaultFrame;
+        in clock : Clock[1] default frame.localClock;
+        return displacementVector : ThreeVectorValue[1] =
+            DisplacementOf(point1, point2, clock.currentTime, frame, clock);
+    }
+    
+    abstract struct CartesianSpatialFrame :> SpatialFrame {
+        doc
+        /*
+         * A CartesianSpatialFrame is a SpatialFrame relative to which all position and displacement
+         * vectors can be represented as CartesianThreeVectorValues.
+         */
+    }
+    
+    abstract function CartesianPositionOf :> PositionOf {
+        doc
+        /*
+         * The PositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+         */
+    
+        in point : Point[1];
+        in time : NumericalValue[1];
+        in frame : CartesianSpatialFrame[1];
+        in clock : Clock[1] default frame.localClock;
+        return positionVector : CartesianThreeVectorValue[1];
+    }
+    
+    abstract function CartesianCurrentPositionOf :> CurrentPositionOf {
+        doc
+        /*
+         * The CurrentPositionOf a Point relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+         */
+    
+        in point : Point[1];
+        in frame : CartesianSpatialFrame[1];
+        in clock : Clock[1] default frame.localClock;
+        return positionVector : CartesianThreeVectorValue[1];
+    }
+    
+    function CartesianDisplacementOf :> DisplacementOf {
+        doc
+        /*
+         * The DisplacementOf two Points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+         */
+    
+        in point1 : Point[1];
+        in point2 : Point[1];
+        in time : NumericalValue[1];
+        in frame : CartesianSpatialFrame[1];
+        in clock : Clock[1] default frame.localClock;
+        return displacementVector : CartesianThreeVectorValue[1];
+    }
+        
+    function CartesianCurrentDisplacementOf :> CurrentDisplacementOf {
+        doc
+        /*
+         * The CurrentDisplacementOf two Points relative to a CartesianSpatialFrame is a CartesianThreeVectorValue.
+         */
+    
+        in point1 : Point[1];
+        in point2 : Point[1];
+        in frame : CartesianSpatialFrame[1];
+        in clock : Clock[1] default frame.localClock;
+        return displacementVector : CartesianThreeVectorValue[1];
+    }
+
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
@@ -10,12 +10,19 @@ standard library package SpatialFrames {
 	private import VectorValues::ThreeVectorValue;
 	private import VectorValues::CartesianThreeVectorValue;
 	private import VectorFunctions::isZeroVector;
+	private import Occurrences::Life;
 	private import Objects::Body;
 	private import Objects::Point;
 	private import ControlFunctions::forAll;
 	private import SequenceFunctions::includes;
 	
-	readonly feature defaultFrame : SpatialFrame[1] {
+	private struct DefaultFrameLife[1] :> SpatialFrame, Life {
+	    doc
+	    /*
+         * DefaultFrameLife is the classifier of the singleton Life of the defaultFrame.
+	     */
+	}
+	feature defaultFrame : DefaultFrameLife[1] {
 		doc
 		/*
 		 * defaultFrame is a fixed SpatialFrame used as a universal default.

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -177,7 +177,7 @@ standard library package Transfers {
         end feature target: Occurrence[0..*] redefines Transfer::target, TransferBefore::target;		 
 	}
 	
-	step transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
+	abstract flow transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
 		doc
 		/*
 		 * transfers is a specialization of performances and binaryLinks restricted to type 
@@ -188,14 +188,14 @@ standard library package Transfers {
 		end feature target: Occurrence[0..*] redefines Transfer::target, binaryLinks::target;
 	}
 	
-	step messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
+	abstract flow messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
 		doc
 		/*
 		 * messageTransfers is a specialization of transfers restricted to type MessageTransfers.
 		 */
 	}
 	
-	step flowTransfers: FlowTransfer[0..*] nonunique subsets transfers {
+	abstract flow flowTransfers: FlowTransfer[0..*] nonunique subsets transfers {
 		doc
 		/*
 		 * flowTransfers is a specialization of transfers restricted to type FlowTransfers.
@@ -203,7 +203,7 @@ standard library package Transfers {
 		 */
 	}
 	  
-	step transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks {
+	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks {
 		doc
 		/*
 		 * transfersBefore is a specialization of transfers and happensBeforeLinks restricted to
@@ -214,7 +214,7 @@ standard library package Transfers {
 		end feature target: Occurrence[0..*] redefines transfers::target, HappensBefore::laterOccurrence;
 	}
 	
-	step flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore {
+	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore {
 		doc
 		/*
 		 * flowTransfersBefore is a specialization of flowTransfers and transfersBefore that is restricted


### PR DESCRIPTION
This PR implements resolutions of issues from KerML FTF Ballot 3 that called for updates to library models.

Resolutions of the following issues are implemented in this PR:

- [KERML-38](https://issues.omg.org/issues/KERML-38) Binary association ends always unique
- [KERML-42](https://issues.omg.org/issues/KERML-42) Occurrences can be data values
- [KERML-43](https://issues.omg.org/issues/KERML-43) Performances can be objects, behaviors can be structures
- [KERML-56](https://issues.omg.org/issues/KERML-56) Universal features can have many values
- [KERML-77](https://issues.omg.org/issues/KERML-77) Problems with IfThenElsePerformance
- [KERML-88](https://issues.omg.org/issues/KERML-88) BaseFunctions::',' has a bad parameter declaration
- [KERML-188](https://issues.omg.org/issues/KERML-188) DataFunctions::Min and Max should not be capitalized
- [KERML-198](https://issues.omg.org/issues/KERML-198) Wrong documentation format for class Occurrence in Semantic Library
- [KERML-227](https://issues.omg.org/issues/KERML-227) Documentation of features in Transfers library model is wrong

Resolutions of the following issues were previously implemented in PR #504:

- [KERML-182](https://issues.omg.org/issues/KERML-182) Update Kernel Semantic Library for validateRedefinitionDirectionConformance
- [KERML-184](https://issues.omg.org/issues/KERML-184) Update Kernel Model Libraries for validateFeatureValueOverriding constraint
- [KERML-186](https://issues.omg.org/issues/KERML-186) Update semantic model of invariants for validateExpressionResultExpressionMembership constraint
- [KERML-195](https://issues.omg.org/issues/KERML-195) Transfer sourceOutput and targetInput directions

Resolutions of the following issues did not require any update to the library model files:

- [KERML-175](https://issues.omg.org/issues/KERML-175) Natural unnecessary explicit general type declaration
- [KERML-176](https://issues.omg.org/issues/KERML-176) Base Overview Type
- [KERML-177](https://issues.omg.org/issues/KERML-177) Legacy, so incorrect, wording in Anything Description
- [KERML-178](https://issues.omg.org/issues/KERML-178) Anything.self subsetting inconsistent declaration with Base.kerml declaration
- [KERML-180](https://issues.omg.org/issues/KERML-180) Occurrence Overview Typo