### PR TITLE
ST6RI-745 Inherited references are not properly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -140,6 +140,18 @@ class InheritKey {
         this.isDirect = false;
     }
 
+    private InheritKey(InheritKey base, boolean isDirect) {
+        this.keys = base.keys;
+        this.isDirect = isDirect;
+    }
+
+    // Create an indirect InheritKey so that redefined elements can be referred by
+    // inherited connectors
+    public static InheritKey makeIndirect(InheritKey ik) {
+    	if (ik == null) return null;
+        return new InheritKey(ik, false);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/PRelation.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/PRelation.java
@@ -115,7 +115,7 @@ class PRelation {
     }
 
     public PRelation(InheritKey ik, Object src, Object dest, Element rel, String description) {
-        this.ik = null;
+        this.ik = ik;
         this.src = src;
         this.dest = dest;
         this.rel = rel;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -515,7 +515,9 @@ public class SysML2PlantUMLText {
 
         Integer newId(Element e) {
             Integer ii = idCounter++;
-            idMap.put(e, ii);
+            if (!isInherited()) {
+                idMap.put(e, ii);
+            }
             if (vpath != null) {
                 vpath.setId(e, ii);
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -120,9 +120,17 @@ public class VDefault extends VTraverser {
         for (Specialization s: typ.getOwnedSpecialization()) {
             Type gt = s.getGeneral();
             if (gt == null) continue;
-            if (ik == null && typ instanceof Feature) {
-                if (!(s instanceof Redefinition)) {
-                    ik = makeInheritKey((Feature) typ);
+            if (ik == null && gt instanceof Feature) {
+                if (s instanceof Redefinition) {
+                    // If we just create an inherit key for redefinition target, always create a cyclic reference
+                    // because redefining feature can be a target in this sense.  So we must create an inherit key
+                    // for the membership owning the target since the redefined target always exists.
+                    Membership ms = gt.getOwningMembership();
+                    if (ms != null) {
+                        ik = makeInheritKey(ms);
+                    }
+                } else {
+                    ik = makeInheritKey((Feature) gt);
                 }
             }
             PRelation pr = new PRelation(ik, typId, gt, s, null);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -52,6 +52,7 @@ import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OwningMembership;
+import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;
@@ -119,8 +120,10 @@ public class VDefault extends VTraverser {
         for (Specialization s: typ.getOwnedSpecialization()) {
             Type gt = s.getGeneral();
             if (gt == null) continue;
-            if (ik != null && typ instanceof Feature) {
-            	ik = makeInheritKey((Feature) typ);
+            if (ik == null && typ instanceof Feature) {
+                if (!(s instanceof Redefinition)) {
+                    ik = makeInheritKey((Feature) typ);
+                }
             }
             PRelation pr = new PRelation(ik, typId, gt, s, null);
             addPRelation(pr);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -474,7 +474,7 @@ public class VPath extends VTraverser {
 
     private String addContextForFeature(Feature f) {
         PC pc = makeFeaturePC(f, f);
-        InheritKey ik = makeInheritKeyOfOwner(f);
+        InheritKey ik = makeInheritKey(f);
         if (createRefPC(ik, pc) == null) return null;
         return "";
     }
@@ -485,7 +485,8 @@ public class VPath extends VTraverser {
         }
         PC pc = makeEndFeaturePC(f);
         InheritKey ik = makeInheritKeyOfOwner(f);
-        if (createRefPC(ik, pc) == null) return null;
+        // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
+        if (createRefPC(InheritKey.makeIndirect(ik), pc) == null) return null;
         return "";
     }
 
@@ -502,7 +503,8 @@ public class VPath extends VTraverser {
         Feature ioTarget = getIOTarget(ife);
         pc = new PCItemFlowEnd(ife, pc, ioTarget);
         InheritKey ik = makeInheritKeyOfOwner(ife);
-        if (createRefPC(ik, pc) == null) return null;
+        // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
+        if (createRefPC(InheritKey.makeIndirect(ik), pc) == null) return null;
         return "";
     }
 
@@ -588,10 +590,10 @@ public class VPath extends VTraverser {
             Type g = sp.getGeneral();
             // Type s = sp.getSpecific();
             if (g == null) continue;
-            if (checkVisited(g)) continue;
             if (g instanceof Feature) {
                 addContextForFeature((Feature) g);
             }
+            if (checkVisited(g)) continue;
             visit(g);
             traverse(g);
             // visit(s); // Typically this will cause double traverse but checkVisit() stops it..


### PR DESCRIPTION
Mainly due to my mistakes, some inherited references were not correctly rendered with `SHOWINHERITED` style and this PR fixes those issues. 

Notice that ST6RI-745 branches out from ST6RI-744.  So it contains the fixes in ST6RI-744 as well.