### PR TITLE
ST6RI-757 Implicit subsetting for occurrenceUsageSuboccurrence specialization is not properly implemented

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
@@ -55,6 +55,14 @@ public class OccurrenceUsageAdapter extends UsageAdapter {
 	}
 	
 	@Override
+	protected boolean isSuboccurrence() {
+		OccurrenceUsage target = getTarget();
+		return super.isSuboccurrence() ||
+				target.isComposite() && 
+			   	target.getOwningType() instanceof OccurrenceUsage;
+	}
+	
+	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
 	}

--- a/sysml/src/examples/Simple Tests/OccurrenceTest.sysml
+++ b/sysml/src/examples/Simple Tests/OccurrenceTest.sysml
@@ -26,4 +26,8 @@ package OccurrenceTest {
 	}
 	
 	individual snapshot s4 : Ind;
+	
+	occurrence o1 {
+	  occurrence o2;
+	}
 }


### PR DESCRIPTION
The `occurrenceUsageSuboccurrenceSpecialization` constraint in the SysML v2 specification requires that "A composite `OccurrenceUsage`, whose `ownedType` is a `Class`, another `OccurrenceUsage`, or any kind of `Feature` typed by a `Class`, must directly or indirectly specialize _`Occurrences::Occurrence::suboccurrences`_." This PR corrects the implicit specialization implementation in the `OccurrenceUsageAdapter` so that an `OccurrenceUsage` gets the proper implicit subsetting of `suboccurrences` whenever its `owningType` is an `OccurrenceUsage`, regardless of the direct typing of the owning `OccurrenceUsage`.