### PR TITLE
ST6RI-749 Bindings with the standard library metadata causes a warning only in Jupyter environment

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,8 +20,6 @@
  *******************************************************************************/
 
 package org.omg.sysml.adapter;
-
-import java.util.stream.Stream;
 
 import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
@@ -100,23 +98,25 @@ public class UsageAdapter extends FeatureAdapter {
 		}
 	}
 
-	public void addVariationSubsetting() {
+	protected void addVariationTyping() {
 		Usage usage = getTarget();
-		Usage variationUsage = UsageUtil.getOwningVariationUsageFor(usage);
-		if (variationUsage != null && UsageUtil.isVariant(usage)) {
-			addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), variationUsage);
+		if (UsageUtil.isVariant(usage)) {
+			Definition variationDefinition = UsageUtil.getOwningVariationDefinitionFor(usage);
+			if (variationDefinition != null) {
+				addImplicitGeneralType(SysMLPackage.eINSTANCE.getFeatureTyping(), variationDefinition);
+			} else {
+				Usage variationUsage = UsageUtil.getOwningVariationUsageFor(usage);
+				if (variationUsage != null) {
+					addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), variationUsage);
+				}
+			}
 		}
 	}
 	
 	@Override
-	public Stream<Feature> getSubsettedNotRedefinedFeatures() {
-		addVariationSubsetting();
-		return super.getSubsettedNotRedefinedFeatures();
-	}
-	
-	@Override
-	protected String getDefaultSupertype() {
-		return super.getDefaultSupertype();
+	public void addDefaultGeneralType() {
+		addVariationTyping();
+		super.addDefaultGeneralType();
 	}
 	
 	// Transformation
@@ -165,27 +165,6 @@ public class UsageAdapter extends FeatureAdapter {
 			membership.setOwnedSubjectParameter(parameter);
 			type.getOwnedRelationship().add(0, membership);
 		}
-	}
-	
-	protected void addVariationTyping() {
-		Usage usage = getTarget();
-		if (UsageUtil.isVariant(usage)) {
-			Definition variationDefinition = UsageUtil.getOwningVariationDefinitionFor(usage);
-			if (variationDefinition != null) {
-				addImplicitGeneralType(SysMLPackage.eINSTANCE.getFeatureTyping(), variationDefinition);
-			} else {
-				Usage variationUsage = UsageUtil.getOwningVariationUsageFor(usage);
-				if (variationUsage != null) {
-					addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), variationUsage);
-				}
-			}
-		}
-	}
-	
-	@Override
-	public void doTransform() {		
-		addVariationTyping();
-		super.doTransform();
 	}
 	
 }


### PR DESCRIPTION
After the 2024-02 release, bindings of enumeration features of metadata usages of metadata definitions from library models, such as
```
part p {
    @ModelingMetadata::StatusInfo { 
        status = ModelingMetadata::StatusKind::tbd; // WARNING
    }
}
```
began causing "Bound features should have conforming types" warnings in the Jupyter environment. This did not happen in the Eclipse editor.

These warnings were caused by the implicit typing of the enumerated value not being properly set to its containing enumeration definition. The typing was only being established when a full transformation was done on the enumerated value declaration. In the Eclipse environment, a full transformation is done on the entire contents of a library model resource when it is read into memory. This is not the case, however, when library resources are preloaded into the Jupyter kernel for SysML, which is why the warnings on happened in the Jupyter environment. There was a change to the implementation of the typing check in 2024-02, such that the check failed if a feature had no types (which should never be the case), which is why the warnings did not happen before 2024-02.

The implicit typing of enumerated values is actually a special case of the general rules for implicit typing of variant features of variations (enumeration definitions are kinds of variation definitions). This PR moves the adding of variation typing into the implicit general type computation for usages, so that it is included in the "on demand" computation of implicit generalization during name resolution, which eliminates the spurious warnings.