### PR TITLE
ST6RI-742 LifeClass implicit specialization is not correct

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/LifeClassAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/LifeClassAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -40,23 +40,19 @@ public class LifeClassAdapter extends ClassAdapter {
 	
 	// Transformation
 
-	protected void addSuperclassing() {
-		LifeClass lifeClass = getTarget();
-		Namespace owner = lifeClass.getOwningNamespace();
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		Namespace owner = getTarget().getOwningNamespace();
 		if (owner instanceof Classifier) {
 			addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubclassification(), (Classifier)owner);
 		}
 	}
 	
-	protected void addMultiplicity() {
-		FeatureUtil.addMultiplicityTo(getTarget());
-	}
-	
 	@Override
 	public void doTransform() {
 		super.doTransform();
-		addSuperclassing();
-		addMultiplicity();
+		FeatureUtil.addMultiplicityTo(getTarget());
 	}
 	
 }


### PR DESCRIPTION
As part of the underlying semantics for individuals, every individual definition is required to by the constraint `validateOccurrenceDefinitionLifeClass` to have "exactly one `ownedMember` that is a `LifeClass`". Further, the constraint `checkLifeClassOccurrenceSpecialization` requires that “A `LifeClass` must specialize its `individualDefinition`." However, do to a bug in the `LifeClassAdapter`, this implicit specialization was not being added. This PR fixes that bug.