### PR TITLE
ST6RI-734 Model-library-related Resolutions from KerML FTF Ballot #4

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
@@ -37,7 +37,7 @@ standard library package Clocks {
 		 
 		private thisClock : Clock :>> self;
 		
-		readonly feature currentTime : NumericalValue[1] {
+		feature currentTime : NumericalValue[1] {
 			doc
 			/*
 			 * A scalar time reference that advances over the lifetime of the Clock. 
@@ -126,7 +126,7 @@ standard library package Clocks {
 		 * A BasicClock is a Clock whose currentTime is a Real number.
 		 */
 		
-		readonly feature :>> currentTime : Real;
+		feature :>> currentTime : Real;
 	}
 	
 	function BasicTimeOf :> TimeOf {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Clocks.kerml
@@ -18,7 +18,7 @@ standard library package Clocks {
 	     */
 	}
 	
-	feature universalClock : UniversalClockLife[1] {
+	readonly feature universalClock : UniversalClockLife[1] {
 		doc
 		/*
 		 * universalClock is a single Clock that can be used as a default universal

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/KerML.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/KerML.kerml
@@ -11,12 +11,14 @@ standard library package KerML {
 		metaclass AnnotatingElement specializes Element {
 			feature annotation : Annotation[0..*];
 			derived feature annotatedElement : Element[1..*] redefines annotatedElement;
+			composite derived feature ownedAnnotatingRelationship : Annotation[0..*] subsets annotation, ownedRelationship;
 		}		
 				
 		metaclass Annotation specializes Relationship {
 			feature annotatingElement : AnnotatingElement[1..1] redefines source;
 			feature annotatedElement : Element[1..1] redefines target, annotatedElement;
 			derived feature owningAnnotatedElement : Element[0..1] subsets annotatedElement, owningRelatedElement;
+			derived feature owningAnnotatingElement : AnnotatingElement[0..1] subsets annotatingElement, owningRelatedElement;
 		}		
 				
 		metaclass Comment specializes AnnotatingElement {
@@ -222,6 +224,11 @@ standard library package KerML {
 			feature redefinedFeature : Feature[1..1] redefines subsettedFeature;
 		}		
 				
+		metaclass ReferenceSubsetting specializes Subsetting {
+			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
+			derived feature referencingFeature : Feature[1..1] redefines subsettingFeature, owningFeature;
+		}		
+				
 		metaclass Specialization specializes Relationship {
 			feature general : Type[1..1] redefines target;
 			feature specific : Type[1..1] redefines source;
@@ -237,7 +244,7 @@ standard library package KerML {
 		metaclass Subsetting specializes Specialization {
 			feature subsettedFeature : Feature[1..1] redefines general;
 			feature subsettingFeature : Feature[1..1] redefines specific;
-			derived feature owningFeature : Feature[1..1] subsets subsettingFeature redefines owningType;
+			derived feature owningFeature : Feature[0..1] subsets subsettingFeature redefines owningType;
 		}		
 				
 		metaclass Type specializes Namespace {
@@ -311,8 +318,6 @@ standard library package KerML {
 		}		
 				
 		metaclass Connector specializes Feature, Relationship {
-			feature isDirected : Boolean[1..1];
-			
 			derived feature relatedFeature : Feature[0..*] redefines relatedElement;
 			derived feature association : Association[0..*] redefines 'type';
 			derived feature connectorEnd : Feature[0..*] redefines endFeature;
@@ -412,7 +417,7 @@ standard library package KerML {
 		}		
 				
 		metaclass MetadataFeature specializes AnnotatingElement, Feature {
-			derived feature 'metaclass' : Metaclass[0..1] redefines 'type';
+			derived feature 'metaclass' : Metaclass[0..1] subsets 'type';
 		}		
 				
 		metaclass MultiplicityRange specializes Multiplicity {
@@ -437,11 +442,6 @@ standard library package KerML {
 				
 		metaclass Predicate specializes Function;		
 				
-		metaclass ReferenceSubsetting specializes Subsetting {
-			feature referencedFeature : Feature[1..1] redefines subsettedFeature;
-			derived feature referencingFeature : Feature[1..1] redefines subsettingFeature, owningFeature;
-		}		
-				
 		metaclass ResultExpressionMembership specializes FeatureMembership {
 			composite derived feature ownedResultExpression : Expression[1..1] redefines ownedMemberFeature;
 		}		
@@ -460,7 +460,7 @@ standard library package KerML {
 		metaclass Structure specializes Class;		
 				
 		metaclass Succession specializes Connector {
-			derived feature transitionStep : Step[0..1] subsets ownedFeature;
+			derived feature transitionStep : Step[0..1];
 			derived feature triggerStep : Step[0..*];
 			derived feature effectStep : Step[0..*];
 			derived feature guardExpression : Expression[0..*];

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
@@ -72,7 +72,7 @@ standard library package Objects {
 		}
 	}
 	
-	abstract assoc struct LinkObject specializes Link, Object disjoint from SelfLink, SelfSameLifeLink, HappensLink {
+	abstract assoc struct LinkObject specializes Link, Object {
 		doc
 		/*
 		 * LinkObject is the most general association structure, being both a Link and an Object.

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
@@ -24,7 +24,7 @@ standard library package Observation {
          */
     }
     
-	feature defaultMonitor[1] : DefaultMonitorLife {
+	readonly feature defaultMonitor[1] : DefaultMonitorLife {
 		doc
 		/*
 		 * defaultMonitor is a single ChangeMonitor that can be used as a default.

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -757,7 +757,7 @@ standard library package Occurrences {
 		 * Occurrence is InsideOf itself and that InsideOf is transitive.
 		 */
 
-		end feature smallerSpace: Occurrence[1..*] redefines source, largerSpace.spaceEnclosedOccurrences;
+		end feature smallerSpace: Occurrence[1..*] redefines source subsets largerSpace.spaceEnclosedOccurrences;
 		end feature largerSpace: Occurrence[1..*] redefines target;
 	}
 

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -733,8 +733,22 @@ standard library package Occurrences {
 		end feature thatOccurrence: Occurrence[1..*] redefines longerOccurrence
 		  subsets thisOccurrence.timeCoincidentOccurrences;
 	}
+	
+	assoc SpaceLink specializes BinaryLink disjoint from Occurrence {
+        doc
+        /*
+         * SpaceLink is the most general association that asserts spatial relationships between a
+         * sourceOccurrence and a targetOccurrence. Because SpaceLinks assert spatial
+         * relationships, they cannot also be Occurrences that happen in space.  Therefore
+         * SpaceLink is disjoint with LinkObject, that is, no SpaceLink can also be a
+         * LinkObject.
+         */
+      
+        end feature sourceOccurrence: Occurrence[0..*] redefines BinaryLink::source;
+        end feature targetOccurrence: Occurrence[0..*] redefines BinaryLink::target;
+    }
 
-	assoc all InsideOf specializes BinaryLink {
+	assoc all InsideOf specializes SpaceLink {
 		doc
 		/*
 		 * InsideOf asserts that its largerSpace completely overlaps its smallerSpace in space (not
@@ -881,7 +895,7 @@ standard library package Occurrences {
 		end feature laterOccurrence: Occurrence[0..*] redefines HappensBefore::laterOccurrence, binaryLinks::target;
 	 }
 
-	assoc all OutsideOf specializes Without {
+	assoc all OutsideOf specializes SpaceLink, Without {
 		doc
 		/*
 		 * OutsideOf asserts that two occurrences do not overlap in space (not necessarily in time,

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/SpatialFrames.kerml
@@ -22,7 +22,8 @@ standard library package SpatialFrames {
          * DefaultFrameLife is the classifier of the singleton Life of the defaultFrame.
          */
     }
-    feature defaultFrame : DefaultFrameLife[1] {
+    
+    readonly feature defaultFrame : DefaultFrameLife[1] {
         doc
         /*
          * defaultFrame is a fixed SpatialFrame used as a universal default.


### PR DESCRIPTION
This PR implements resolutions of issues from KerML FTF Ballot 4 that called for updates to library models.

*Note:* This PR is based off of branch ST6RI-736 (see PR #527).

Resolutions of the following issues are implemented in this PR:

[KERML-25](https://issues.omg.org/issues/KERML-25) Reflective KerML abstract syntax model has inconsistencies
[KERML-44](https://issues.omg.org/issues/KERML-44) Spatial links can be occurrences
[KERML-49](https://issues.omg.org/issues/KERML-49) Some readonly features are intended to have changing values
[KERML-158](https://issues.omg.org/issues/KERML-158) InsideOf association end feature redefines cross feature
[KERML-231](https://issues.omg.org/issues/KERML-231) LinkObject disjointness is redundant

Resolution of the following library-related issue did not require a library model update:

[KERML-39](https://issues.omg.org/browse/KERML-39) Link participant feature called an association end