### PR TITLE
ST6RI-739 Model-library-related issues from KerML FTF Ballot #5

### DIFF
--- a/org.omg.kerml.xpect.tests/library/KerML.kerml
+++ b/org.omg.kerml.xpect.tests/library/KerML.kerml
@@ -22,7 +22,7 @@ standard library package KerML {
 		}		
 				
 		metaclass Comment specializes AnnotatingElement {
-			feature locale : String[0..1];
+			feature 'locale' : String[0..1];
 			feature body : String[1..1];
 		}		
 				

--- a/org.omg.kerml.xpect.tests/library/Objects.kerml
+++ b/org.omg.kerml.xpect.tests/library/Objects.kerml
@@ -29,7 +29,8 @@ standard library package Objects {
 
 		feature self: Object redefines Occurrence::self;
 		
-		composite subobjects: Object[0..*] subsets objects, suboccurrences {
+		composite subobjects: Object[0..*] subsets objects, suboccurrences
+			intersects objects, suboccurrences {
 			doc
 			/*
 			 * The suboccurrences of this Object that are also Objects.
@@ -43,14 +44,16 @@ standard library package Objects {
 			 */
 		}
 		
-		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences {
+		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * Performances that are enacted by this object.
 			 */
 		}
 		
-		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences {
+		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences, suboccurrences {
 			doc
 			/*
 			 * Performances that are owned by this object.
@@ -72,14 +75,14 @@ standard library package Objects {
 		}
 	}
 	
-	abstract assoc struct LinkObject specializes Link, Object {
+	abstract assoc struct LinkObject specializes Link, Object intersects Link, Object {
 		doc
 		/*
 		 * LinkObject is the most general association structure, being both a Link and an Object.
 		 */
 	}
 	
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject intersects BinaryLink, LinkObject {
 		doc
 		/*
 		 * BinaryLinkObject is the most general binary association structure, being both a 
@@ -94,14 +97,15 @@ standard library package Objects {
 		 */
 	}
 	
-	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects {
+	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects intersects links, objects {
 		doc
 		/*
 		 * linkObjects is a specializations of links and objects restricted to type LinkObjects. 
 		 */
 	}
 	
-	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects {
+	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects
+		intersects binaryLinks, linkObjects {
 		doc
 		/*
 		 * binaryLinkObjects is a specialization of binaryLinks and linkObjects restricted to 

--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -174,7 +174,8 @@ standard library package Occurrences {
 			subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
 		}
 
-		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences {
+		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences
+			intersects timeEnclosedOccurrences, spaceEnclosedOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
@@ -192,7 +193,8 @@ standard library package Occurrences {
 			binding startShot[1] = endShot[1];
 		}
 
-		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences 
+			intersects timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
@@ -670,13 +672,12 @@ standard library package Occurrences {
 		return t1First = includes(t1.endShot.successors, t2.endShot);
 	}
 
-	assoc all SelfSameLifeLink specializes BinaryLink disjoint from Occurrence {
+	assoc all SelfSameLifeLink specializes BinaryLink {
 		doc
 		/*
 		 * SelfSameLifeLink is a binary association that is equivalent to SelfLink if the
 		 * linked things are DataValues, but asserts that the link things are portions of
-		 * the same Life if they are Occurrences. A SelfSameLifeLink is not an Occurrence
-		 * (and so SelfSameLifeLink is disjoint with LinkObject).
+		 * the same Life if they are Occurrences. 
 		 */
 
 		end feature myselfSameLife: Anything[1..*] redefines source;

--- a/org.omg.kerml.xpect.tests/library/Performances.kerml
+++ b/org.omg.kerml.xpect.tests/library/Performances.kerml
@@ -44,7 +44,8 @@ standard library package Performances {
 		feature redefines isDispatch default true;
   		feature redefines dispatchScope default thisPerformance;
   		
-		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences {
+		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences
+			intersects performances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * timeEnclosedOccurrences of this Performance that are also Performances.
@@ -59,7 +60,8 @@ standard library package Performances {
 		}
 		connector :HappensDuring from self[1] to thisPerformance[1]; 
 		
-		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences {
+		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences
+			intersects enclosedPerformances, suboccurrences {
 			doc
 			/*
 			 * enclosedPerformances that are composite. 
@@ -117,7 +119,8 @@ standard library package Performances {
 		return : ScalarValue[1];
 	}
 	
-	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation {
+	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation
+		intersects LiteralEvaluation, BooleanEvaluation {
 		doc
 		/*
 		 * LiteralBooleanEvaluation is a specialization of LiteralEvaluation for the case of LiteralBooleans.
@@ -241,7 +244,8 @@ standard library package Performances {
 		 */
 	}
 	
-	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations {
+	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations
+		intersects literalEvaluations, booleanEvaluations {
 		doc
 		/*
 		 * literaBooleanlEvaluations is a specialization of literalEvaluations and booleanEvaluations restricted 

--- a/org.omg.kerml.xpect.tests/library/Transfers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Transfers.kerml
@@ -151,7 +151,7 @@ standard library package Transfers {
 		}
 	}
 	
-	interaction TransferBefore specializes Transfer, HappensBefore {
+	interaction TransferBefore specializes Transfer, HappensBefore intersects Transfer, HappensBefore {
 		doc
 		/*
 		 * TransferBefore is a specialization of Transfer in which the source happens before
@@ -167,7 +167,7 @@ standard library package Transfers {
 	  	private succession self then target;
 	}
 	
-	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore {
+	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
 		doc
 		/*
 		 * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 
@@ -193,6 +193,9 @@ standard library package Transfers {
 		/*
 		 * messageTransfers is a specialization of transfers restricted to type MessageTransfers.
 		 */
+		
+		end feature source: Occurrence[0..*] redefines MessageTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines MessageTransfer::target, transfers::target;		
 	}
 	
 	abstract flow flowTransfers: FlowTransfer[0..*] nonunique subsets transfers {
@@ -201,25 +204,33 @@ standard library package Transfers {
 		 * flowTransfers is a specialization of transfers restricted to type FlowTransfers.
 		 * It is the default subsetting for non-succession item flows.
 		 */
+		 
+		end feature source: Occurrence[0..*] redefines FlowTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines FlowTransfer::target, transfers::target;
 	}
 	  
-	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks {
+	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks
+		intersects transfers, happensBeforeLinks {
 		doc
 		/*
 		 * transfersBefore is a specialization of transfers and happensBeforeLinks restricted to
 		 * type TransferBefore.
 		 */
 	
-		end feature source: Occurrence[0..*] redefines transfers::source, HappensBefore::earlierOccurrence;
-		end feature target: Occurrence[0..*] redefines transfers::target, HappensBefore::laterOccurrence;
+		end feature source: Occurrence[0..*] redefines TransferBefore::source, transfers::source, happensBeforeLinks::earlierOccurrence;
+		end feature target: Occurrence[0..*] redefines TransferBefore::target, transfers::target, happensBeforeLinks::laterOccurrence;
 	}
 	
-	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore {
+	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore
+		intersects flowTransfers, transfersBefore {
 		doc
 		/*
 		 * flowTransfersBefore is a specialization of flowTransfers and transfersBefore that is restricted
 		 * to type FlowTransferBefore. IT is the default subsetting for succession item flows.
 		 */
+    
+		end feature source: Occurrence[0..*] redefines FlowTransferBefore::source, flowTransfers::source, transfersBefore::source;
+		end feature target: Occurrence[0..*] redefines FlowTransferBefore::target, flowTransfers::target, transfersBefore::target;
 	}
 
 	behavior SendPerformance specializes Performance  {

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -674,13 +674,17 @@ class KerMLValidator extends AbstractKerMLValidator {
 		}		
 		
 		// validateConnectorBinarySpecialization
-		// NOTE: It is sufficient to check owned ends, since they will redefine ends from any supertypes.
-		val connectorEnds = TypeUtil.getOwnedEndFeaturesOf(c)
+		val connectorEnds = TypeUtil.getAllEndFeaturesOf(c)
 		if (connectorEnds.size() > 2) {
 			val binaryLinkType = SysMLLibraryUtil.getLibraryElement(c, "Links::BinaryLink") as Type
 			if (c.conformsTo(binaryLinkType)) {
-				for (var i = 2; i < connectorEnds.size(); i++) {
-					error(INVALID_CONNECTOR_BINARY_SPECIALIZATION_MSG, connectorEnds.get(i), null, INVALID_CONNECTOR_BINARY_SPECIALIZATION)
+				val ownedConnectorEnds = TypeUtil.getOwnedEndFeaturesOf(c)
+				if (ownedConnectorEnds.size() <= 2) {
+					error(INVALID_CONNECTOR_BINARY_SPECIALIZATION_MSG, c, null, INVALID_CONNECTOR_BINARY_SPECIALIZATION)
+				} else {
+					for (var i = 2; i < connectorEnds.size(); i++) {
+						error(INVALID_CONNECTOR_BINARY_SPECIALIZATION_MSG, connectorEnds.get(i), null, INVALID_CONNECTOR_BINARY_SPECIALIZATION)
+					}
 				}
 			}
 		}

--- a/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/KerML.kerml
@@ -22,7 +22,7 @@ standard library package KerML {
 		}		
 				
 		metaclass Comment specializes AnnotatingElement {
-			feature locale : String[0..1];
+			feature 'locale' : String[0..1];
 			feature body : String[1..1];
 		}		
 				

--- a/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
@@ -29,7 +29,8 @@ standard library package Objects {
 
 		feature self: Object redefines Occurrence::self;
 		
-		composite subobjects: Object[0..*] subsets objects, suboccurrences {
+		composite subobjects: Object[0..*] subsets objects, suboccurrences
+			intersects objects, suboccurrences {
 			doc
 			/*
 			 * The suboccurrences of this Object that are also Objects.
@@ -43,14 +44,16 @@ standard library package Objects {
 			 */
 		}
 		
-		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences {
+		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * Performances that are enacted by this object.
 			 */
 		}
 		
-		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences {
+		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences, suboccurrences {
 			doc
 			/*
 			 * Performances that are owned by this object.
@@ -72,14 +75,14 @@ standard library package Objects {
 		}
 	}
 	
-	abstract assoc struct LinkObject specializes Link, Object {
+	abstract assoc struct LinkObject specializes Link, Object intersects Link, Object {
 		doc
 		/*
 		 * LinkObject is the most general association structure, being both a Link and an Object.
 		 */
 	}
 	
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject intersects BinaryLink, LinkObject {
 		doc
 		/*
 		 * BinaryLinkObject is the most general binary association structure, being both a 
@@ -94,14 +97,15 @@ standard library package Objects {
 		 */
 	}
 	
-	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects {
+	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects intersects links, objects {
 		doc
 		/*
 		 * linkObjects is a specializations of links and objects restricted to type LinkObjects. 
 		 */
 	}
 	
-	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects {
+	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects
+		intersects binaryLinks, linkObjects {
 		doc
 		/*
 		 * binaryLinkObjects is a specialization of binaryLinks and linkObjects restricted to 

--- a/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
@@ -174,7 +174,8 @@ standard library package Occurrences {
 			subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
 		}
 
-		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences {
+		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences
+			intersects timeEnclosedOccurrences, spaceEnclosedOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
@@ -192,7 +193,8 @@ standard library package Occurrences {
 			binding startShot[1] = endShot[1];
 		}
 
-		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences 
+			intersects timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
@@ -670,13 +672,12 @@ standard library package Occurrences {
 		return t1First = includes(t1.endShot.successors, t2.endShot);
 	}
 
-	assoc all SelfSameLifeLink specializes BinaryLink disjoint from Occurrence {
+	assoc all SelfSameLifeLink specializes BinaryLink {
 		doc
 		/*
 		 * SelfSameLifeLink is a binary association that is equivalent to SelfLink if the
 		 * linked things are DataValues, but asserts that the link things are portions of
-		 * the same Life if they are Occurrences. A SelfSameLifeLink is not an Occurrence
-		 * (and so SelfSameLifeLink is disjoint with LinkObject).
+		 * the same Life if they are Occurrences. 
 		 */
 
 		end feature myselfSameLife: Anything[1..*] redefines source;

--- a/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Performances.kerml
@@ -44,7 +44,8 @@ standard library package Performances {
 		feature redefines isDispatch default true;
   		feature redefines dispatchScope default thisPerformance;
   		
-		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences {
+		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences
+			intersects performances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * timeEnclosedOccurrences of this Performance that are also Performances.
@@ -59,7 +60,8 @@ standard library package Performances {
 		}
 		connector :HappensDuring from self[1] to thisPerformance[1]; 
 		
-		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences {
+		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences
+			intersects enclosedPerformances, suboccurrences {
 			doc
 			/*
 			 * enclosedPerformances that are composite. 
@@ -117,7 +119,8 @@ standard library package Performances {
 		return : ScalarValue[1];
 	}
 	
-	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation {
+	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation
+		intersects LiteralEvaluation, BooleanEvaluation {
 		doc
 		/*
 		 * LiteralBooleanEvaluation is a specialization of LiteralEvaluation for the case of LiteralBooleans.
@@ -241,7 +244,8 @@ standard library package Performances {
 		 */
 	}
 	
-	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations {
+	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations
+		intersects literalEvaluations, booleanEvaluations {
 		doc
 		/*
 		 * literaBooleanlEvaluations is a specialization of literalEvaluations and booleanEvaluations restricted 

--- a/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
@@ -151,7 +151,7 @@ standard library package Transfers {
 		}
 	}
 	
-	interaction TransferBefore specializes Transfer, HappensBefore {
+	interaction TransferBefore specializes Transfer, HappensBefore intersects Transfer, HappensBefore {
 		doc
 		/*
 		 * TransferBefore is a specialization of Transfer in which the source happens before
@@ -167,7 +167,7 @@ standard library package Transfers {
 	  	private succession self then target;
 	}
 	
-	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore {
+	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
 		doc
 		/*
 		 * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 
@@ -193,6 +193,9 @@ standard library package Transfers {
 		/*
 		 * messageTransfers is a specialization of transfers restricted to type MessageTransfers.
 		 */
+		
+		end feature source: Occurrence[0..*] redefines MessageTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines MessageTransfer::target, transfers::target;		
 	}
 	
 	abstract flow flowTransfers: FlowTransfer[0..*] nonunique subsets transfers {
@@ -201,25 +204,33 @@ standard library package Transfers {
 		 * flowTransfers is a specialization of transfers restricted to type FlowTransfers.
 		 * It is the default subsetting for non-succession item flows.
 		 */
+		 
+		end feature source: Occurrence[0..*] redefines FlowTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines FlowTransfer::target, transfers::target;
 	}
 	  
-	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks {
+	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks
+		intersects transfers, happensBeforeLinks {
 		doc
 		/*
 		 * transfersBefore is a specialization of transfers and happensBeforeLinks restricted to
 		 * type TransferBefore.
 		 */
 	
-		end feature source: Occurrence[0..*] redefines transfers::source, HappensBefore::earlierOccurrence;
-		end feature target: Occurrence[0..*] redefines transfers::target, HappensBefore::laterOccurrence;
+		end feature source: Occurrence[0..*] redefines TransferBefore::source, transfers::source, happensBeforeLinks::earlierOccurrence;
+		end feature target: Occurrence[0..*] redefines TransferBefore::target, transfers::target, happensBeforeLinks::laterOccurrence;
 	}
 	
-	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore {
+	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore
+		intersects flowTransfers, transfersBefore {
 		doc
 		/*
 		 * flowTransfersBefore is a specialization of flowTransfers and transfersBefore that is restricted
 		 * to type FlowTransferBefore. IT is the default subsetting for succession item flows.
 		 */
+    
+		end feature source: Occurrence[0..*] redefines FlowTransferBefore::source, flowTransfers::source, transfersBefore::source;
+		end feature target: Occurrence[0..*] redefines FlowTransferBefore::target, flowTransfers::target, transfersBefore::target;
 	}
 
 	behavior SendPerformance specializes Performance  {

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ConnectionTest.sysml.xt
@@ -7,11 +7,12 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 		File {from ="/library.kernel/Occurrences.kerml"}
        	File {from ="/library.kernel/Objects.kerml"}
        	File {from ="/library.kernel/Performances.kerml"}
-		File {from ="/library.kernel/BaseFunctions.kerml"}
+       	File {from ="/library.kernel/Transfers.kerml"}
 		File {from ="/library.systems/Items.sysml"}
 		File {from ="/library.systems/Parts.sysml"}
 		File {from ="/library.systems/Ports.sysml"}
 		File {from ="/library.systems/Connections.sysml"}
+		File {from ="/library.systems/Actions.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -20,13 +21,14 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 				File {from ="/library.kernel/Base.kerml"}
 				File {from ="/library.kernel/Links.kerml"}
 				File {from ="/library.kernel/Occurrences.kerml"}
-       			File {from ="/library.kernel/Objects.kerml"}
-       			File {from ="/library.kernel/Performances.kerml"}
-				File {from ="/library.kernel/BaseFunctions.kerml"}
+ 		      	File {from ="/library.kernel/Objects.kerml"}
+ 		      	File {from ="/library.kernel/Performances.kerml"}
+ 		      	File {from ="/library.kernel/Transfers.kerml"}
 				File {from ="/library.systems/Items.sysml"}
 				File {from ="/library.systems/Parts.sysml"}
 				File {from ="/library.systems/Ports.sysml"}
 				File {from ="/library.systems/Connections.sysml"}
+				File {from ="/library.systems/Actions.sysml"}
 			}
 		}
 	}
@@ -77,10 +79,7 @@ package ConnectionTest {
 		end end2 ::> d2;
 	}
 	
-	flow def F {
-		end f_p : P;
-		end f_q;
-	}
+	abstract flow def F;
 	
 	message : F from p to p;
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
@@ -38,25 +38,16 @@ END_SETUP
 */
 package P {
 	part def A;	
-	part def B;	
-	part def C;	
-	part def D;	
-	part def E;
 	
-	flow def DE {
-		end : D[1];
-		end : E[1];
-	}
-	flow def BC {
-		end : B[1];
-		end : C[1];
-	}
+	abstract flow def F;
+	abstract flow def G;
+	
 	part apart : A {
-		part b : B[1];
-		part c : C[1];
+		part b;
+		part c;
 		
-		message bc : BC from b to c;
-		message de : DE, BC from b to c;
+		message : F from b to c;
+		message : F, G from b to c;
 		
 		// XPECT errors --> "A flow connection must be typed by flow connection definitions." at "message :A from b to c;"
 		message :A from b to c;

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta.json
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.meta.json
@@ -4,6 +4,6 @@
     "ScalarValues": "ScalarValues.kerml",
     "VectorValues": "VectorValues.kerml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/KerML/20240201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
@@ -1,11 +1,11 @@
 {
   "name": "Kernel Data Type Library",
-  "version": "0.33.0",
+  "version": "1.0.0-beta2",
   "description": "Standard data type library for the Kernel Modeling Language (KerML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/Collections.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/Collections.kerml
@@ -90,7 +90,8 @@ standard library package Collections {
 		 */
 	}
 
-	datatype OrderedSet :> OrderedCollection, UniqueCollection {
+	datatype OrderedSet :> OrderedCollection, UniqueCollection 
+		intersects OrderedCollection, UniqueCollection {
 		doc
 		/*
 		 * OrderedSet is a variable-size, ordered collection of unique elements.

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/VectorValues.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/VectorValues.kerml
@@ -18,7 +18,7 @@ standard library package VectorValues {
 		 */
 	}
 	
-	datatype NumericalVectorValue :> VectorValue, Array {
+	datatype NumericalVectorValue :> VectorValue, Array intersects VectorValue, Array {
 		doc
 		/*
 		 * A NumericalVectorValue is a kind of VectorValue that is specifically represented
@@ -53,7 +53,8 @@ standard library package VectorValues {
 		feature :>> dimension = 3;
 	}
 	
-	datatype CartesianThreeVectorValue :> CartesianVectorValue, ThreeVectorValue {
+	datatype CartesianThreeVectorValue :> CartesianVectorValue, ThreeVectorValue 
+		intersects CartesianVectorValue, ThreeVectorValue {
 		doc
 		/*
 		 * A CartesianThreeVectorValue is a NumericalVectorValue that is both Cartesian and

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.meta.json
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.meta.json
@@ -8,6 +8,7 @@
     "DataFunctions": "DataFunctions.kerml",
     "IntegerFunctions": "IntegerFunctions.kerml",
     "NaturalFunctions": "NaturalFunctions.kerml",
+    "NumericalFunctions": "NumericalFunctions.kerml",
     "OccurrenceFunctions": "OccurrenceFunctions.kerml",
     "RationalFunctions": "RationalFunctions.kerml",
     "RealFunctions": "RealFunctions.kerml",
@@ -17,6 +18,6 @@
     "TrigFunctions": "TrigFunctions.kerml",
     "VectorFunctions": "VectorFunctions.kerml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/KerML/20240201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
@@ -1,15 +1,15 @@
 {
   "name": "Kernel Function Library",
-  "version": "0.33.0",
+  "version": "1.0.0-beta2",
   "description": "Standard function library for the Kernel Modeling Language (KerML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     }  
   ]
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta.json
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.meta.json
@@ -17,6 +17,6 @@
     "TransitionPerformances": "TransitionPerformances.kerml",
     "Triggers": "Triggers.kerml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/KerML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/KerML/20240201"
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
@@ -1,15 +1,15 @@
 {
   "name": "Kernel Semantic Library",
-  "version": "0.33.0",
+  "version": "1.0.0-beta2",
   "description": "Standard semantic library for the Kernel Modeling Language (KerML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
@@ -29,7 +29,8 @@ standard library package Objects {
 
 		feature self: Object redefines Occurrence::self;
 		
-		composite subobjects: Object[0..*] subsets objects, suboccurrences {
+		composite subobjects: Object[0..*] subsets objects, suboccurrences
+			intersects objects, suboccurrences {
 			doc
 			/*
 			 * The suboccurrences of this Object that are also Objects.
@@ -43,14 +44,16 @@ standard library package Objects {
 			 */
 		}
 		
-		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences {
+		abstract step enactedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * Performances that are enacted by this object.
 			 */
 		}
 		
-		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences {
+		composite step ownedPerformances: Performance[0..*] subsets involvingPerformances, timeEnclosedOccurrences, suboccurrences
+			intersects involvingPerformances, timeEnclosedOccurrences, suboccurrences {
 			doc
 			/*
 			 * Performances that are owned by this object.
@@ -72,14 +75,14 @@ standard library package Objects {
 		}
 	}
 	
-	abstract assoc struct LinkObject specializes Link, Object {
+	abstract assoc struct LinkObject specializes Link, Object intersects Link, Object {
 		doc
 		/*
 		 * LinkObject is the most general association structure, being both a Link and an Object.
 		 */
 	}
 	
-	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject {
+	assoc struct BinaryLinkObject specializes BinaryLink, LinkObject intersects BinaryLink, LinkObject {
 		doc
 		/*
 		 * BinaryLinkObject is the most general binary association structure, being both a 
@@ -94,14 +97,15 @@ standard library package Objects {
 		 */
 	}
 	
-	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects {
+	abstract feature linkObjects: LinkObject[0..*] nonunique subsets links, objects intersects links, objects {
 		doc
 		/*
 		 * linkObjects is a specializations of links and objects restricted to type LinkObjects. 
 		 */
 	}
 	
-	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects {
+	abstract feature binaryLinkObjects: BinaryLinkObject[0..*] nonunique subsets binaryLinks, linkObjects
+		intersects binaryLinks, linkObjects {
 		doc
 		/*
 		 * binaryLinkObjects is a specialization of binaryLinks and linkObjects restricted to 

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -670,13 +670,12 @@ standard library package Occurrences {
 		return t1First = includes(t1.endShot.successors, t2.endShot);
 	}
 
-	assoc all SelfSameLifeLink specializes BinaryLink disjoint from Occurrence {
+	assoc all SelfSameLifeLink specializes BinaryLink {
 		doc
 		/*
 		 * SelfSameLifeLink is a binary association that is equivalent to SelfLink if the
 		 * linked things are DataValues, but asserts that the link things are portions of
-		 * the same Life if they are Occurrences. A SelfSameLifeLink is not an Occurrence
-		 * (and so SelfSameLifeLink is disjoint with LinkObject).
+		 * the same Life if they are Occurrences. 
 		 */
 
 		end feature myselfSameLife: Anything[1..*] redefines source;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -174,7 +174,8 @@ standard library package Occurrences {
 			subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
 		}
 
-		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences {
+		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences
+			intersects timeEnclosedOccurrences, spaceEnclosedOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,
@@ -192,7 +193,8 @@ standard library package Occurrences {
 			binding startShot[1] = endShot[1];
 		}
 
-		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
+		feature spaceTimeCoincidentOccurrences: Occurrence[1..*] subsets timeCoincidentOccurrences, spaceEnclosedOccurrences 
+			intersects timeCoincidentOccurrences, spaceEnclosedOccurrences inverse of spaceTimeCoincidentOccurrences {
 			doc
 			/*
 			 * Occurrences that this one completely includes in both space and time,

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Performances.kerml
@@ -44,7 +44,8 @@ standard library package Performances {
 		feature redefines isDispatch default true;
   		feature redefines dispatchScope default thisPerformance;
   		
-		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences {
+		step enclosedPerformances: Performance[0..*] subsets performances, timeEnclosedOccurrences
+			intersects performances, timeEnclosedOccurrences {
 			doc
 			/*
 			 * timeEnclosedOccurrences of this Performance that are also Performances.
@@ -59,7 +60,8 @@ standard library package Performances {
 		}
 		connector :HappensDuring from self[1] to thisPerformance[1]; 
 		
-		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences {
+		composite step subperformances: Performance[0..*] subsets enclosedPerformances, suboccurrences
+			intersects enclosedPerformances, suboccurrences {
 			doc
 			/*
 			 * enclosedPerformances that are composite. 
@@ -117,7 +119,8 @@ standard library package Performances {
 		return : ScalarValue[1];
 	}
 	
-	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation {
+	abstract predicate LiteralBooleanEvaluation specializes LiteralEvaluation, BooleanEvaluation
+		intersects LiteralEvaluation, BooleanEvaluation {
 		doc
 		/*
 		 * LiteralBooleanEvaluation is a specialization of LiteralEvaluation for the case of LiteralBooleans.
@@ -241,7 +244,8 @@ standard library package Performances {
 		 */
 	}
 	
-	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations {
+	abstract expr literalBooleanEvaluations: LiteralBooleanEvaluation[0..*] nonunique subsets literalEvaluations, booleanEvaluations
+		intersects literalEvaluations, booleanEvaluations {
 		doc
 		/*
 		 * literaBooleanlEvaluations is a specialization of literalEvaluations and booleanEvaluations restricted 

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -193,6 +193,9 @@ standard library package Transfers {
 		/*
 		 * messageTransfers is a specialization of transfers restricted to type MessageTransfers.
 		 */
+		
+		end feature source: Occurrence[0..*] redefines MessageTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines MessageTransfer::target, transfers::target;		
 	}
 	
 	abstract flow flowTransfers: FlowTransfer[0..*] nonunique subsets transfers {
@@ -201,6 +204,9 @@ standard library package Transfers {
 		 * flowTransfers is a specialization of transfers restricted to type FlowTransfers.
 		 * It is the default subsetting for non-succession item flows.
 		 */
+		 
+		end feature source: Occurrence[0..*] redefines FlowTransfer::source, transfers::source;
+		end feature target: Occurrence[0..*] redefines FlowTransfer::target, transfers::target;
 	}
 	  
 	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks
@@ -211,8 +217,8 @@ standard library package Transfers {
 		 * type TransferBefore.
 		 */
 	
-		end feature source: Occurrence[0..*] redefines transfers::source, HappensBefore::earlierOccurrence;
-		end feature target: Occurrence[0..*] redefines transfers::target, HappensBefore::laterOccurrence;
+		end feature source: Occurrence[0..*] redefines TransferBefore::source, transfers::source, happensBeforeLinks::earlierOccurrence;
+		end feature target: Occurrence[0..*] redefines TransferBefore::target, transfers::target, happensBeforeLinks::laterOccurrence;
 	}
 	
 	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore
@@ -222,6 +228,9 @@ standard library package Transfers {
 		 * flowTransfersBefore is a specialization of flowTransfers and transfersBefore that is restricted
 		 * to type FlowTransferBefore. IT is the default subsetting for succession item flows.
 		 */
+    
+		end feature source: Occurrence[0..*] redefines FlowTransferBefore::source, flowTransfers::source, transfersBefore::source;
+		end feature target: Occurrence[0..*] redefines FlowTransferBefore::target, flowTransfers::target, transfersBefore::target;
 	}
 
 	behavior SendPerformance specializes Performance  {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -151,7 +151,7 @@ standard library package Transfers {
 		}
 	}
 	
-	interaction TransferBefore specializes Transfer, HappensBefore {
+	interaction TransferBefore specializes Transfer, HappensBefore intersects Transfer, HappensBefore {
 		doc
 		/*
 		 * TransferBefore is a specialization of Transfer in which the source happens before
@@ -167,7 +167,7 @@ standard library package Transfers {
 	  	private succession self then target;
 	}
 	
-	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore {
+	interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
 		doc
 		/*
 		 * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 
@@ -203,7 +203,8 @@ standard library package Transfers {
 		 */
 	}
 	  
-	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks {
+	abstract flow transfersBefore: TransferBefore[0..*] nonunique subsets transfers, happensBeforeLinks
+		intersects transfers, happensBeforeLinks {
 		doc
 		/*
 		 * transfersBefore is a specialization of transfers and happensBeforeLinks restricted to
@@ -214,7 +215,8 @@ standard library package Transfers {
 		end feature target: Occurrence[0..*] redefines transfers::target, HappensBefore::laterOccurrence;
 	}
 	
-	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore {
+	abstract flow flowTransfersBefore: FlowTransferBefore[0..*] nonunique subsets flowTransfers, transfersBefore
+		intersects flowTransfers, transfersBefore {
 		doc
 		/*
 		 * flowTransfersBefore is a specialization of flowTransfers and transfersBefore that is restricted

--- a/sysml/src/examples/Simple Tests/ConnectionTest.sysml
+++ b/sysml/src/examples/Simple Tests/ConnectionTest.sysml
@@ -43,10 +43,7 @@ package ConnectionTest {
 		end end2 ::> d2;
 	}
 	
-	flow def F {
-		end f_p : P;
-		end f_q;
-	}
+	abstract flow def F;
 	
 	message : F from p to p;
 }


### PR DESCRIPTION
This PR implements resolutions of issues from KerML FTF Ballot 5 that called for updates to library models.

Resolutions of the following issues are implemented in this PR:

- [KERML-45](https://issues.omg.org/issues/KERML-45) LinkObject is irreflexive
- [KERML-46](https://issues.omg.org/issues/KERML-46) Intersection missing for some multiple specializations
- [KERML-120](https://issues.omg.org/issues/KERML-120) FlowTransferBefore needs end feature declarations

In addition, the `.meta.json` and `.project.json` files in the model library directories have been updated to reflect the new normative KerML URI `https://www.omg.org/spec/KerML/240201` and the versions have been updated to `1.0.0-beta2`.