### PR TITLE
ST6RI-684 (alternate update) Implement invocation delegates for operations

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/OperationInvocationDelegateSelector.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/OperationInvocationDelegateSelector.java
@@ -53,7 +53,7 @@ public class OperationInvocationDelegateSelector extends BasicInvocationDelegate
 		return delegate.dynamicInvoke(target, arguments);
 	}
 	
-	protected BasicInvocationDelegate calculateInvocationDelegateRecursive(EClass eClass) {
+	public BasicInvocationDelegate calculateInvocationDelegateRecursive(EClass eClass) {
 		BasicInvocationDelegate delegate = delegateMap.get(eClass);
 		
 		if (delegate != null) {


### PR DESCRIPTION
This PR proposes a solution to the performance hit introduced in PR #554 (commit 32e3509fc5ca11b8ac364c617a1f67322b651526), as an alternative to the change proposed in PR #555. The update in this PR is to simply add a cache for invocation delegates. There is no change to the implementation of the import and inheritance related operations from commit 32e3509fc5ca11b8ac364c617a1f67322b651526.