### PR TITLE
ST6RI-759: Feature chains referring to features that do not belong to the owning features are not correctly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -24,15 +24,19 @@
 
 package org.omg.sysml.plantuml;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureMembership;
+import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Type;
 
 
@@ -53,8 +57,21 @@ class InheritKey {
         return false;
     }
 
+    private static List<Feature> belongingFeatures(Type typ) {
+        List<Feature> fs = new ArrayList<>();
+        for (Relationship rel : typ.getOwnedRelationship()) {
+            if (rel instanceof FeatureMembership
+                || rel instanceof FeatureValue) {
+                for (Element tgt: rel.getTarget()) {
+                    fs.add((Feature) tgt);
+                }
+            }
+        }
+        return fs;
+    }
+
     private static boolean isBelonging(Type typ, Feature f) {
-        if (containsWithRedefined(typ.getOwnedFeature(), f)) return true;
+        if (containsWithRedefined(belongingFeatures(typ), f)) return true;
         // if (typ.getOwnedFeature().contains(f)) return true;
         if (containsWithRedefined(typ.getInheritedFeature(), f)) return true;
         // if (typ.getInheritedFeature().contains(f)) return true;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -59,7 +59,7 @@ class InheritKey {
 
     private static List<Feature> belongingFeatures(Type typ) {
         List<Feature> fs = new ArrayList<>();
-        for (Relationship rel : typ.getOwnedRelationship()) {
+        for (Relationship rel : Visitor.toOwnedRelationshipArray(typ)) {
             if (rel instanceof FeatureMembership
                 || rel instanceof FeatureValue) {
                 for (Element tgt: rel.getTarget()) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -162,11 +162,36 @@ class InheritKey {
         this.isDirect = isDirect;
     }
 
+    private InheritKey(InheritKey base, int len) {
+        this.keys = new Type[len];
+        this.isDirect = base.isDirect;
+        System.arraycopy(base.keys, 0, keys, 0, len);
+    }
+
+    public static InheritKey makeTargetKey(Type tgt, Feature ref) {
+        if (isBelonging(tgt, ref)) {
+            return new InheritKey(tgt);
+        }
+        return null;
+    }
+
     // Create an indirect InheritKey so that redefined elements can be referred by
     // inherited connectors
     public static InheritKey makeIndirect(InheritKey ik) {
     	if (ik == null) return null;
         return new InheritKey(ik, false);
+    }
+
+    public static InheritKey findTop(InheritKey ik, Feature f) {
+    	if (ik == null) return null;
+        int end = ik.keys.length - 1;
+        for (int i = end; i >= 0; i--) {
+            if (isBelonging(ik.keys[i], f)) {
+                if (i == end) return ik;
+                return new InheritKey(ik, i + 1);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -681,12 +681,12 @@ public class SysML2PlantUMLText {
         return evalInternal(ex, evalTarget);
     }
 
-    InheritKey makeInheritKey(Feature ref) {
-        return InheritKey.construct(namespaces, inheritingIdices, ref);
+    InheritKey makeInheritKey(Feature tgt) {
+        return InheritKey.construct(namespaces, inheritingIdices, tgt);
     }
 
-    InheritKey makeInheritKey(Membership ref) {
-        return InheritKey.construct(namespaces, inheritingIdices, ref);
+    InheritKey makeInheritKey(Membership tgt) {
+        return InheritKey.construct(namespaces, inheritingIdices, tgt);
     }
 
     boolean matchCurrentInheritings(InheritKey ik) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VActionMembers.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -35,14 +35,15 @@ import org.omg.sysml.lang.sysml.Type;
 
 public class VActionMembers extends VBehavior {
 
-    private void addNode(Feature f, String type) {
+    private int addNode(Feature f, String type) {
         String name = getNameAnyway(f);
         append(type);
         append(' ');
-        addNameWithId(f, name, true);
+        int id = addNameWithId(f, name, true);
         append(' ');
         addLink(f);
         append('\n');
+        return id;
     }
 
     public String caseFeature(Feature f) {
@@ -51,22 +52,24 @@ public class VActionMembers extends VBehavior {
             VSSRMembers vs = new VSSRMembers(this);
             return vs.start(f);
         }
-        addFeatureValueBindings(f);
         FeatureDirectionKind fdk = f.getDirection();
         if (fdk == null) return null;
+        String nodeKind;
         switch (fdk) {
         case IN:
-            addNode(f, "portin");
+            nodeKind = "portin";
             break;
         case OUT:
-            addNode(f, "portout");
+            nodeKind = "portout";
             break;
         case INOUT:
-            addNode(f, "port");
+            nodeKind = "port";
             break;
         default:
             return null;
         }
+        int id = addNode(f, nodeKind);
+        addFeatureValueBindings(id, f);
         return "";
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VComposite.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  * Copyright (c) 2023 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -76,7 +76,7 @@ public class VComposite extends VMixed {
         String featureText = getFeatureText(f);
         if (featureText.isEmpty()) return "";
         int id = addPUMLLine(f, "rec usage ", featureText);
-        addFeatureValueBindings(f);
+        addFeatureValueBindings(id, f);
 
         VComposite vc = new VComposite(this);
         vc.traverse(f);
@@ -136,7 +136,6 @@ public class VComposite extends VMixed {
 
     @Override
     public String casePortUsage(PortUsage pu) {
-        addFeatureValueBindings(pu);
         String name = extractTitleName(pu);
         if (name == null) return "";
 
@@ -144,9 +143,10 @@ public class VComposite extends VMixed {
         vc.traverse(pu);
         String ret = vc.getString();
 
+        int id;
         if (ret.isEmpty()) {
             int pt = getCurrentLength();
-            int id = addPUMLLine(pu, "", name);
+            id = addPUMLLine(pu, "", name);
             if (isPortOut(id)) {
                 insert(pt, "portout ");
             } else {
@@ -154,9 +154,10 @@ public class VComposite extends VMixed {
             }
             append('\n');
         } else {
-            addPUMLLine(pu, "rec usage ", name);
+            id = addPUMLLine(pu, "rec usage ", name);
             vc.closeBlock();
         }
+        addFeatureValueBindings(id, pu);
 
         return "";
     }
@@ -164,7 +165,6 @@ public class VComposite extends VMixed {
     private void addTypeSimple(Type typ) {
         if (typ instanceof Feature) {
             Feature f = (Feature) typ;
-            addFeatureValueBindings(f);
             FeatureDirectionKind fdk = f.getDirection();
             if (fdk != null) {
                 String name = extractTitleName(f);
@@ -174,19 +174,22 @@ public class VComposite extends VMixed {
                 vc.traverse(f);
                 String ret = vc.getString();
 
+                int id;
                 if (ret.isEmpty() && !isEmpty()) {
                     if (fdk == FeatureDirectionKind.OUT) {
-                        addPUMLLine(f, "portout ", name);
+                        id = addPUMLLine(f, "portout ", name);
                     } else {
-                        addPUMLLine(f, "portin ", name);
+                        id = addPUMLLine(f, "portin ", name);
                     }
                 } else {
-                    addPUMLLine(f, "rec usage ", name);
+                    id = addPUMLLine(f, "rec usage ", name);
                     vc.closeBlock();
                 }
+                addFeatureValueBindings(id, f);
             } else {
                 if (!addType(typ, "usage ")) return;
             }
+
         } else if (typ instanceof Usage) {
             if (!addType(typ, "usage ")) return;
         } else {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -94,7 +94,7 @@ public class VDefault extends VTraverser {
         return sb.toString();        
     }
 
-    protected void addFeatureValueBindings(Type typ) {
+    protected void addFeatureValueBindings(int typId, Type typ) {
         // To properly process inheritings, use VTraverser.
         VTraverser vt = new VTraverser(this) {
             @Override
@@ -102,7 +102,9 @@ public class VDefault extends VTraverser {
                 Expression v = fv.getValue();
                 Element tgt = resolveReference(v);
                 if (tgt != null) {
-                    addPRelation(typ, tgt, fv, "=");
+                	InheritKey ik = makeInheritKey((Feature) typ);
+                    PRelation pr = new PRelation(ik, typId, tgt, fv, "=");
+                    addPRelation(pr);
                 }
                 return "";
             }
@@ -176,8 +178,8 @@ public class VDefault extends VTraverser {
             // return resolvePathStepExpression((PathStepExpression) f, null);
             return f;
         } else if (f instanceof FeatureReferenceExpression) {
-            FeatureReferenceExpression fre = (FeatureReferenceExpression) f;
-            return fre.getReferent();
+            //FeatureReferenceExpression fre = (FeatureReferenceExpression) f;
+            return f;
         } else if (!f.getOwnedFeatureChaining().isEmpty()) {
             return f;
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -317,6 +317,7 @@ public class VPath extends VTraverser {
     // Make an InheritKey for ref, which is either a connector end or FeatureReferenceExpression or FeatureChainExpression.
     // These are (indirectly) owned by the innermost feature, which effectively determines the target scope.
     private InheritKey makeInheritKeyForReferer(PC pc) {
+    	if (pc == null) return null;
         Element e = pc.getTarget();
         if (!(e instanceof Feature)) return null;
         Feature ref = (Feature) e;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -42,7 +42,9 @@ import org.omg.sysml.lang.sysml.FeatureChainExpression;
 import org.omg.sysml.lang.sysml.FeatureChaining;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
+import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.ItemFlowEnd;
+import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Specialization;
@@ -508,8 +510,23 @@ public class VPath extends VTraverser {
         return "";
     }
 
+    private InheritKey makeInheritKeyForExpression(Expression ex) {
+        //Membership ms = getCurrentMembership();
+        //if (ms instanceof FeatureValue) {
+        	// FeatureValue is so special that the target 'ex' is not owned by the current context.
+        	// So we need to use the current namespace instead.
+            Namespace ns = getCurrentNamespace();
+            if (ns instanceof Feature) {
+                InheritKey ik = makeInheritKey((Feature) ns);
+                return InheritKey.makeIndirect(ik);
+            }
+            return null;
+        //}
+        //return InheritKey.makeIndirect(makeInheritKey(ex));
+    }
+
     private String addContextForFeatureChainExpression(FeatureChainExpression fce) {
-        InheritKey ik = makeInheritKey(fce);
+        InheritKey ik = makeInheritKeyForExpression(fce);
         PC pc = new PCFeatureChainExpression(fce);
         createRefPC(ik, pc);
         return "";
@@ -518,7 +535,7 @@ public class VPath extends VTraverser {
     private String addContextForFeatureReferenceExpression(FeatureReferenceExpression fre) {
         Feature f = fre.getReferent();
         if (f == null) return "";
-        InheritKey ik = makeInheritKey(fre);
+        InheritKey ik = makeInheritKeyForExpression(fre);
         PC pc = new PCFeature(fre, f);
         createRefPC(ik, pc);
         return "";

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -42,9 +42,7 @@ import org.omg.sysml.lang.sysml.FeatureChainExpression;
 import org.omg.sysml.lang.sysml.FeatureChaining;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
-import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.ItemFlowEnd;
-import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Specialization;
@@ -225,6 +223,33 @@ public class VPath extends VTraverser {
         	super(tgt);
         	this.f = f;
         }
+
+        protected PCFeature(PCFeature pc) {
+            super(pc);
+            this.f = pc.f;
+        }
+    }
+
+    private class PCFeatureTop extends PCFeature {
+        @Override
+        public PC enter(Namespace ns) {
+            return this;
+        }
+
+        @Override
+        public Element requiredElement() {
+            // no target inherit.
+            return null;
+        }
+
+        @Override
+        public PC leave() {
+            return this;
+        }
+
+        public PCFeatureTop(PCFeature pc) {
+            super(pc);
+        }
     }
 
     private class PCFeatureChain extends PC {
@@ -289,17 +314,31 @@ public class VPath extends VTraverser {
         }
     }
 
-    /* It makes an inherit key of the feature owning feature
-       (such as connector and subsetting feature) */
-    private InheritKey makeInheritKeyOfOwner(Feature f) {
-        Type owningType = f.getOwningType();
-        if (owningType instanceof Feature) {
-            return makeInheritKey((Feature) owningType);
-        } else {
-            /* non-feature types cannot be inherited and it returns null */
-            return null;
+    // Make an InheritKey for ref, which is either a connector end or FeatureReferenceExpression or FeatureChainExpression.
+    // These are (indirectly) owned by the innermost feature, which effectively determines the target scope.
+    private InheritKey makeInheritKeyForReferer(PC pc) {
+        Element e = pc.getTarget();
+        if (!(e instanceof Feature)) return null;
+        Feature ref = (Feature) e;
+
+        Namespace ns = getCurrentNamespace();
+        if (ns instanceof Feature) {
+            Feature tgt = (Feature) ns;
+            InheritKey ik = makeInheritKey(tgt);
+            if (ik != null) {
+                // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
+                ik = InheritKey.makeIndirect(ik);
+                return InheritKey.findTop(ik, ref);
+            }
         }
+        if (ns instanceof Type) {
+            // In case that tgt inherits ref, we need to make an InheritKey for tgt.
+            Type tgt = (Type) ns;
+            return InheritKey.makeTargetKey(tgt, ref);
+        }
+        return null;
     }
+
 
     /*
       ife : ItemFlowEnd :> baseTarget (e.g. action) {
@@ -419,7 +458,11 @@ public class VPath extends VTraverser {
 
         RefPC(PC pc, InheritKey ik) {
             if (ik == null) {
-                this.pc = pc;
+                if (pc instanceof PCFeature) {
+                    this.pc = new PCFeatureTop((PCFeature) pc);
+                } else {
+                    this.pc = pc;
+                }
             } else {
                 this.pc = new PCInheritKey(ik, pc);
             }
@@ -486,9 +529,8 @@ public class VPath extends VTraverser {
             return addContextForItemFlowEnd((ItemFlowEnd) f);
         }
         PC pc = makeEndFeaturePC(f);
-        InheritKey ik = makeInheritKeyOfOwner(f);
-        // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
-        if (createRefPC(InheritKey.makeIndirect(ik), pc) == null) return null;
+        InheritKey ik = makeInheritKeyForReferer(pc);
+        if (createRefPC(ik, pc) == null) return null;
         return "";
     }
 
@@ -504,30 +546,14 @@ public class VPath extends VTraverser {
         if (pc == null) return null;
         Feature ioTarget = getIOTarget(ife);
         pc = new PCItemFlowEnd(ife, pc, ioTarget);
-        InheritKey ik = makeInheritKeyOfOwner(ife);
-        // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
-        if (createRefPC(InheritKey.makeIndirect(ik), pc) == null) return null;
+        InheritKey ik = makeInheritKeyForReferer(pc);
+        if (createRefPC(ik, pc) == null) return null;
         return "";
     }
 
-    private InheritKey makeInheritKeyForExpression(Expression ex) {
-        //Membership ms = getCurrentMembership();
-        //if (ms instanceof FeatureValue) {
-        	// FeatureValue is so special that the target 'ex' is not owned by the current context.
-        	// So we need to use the current namespace instead.
-            Namespace ns = getCurrentNamespace();
-            if (ns instanceof Feature) {
-                InheritKey ik = makeInheritKey((Feature) ns);
-                return InheritKey.makeIndirect(ik);
-            }
-            return null;
-        //}
-        //return InheritKey.makeIndirect(makeInheritKey(ex));
-    }
-
     private String addContextForFeatureChainExpression(FeatureChainExpression fce) {
-        InheritKey ik = makeInheritKeyForExpression(fce);
         PC pc = new PCFeatureChainExpression(fce);
+        InheritKey ik = makeInheritKeyForReferer(pc);
         createRefPC(ik, pc);
         return "";
     }
@@ -535,8 +561,8 @@ public class VPath extends VTraverser {
     private String addContextForFeatureReferenceExpression(FeatureReferenceExpression fre) {
         Feature f = fre.getReferent();
         if (f == null) return "";
-        InheritKey ik = makeInheritKeyForExpression(fre);
         PC pc = new PCFeature(fre, f);
+        InheritKey ik = makeInheritKeyForReferer(pc);
         createRefPC(ik, pc);
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -284,7 +284,7 @@ public abstract class VStructure extends VDefault {
     protected boolean addType(Type typ, String name, String keyword) {
         int id = addPUMLLine(typ, keyword, name);
         addSpecializations(id, typ);
-        addFeatureValueBindings(typ);
+        addFeatureValueBindings(id, typ);
         return true;
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2022 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -146,7 +146,7 @@ public class VTree extends VStructure {
             int id = addPUMLLine(u, "comp usage ", name, "<<subject>>");
             process(new VCompartment(this), u);
             addSpecializations(id, u);
-            addFeatureValueBindings(u);
+            addFeatureValueBindings(id, u);
             return true;
         }
         return false;


### PR DESCRIPTION
So far, the visualizer wrongly assumed feature chains refer to features directly or indirectly owned by the owning feature of the feature chains.  Therefore, the example below was incorrectly rendered:

```
action a1 {
	first a3.a31 then a11;
	action a11;
}
	
action a3 {
	action a31;
}
```

as 

![image](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/assets/10537/feb05a77-354b-4da3-bcf2-cdaa7c272351)
