### PR TITLE
ST6RI-751 References to result parameters, subject parameters and objectives do not always resolve correctly

### DIFF
--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScope.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScope.xtend
@@ -54,6 +54,7 @@ import org.omg.sysml.lang.sysml.util.ISysMLScope
 import com.google.inject.Inject
 import org.eclipse.xtext.naming.IQualifiedNameConverter
 import org.eclipse.emf.ecore.util.EcoreUtil
+import org.omg.sysml.util.NamespaceUtil
 
 class KerMLScope extends AbstractScope implements ISysMLScope {
 	
@@ -250,6 +251,7 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 				ownedvisited.add(ns)		
 			}
 			
+			NamespaceUtil.addAdditionalMembersTo(ns)
 			for (mem: ns.ownedMembership.clone) { // Clone to avoid any possible ConcurrentModificationException.
 				if (!scopeProvider.visited.contains(mem)) {
 					if (includeAll || isInsideScope || mem.visibility == VisibilityKind.PUBLIC || 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,6 +22,7 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.CalculationDefinition;
+import org.omg.sysml.util.UsageUtil;
 
 public class CalculationDefinitionAdapter extends ActionDefinitionAdapter {
 
@@ -34,9 +35,10 @@ public class CalculationDefinitionAdapter extends ActionDefinitionAdapter {
 	}
 	
 	@Override
-	public void doTransform() {
-		super.doTransform();
-		addResultParameter();
-		createResultConnector(getTarget().getResult());
+	public void addResultParameter() {
+		CalculationDefinition target = getTarget();
+		UsageUtil.addResultParameterTo(target);
+		createResultConnector(target.getResult());
 	}
+	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
@@ -35,10 +35,15 @@ public class CalculationDefinitionAdapter extends ActionDefinitionAdapter {
 	}
 	
 	@Override
-	public void addResultParameter() {
+	public void addAdditionalMembers() {
 		CalculationDefinition target = getTarget();
 		UsageUtil.addResultParameterTo(target);
-		createResultConnector(target.getResult());
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		createResultConnector(getTarget().getResult());
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +25,7 @@ import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.CalculationDefinition;
 import org.omg.sysml.lang.sysml.CalculationUsage;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.UsageUtil;
 
 public class CalculationUsageAdapter extends ActionUsageAdapter {
 
@@ -51,9 +52,10 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 	}
 	
 	@Override
-	public void doTransform() {
-		super.doTransform();
-		addResultParameter();
-		createResultConnector(getTarget().getResult());
+	public void addResultParameter() {
+		CalculationUsage target = getTarget();
+		UsageUtil.addResultParameterTo(target);
+		createResultConnector(target.getResult());
 	}
+	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -52,10 +52,14 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 	}
 	
 	@Override
-	public void addResultParameter() {
-		CalculationUsage target = getTarget();
-		UsageUtil.addResultParameterTo(target);
-		createResultConnector(target.getResult());
+	public void addAdditionalMembers() {
+		UsageUtil.addResultParameterTo(getTarget());
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		createResultConnector(getTarget().getResult());		
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseDefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,11 +22,8 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.CaseDefinition;
-import org.omg.sysml.lang.sysml.ObjectiveMembership;
-import org.omg.sysml.lang.sysml.RequirementUsage;
-import org.omg.sysml.lang.sysml.SysMLFactory;
-import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.util.UsageUtil;
 
 public class CaseDefinitionAdapter extends CalculationDefinitionAdapter {
 
@@ -48,22 +45,12 @@ public class CaseDefinitionAdapter extends CalculationDefinitionAdapter {
 	
 	// Transformation
 	
-	public static RequirementUsage addObjectiveRequirementTo(Type type) {
-		RequirementUsage objective = SysMLFactory.eINSTANCE.createRequirementUsage();
-		ObjectiveMembership membership = SysMLFactory.eINSTANCE.createObjectiveMembership();
-		membership.setOwnedObjectiveRequirement(objective);
-		type.getOwnedRelationship().add(membership);
-		return objective;
-	}
-
 	@Override
 	public void doTransform() {
 		CaseDefinition definition = getTarget();
 		super.doTransform();
-		UsageAdapter.computeSubjectParameterOf(definition);
-		if (definition.getObjectiveRequirement() == null) {
-			addObjectiveRequirementTo(definition);
-		}
+		UsageUtil.addSubjectParameterTo(definition);
+		UsageUtil.addObjectiveRequirementTo(definition);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseDefinitionAdapter.java
@@ -22,7 +22,6 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.CaseDefinition;
-import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.util.UsageUtil;
 
 public class CaseDefinitionAdapter extends CalculationDefinitionAdapter {
@@ -36,21 +35,14 @@ public class CaseDefinitionAdapter extends CalculationDefinitionAdapter {
 		return (CaseDefinition)super.getTarget();
 	}
 
-	// Utility
-	
-	@Override
-	public Usage getSubjectParameter() {
-		return getTarget().getSubjectParameter();
-	}
-	
 	// Transformation
 	
-	@Override
-	public void doTransform() {
-		CaseDefinition definition = getTarget();
-		super.doTransform();
-		UsageUtil.addSubjectParameterTo(definition);
-		UsageUtil.addObjectiveRequirementTo(definition);
+	@Override 
+	public void addAdditionalMembers() {
+		CaseDefinition target = getTarget();
+		UsageUtil.addSubjectParameterTo(target);
+		UsageUtil.addObjectiveRequirementTo(target);
+		super.addAdditionalMembers();
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
@@ -24,7 +24,6 @@ package org.omg.sysml.adapter;
 import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.util.UsageUtil;
 
 public class CaseUsageAdapter extends CalculationUsageAdapter {
@@ -39,11 +38,6 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	}
 	
 	// Utility
-	
-	@Override
-	public Usage getSubjectParameter() {
-		return getTarget().getSubjectParameter();
-	}
 	
 	@Override
 	public boolean hasRelevantSubjectParameter() {
@@ -67,14 +61,12 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	
 	// Transformation
 	
-	@Override
-	public void doTransform() {
+	@Override 
+	public void addAdditionalMembers() {
 		CaseUsage usage = getTarget();
-		super.doTransform();
 		UsageUtil.addSubjectParameterTo(usage);
-		if (usage.getObjectiveRequirement() == null) {
-			UsageUtil.addObjectiveRequirementTo(usage);
-		}
+		UsageUtil.addObjectiveRequirementTo(usage);
+		super.addAdditionalMembers();
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +25,7 @@ import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.util.UsageUtil;
 
 public class CaseUsageAdapter extends CalculationUsageAdapter {
 
@@ -65,14 +66,14 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	}
 	
 	// Transformation
-
+	
 	@Override
 	public void doTransform() {
 		CaseUsage usage = getTarget();
 		super.doTransform();
-		UsageAdapter.computeSubjectParameterOf(usage);
+		UsageUtil.addSubjectParameterTo(usage);
 		if (usage.getObjectiveRequirement() == null) {
-			CaseDefinitionAdapter.addObjectiveRequirementTo(usage);
+			UsageUtil.addObjectiveRequirementTo(usage);
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,6 +22,7 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.ConstraintDefinition;
+import org.omg.sysml.util.UsageUtil;
 
 public class ConstraintDefinitionAdapter extends OccurrenceDefinitionAdapter {
 
@@ -35,10 +36,9 @@ public class ConstraintDefinitionAdapter extends OccurrenceDefinitionAdapter {
 	}
 
 	@Override
-	public void doTransform() {
+	public void addResultParameter() {
 		ConstraintDefinition definition = getTarget();
-		super.doTransform();
-		addResultParameter();
+		UsageUtil.addResultParameterTo(definition);
 		createResultConnector(definition.getResult());
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
@@ -36,10 +36,14 @@ public class ConstraintDefinitionAdapter extends OccurrenceDefinitionAdapter {
 	}
 
 	@Override
-	public void addResultParameter() {
-		ConstraintDefinition definition = getTarget();
-		UsageUtil.addResultParameterTo(definition);
-		createResultConnector(definition.getResult());
+	public void addAdditionalMembers() {
+		UsageUtil.addResultParameterTo(getTarget());
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		createResultConnector(getTarget().getResult());		
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -78,15 +78,18 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 		ConstraintUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return target.isComposite() &&
-				(owningType instanceof ItemDefinition || owningType instanceof ItemUsage);
-				
+				(owningType instanceof ItemDefinition || owningType instanceof ItemUsage);				
 	}
 	
 	@Override
-	public void addResultParameter() {
-		ConstraintUsage constraint = getTarget();
-		UsageUtil.addResultParameterTo(constraint);
-		createResultConnector(constraint.getResult());
+	public void addAdditionalMembers() {
+		UsageUtil.addResultParameterTo(getTarget());
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		createResultConnector(getTarget().getResult());		
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -83,11 +83,10 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 	}
 	
 	@Override
-	public void doTransform() {
+	public void addResultParameter() {
 		ConstraintUsage constraint = getTarget();
-		super.doTransform();
-		addResultParameter();
+		UsageUtil.addResultParameterTo(constraint);
 		createResultConnector(constraint.getResult());
-	}	
+	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/DefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/DefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,6 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.Definition;
-import org.omg.sysml.lang.sysml.Usage;
 
 public class DefinitionAdapter extends ClassifierAdapter {
 	
@@ -33,12 +32,6 @@ public class DefinitionAdapter extends ClassifierAdapter {
 	@Override
 	public Definition getTarget() {
 		return (Definition)super.getTarget();
-	}
-	
-	// Utility
-
-	public Usage getSubjectParameter() {
-		return null;
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -31,12 +31,12 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.Multiplicity;
-import org.omg.sysml.lang.sysml.ParameterMembership;
 import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.ExpressionUtil;
 import org.omg.sysml.util.FeatureUtil;
 import org.omg.sysml.util.ImplicitGeneralizationMap;
+import org.omg.sysml.util.TypeUtil;
 
 public class ExpressionAdapter extends StepAdapter {
 
@@ -129,16 +129,12 @@ public class ExpressionAdapter extends StepAdapter {
 		}
 	}
 	
-	protected void computeOutput() {
+	public void addResultParameter() {
 		Expression expression = getTarget();
-		if (expression.getOutput().isEmpty()) {
-			Feature parameter = SysMLFactory.eINSTANCE.createFeature();
-			ParameterMembership membership = SysMLFactory.eINSTANCE.createReturnParameterMembership();
-			membership.setOwnedMemberParameter(parameter);
-			expression.getOwnedRelationship().add(membership);
-		}		
+		TypeUtil.addResultParameterTo(expression);
+		createResultConnector(expression.getResult());
 	}
-			
+	
 	@Override
 	public void doTransform() {
 		Expression expression = getTarget();
@@ -147,8 +143,6 @@ public class ExpressionAdapter extends StepAdapter {
 				expression.getOwningMembership() instanceof FeatureValue) {
 			addImplicitFeaturingTypesIfNecessary();
 		}
-		computeOutput();
-		createResultConnector(expression.getResult());
 	}
 		
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -129,10 +129,9 @@ public class ExpressionAdapter extends StepAdapter {
 		}
 	}
 	
-	public void addResultParameter() {
-		Expression expression = getTarget();
-		TypeUtil.addResultParameterTo(expression);
-		createResultConnector(expression.getResult());
+	@Override
+	public void addAdditionalMembers() {
+		TypeUtil.addResultParameterTo(getTarget());
 	}
 	
 	@Override
@@ -143,6 +142,7 @@ public class ExpressionAdapter extends StepAdapter {
 				expression.getOwningMembership() instanceof FeatureValue) {
 			addImplicitFeaturingTypesIfNecessary();
 		}
+		createResultConnector(expression.getResult());
 	}
 		
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
@@ -36,10 +36,14 @@ public class FunctionAdapter extends BehaviorAdapter {
 	}
 
 	@Override
-	public void addResultParameter() {
-		Function target = getTarget();
-		TypeUtil.addResultParameterTo(target);
-		createResultConnector(target.getResult());
+	public void addAdditionalMembers() {
+		TypeUtil.addResultParameterTo(getTarget());
+	}
+	
+	@Override
+	public void doTransform() {
+		super.doTransform();
+		createResultConnector(getTarget().getResult());		
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
@@ -22,6 +22,7 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.Function;
+import org.omg.sysml.util.TypeUtil;
 
 public class FunctionAdapter extends BehaviorAdapter {
 
@@ -35,9 +36,10 @@ public class FunctionAdapter extends BehaviorAdapter {
 	}
 
 	@Override
-	public void doTransform() {
-		super.doTransform();
-		createResultConnector(getTarget().getResult());
+	public void addResultParameter() {
+		Function target = getTarget();
+		TypeUtil.addResultParameterTo(target);
+		createResultConnector(target.getResult());
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/NamespaceAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/NamespaceAdapter.java
@@ -50,4 +50,13 @@ public class NamespaceAdapter extends ElementAdapter {
 		importedMembership = null;
 	}
 	
+	public void addAdditionalMembers() {
+	}
+	
+	@Override
+	public void doTransform() {
+		addAdditionalMembers();
+		super.doTransform();
+	}
+	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementDefinitionAdapter.java
@@ -23,6 +23,7 @@ package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.util.UsageUtil;
 
 public class RequirementDefinitionAdapter extends ConstraintDefinitionAdapter {
 
@@ -46,7 +47,7 @@ public class RequirementDefinitionAdapter extends ConstraintDefinitionAdapter {
 	@Override
 	public void doTransform() {
 		super.doTransform();
-		UsageAdapter.computeSubjectParameterOf(getTarget());
+		UsageUtil.addSubjectParameterTo(getTarget());
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementDefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,6 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.RequirementDefinition;
-import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.util.UsageUtil;
 
 public class RequirementDefinitionAdapter extends ConstraintDefinitionAdapter {
@@ -35,19 +34,12 @@ public class RequirementDefinitionAdapter extends ConstraintDefinitionAdapter {
 		return (RequirementDefinition)super.getTarget();
 	}
 
-	// Utility
-	
-	@Override
-	public Usage getSubjectParameter() {
-		return getTarget().getSubjectParameter();
-	}
-	
 	// Transformation
-
-	@Override
-	public void doTransform() {
-		super.doTransform();
-		UsageUtil.addSubjectParameterTo(getTarget());
-	}
 	
+	@Override
+	public void addAdditionalMembers() {
+		UsageUtil.addSubjectParameterTo(getTarget());
+		super.addAdditionalMembers();
+	}
+
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -30,7 +30,6 @@ import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
-import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
 public class RequirementUsageAdapter extends ConstraintUsageAdapter {
@@ -80,17 +79,17 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	@Override
 	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
 		return UsageUtil.isObjective(getTarget())? 
-				Collections.singletonList(TypeUtil.getObjectiveRequirementOf(type)):
+				Collections.singletonList(UsageUtil.getObjectiveRequirementOf(type)):
 			    super.getRelevantFeatures(type, skip);
 	}
 	
 	// Transformation
-
+	
 	@Override
 	public void doTransform() {
 		RequirementUsage target = getTarget();
 		super.doTransform();
-		computeSubjectParameterOf(target);
+		UsageUtil.addSubjectParameterTo(target);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -29,7 +29,6 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.util.UsageUtil;
 
 public class RequirementUsageAdapter extends ConstraintUsageAdapter {
@@ -44,11 +43,6 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	}
 	
 	// Utility
-	
-	@Override
-	public Usage getSubjectParameter() {
-		return getTarget().getSubjectParameter();
-	}
 	
 	@Override
 	public boolean hasRelevantSubjectParameter() {
@@ -86,10 +80,9 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	// Transformation
 	
 	@Override
-	public void doTransform() {
-		RequirementUsage target = getTarget();
-		super.doTransform();
-		UsageUtil.addSubjectParameterTo(target);
+	public void addAdditionalMembers() {
+		UsageUtil.addSubjectParameterTo(getTarget());
+		super.addAdditionalMembers();
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -357,15 +357,11 @@ public class TypeAdapter extends NamespaceAdapter {
 		}
 	}
 
-	public void addResultParameter() {
-	}
-	
 	@Override
 	public void doTransform() {
 		super.doTransform();
 		computeImplicitGeneralTypes();
 		removeUnnecessaryImplicitGeneralTypes();
-		addResultParameter();
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -46,8 +46,6 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
-import org.omg.sysml.lang.sysml.ReturnParameterMembership;
-import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
@@ -330,17 +328,6 @@ public class TypeAdapter extends NamespaceAdapter {
 	
 	// Transformation
 	
-	public void addResultParameter() {
-		Type type = getTarget();
-		if (type.getOwnedFeatureMembership().stream().noneMatch(ReturnParameterMembership.class::isInstance)) {
-			ReturnParameterMembership membership = SysMLFactory.eINSTANCE.createReturnParameterMembership();
-			Feature resultParameter = SysMLFactory.eINSTANCE.createReferenceUsage();
-			membership.setOwnedMemberParameter(resultParameter);
-			type.getOwnedRelationship().add(membership);
-			ElementUtil.transform(resultParameter);
-		}
-	}
-	
 	public BindingConnector addBindingConnector(Feature source, Feature target) {
 		Type type = getTarget();
 		BindingConnector connector = ConnectorUtil.createBindingConnector(source, target);
@@ -370,11 +357,15 @@ public class TypeAdapter extends NamespaceAdapter {
 		}
 	}
 
+	public void addResultParameter() {
+	}
+	
 	@Override
 	public void doTransform() {
 		super.doTransform();
 		computeImplicitGeneralTypes();
 		removeUnnecessaryImplicitGeneralTypes();
+		addResultParameter();
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -33,14 +33,11 @@ import org.omg.sysml.lang.sysml.PartDefinition;
 import org.omg.sysml.lang.sysml.PartUsage;
 import org.omg.sysml.lang.sysml.StateSubactionKind;
 import org.omg.sysml.lang.sysml.StateSubactionMembership;
-import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Subsetting;
-import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.util.FeatureUtil;
-import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
 public class UsageAdapter extends FeatureAdapter {
@@ -140,7 +137,7 @@ public class UsageAdapter extends FeatureAdapter {
 		Type owningType = usage.getOwningType();		
 		return !(owningType instanceof Usage) || owningType.isAbstract() || 
 			   !UsageUtil.hasRelevantSubjectParameter((Usage)owningType)? null:
-			   TypeUtil.getSubjectParameterOf(((Usage)owningType).getOwningType());
+			   UsageUtil.getSubjectParameterOf(((Usage)owningType).getOwningType());
 	}
 	
 	@Override
@@ -154,16 +151,6 @@ public class UsageAdapter extends FeatureAdapter {
 			}
 		} else {
 			super.computeValueConnector();
-		}
-	}
-	
-	protected static void computeSubjectParameterOf(Type type) {
-		if (type != null && 
-			type.getOwnedMembership().stream().noneMatch(SubjectMembership.class::isInstance)) {
-			Usage parameter = SysMLFactory.eINSTANCE.createReferenceUsage();
-			SubjectMembership membership = SysMLFactory.eINSTANCE.createSubjectMembership();
-			membership.setOwnedSubjectParameter(parameter);
-			type.getOwnedRelationship().add(0, membership);
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -52,10 +52,6 @@ public class UsageAdapter extends FeatureAdapter {
 	}
 	
 	// Utility
-	
-	public Usage getSubjectParameter() {
-		return null;
-	}
 	
 	public boolean hasRelevantSubjectParameter() {
 		return false;

--- a/org.omg.sysml/src/org/omg/sysml/delegate/CaseDefinition_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/CaseDefinition_subjectParameter_SettingDelegate.java
@@ -25,7 +25,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.CaseDefinition;
-import org.omg.sysml.util.TypeUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class CaseDefinition_subjectParameter_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -35,7 +35,7 @@ public class CaseDefinition_subjectParameter_SettingDelegate extends BasicDerive
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return TypeUtil.basicGetSubjectParameterOf((CaseDefinition)owner);
+		return UsageUtil.basicGetSubjectParameterOf((CaseDefinition)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/CaseDefinition_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/CaseDefinition_subjectParameter_SettingDelegate.java
@@ -35,7 +35,7 @@ public class CaseDefinition_subjectParameter_SettingDelegate extends BasicDerive
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return UsageUtil.basicGetSubjectParameterOf((CaseDefinition)owner);
+		return UsageUtil.getSubjectParameterOf((CaseDefinition)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/CaseUsage_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/CaseUsage_subjectParameter_SettingDelegate.java
@@ -35,7 +35,7 @@ public class CaseUsage_subjectParameter_SettingDelegate extends BasicDerivedObje
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return UsageUtil.basicGetSubjectParameterOf((CaseUsage)owner);
+		return UsageUtil.getSubjectParameterOf((CaseUsage)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/CaseUsage_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/CaseUsage_subjectParameter_SettingDelegate.java
@@ -25,7 +25,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.CaseUsage;
-import org.omg.sysml.util.TypeUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class CaseUsage_subjectParameter_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -35,7 +35,7 @@ public class CaseUsage_subjectParameter_SettingDelegate extends BasicDerivedObje
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return TypeUtil.basicGetSubjectParameterOf((CaseUsage)owner);
+		return UsageUtil.basicGetSubjectParameterOf((CaseUsage)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/RequirementDefinition_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/RequirementDefinition_subjectParameter_SettingDelegate.java
@@ -25,7 +25,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
-import org.omg.sysml.util.TypeUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class RequirementDefinition_subjectParameter_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -35,7 +35,7 @@ public class RequirementDefinition_subjectParameter_SettingDelegate extends Basi
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return TypeUtil.basicGetSubjectParameterOf((RequirementDefinition)owner);
+		return UsageUtil.basicGetSubjectParameterOf((RequirementDefinition)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/RequirementDefinition_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/RequirementDefinition_subjectParameter_SettingDelegate.java
@@ -35,7 +35,7 @@ public class RequirementDefinition_subjectParameter_SettingDelegate extends Basi
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return UsageUtil.basicGetSubjectParameterOf((RequirementDefinition)owner);
+		return UsageUtil.getSubjectParameterOf((RequirementDefinition)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/RequirementUsage_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/RequirementUsage_subjectParameter_SettingDelegate.java
@@ -35,7 +35,7 @@ public class RequirementUsage_subjectParameter_SettingDelegate extends BasicDeri
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return UsageUtil.basicGetSubjectParameterOf((RequirementUsage)owner);
+		return UsageUtil.getSubjectParameterOf((RequirementUsage)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/RequirementUsage_subjectParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/RequirementUsage_subjectParameter_SettingDelegate.java
@@ -25,7 +25,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.omg.sysml.lang.sysml.RequirementUsage;
-import org.omg.sysml.util.TypeUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class RequirementUsage_subjectParameter_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -35,7 +35,7 @@ public class RequirementUsage_subjectParameter_SettingDelegate extends BasicDeri
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		return TypeUtil.basicGetSubjectParameterOf((RequirementUsage)owner);
+		return UsageUtil.basicGetSubjectParameterOf((RequirementUsage)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/NamespaceUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/NamespaceUtil.java
@@ -47,7 +47,15 @@ public class NamespaceUtil {
 	private NamespaceUtil() {
 	}
 	
+	public static NamespaceAdapter getNamespaceAdapter(Namespace namespace) {
+		return (NamespaceAdapter)ElementUtil.getElementAdapter(namespace);
+	}
+	
 	// Membership
+	
+	public static void addAdditionalMembersTo(Namespace namespace) {
+		getNamespaceAdapter(namespace).addAdditionalMembers();
+	}
 	
 	public static Stream<Element> getOwnedMembersOf(Namespace namespace) {
 		return namespace.getOwnedMembership().stream().

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -231,7 +231,7 @@ public class TypeUtil {
 	
 	private static Feature getResultParameterOf(Type type, Set<Type> visited) {
 		visited.add(type);
-		getTypeAdapter(type).addResultParameter();
+		getTypeAdapter(type).addAdditionalMembers();
 		Feature resultParameter = getOwnedResultParameterOf(type);
 		if (resultParameter == null) {
 			for (Type general: getSupertypesOf(type)) {
@@ -251,7 +251,7 @@ public class TypeUtil {
 	}
 	
 	public static void addResultParameterTo(Type type, Feature resultParameter) {
-		if (type.getOwnedFeatureMembership().stream().noneMatch(ReturnParameterMembership.class::isInstance)) {
+		if (type.getOwnedRelationship().stream().noneMatch(ReturnParameterMembership.class::isInstance)) {
 			ReturnParameterMembership membership = SysMLFactory.eINSTANCE.createReturnParameterMembership();
 			membership.setOwnedMemberParameter(resultParameter);
 			type.getOwnedRelationship().add(membership);

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -53,6 +53,7 @@ import org.omg.sysml.lang.sysml.OccurrenceDefinition;
 import org.omg.sysml.lang.sysml.OccurrenceUsage;
 import org.omg.sysml.lang.sysml.ParameterMembership;
 import org.omg.sysml.lang.sysml.RequirementUsage;
+import org.omg.sysml.lang.sysml.ReturnParameterMembership;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -225,14 +226,12 @@ public class TypeUtil {
 	}
 	
 	public static Feature getResultParameterOf(Type type) {
-		// NOTE: This method will fill in an inherited result Parameter if this Type does not
-		// have an owned result Parameter. It is for use when transform may have not yet been
-		// called on this Type.
 		return getResultParameterOf(type, new HashSet<>());
 	}
 	
 	private static Feature getResultParameterOf(Type type, Set<Type> visited) {
 		visited.add(type);
+		getTypeAdapter(type).addResultParameter();
 		Feature resultParameter = getOwnedResultParameterOf(type);
 		if (resultParameter == null) {
 			for (Type general: getSupertypesOf(type)) {
@@ -245,6 +244,18 @@ public class TypeUtil {
 			}
 		}
 		return resultParameter;
+	}
+
+	public static void addResultParameterTo(Type type) {
+		addResultParameterTo(type, SysMLFactory.eINSTANCE.createFeature());
+	}
+	
+	public static void addResultParameterTo(Type type, Feature resultParameter) {
+		if (type.getOwnedFeatureMembership().stream().noneMatch(ReturnParameterMembership.class::isInstance)) {
+			ReturnParameterMembership membership = SysMLFactory.eINSTANCE.createReturnParameterMembership();
+			membership.setOwnedMemberParameter(resultParameter);
+			type.getOwnedRelationship().add(membership);
+		}
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -34,13 +34,9 @@ import java.util.stream.Stream;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
-import org.omg.sysml.adapter.DefinitionAdapter;
 import org.omg.sysml.adapter.TypeAdapter;
 import org.omg.sysml.lang.sysml.Association;
 import org.omg.sysml.lang.sysml.BindingConnector;
-import org.omg.sysml.lang.sysml.CaseDefinition;
-import org.omg.sysml.lang.sysml.CaseUsage;
-import org.omg.sysml.lang.sysml.Definition;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
@@ -52,13 +48,10 @@ import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.OccurrenceDefinition;
 import org.omg.sysml.lang.sysml.OccurrenceUsage;
 import org.omg.sysml.lang.sysml.ParameterMembership;
-import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.ReturnParameterMembership;
-import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Usage;
 
 public class TypeUtil {
 	
@@ -445,28 +438,6 @@ public class TypeUtil {
 				collect(Collectors.toList());
 	}
 
-	// Subject parameters
-
-	public static Feature getSubjectParameterOf(Type type) {
-		return type instanceof Definition? ((DefinitionAdapter)ElementUtil.getElementAdapter((Definition)type)).getSubjectParameter():
-			   type instanceof Usage? UsageUtil.getUsageAdapter((Usage)type).getSubjectParameter():
-			   null;
-	}
-
-	public static Usage basicGetSubjectParameterOf(Type type) {
-		ElementUtil.transform(type);
-		return (Usage)getOwnedFeatureByMembershipIn(type, SubjectMembership.class);
-	}
-	
-	// Objective requirements
-
-	public static RequirementUsage getObjectiveRequirementOf(Type type) {
-		ElementUtil.transform(type);
-		return type instanceof CaseDefinition? ((CaseDefinition)type).getObjectiveRequirement():
-			   type instanceof CaseUsage? ((CaseUsage)type).getObjectiveRequirement():
-			   null;
-	}
-	
 	// Associations
 
 	public static Type getSourceTypeOf(Association association) {

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -27,10 +27,13 @@ import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.adapter.DefinitionAdapter;
 import org.omg.sysml.adapter.UsageAdapter;
 import org.omg.sysml.lang.sysml.AcceptActionUsage;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.ActorMembership;
+import org.omg.sysml.lang.sysml.CaseDefinition;
+import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.FramedConcernMembership;
 import org.omg.sysml.lang.sysml.ConcernUsage;
 import org.omg.sysml.lang.sysml.Connector;
@@ -122,6 +125,17 @@ public class UsageUtil {
 		return usage.getOwningFeatureMembership() instanceof SubjectMembership;
 	}
 
+	public static Feature getSubjectParameterOf(Type type) {
+		return type instanceof Definition? ((DefinitionAdapter)ElementUtil.getElementAdapter((Definition)type)).getSubjectParameter():
+			   type instanceof Usage? getUsageAdapter((Usage)type).getSubjectParameter():
+			   null;
+	}
+
+	public static Usage basicGetSubjectParameterOf(Type type) {
+		ElementUtil.transform(type);
+		return (Usage)TypeUtil.getOwnedFeatureByMembershipIn(type, SubjectMembership.class);
+	}
+
 	public static boolean hasRelevantSubjectParameter(Usage usage) {
 		return getUsageAdapter(usage).hasRelevantSubjectParameter();
 	}
@@ -131,6 +145,33 @@ public class UsageUtil {
 		return subject == null? null: FeatureUtil.getValuationFor(subject);
 	}
 	
+	public static void addSubjectParameterTo(Type type) {
+		if (type.getOwnedMembership().stream().noneMatch(SubjectMembership.class::isInstance)) {
+			Usage parameter = SysMLFactory.eINSTANCE.createReferenceUsage();
+			SubjectMembership membership = SysMLFactory.eINSTANCE.createSubjectMembership();
+			membership.setOwnedSubjectParameter(parameter);
+			type.getOwnedRelationship().add(0, membership);
+		}
+	}
+	
+	// Objectives
+
+	public static RequirementUsage getObjectiveRequirementOf(Type type) {
+		ElementUtil.transform(type);
+		return type instanceof CaseDefinition? ((CaseDefinition)type).getObjectiveRequirement():
+			   type instanceof CaseUsage? ((CaseUsage)type).getObjectiveRequirement():
+			   null;
+	}
+
+	public static void addObjectiveRequirementTo(Type type) {
+		if (type.getOwnedRelationship().stream().noneMatch(ObjectiveMembership.class::isInstance)) {
+			RequirementUsage objective = SysMLFactory.eINSTANCE.createRequirementUsage();
+			ObjectiveMembership membership = SysMLFactory.eINSTANCE.createObjectiveMembership();
+			membership.setOwnedObjectiveRequirement(objective);
+			type.getOwnedRelationship().add(membership);
+		}
+	}
+
 	// Actors
 	
 	public static boolean isActorParameter(Usage usage) {

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -62,6 +62,7 @@ import org.omg.sysml.lang.sysml.StateSubactionMembership;
 import org.omg.sysml.lang.sysml.StateUsage;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Succession;
+import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.TransitionFeatureKind;
 import org.omg.sysml.lang.sysml.TransitionFeatureMembership;
 import org.omg.sysml.lang.sysml.TransitionUsage;
@@ -108,7 +109,13 @@ public class UsageUtil {
 		Membership owningMembership = usage.getOwningMembership();
 		return owningMembership instanceof VariantMembership? (VariantMembership)owningMembership: null;
 	}
-
+	
+	// Results
+	
+	public static void addResultParameterTo(Type type) {
+		TypeUtil.addResultParameterTo(type, SysMLFactory.eINSTANCE.createReferenceUsage());
+	}
+	
 	// Subjects
 
 	public static boolean isSubjectParameter(Usage usage) {

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
-import org.omg.sysml.adapter.DefinitionAdapter;
 import org.omg.sysml.adapter.UsageAdapter;
 import org.omg.sysml.lang.sysml.AcceptActionUsage;
 import org.omg.sysml.lang.sysml.ActionUsage;
@@ -125,14 +124,8 @@ public class UsageUtil {
 		return usage.getOwningFeatureMembership() instanceof SubjectMembership;
 	}
 
-	public static Feature getSubjectParameterOf(Type type) {
-		return type instanceof Definition? ((DefinitionAdapter)ElementUtil.getElementAdapter((Definition)type)).getSubjectParameter():
-			   type instanceof Usage? getUsageAdapter((Usage)type).getSubjectParameter():
-			   null;
-	}
-
-	public static Usage basicGetSubjectParameterOf(Type type) {
-		ElementUtil.transform(type);
+	public static Usage getSubjectParameterOf(Type type) {
+		NamespaceUtil.addAdditionalMembersTo(type);
 		return (Usage)TypeUtil.getOwnedFeatureByMembershipIn(type, SubjectMembership.class);
 	}
 
@@ -157,7 +150,7 @@ public class UsageUtil {
 	// Objectives
 
 	public static RequirementUsage getObjectiveRequirementOf(Type type) {
-		ElementUtil.transform(type);
+		NamespaceUtil.addAdditionalMembersTo(type);
 		return type instanceof CaseDefinition? ((CaseDefinition)type).getObjectiveRequirement():
 			   type instanceof CaseUsage? ((CaseUsage)type).getObjectiveRequirement():
 			   null;


### PR DESCRIPTION
Currently, there are three cases in which elements are still being physically added to the parse tree (rather than cached in adapters like is done for implicit relationships), when they are not declared explicitly in a model: result parameters for expressions, subject parameters for requirements and cases and objectives for cases. This is not actually called for in the specifications, but is still necessary in order for implied redefinitions to be added correctly in the case of multiple specializations. 

For example, in the following model:
```
analysis def A {
    subject s;
    objective o;
    return r;
}
part context {
    part p {
        v = a.v;
        o = a.o;
        r = a.r;
    }
    analysis a : A {
      // subject added that redefines s.
      // objective added that redefines o.
      // return parameter added that redefines r.
    }
}
```
subject, objective and result features are added to the parse tree for the analysis case usage `a`. These features implicitly redefine the corresponding features `s`, `o` and `r` from the analysis case definition `A`. Because of these redefinitions, the references to `s`, `o` and `r` within part usage `p` should resolve to the features of the usage `a`. 

This PR fixes a bug that could result in these references incorrectly resolving to the features of the definition `A` when the declaration of `a` is lexically after the declaration of `p`. It also moves utility methods related to subjects and objectives out of class `TypeUtil` into the SysML-specific class `UsageUtil`.