### PR TITLE
ST6RI-744 Properly show ends in particular start or done actions (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -361,15 +361,11 @@ public class VCompartment extends VStructure {
     }
 
     private void addEnd(Feature f) {
-        Element e = ConnectorUtil.getRelatedFeatureOfEnd(f);
-        if (e == null) return;
-        // We should construct proper text from end but for the time being, we use just the text as it is.
-        /*
-        if (e instanceof Subsetting) {
-            Subsetting ss = (Subsetting) e;
-            e = ss.getSubsettedFeature();
-        }*/
-        appendText(getText(e), true);
+        Feature relatedFeature = ConnectorUtil.getRelatedFeatureOfEnd(f);
+        if (relatedFeature == null) return;
+        append(getRefName(relatedFeature));
+        // Previously, textual notation was used to render ends.
+        // appendText(getText(e), true);
     }
 
     private void addConnectorText(Connector c, boolean isInherited) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -363,7 +363,7 @@ public class VCompartment extends VStructure {
     private void addEnd(Feature f) {
         Feature relatedFeature = ConnectorUtil.getRelatedFeatureOfEnd(f);
         if (relatedFeature == null) return;
-        append(getRefName(relatedFeature));
+        append(getRefName(relatedFeature, currentType));
         // Previously, textual notation was used to render ends.
         // appendText(getText(e), true);
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -172,7 +172,7 @@ public abstract class VStructure extends VDefault {
     private String redefinedFeatureText(Feature f) {
         Feature rf = getRedefinedFeature(f);
         if (rf == null) return null;
-        return getRefName(rf);
+        return getRefName(rf, f.getOwningNamespace());
     }
 
     private boolean addRedefinedFeatureText(Feature f) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -468,21 +468,21 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return null;
     }
 
-    private static String getNameWithNamespace(Feature f) {
+    private static String getNameWithNamespace(Feature f, org.omg.sysml.lang.sysml.Namespace enclosingNs) {
         String name = getFeatureName(f);
         if (name == null) return null;
 
         org.omg.sysml.lang.sysml.Namespace pkg = f.getOwningNamespace();
-        if (pkg == null) return name;
+        if ((pkg == null) || pkg.equals(enclosingNs)) return name;
         String pkgName = pkg.getDeclaredName();
         if (pkgName == null) return name;
         return pkgName + "::" + name;
     }
 
 
-    protected static String getRefName(Feature f) {
+    protected static String getRefName(Feature f, org.omg.sysml.lang.sysml.Namespace enclosingNs) {
         List<FeatureChaining> fcs = f.getOwnedFeatureChaining();
-        if (fcs.isEmpty()) return getNameWithNamespace(f);
+        if (fcs.isEmpty()) return getNameWithNamespace(f, enclosingNs);
         return getFeatureChainName(fcs);
     }
 
@@ -491,7 +491,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
         if (rs == null) return false;
         Feature rsf = rs.getSubsettedFeature();
         if (rsf == null) return false;
-        String name = getRefName(rsf);
+        String name = getRefName(rsf, f.getOwningNamespace());
         if (name == null) return false;
         sb.append("::> ");
         sb.append(name);
@@ -509,7 +509,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
 
             Feature sf = s.getSubsettedFeature();
             if (sf == null) continue;
-            String name = getRefName(sf);
+            String name = getRefName(sf, f.getOwningNamespace());
             if (name == null) continue;
             if (added) {
                 sb.append(", ");


### PR DESCRIPTION
As the current visualizer uses textual notation to print ends in compartment, it may show cluttered text in ends such as `start` and `done` actions in successions.  This PR fixes this issue by making proper names from the referenced features. 