### PR TITLE
ST6RI-724 (Update) Model library updates from SysML v2 FTF Ballot #9

### DIFF
--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -21,7 +21,7 @@ standard library package Time {
     import ISQSpaceTime::TimeUnit;
     import ISQSpaceTime::time;
     
-    readonly part universalClock : Clock[1] = Clocks::universalClock {
+    readonly part universalClock : Clock[1] :> Clocks::universalClock {
    	    doc
 	    /*
 	     * universalClock is a single Clock that can be used as a default universal time reference.


### PR DESCRIPTION
In order to avoid a warning caused by the implementation of the resolution to KERML-56 (in PR #520), the declaration of `Time::universalClock` in the Quantities and Units Library has been changed from binding to `Clocks::universalClock` to subsetting it. This is consistent with the proposed resolution to 

- [SYSML2-182](https://issues.omg.org/issues/SYSML2-182) Universal features can have many value

However, this resolution has not yet been approved by the SysML v2 FTF, so it must be considered preliminary.