### PR TITLE
ST6RI-724 Model library updates from SysML v2 FTF Ballot #9

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -206,13 +206,15 @@ public class TypeAdapter extends NamespaceAdapter {
 				filter(spec->spec.getSpecific() == target && spec.getGeneral() != target).
 				map(Specialization::getGeneral).
 				collect(Collectors.toList());
-		implicitGeneralTypes.values().forEach(generals::addAll);
+		List<Type> implicitGenerals = new ArrayList<>();
+		implicitGeneralTypes.values().forEach(implicitGenerals::addAll);
 		for (Object eClass: implicitGeneralTypes.keySet().toArray()) {
 			if (eClass != SysMLPackage.eINSTANCE.getRedefinition()) {
-				List<Type> implicitGenerals = implicitGeneralTypes.get(eClass);
-				implicitGenerals.removeIf(gen->
-					generals.stream().anyMatch(type->type != gen && conforms(type, gen)));
-				if (implicitGenerals.isEmpty()) {
+				List<Type> implicitEClassGenerals = implicitGeneralTypes.get(eClass);
+				implicitEClassGenerals.removeIf(gen->
+					generals.stream().anyMatch(type->conforms(type, gen)) ||
+					implicitGenerals.stream().anyMatch(type->type != gen && conforms(type, gen)));
+				if (implicitEClassGenerals.isEmpty()) {
 					implicitGeneralTypes.remove(eClass);
 				}
 			}

--- a/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
@@ -14,6 +14,8 @@ standard library package SpatialItems {
 	private import Time::TimeInstantValue;
 	private import ScalarValues::Natural;
 	private import ISQ::universalCartesianSpatial3dCoordinateFrame;
+	private import ISQ::Position3dVector;
+	private import ISQ::Displacement3dVector;
 	private import VectorFunctions::isZeroVector;
 	private import SequenceFunctions::isEmpty;
 	private import ControlFunctions::forAll;
@@ -97,9 +99,8 @@ standard library package SpatialItems {
 		in timeInstant : TimeInstantValue[1];
 		in enclosingItem :>> 'frame' : SpatialItem[1];
 		in clock : Clock[1] default enclosingItem.localClock;
-		return positionVector : VectorQuantityValue[1] {
+		return positionVector : Position3dVector[1] {
 			attribute :>> mRef = enclosingItem.coordinateFrame;
-			attribute :>> isBound = true;
 		}
 	}
 
@@ -113,9 +114,8 @@ standard library package SpatialItems {
 		in point : Point[1];
 		in enclosingItem :>> 'frame' : SpatialItem[1];
 		in clock : Clock[1] default enclosingItem.localClock;
-		return positionVector : VectorQuantityValue[1] {
+		return positionVector : Position3dVector[1] {
 			attribute :>> mRef = enclosingItem.coordinateFrame;
-			attribute :>> isBound = true;
 		}
 	}
 
@@ -132,9 +132,8 @@ standard library package SpatialItems {
 		in timeInstant : TimeInstantValue[1];
 		in spatialItem :>> 'frame' : SpatialItem[1];
 		in clock : Clock[1] default spatialItem.localClock;
-		return displacementVector : VectorQuantityValue[1] {
+		return displacementVector : Displacement3dVector[1] {
 			attribute :>> mRef = spatialItem.coordinateFrame;
-			attribute :>> isBound = false;
 		}
 	}
 
@@ -149,9 +148,8 @@ standard library package SpatialItems {
 		in point2 : Point[1];
 		in spatialItem :>> 'frame' : SpatialItem[1];
 		in clock : Clock[1] default spatialItem.localClock;
-		return displacementVector : VectorQuantityValue[1] {
+		return displacementVector : Displacement3dVector[1] {
 			attribute :>> mRef = spatialItem.coordinateFrame;
-			attribute :>> isBound = false;
 		}
 	}
 

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -335,6 +335,14 @@ standard library package Actions {
 		/*
 		 * assignmentActions is the base feature for all AssignmentActionsUsages.
 		 */
+		 
+        in :>> target : Occurrence[1] default that as Occurrence {
+            doc
+            /*
+             * The default target for assignmentActions is its featuring instance (if that is 
+             * an Occurrence).
+             */
+        }
 	}
 	
 	action def IfThenAction :> Action, IfThenPerformance {

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -68,14 +68,14 @@ standard library package Actions {
 			}
 		}
 	
-		action sendSubactions: SendAction[0..*] :> subactions {
+		action sendSubactions: SendAction[0..*] :> subactions, sendActions {
 			doc
 			/*
 			 * The subactions of this Action that are SendActions. 
 			 */
 		}
 	
-		action acceptSubactions: AcceptAction[0..*] :> subactions {
+		action acceptSubactions: AcceptAction[0..*] :> subactions, acceptActions {
 			doc
 			/*
 			 * The subactions of this Action that are AcceptActions. 

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -124,7 +124,7 @@ standard library package Actions {
 			 */
 		}
 		
-		abstract action decisionTransitions : DecisionTransitionAction[0..*] :> transitionActions {
+		abstract action decisionTransitions : DecisionTransitionAction[0..*] :> transitions {
 			doc
 			/*
 			 * The subactions of this Action that are DecisionTransitionActions. 

--- a/sysml.library/Systems Library/Connections.sysml
+++ b/sysml.library/Systems Library/Connections.sysml
@@ -52,8 +52,8 @@ standard library package Connections {
 		 * FlowConnectionDefinitions.
 		 */
 	
-		end source: Occurrence[0..*] :>> BinaryConnection::source, Transfer::source;
-		end target: Occurrence[0..*] :>> BinaryConnection::target, Transfer::target;
+		end occurrence source: Occurrence[0..*] :>> BinaryConnection::source, Transfer::source;
+		end occurrence target: Occurrence[0..*] :>> BinaryConnection::target, Transfer::target;
 		
 		ref payload :>> 'item';
 		
@@ -90,6 +90,9 @@ standard library package Connections {
 		 * It is the base type for FlowConnectionUsages that identify their source output and
 		 * target input.
 		 */
+		
+        end occurrence source: Occurrence[0..*] :>> MessageConnection::source, FlowTransfer::source;
+        end occurrence target: Occurrence[0..*] :>> MessageConnection::target, FlowTransfer::target;
 	}
 	
 	abstract flow def SuccessionFlowConnection :> FlowConnection, FlowTransferBefore {
@@ -99,8 +102,8 @@ standard library package Connections {
 		 * temporally ordered transfers. It is the base type for all SuccessionFlowConnectionUsages.
 		 */
 	
-		end source: Occurrence[0..*] :>> FlowConnection::source, FlowTransferBefore::source;
-		end target: Occurrence[0..*] :>> FlowConnection::target, FlowTransferBefore::target;
+		end occurrence source: Occurrence[0..*] :>> FlowConnection::source, FlowTransferBefore::source;
+		end occurrence target: Occurrence[0..*] :>> FlowConnection::target, FlowTransferBefore::target;
 	}
 	
 	abstract connection connections: Connection[0..*] nonunique :> linkObjects, parts {

--- a/sysml.library/Systems Library/Connections.sysml
+++ b/sysml.library/Systems Library/Connections.sysml
@@ -1,153 +1,153 @@
 standard library package Connections {
-	doc
-	/*
-	 * This package defines the base types for connections and related structural elements 
-	 * in the SysML language.
-	 */
+    doc
+    /*
+     * This package defines the base types for connections and related structural elements 
+     * in the SysML language.
+     */
 
-	private import Base::Anything;
-	private import Occurrences::Occurrence;
-	private import Occurrences::HappensDuring;
-	private import Objects::LinkObject;
-	private import Objects::linkObjects;
-	private import Objects::BinaryLinkObject;
-	private import Objects::binaryLinkObjects;
-	private import Transfers::Transfer;
-	private import Transfers::transfers;
-	private import Transfers::FlowTransfer;
-	private import Transfers::flowTransfers;
-	private import Transfers::FlowTransferBefore;
-	private import Transfers::flowTransfersBefore;
-	private import ScalarValues::Natural;
-	private import Parts::Part;
-	private import Parts::parts;
-	private import Actions::Action;
-	private import Actions::actions;
+    private import Base::Anything;
+    private import Occurrences::Occurrence;
+    private import Occurrences::HappensDuring;
+    private import Objects::LinkObject;
+    private import Objects::linkObjects;
+    private import Objects::BinaryLinkObject;
+    private import Objects::binaryLinkObjects;
+    private import Transfers::Transfer;
+    private import Transfers::transfers;
+    private import Transfers::FlowTransfer;
+    private import Transfers::flowTransfers;
+    private import Transfers::FlowTransferBefore;
+    private import Transfers::flowTransfersBefore;
+    private import ScalarValues::Natural;
+    private import Parts::Part;
+    private import Parts::parts;
+    private import Actions::Action;
+    private import Actions::actions;
 
-	abstract connection def Connection :> LinkObject, Part {
-		doc
-		/*
-		 * Connection is the most general class of links between things within some 
-		 * containing structure. Connection is the base type of all ConnectionDefinitions.
-		 */
-	}
-	 
-	abstract connection def BinaryConnection :> Connection, BinaryLinkObject {
-		doc
-		/*
-		 * BinaryConnection is the most general class of binary links between two things 
-		 * within some containing structure. BinaryConnection is the base type of all 
-		 * ConnectionDefinitions with exactly two ends.
-		 */
-	
-		end source: Anything[0..*] :>> BinaryLinkObject::source;
-		end target: Anything[0..*] :>> BinaryLinkObject::target;
-	}
-	
-	abstract flow def MessageConnection :> BinaryConnection, Transfer, Action {
-		doc
-		/*
-		 * MessageConnection is the class of binary connections that represent a transfer 
-		 * of objects or values between two occurrences. It is the base type of all
-		 * FlowConnectionDefinitions.
-		 */
-	
-		end occurrence source: Occurrence[0..*] :>> BinaryConnection::source, Transfer::source;
-		end occurrence target: Occurrence[0..*] :>> BinaryConnection::target, Transfer::target;
-		
-		ref payload :>> 'item';
-		
-		private ref part thisConnection = self;
-		
-		in event occurrence sourceEvent [1] default thisConnection.start {
-			doc
-			/* 
-			 * An occurrence happening during the source of this flow connection
-			 * that is either the start of the connection or happens before it.
-			 */
-		}
-		in event occurrence targetEvent [1] default thisConnection.done {
-			doc
-			/* 
-			 * An occurrence happening during the target of this flow connection
-			 * that is either the end of the connection or happens after it.
-			 */
-		}
-		
-		connection :HappensDuring connect sourceEvent to source[1];
-		connection :HappensDuring connect targetEvent to target[1];
-		
-		private attribute seBeforeNum: Natural[1] = if sourceEvent==thisConnection.start ? 0 else 1;
-		private attribute teAfterNum: Natural[1] = if targetEvent==thisConnection.done ? 0 else 1;
-		succession [seBeforeNum] first sourceEvent[0..1] then self[0..1];
-		succession [teAfterNum] first self[0..1] then targetEvent[0..1];
-	}
-	
-	abstract flow def FlowConnection :> MessageConnection, FlowTransfer {
-		doc
-		/*
-		 * FlowConnection is the subclass of message connections that a alsow flow transfers.
-		 * It is the base type for FlowConnectionUsages that identify their source output and
-		 * target input.
-		 */
-		
+    abstract connection def Connection :> LinkObject, Part {
+        doc
+        /*
+         * Connection is the most general class of links between things within some 
+         * containing structure. Connection is the base type of all ConnectionDefinitions.
+         */
+    }
+     
+    abstract connection def BinaryConnection :> Connection, BinaryLinkObject {
+        doc
+        /*
+         * BinaryConnection is the most general class of binary links between two things 
+         * within some containing structure. BinaryConnection is the base type of all 
+         * ConnectionDefinitions with exactly two ends.
+         */
+    
+        end source: Anything[0..*] :>> BinaryLinkObject::source;
+        end target: Anything[0..*] :>> BinaryLinkObject::target;
+    }
+    
+    abstract flow def MessageConnection :> BinaryConnection, Transfer, Action {
+        doc
+        /*
+         * MessageConnection is the class of binary connections that represent a transfer 
+         * of objects or values between two occurrences. It is the base type of all
+         * FlowConnectionDefinitions.
+         */
+    
+        end occurrence source: Occurrence[0..*] :>> BinaryConnection::source, Transfer::source;
+        end occurrence target: Occurrence[0..*] :>> BinaryConnection::target, Transfer::target;
+        
+        ref payload :>> 'item';
+        
+        private ref part thisConnection = self;
+        
+        in event occurrence sourceEvent [1] default thisConnection.start {
+            doc
+            /* 
+             * An occurrence happening during the source of this flow connection
+             * that is either the start of the connection or happens before it.
+             */
+        }
+        in event occurrence targetEvent [1] default thisConnection.done {
+            doc
+            /* 
+             * An occurrence happening during the target of this flow connection
+             * that is either the end of the connection or happens after it.
+             */
+        }
+        
+        connection :HappensDuring connect sourceEvent to source[1];
+        connection :HappensDuring connect targetEvent to target[1];
+        
+        private attribute seBeforeNum: Natural[1] = if sourceEvent==thisConnection.start ? 0 else 1;
+        private attribute teAfterNum: Natural[1] = if targetEvent==thisConnection.done ? 0 else 1;
+        succession [seBeforeNum] first sourceEvent[0..1] then self[0..1];
+        succession [teAfterNum] first self[0..1] then targetEvent[0..1];
+    }
+    
+    abstract flow def FlowConnection :> MessageConnection, FlowTransfer {
+        doc
+        /*
+         * FlowConnection is the subclass of message connections that a alsow flow transfers.
+         * It is the base type for FlowConnectionUsages that identify their source output and
+         * target input.
+         */
+        
         end occurrence source: Occurrence[0..*] :>> MessageConnection::source, FlowTransfer::source;
         end occurrence target: Occurrence[0..*] :>> MessageConnection::target, FlowTransfer::target;
-	}
-	
-	abstract flow def SuccessionFlowConnection :> FlowConnection, FlowTransferBefore {
-		doc
-		/*
-		 * SuccessionFlowConnection is the subclass of flow connections that represent 
-		 * temporally ordered transfers. It is the base type for all SuccessionFlowConnectionUsages.
-		 */
-	
-		end occurrence source: Occurrence[0..*] :>> FlowConnection::source, FlowTransferBefore::source;
-		end occurrence target: Occurrence[0..*] :>> FlowConnection::target, FlowTransferBefore::target;
-	}
-	
-	abstract connection connections: Connection[0..*] nonunique :> linkObjects, parts {
-		doc
-		/*
-		 * connections is the base feature of all ConnectionUsages.
-		 */
-	}
-	
-	abstract connection binaryConnections: Connection[0..*] nonunique :> connections, binaryLinkObjects {
-		doc
-		/*
-		 * binaryConnections is the base feature of all binary ConnectionUsages.
-		 */
-	}
-	
-	abstract message messageConnections: MessageConnection[0..*] nonunique :> binaryConnections, transfers, actions {
-		doc
-		/*
-		 * messageConnections is the base feature of all FlowConnectionUsages.
-		 */
-	
-		end occurrence source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
-		end occurrence target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
-	}
-	
-	abstract message flowConnections: FlowConnection[0..*] nonunique :> messageConnections, flowTransfers {
-		doc
-		/*
-		 * flowConnections is the base feature of all FlowConnectionUsages that identify their source output
-		 * and target input.
-		 */
-	
-		end occurrence source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
-		end occurrence target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
-	}
-	
-	abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, flowTransfersBefore {
-		doc
-		/*
-		 * successionFlowConnections is the base feature of all SuccessionFlowConnectionUsages.
-		 */
-	
-		end occurrence source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
-		end occurrence target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
-	}
+    }
+    
+    abstract flow def SuccessionFlowConnection :> FlowConnection, FlowTransferBefore {
+        doc
+        /*
+         * SuccessionFlowConnection is the subclass of flow connections that represent 
+         * temporally ordered transfers. It is the base type for all SuccessionFlowConnectionUsages.
+         */
+    
+        end occurrence source: Occurrence[0..*] :>> FlowConnection::source, FlowTransferBefore::source;
+        end occurrence target: Occurrence[0..*] :>> FlowConnection::target, FlowTransferBefore::target;
+    }
+    
+    abstract connection connections: Connection[0..*] nonunique :> linkObjects, parts {
+        doc
+        /*
+         * connections is the base feature of all ConnectionUsages.
+         */
+    }
+    
+    abstract connection binaryConnections: Connection[0..*] nonunique :> connections, binaryLinkObjects {
+        doc
+        /*
+         * binaryConnections is the base feature of all binary ConnectionUsages.
+         */
+    }
+    
+    abstract message messageConnections: MessageConnection[0..*] nonunique :> binaryConnections, transfers, actions {
+        doc
+        /*
+         * messageConnections is the base feature of all FlowConnectionUsages.
+         */
+    
+        end occurrence source: Occurrence[0..*] :>> MessageConnection::source, binaryConnections::source, transfers::source;
+        end occurrence target: Occurrence[0..*] :>> MessageConnection::target, binaryConnections::target, transfers::target;
+    }
+    
+    abstract message flowConnections: FlowConnection[0..*] nonunique :> messageConnections, flowTransfers {
+        doc
+        /*
+         * flowConnections is the base feature of all FlowConnectionUsages that identify their source output
+         * and target input.
+         */
+    
+        end occurrence source: Occurrence[0..*] :>> FlowConnection::source, messageConnections::source, flowTransfers::source;
+        end occurrence target: Occurrence[0..*] :>> FlowConnection::target, messageConnections::target, flowTransfers::target;
+    }
+    
+    abstract message successionFlowConnections: SuccessionFlowConnection[0..*] nonunique :> flowConnections, flowTransfersBefore {
+        doc
+        /*
+         * successionFlowConnections is the base feature of all SuccessionFlowConnectionUsages.
+         */
+    
+        end occurrence source: Occurrence[0..*] :>> SuccessionFlowConnection::source, flowConnections::source, flowTransfersBefore::source;
+        end occurrence target: Occurrence[0..*] :>> SuccessionFlowConnection::target, flowConnections::target, flowTransfersBefore::target;
+    }
 }

--- a/sysml.library/Systems Library/Views.sysml
+++ b/sysml.library/Systems Library/Views.sysml
@@ -27,7 +27,7 @@ standard library package Views {
 			 */
 		}
 		
-		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] :>> viewpointChecks {
+		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] :> viewpointChecks, checkedConstraints {
 		doc
 			/*
 			 * Checks that the View satisfies all required ViewpointUsages.


### PR DESCRIPTION
This PR implements resolutions of issues from SysML v2 FTF Ballot 9 that called for updates to library models. In addition, it makes a further revision to `TypeAdapter::removeUnnecessaryImplicitGeneralTypes` (as already revised in PR #514) to ensure removal of implict general types that are the identical to explicit general types.

Resolutions of the following issues are implemented in this PR:

- [SYSML2-79](https://issues.omg.org/issues/SYSML2-79) View::viewpointSatisfactions should subset viewpointChecks and checkedConstraints
- [SYSML2-83](https://issues.omg.org/issues/SYSML2-83) Narrow down return types of SpatialItem::PositionOf and ::CurrentPositionOf
- [SYSML2-102](https://issues.omg.org/issues/SYSML2-102) Semantic constraint for target of AssignmentActionUsage is missing
- [SYSML2-219](https://issues.omg.org/issues/SYSML2-219) Action::decisionTransitions should subset Action::transitions
- [SYSML2-305](https://issues.omg.org/issues/SYSML2-305) Message and flow connection ends should be occurrence usages [fully implemented]
- [SYSML2-490](https://issues.omg.org/issues/SYSML2-490) Actions::acceptSubactions and sendSubactions should subset acceptActions and sendActions

Resolutions of the following issues were previously implemented in PRs #487, #504 and #506:

- [SYSML2-295](https://issues.omg.org/issues/SYSML2-295) Causation end features need to redefine source and target
- [SYSML2-305](https://issues.omg.org/issues/SYSML2-305) Message and flow connection ends should be occurrence usages [partially implemented]
- [SYSML2-491](https://issues.omg.org/issues/SYSML2-491) KerML constraint requires updates to Systems Library Models
- [SYSML2-492](https://issues.omg.org/issues/SYSML2-492) KerML constraint requires updates to Domain Library Models
- [SYSML2-497](https://issues.omg.org/issues/SYSML2-497) validateTriggerInvocationExpressionAfterArgument constraint is too strong
- [SYSML2-498](https://issues.omg.org/issues/SYSML2-498) validateTriggerInvocationExpressionWhenArgument constraint is wrong
- [SYSML2-500](https://issues.omg.org/issues/SYSML2-500) The derivation of AssignmentActionUsage::referent is wrong

Resolutions of the following issues did not require any update to the library model files:

- [SYSML2-378](https://issues.omg.org/issues/SYSML2-378) Sample::calculation has an incorrect type
- [SYSML2-393](https://issues.omg.org/issues/SYSML2-393) Documentation of Time::defaultClock is missing
- [SYSML2-488](https://issues.omg.org/issues/SYSML2-488) Constraints missing to enforce variations being abstract

