### PR TITLE
ST6RI-731 Model-level evaluation of the list range construction operator

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -202,6 +202,7 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		checkExpressionIsModelLevelEvaluable(instance, "1..3");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::size(null)");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::includes(null, 1)");
+		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::excludes(null, 1)");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::isEmpty(null)");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::notEmpty(null)");
 	}
@@ -287,6 +288,9 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		assertArrayEquals(new Object[] {}, evaluateListValue(null, null, "5..3"));
 		assertEquals(3, evaluateIntegerValue(null, null, "SequenceFunctions::size((1, 2, 3))"));
 		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::includes((1, 2, 3), 1)"));
+		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::includes((1, 2, 3), 5)"));
+		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::excludes((1, 2, 3), 1)"));
+		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::excludes((1, 2, 3), 5)"));
 		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty(null)"));
 		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty(1)"));
 		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty((1,2,3))"));

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -21,6 +21,7 @@
 
 package org.omg.sysml.interactive.tests;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.junit.Test;
+import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.interactive.SysMLInteractive;
 import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.Element;
@@ -119,6 +121,11 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		return ((LiteralRational)result).getValue();
 	}
 	
+	protected Object[] evaluateListValue(SysMLInteractive instance, Element target, String text) {
+		List<Element> results = evaluateExpression(instance, target, text);
+		return results.stream().map(EvaluationUtil::valueOf).toArray();
+	}
+	
 	protected MetadataFeature checkAnnotatingFeature(SysMLInteractive instance, String annotationName, String elementName) {
 		Element target = instance.resolve(elementName);
 		assertTrue(target instanceof Namespace);
@@ -189,9 +196,14 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 	@Test
 	public void testListOpsModelLevelEvaluability() throws Exception {
 		SysMLInteractive instance = getSysMLInteractiveInstance();
+		checkExpressionIsModelLevelEvaluable(instance, "null");
+		checkExpressionIsModelLevelEvaluable(instance, "()");
 		checkExpressionIsModelLevelEvaluable(instance, "(1, 2, 3)");
+		checkExpressionIsModelLevelEvaluable(instance, "1..3");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::size(null)");
 		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::includes(null, 1)");
+		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::isEmpty(null)");
+		checkExpressionIsModelLevelEvaluable(instance, "SequenceFunctions::notEmpty(null)");
 	}
 
 	@Test
@@ -267,8 +279,20 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 	
 	@Test
 	public void testListEvaluation() throws Exception {
+		assertArrayEquals(new Object[] {}, evaluateListValue(null, null, "null"));
+		assertArrayEquals(new Object[] {}, evaluateListValue(null, null, "()"));
+		assertArrayEquals(new Object[] {1, 2, 3}, evaluateListValue(null, null, "(1, 2, 3)"));
+		assertArrayEquals(new Object[] {1, 2, 3}, evaluateListValue(null, null, "1..3"));
+		assertArrayEquals(new Object[] {-1, 0, 1, 2}, evaluateListValue(null, null, "-1..2"));
+		assertArrayEquals(new Object[] {}, evaluateListValue(null, null, "5..3"));
 		assertEquals(3, evaluateIntegerValue(null, null, "SequenceFunctions::size((1, 2, 3))"));
 		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::includes((1, 2, 3), 1)"));
+		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty(null)"));
+		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty(1)"));
+		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::isEmpty((1,2,3))"));
+		assertEquals(false, evaluateBooleanValue(null, null, "SequenceFunctions::notEmpty(null)"));
+		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::notEmpty(1)"));
+		assertEquals(true, evaluateBooleanValue(null, null, "SequenceFunctions::notEmpty((1,2,3))"));
 	}
 	
 	@Test

--- a/org.omg.sysml/src/org/omg/sysml/expressions/LibraryFunctionFactory.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/LibraryFunctionFactory.java
@@ -46,6 +46,7 @@ public class LibraryFunctionFactory {
 		put(new NotEmptyFunction());
 		put(new IncludesFunction());
 		put(new ListConcatFunction());
+		put(new ListRangeFunction());
 		put(new IndexFunction());
 		
 		put(new IsTypeFunction());

--- a/org.omg.sysml/src/org/omg/sysml/expressions/LibraryFunctionFactory.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/LibraryFunctionFactory.java
@@ -45,6 +45,7 @@ public class LibraryFunctionFactory {
 		put(new IsEmptyFunction());
 		put(new NotEmptyFunction());
 		put(new IncludesFunction());
+		put(new ExcludesFunction());
 		put(new ListConcatFunction());
 		put(new ListRangeFunction());
 		put(new IndexFunction());

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/DataFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/DataFunction.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.expressions.functions;
+
+public abstract class DataFunction implements LibraryFunction {
+
+	@Override
+	public String getPackageName() {
+		return "DataFunctions";
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ExcludesFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ExcludesFunction.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+package org.omg.sysml.expressions.functions;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
+import org.omg.sysml.expressions.util.EvaluationUtil;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.InvocationExpression;
+
+public class ExcludesFunction extends SequenceFunction {
+
+	@Override
+	public String getOperatorName() {
+		return "excludes";
+	}
+	
+	@Override
+	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
+		EList<Element> list = evaluator.evaluateArgument(invocation, 0, target);
+		Element value = evaluator.argumentValue(invocation, 1, target);
+		Boolean result = list == null && value == null? null: list.stream().noneMatch(x->EvaluationUtil.equal(x, value));
+		return result == null? EvaluationUtil.singletonList(invocation): 
+			EvaluationUtil.booleanResult(result);
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/expressions/functions/ListRangeFunction.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/functions/ListRangeFunction.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,48 +21,32 @@
 
 package org.omg.sysml.expressions.functions;
 
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.omg.sysml.expressions.ModelLevelExpressionEvaluator;
 import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.InvocationExpression;
 
-public abstract class ArithmeticFunction extends DataFunction {
-	
-	protected EList<Element> unaryIntegerOp(int x) {
-		return null;
-	}
-	
-	protected EList<Element> unaryRealOp(double x) {
-		return null;
+public class ListRangeFunction extends DataFunction {
+
+	@Override
+	public String getOperatorName() {
+		return "'..'";
 	}
 
-	protected EList<Element> binaryIntegerOp(int x, int y) {
-		return null;
-	}
-	
-	protected EList<Element> binaryRealOp(double x, double y) {
-		return null;
-	}
-
-	protected EList<Element> binaryStringOp(String x, String y) {
-		return null;
-	}
-	
 	@Override
 	public EList<Element> invoke(InvocationExpression invocation, Element target, ModelLevelExpressionEvaluator evaluator) {
 		Object x = EvaluationUtil.valueOf(evaluator.argumentValue(invocation, 0, target));
 		Object y = EvaluationUtil.valueOf(evaluator.argumentValue(invocation, 1, target));
-		return EvaluationUtil.numberOfArgs(invocation) == 1?
-					x instanceof Integer? unaryIntegerOp((Integer)x):
-					x instanceof Double? unaryRealOp((Double)x):
-					EvaluationUtil.nullList():
-			   x instanceof Integer && y instanceof Integer? binaryIntegerOp((Integer)x, (Integer)y):
-			   x instanceof Double && y instanceof Integer? binaryRealOp((Double)x, (Integer)y):
-			   x instanceof Integer && y instanceof Double? binaryRealOp((Integer)x, (Double)y):
-			   x instanceof Double && y instanceof Double? binaryRealOp((Double)x, (Double)y):
-			   x instanceof String && y instanceof String? binaryStringOp((String)x, (String)y):
-			   EvaluationUtil.singletonList(invocation);
+		if (x instanceof Integer && y instanceof Integer) {
+			EList<Element> result = new BasicEList<>();
+			for (int i = (Integer)x; i <= (Integer)y; i++) {
+				result.add(EvaluationUtil.literalInteger(i));
+			}
+			return result;
+		}
+		return EvaluationUtil.singletonList(invocation);
 	}
-
+	
 }


### PR DESCRIPTION
This PR adds two additional model-level evaluable function implementations, under `org.omg.sysml.expressions.functions`.

1. `ListRangeFunction` implements the _range construction operator_ `'..'`. An expression of the form _`e1`_`...`_`e2`_, in which _`e1`_ and _`e2`_ evaluate to integers, results in an ordered sequence of a range of sequential integers from the value of _`e1`_ to the value of _`e2`_, inclusive. For example, `1..3` evaluates to the sequence `(1, 2, 3)`. If the value of _`e1`_ is greater than the value of _`e2`_, then the result is the empty sequence.
2. `ExcludesFunction` implements the `SequenceFunctions::excludes` function. This function tests whether a value is _excluded_ from a sequence. For example, `excludes(1..3, 2)` is false, while `excludes(1..3, 0)` is true. It is the inverse of the `includes` function, which was already implemented.

It also adds tests to `org.omg.sysml.interactive.tests.ModelLevelEvaluationTest` for the above new function implementations, as well as adding some additional tests for other sequence-related functions previously implemented.