### PR TITLE
ST6RI-747 The direction property is not serialized in XMI for parameters owned by ParameterMemberships

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
@@ -652,7 +652,7 @@ public class FeatureImpl extends TypeImpl implements Feature {
 	public FeatureDirectionKind getDirection() {
 		FeatureMembership owningFeatureMembership = getOwningFeatureMembership();
 		if (owningFeatureMembership instanceof ParameterMembership) {
-			return ((ParameterMembership)owningFeatureMembership).parameterDirection();
+			direction = ((ParameterMembership)owningFeatureMembership).parameterDirection();
 		} else if (owningFeatureMembership != null) {
 			Type owningType = owningFeatureMembership.getOwningType();
 			if (owningType instanceof ItemFlowEnd) {
@@ -660,7 +660,7 @@ public class FeatureImpl extends TypeImpl implements Feature {
 				if (!redefinitions.isEmpty()) {
 					Feature redefinedFeature = redefinitions.get(0).getRedefinedFeature();
 					if (redefinedFeature != null) {
-						return owningType.directionOf(redefinedFeature);
+						direction = owningType.directionOf(redefinedFeature);
 					}
 				}
 			}


### PR DESCRIPTION
The implementation of the resolution of [KERML-75](https://issues.omg.org/issues/KERML-75) in PR #528 inadvertently caused the `direction` property of parameters owned via `ParameterMemberships` to not be serialized in XMI. This PR fixes that bug. (Note that this bug did _not_ effect serialization to JSON.)