### PR TITLE
ST6RI-748: Standard library elements are rendered without SHOWLIB and SHOWINHERITED styles (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -73,6 +73,8 @@ public class SysML2PlantUMLText {
         MIXED;
     }
 
+    private static final int MAX_VISITS = 1000;
+
     private final List<SysML2PlantUMLStyle> styles = new ArrayList<SysML2PlantUMLStyle>();
     private final Map<String, String> styleValueMap = new HashMap<String, String>();
     private StyleSwitch styleSwitch;
@@ -468,6 +470,7 @@ public class SysML2PlantUMLText {
         
         init();
 
+        numVisits = 0;
         for (EObject eObj : eObjs) {
             if (eObj instanceof Element) {
                 Element e = (Element) eObj;
@@ -475,6 +478,8 @@ public class SysML2PlantUMLText {
             }
         }
         vpath.init();
+
+        numVisits = 0;
         for (EObject eObj : eObjs) {
             if (eObj instanceof Element) {
                 Element e = (Element) eObj;
@@ -599,8 +604,13 @@ public class SysML2PlantUMLText {
     private List<Namespace> namespaces;
     private List<Integer> inheritingIdices;
 
-    
+    private int numVisits;
+    void countVisits() {
+        numVisits++;
+    }
+
     boolean pushNamespace(Namespace ns) {
+        if (numVisits > MAX_VISITS) return false;
         if (namespaces.contains(ns)) return false;
         namespaces.add(ns);
         return true;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -561,7 +561,7 @@ public class VCompartment extends VStructure {
 
     public void startType(Type typ) {
         this.currentType = typ;
-        traverse(typ, false, true);
+        if (traverse(typ, false, true) == null) return;
         addDocumentations();
         addCompartmentEntries(compartmentEntries, 0);
         popNamespace();

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -49,13 +49,8 @@ public abstract class VTraverser extends Visitor {
         return currentMembership;
     }
 
-    private static final int MAX_TRAVERSE = 1000;
-    private int traversed = 0;
-
     protected boolean checkVisited(Namespace n) {
     	if (visited.contains(n)) return true;
-        if (traversed > MAX_TRAVERSE) return true;
-        traversed++;
     	visited.add(n);
     	return false;
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -49,8 +49,13 @@ public abstract class VTraverser extends Visitor {
         return currentMembership;
     }
 
+    private static final int MAX_TRAVERSE = 1000;
+    private int traversed = 0;
+
     protected boolean checkVisited(Namespace n) {
     	if (visited.contains(n)) return true;
+        if (traversed > MAX_TRAVERSE) return true;
+        traversed++;
     	visited.add(n);
     	return false;
     }
@@ -117,6 +122,7 @@ public abstract class VTraverser extends Visitor {
 
     private void traverseRest(VPath vpath) {
         for (Element e: vpath.rest()) {
+            if (!showLib() && isModelLibrary(e)) continue;
             currentMembership = null;
             setInherited(true);
             visit(e);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -745,6 +745,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
 
     public String visit(Element e) {
     	if (e == null) return null;
+        s2p.countVisits();
         return doSwitch(e);
     }
 }


### PR DESCRIPTION
he standard library elements are rendered even without SHOWLIB and SHOWINHERITED style if they are referred by some connectors.  Also this PR limits the maximum number of elements to be processed, which is useful for rendering with `SHOWLIB` style.