### PR TITLE
ST6RI-755 Fix Maven build due to the update of org.eclipse.equinox.common

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,14 @@
 <extensions>
+  <!--
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
     <version>2.7.5</version>
+    </extension>
+  -->
+  <extension>
+   <groupId>org.eclipse.tycho.extras</groupId>
+   <artifactId>tycho-pomless</artifactId>
+   <version>1.5.1</version>
   </extension>
 </extensions>


### PR DESCRIPTION
The `org.eclipse.equinox.common` plugin was updated to version 3.19.0 on 8 March 2024. Unlike previous versions, this new version was compiled using Java 17. The Maven `tycho-build` extension indirectly depends on this plugin, causing the new version to be loaded during a Maven build. At this time, our Maven build must run under a Java 11 JRE. As a result, the new `org.eclipse.equinox.common` version caused the build to fail with the error:

> Exception in thread "main" java.lang.UnsupportedClassVersionError: org/eclipse/core/runtime/IProgressMonitor has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

To work around this for the time being, this PR removes the `tycho-build` extension and replaces it with the older `tycho-pomless` extension, which does not have the problematic dependency.