### PR TITLE
ST6RI-750 The elementId is not being serialized in XMI for LibraryPackages

### DIFF
--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
@@ -112,7 +112,7 @@ public class LibraryPackageImpl extends PackageImpl implements LibraryPackage {
 						KERML_LIBRARY_BASE_URI: SYSML_LIBRARY_BASE_URI;
 				String qualifiedName = getQualifiedName();
 				if (qualifiedName != null) {
-					return ElementUtil.constructNameUUID(UUID_NAMESPACE_URL, uri + qualifiedName).toString();
+					elementId = ElementUtil.constructNameUUID(UUID_NAMESPACE_URL, uri + qualifiedName).toString();
 				}
 			}
 		}


### PR DESCRIPTION
The implementation of deterministic UUIDs for standard library packages in PR #457 inadvertently caused the `elementId` property of standard library packages to not be serialized in XMI. This PR fixes that bug. (Note that this bug did _not_ effect serialization to JSON.)