### PR TITLE
ST6RI-727 Implicit redefinitions should be added even if there are owned redefinitions

### DIFF
--- a/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
+++ b/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022, 2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2022-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -87,18 +87,21 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 		// Add implicit generalization.
 		ElementUtil.transform(instantiation);
 		
-		// Add parameters corresponding to parameters in original expression.
+		// Evaluate value Expressions for parameters on original instantiation.
 		for (Feature parameter: TypeUtil.getOwnedParametersOf(expression)) {
-			Feature newParameter = SysMLFactory.eINSTANCE.createFeature();
-			newParameter.setDirection(parameter.getDirection());
-			for (Feature redefinedFeature: FeatureUtil.getRedefinedFeaturesWithComputedOf(parameter, null)) {
-				Redefinition newRedefinition = SysMLFactory.eINSTANCE.createRedefinition();
-				newRedefinition.setRedefinedFeature(redefinedFeature);
-				newParameter.getOwnedRelationship().add(newRedefinition);
-			}
-			
 			Expression valueExpression = FeatureUtil.getValueExpressionFor(parameter);
 			if (valueExpression != null) {
+				// Add a new parameter to hold the result of the Expression evaluation.
+				Feature newParameter = SysMLFactory.eINSTANCE.createFeature();
+				TypeUtil.addOwnedFeatureTo(instantiation, newParameter);
+				
+				newParameter.setDirection(parameter.getDirection());
+				for (Feature redefinedFeature: FeatureUtil.getRedefinedFeaturesWithComputedOf(parameter, null)) {
+					Redefinition newRedefinition = SysMLFactory.eINSTANCE.createRedefinition();
+					newRedefinition.setRedefinedFeature(redefinedFeature);
+					newParameter.getOwnedRelationship().add(newRedefinition);
+				}				
+
 				// Evaluate the value expression for the original parameter with the given target,
 				// NOT including the bindings in the original invocation expression.
 				EList<Element> values = evaluate(valueExpression, target);
@@ -113,9 +116,8 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 					}
 				}
 			}
-			
-			TypeUtil.addOwnedFeatureTo(instantiation, newParameter);
 		}
+		
 		return instantiation;
 	}
 }

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ExpressionEvaluationTest.java
@@ -327,6 +327,25 @@ public class ExpressionEvaluationTest extends SysMLInteractiveTest {
 		assertElement("LiteralInteger 234", instance.eval("arr2#(2,3,4)", "IndexOperatorTest"));
 	}
 	
+	// Test named-argument invocation.
+	public final String invocationTest =
+			"package InvocationTest {\n"
+			+ "	   calc def Test {"
+			+ "        in x;"
+			+ "        in y;"
+			+ "        x"
+			+ "     }"
+			+ "}";
+	
+	@Test
+	public void testInvocationEvaluation() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		process(instance, invocationTest);
+//		assertElement("LiteralInteger 1", instance.eval("Test(1, 2)", "InvocationTest"));
+//		assertElement("LiteralInteger 1", instance.eval("Test(x = 1, y = 2)", "InvocationTest"));
+		assertElement("LiteralInteger 1", instance.eval("Test(y = 2, x = 1)", "InvocationTest"));
+	}
+	
 	@Test
 	public void testArithmeticEvaluation() throws Exception {
 		SysMLInteractive instance = getSysMLInteractiveInstance();

--- a/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
@@ -84,6 +84,10 @@ standard library package TradeStudies {
 		 * selectedAlternative have the minimum ObjectiveFunction value of all the
 		 * given alternatives.
 		 */
+		 
+		subject :>> selectedAlternative;
+		in ref :>> alternatives;
+		in calc :>>fn;
 	
 		out attribute :>> best = alternatives->minimize {
 			doc
@@ -103,6 +107,10 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 	
+        subject :>> selectedAlternative;
+        in ref :>> alternatives;
+        in calc :>>fn;
+    
 		out attribute :>> best = alternatives->maximize {
 			doc
 			/*
@@ -154,6 +162,7 @@ standard library package TradeStudies {
 			 * defined one.
 			 */
 		
+            subject :>> selectedAlternative;
 			in ref :>> alternatives = studyAlternatives;
 			in calc :>> fn = evaluationFunction;
 		}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
@@ -65,11 +65,18 @@ package ConnectionTest {
 	
 	connection bus : C connect (d1, d2, d3, d4);
 	
+	connection : C {
+	    end :>> end1 ::> d1;
+	    end end2 ::> d2;
+	    end end3 ::> d3;
+	}
+	
 	connection {
 		part q;
 		end end1 ::> d1 :> q;
 		end end2 ::> d2;
 	}
+	
 	flow def F {
 		end f_p : P;
 		end f_q;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -322,7 +322,10 @@ public class FeatureAdapter extends TypeAdapter {
 	}
 	
 	public boolean isComputeRedefinitions() {
-		return isAddImplicitGeneralTypes && isComputeRedefinitions;
+		Feature target = getTarget();
+		return isAddImplicitGeneralTypes && isComputeRedefinitions &&
+				(!FeatureUtil.isParameter(target) ||
+				 target.getOwnedRedefinition().isEmpty());
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -322,12 +322,11 @@ public class FeatureAdapter extends TypeAdapter {
 	}
 	
 	public boolean isComputeRedefinitions() {
-		EList<Redefinition> ownedRedefinitions = getTarget().getOwnedRedefinition();
-		return isAddImplicitGeneralTypes && isComputeRedefinitions && ownedRedefinitions.isEmpty();
+		return isAddImplicitGeneralTypes && isComputeRedefinitions;
 	}
 	
 	/**
-	 * If this Feature has no Redefinitions, compute relevant Redefinitions, as appropriate.
+	 * Compute relevant implicit Redefinitions, as appropriate.
 	 */
 	public void addComputedRedefinitions(Element skip) {
 		if (isComputeRedefinitions()) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/InvocationExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/InvocationExpressionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,6 @@
 package org.omg.sysml.adapter;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
@@ -98,20 +97,6 @@ public class InvocationExpressionAdapter extends ExpressionAdapter {
 			}
 		}
 		return input;
-	}
-	
-	// Computed Redefinition
-
-	@Override
-	public List<Feature> getRelevantFeatures() {
-		Expression target = getTarget();
-		Type type = getExpressionType();
-		int m = type == null ? 0 : 
-			(int)TypeUtil.getAllParametersOf(target, null).stream().
-				filter(FeatureUtil::isInputParameter).count();
-		List<Feature> features = target.getOwnedFeature();
-		int n = features.size();
-		return m >= n ? Collections.emptyList() : features.subList(m, n);
 	}
 	
 	// Transformation

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -21,14 +21,11 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Definition;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureValue;
@@ -94,7 +91,7 @@ public class UsageAdapter extends FeatureAdapter {
 		}
 	}
 		
-// Implicit Generalization
+	// Implicit Generalization
 	
 	protected void addSubsetting(String subsettedFeatureName) {
 		Feature feature = (Feature)getLibraryType(subsettedFeatureName);
@@ -120,26 +117,6 @@ public class UsageAdapter extends FeatureAdapter {
 	@Override
 	protected String getDefaultSupertype() {
 		return super.getDefaultSupertype();
-	}
-	
-	// Computed Redefinitions
-	
-	/**
-	 * A subject Parameter always redefines a subject Parameter.
-	 */
-	@Override
-	public List<? extends Feature> getParameterRelevantFeatures(Type type, Element skip) {
-		if (UsageUtil.isSubjectParameter(getTarget())) {
-			Feature typeSubject = TypeUtil.getSubjectParameterOf(type);
-			return typeSubject == null? Collections.emptyList(): 
-				Collections.singletonList(typeSubject);
-		}
-		return super.getParameterRelevantFeatures(type, skip);
-	}
-	
-	@Override
-	public boolean isIgnoredParameter() {
-		return super.isIgnoredParameter() || UsageUtil.isSubjectParameter(getTarget());
 	}
 	
 	// Transformation

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -450,6 +450,7 @@ public class TypeUtil {
 	// Objective requirements
 
 	public static RequirementUsage getObjectiveRequirementOf(Type type) {
+		ElementUtil.transform(type);
 		return type instanceof CaseDefinition? ((CaseDefinition)type).getObjectiveRequirement():
 			   type instanceof CaseUsage? ((CaseUsage)type).getObjectiveRequirement():
 			   null;

--- a/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
+++ b/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
@@ -84,6 +84,10 @@ standard library package TradeStudies {
 		 * selectedAlternative have the minimum ObjectiveFunction value of all the
 		 * given alternatives.
 		 */
+		 
+		subject :>> selectedAlternative;
+		in ref :>> alternatives;
+		in calc :>>fn;
 	
 		out attribute :>> best = alternatives->minimize {
 			doc
@@ -103,6 +107,10 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 	
+        subject :>> selectedAlternative;
+        in ref :>> alternatives;
+        in calc :>>fn;
+    
 		out attribute :>> best = alternatives->maximize {
 			doc
 			/*
@@ -154,6 +162,7 @@ standard library package TradeStudies {
 			 * defined one.
 			 */
 		
+            subject :>> selectedAlternative;
 			in ref :>> alternatives = studyAlternatives;
 			in calc :>> fn = evaluationFunction;
 		}

--- a/sysml/src/examples/Analysis Examples/Dynamics.sysml
+++ b/sysml/src/examples/Analysis Examples/Dynamics.sysml
@@ -51,6 +51,14 @@ package Dynamics {
 	// Analysis actions
 	
 	action dyn1 : StraightLineVehicleDynamics {
+        in attribute dt : TimeValue;
+        in attribute whlpwr : PowerValue;
+        in attribute Cd : Real;
+        in attribute Cf: Real;
+        in attribute tm : MassValue;
+        in attribute v_in : SpeedValue;
+        in attribute x_in : LengthValue;
+
 		attribute tp : PowerValue = Power(whlpwr, Cd, Cf, tm, v_in);
 		
 		out attribute :>> a_out : AccelerationValue = Acceleration(dt, tm, tp);

--- a/sysml/src/examples/Simple Tests/ConnectionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConnectionTest.sysml
@@ -31,6 +31,12 @@ package ConnectionTest {
 	
 	connection bus : C connect (d1, d2, d3, d4);
 	
+	connection : C {
+	    end :>> end1 ::> d1;
+	    end end2 ::> d2;
+	    end end3 ::> d3;
+	}
+	
 	connection {
 		part q;
 		end end1 ::> d1 :> q;


### PR DESCRIPTION
1. Corrects `FeatureAdapter::isComputeRedefinitions` so that implicit redefinitions are added even if a `Feature` already has `ownedRedefinitions`, consistent with the rules for implied redefinitions per the specifications.
    * Except that, for now, implicit redefinitions are still _not_ added for parameters that already have `ownedRedefinitions`. See also 
       * [KERML-308 checkFeatureParameterRedefinition fails for named-argument invocations](https://issues.omg.org/issues/KERML-308)
2. Removes the special handling of the redefinition of subject parameters, in which a subject will redefine the subject of a supertype, regardless of its position in the list of parameters. Instead, subject parameter redefinition is handled by the normal rule for implied redefinitions of parameters in order, per the specification. (Note that, in a valid model, a subject parameter must always be the first parameter, so, in this case, an owned subject parameter will still always redefine any subject parameters of superypes.)
3. Corrects the `TradeStudies::TradeStudy` model per the resolution to the issue below (because otherwise the above changes result in validation errors being flagged for the model).
   * [SYSML2-552 Errors in the TradeStudy domain model](https://issues.omg.org/issues/SYSML2-552)