### PR TITLE
ST6RI-741 Model-library/example-related issues from SysML v2 FTF Ballot #11

### DIFF
--- a/sysml.library/Domain Libraries/Analysis/.meta.json
+++ b/sysml.library/Domain Libraries/Analysis/.meta.json
@@ -5,6 +5,6 @@
     "StateSpaceRepresentation": "StateSpaceRepresentation.sysml",
     "TradeStudies": "TradeStudies.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Analysis/.project.json
+++ b/sysml.library/Domain Libraries/Analysis/.project.json
@@ -1,27 +1,27 @@
 {
   "name": "SysML Analysis Library",
-  "version": "0.33.0",
+  "version": "1.0.0-beta2",
   "description": "Standard analysis domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Quantities-and-Units-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Quantities-and-Units-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Analysis/.project.json
+++ b/sysml.library/Domain Libraries/Analysis/.project.json
@@ -1,6 +1,6 @@
 {
   "name": "SysML Analysis Library",
-  "version": "1.0.0-beta2",
+  "version": "2.0.0-beta2",
   "description": "Standard analysis domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
@@ -17,11 +17,11 @@
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "1.0.0-beta2"
+      "versionConstraint": "2.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Quantities-and-Units-Library.kpar",
-      "versionConstraint": "1.0.0-beta2"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.meta.json
+++ b/sysml.library/Domain Libraries/Cause and Effect/.meta.json
@@ -3,6 +3,6 @@
     "CausationConnections": "CausationConnections.sysml",
     "CauseAndEffect": "CauseAndEffect.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project.json
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project.json
@@ -1,23 +1,23 @@
 {
   "name": "SysML Cause and Effect Library",
-  "version": "0.33.0",
+  "version": "2.0.0-beta2",
   "description": "Standard cause-and-effect domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project.json
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project.json
@@ -4,19 +4,19 @@
   "description": "Standard cause-and-effect domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
       "versionConstraint": "0.33.0"
     }
   ]

--- a/sysml.library/Domain Libraries/Geometry/.meta.json
+++ b/sysml.library/Domain Libraries/Geometry/.meta.json
@@ -3,6 +3,6 @@
     "ShapeItems": "ShapeItems.sysml",
     "SpatialItems": "SpatialItems.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Geometry/.project.json
+++ b/sysml.library/Domain Libraries/Geometry/.project.json
@@ -4,23 +4,23 @@
   "description": "Standard geometry domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Quantities-and-Units-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Quantities-and-Units-Library.kpar",
       "versionConstraint": "0.33.0"
     }
   ]

--- a/sysml.library/Domain Libraries/Geometry/.project.json
+++ b/sysml.library/Domain Libraries/Geometry/.project.json
@@ -1,27 +1,27 @@
 {
   "name": "SysML Geometry Library",
-  "version": "0.33.0",
+  "version": "2.0.0-beta2",
   "description": "Standard geometry domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Quantities-and-Units-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Metadata/.meta.json
+++ b/sysml.library/Domain Libraries/Metadata/.meta.json
@@ -5,6 +5,6 @@
     "ParametersOfInterestMetadata": "ParametersOfInterestMetadata.sysml",
     "RiskMetadata": "RiskMetadata.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Metadata/.project.json
+++ b/sysml.library/Domain Libraries/Metadata/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Metadata Library",
-  "version": "0.33.0",
+  "version": "2.0.0-beta2",
   "description": "Standard metadata domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Metadata/.project.json
+++ b/sysml.library/Domain Libraries/Metadata/.project.json
@@ -4,15 +4,15 @@
   "description": "Standard metadata domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
       "versionConstraint": "0.33.0"
     }
   ]

--- a/sysml.library/Domain Libraries/Quantities and Units/.meta.json
+++ b/sysml.library/Domain Libraries/Quantities and Units/.meta.json
@@ -18,10 +18,11 @@
     "QuantityCalculations": "QuantityCalculations.sysml",
     "SI": "SI.sysml",
     "SIPrefixes": "SIPrefixes.sysml",
+    "TensorCalculations": "TensorCalculations.sysml",
     "Time": "Time.sysml",
     "USCustomaryUnits": "USCustomaryUnits.sysml",
     "VectorCalculations": "VectorCalculations.sysml"
   },
   "created": "2022-12-16T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/.project.json
+++ b/sysml.library/Domain Libraries/Quantities and Units/.project.json
@@ -4,19 +4,19 @@
   "description": "Standard quantities and units domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
       "versionConstraint": "0.33.0"
     }
   ]

--- a/sysml.library/Domain Libraries/Quantities and Units/.project.json
+++ b/sysml.library/Domain Libraries/Quantities and Units/.project.json
@@ -1,23 +1,23 @@
 {
   "name": "SysML Quantities and Units Library",
-  "version": "0.33.0",
+  "version": "2.0.0-beta2",
   "description": "Standard quantities and units domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Requirement Derivation/.meta.json
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.meta.json
@@ -3,6 +3,6 @@
     "DerivationConnections": "DerivationConnections.sysml",
     "RequirementsDerivation": "RequirementsDerivation.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Domain Libraries/Requirement Derivation/.project.json
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Requirement Derivation Library",
-  "version": "0.33.0",
+  "version": "2.0.0-beta2",
   "description": "Standard requirements derivation domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "1.0.0-beta2"
     },
     {
       "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "versionConstraint": "2.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Requirement Derivation/.project.json
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.project.json
@@ -4,15 +4,15 @@
   "description": "Standard requirements derivation domain library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
       "versionConstraint": "0.33.0"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20240201/Systems-Library.kpar",
       "versionConstraint": "0.33.0"
     }
   ]

--- a/sysml.library/Systems Library/.meta.json
+++ b/sysml.library/Systems Library/.meta.json
@@ -16,10 +16,11 @@
     "Requirements": "Requirements.sysml",
     "StandardViewDefinitions": "StandardViewDefinitions.sysml",
     "States": "States.sysml",
+    "SysML": "SysML.sysml",
     "UseCases": "UseCases.sysml",
     "VerificationCases": "VerificationCases.sysml",
     "Views": "Views.sysml"
   },
-  "created": "2023-02-20T00:00:00Z",
-  "metamodel": "https://www.omg.org/spec/SysML/20230201"
+  "created": "2024-02-20T00:00:00Z",
+  "metamodel": "https://www.omg.org/spec/SysML/20240201"
 }

--- a/sysml.library/Systems Library/.project.json
+++ b/sysml.library/Systems Library/.project.json
@@ -1,6 +1,6 @@
 {
   "name": "SysML Systems Library",
-  "version": "1.0.0-beta2",
+  "version": "2.0.0-beta2",
   "description": "Standard semantic library for the Systems Modeling Language (SysML)",
   "usage": [
     {

--- a/sysml.library/Systems Library/.project.json
+++ b/sysml.library/Systems Library/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Systems Library",
-  "version": "0.33.0",
+  "version": "1.0.0-beta2",
   "description": "Standard semantic library for the Systems Modeling Language (SysML)",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Semantic-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Data-Type-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar",
-      "versionConstraint": "0.33.0"
+      "resource": "https://www.omg.org/spec/KerML/20240201/Function-Library.kpar",
+      "versionConstraint": "1.0.0-beta2"
     }
   ]
 }

--- a/sysml.library/Systems Library/VerificationCases.sysml
+++ b/sysml.library/Systems Library/VerificationCases.sysml
@@ -39,7 +39,7 @@ standard library package VerificationCases {
 			 */
 		}
 		
-		abstract verification subVerificationCases : Case[0..*] :> verificationCases, subcases {
+		abstract verification subVerificationCases : VerificationCase[0..*] :> verificationCases, subcases {
 			doc
 			/*
 			 * The subcases of this VerificationCase that are VerificationCaseUsages.

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
@@ -143,7 +143,7 @@ package SimpleVehicleModel{
                 attribute mass:>ISQ::mass;
             }
             part def FrontAxle:>Axle{
-                attribute steeringAngle:>ISQ::planeAngle;
+                attribute steeringAngle:>ISQ::angularMeasure;
             }
             part def HalfAxle{
                 port shankCompositePort:ShankCompositePort{

--- a/sysml/src/validation/03-Function-based Behavior/3c-Function-based Behavior-structure mod-2.sysml
+++ b/sysml/src/validation/03-Function-based Behavior/3c-Function-based Behavior-structure mod-2.sysml
@@ -35,12 +35,12 @@ package '3c-Function-based Behavior-structure mod-2' {
 			action 'connect trailer to vehicle' {
 				// Assert that exactly one connection exists during the
 				// performance of this action.
-				abstract ref connection :>> trailerHitch[1];
+				abstract ref :>> trailerHitch[1];
 			}
 			then action 'disconnect trailer from vehicle' {
 				// Assert that exactly no connection exists during the
 				// performance of this action.
-				abstract ref connection :>> trailerHitch[0];				
+				abstract ref :>> trailerHitch[0];		
 			}
 		}
 		


### PR DESCRIPTION
This PR implements resolutions of issues from SysML v2 FTF Ballot 11 that called for updates to library models.

Resolution of the following issue is implemented in this PR:

- [SYSML2-158](https://issues.omg.org/issues/SYSML2-158) Example FrontAxle definition
- [SYSML2-634](https://issues.omg.org/issues/SYSML2-634) VerificationCase::subVerificationCases is typed incorrectly

In addition, the `.meta.json` and `.project.json` files in the model library directories have been updated to reflect the new normative SysML URI `https://www.omg.org/spec/SysML/240201` and the versions have been updated to `2.0.0-beta2`. KerML library projects are now required to be version `1.0.0-beta2`, as will be implemented in PR #541.