### PR TITLE
ST6RI-767: Some redefinitions are not correctly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -25,7 +25,6 @@
 package org.omg.sysml.plantuml;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -35,7 +34,6 @@ import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
-import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.FeatureUtil;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -253,7 +253,7 @@ class InheritKey {
         return matchRedefined(f, ft, new HashSet<Feature>());
     }
 
-    public static boolean matchElement(Element e, Element et) {
+    public static boolean matchElementWithRedefined(Element e, Element et) {
         if (e.equals(et)) return true;
         if ((e instanceof Feature) && (et instanceof Feature)) {
             return matchRedefined((Feature) e, (Feature) et);
@@ -277,14 +277,14 @@ class InheritKey {
             for (int i = 0; i < iSize; i++) {
                 int idx = inheritIdices.get(i);
                 Namespace ns = ctx.get(idx);
-                if (!matchElement(ns, ik.keys[i])) return false;
+                if (!matchElementWithRedefined(ns, ik.keys[i])) return false;
             }
             if (diff == 0) return true;
 
             // diff must be 1
             if (ik.isDirect) return false;
             // case ^ow)
-            return matchElement(ctx.get(ctxSize - 1), ik.keys[kLen - 1]);
+            return matchElementWithRedefined(ctx.get(ctxSize - 1), ik.keys[kLen - 1]);
         }
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -38,6 +38,7 @@ import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.FeatureUtil;
 
 
 /* InheritKey identifies a feature or a membership with the context of inheriting.
@@ -238,19 +239,9 @@ class InheritKey {
         return constructInternal(ctx, inheritIdices, idx);
     }
 
-    private static boolean matchRedefined(Feature f, Feature ft, Set<Feature> visited) {
-        if (visited.contains(f)) return false;
-        visited.add(f);
-        for (Redefinition rd: f.getOwnedRedefinition()) {
-            Feature rf = rd.getRedefinedFeature();
-            if (ft.equals(rf)) return true;
-            return matchRedefined(rf, ft, visited);
-        }
-        return false;
-    }
-
     private static boolean matchRedefined(Feature f, Feature ft) {
-        return matchRedefined(f, ft, new HashSet<Feature>());
+        Set<Feature> redefs = FeatureUtil.getAllRedefinedFeaturesOf(f);
+        return redefs.contains(ft);
     }
 
     public static boolean matchElementWithRedefined(Element e, Element et) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -52,7 +52,6 @@ import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OwningMembership;
-import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -118,23 +118,15 @@ public class VDefault extends VTraverser {
 
     protected void addSpecializations(int typId, Type typ) {
         if (typId < 0) return;
-        InheritKey ik = null;
+        InheritKey ik;
+        if (typ instanceof Feature) {
+            ik = makeInheritKey((Feature) typ);
+        } else {
+            ik = null;
+        }
         for (Specialization s: typ.getOwnedSpecialization()) {
             Type gt = s.getGeneral();
             if (gt == null) continue;
-            if (ik == null && gt instanceof Feature) {
-                if (s instanceof Redefinition) {
-                    // If we just create an inherit key for redefinition target, always create a cyclic reference
-                    // because redefining feature can be a target in this sense.  So we must create an inherit key
-                    // for the membership owning the target since the redefined target always exists.
-                    Membership ms = gt.getOwningMembership();
-                    if (ms != null) {
-                        ik = makeInheritKey(ms);
-                    }
-                } else {
-                    ik = makeInheritKey((Feature) gt);
-                }
-            }
             PRelation pr = new PRelation(ik, typId, gt, s, null);
             addPRelation(pr);
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -60,9 +60,14 @@ public class VPath extends VTraverser {
 
     private boolean initialized;
 
-	// PC (PathContext) management. 
+    // PC (PathContext) management. 
     private abstract class PC {
         private final Element idTarget;
+
+        // If it's true, PC does consider Redefinition when it match with idTarget.
+        // This is used for Redefinition.
+        protected final boolean noRedefine;
+
         private PC next;
         private PC prev;
         public void setPrev(PC prev) {
@@ -88,11 +93,13 @@ public class VPath extends VTraverser {
         protected PC(PC prev) {
             this.prev = prev;
             this.idTarget = prev.idTarget;
+            this.noRedefine = prev.noRedefine;
         }
 
-        protected PC(Element idTarget) {
+        protected PC(Element idTarget, boolean noRedefine) {
             this.prev = null;
             this.idTarget = idTarget;
+            this.noRedefine = noRedefine;
         }
 
         private boolean isSet;
@@ -120,7 +127,11 @@ public class VPath extends VTraverser {
         private boolean match(Element e) {
             if (isTerminal()) return false;
             Element et = getTarget();
-            return InheritKey.matchElement(e, et);
+            if (noRedefine) {
+                return e.equals(et);
+            } else {
+                return InheritKey.matchElementWithRedefined(e, et);
+            }
         }
 
         public Element requiredElement() {
@@ -196,7 +207,7 @@ public class VPath extends VTraverser {
         }
 
         public PCFeatureChainExpression(FeatureChainExpression fce) {
-            super(fce);
+            super(fce, false);
             this.fce = fce;
         }
     }
@@ -219,9 +230,9 @@ public class VPath extends VTraverser {
             this.f = f;
         }
         
-        public PCFeature(Element tgt, Feature f) {
-        	super(tgt);
-        	this.f = f;
+        public PCFeature(Element tgt, Feature f, boolean noRedefine) {
+            super(tgt, noRedefine);
+            this.f = f;
         }
 
         protected PCFeature(PCFeature pc) {
@@ -283,8 +294,8 @@ public class VPath extends VTraverser {
             this.index = prev.index + 1;
         }
 
-        public PCFeatureChain(Element tgt, Feature f) {
-            super(tgt);
+        public PCFeatureChain(Element tgt, Feature f, boolean noRedefine) {
+            super(tgt, noRedefine);
             this.fcs = f.getOwnedFeatureChaining();
             this.index = 0;
         }
@@ -362,7 +373,7 @@ public class VPath extends VTraverser {
         private final PC basePC;
 
         public PCItemFlowEnd(ItemFlowEnd ife, PC basePC, Feature ioTarget) {
-            super(ife);
+            super(ife, false);
             this.basePC = basePC;
             this.ioTarget = ioTarget;
         }
@@ -423,7 +434,7 @@ public class VPath extends VTraverser {
         }
 
         public PCInheritKey(InheritKey ik, PC pc) {
-            super((Element) null);
+            super((Element) null, pc.noRedefine);
             this.ik = ik;
             this.pc = pc;
             pc.setPrev(this);
@@ -496,19 +507,19 @@ public class VPath extends VTraverser {
 
     private List<RefPC> current = new ArrayList<RefPC>();
 
-    private PC makeFeaturePC(Element tgt, Feature f) {
+    private PC makeFeaturePC(Element tgt, Feature f, boolean noRedefine) {
         List<FeatureChaining> fcs = f.getOwnedFeatureChaining();
         if (fcs.isEmpty()) {
-            return new PCFeature(tgt, f);
+            return new PCFeature(tgt, f, noRedefine);
         } else {
-            return new PCFeatureChain(tgt, f);
+            return new PCFeatureChain(tgt, f, noRedefine);
         }
     }
 
     private PC makeEndFeaturePC(Feature end) {
         Feature sf = ConnectorUtil.getRelatedFeatureOfEnd(end);
         if (sf == null) return null;
-        return makeFeaturePC(end, sf);
+        return makeFeaturePC(end, sf, false);
     }
 
     private RefPC createRefPC(InheritKey ik, PC pc) {
@@ -518,9 +529,10 @@ public class VPath extends VTraverser {
         return rpc;
     }
 
-    private String addContextForFeature(Feature f) {
-        PC pc = makeFeaturePC(f, f);
-        InheritKey ik = makeInheritKey(f);
+    private String addContextForFeature(Feature f, boolean isRedefinition) {
+        PC pc = makeFeaturePC(f, f, isRedefinition);
+        InheritKey ik = makeInheritKeyForReferer(pc);
+        // InheritKey ik = makeInheritKey(f);
         if (createRefPC(ik, pc) == null) return null;
         return "";
     }
@@ -562,7 +574,7 @@ public class VPath extends VTraverser {
     private String addContextForFeatureReferenceExpression(FeatureReferenceExpression fre) {
         Feature f = fre.getReferent();
         if (f == null) return "";
-        PC pc = new PCFeature(fre, f);
+        PC pc = new PCFeature(fre, f, false);
         InheritKey ik = makeInheritKeyForReferer(pc);
         createRefPC(ik, pc);
         return "";
@@ -635,7 +647,7 @@ public class VPath extends VTraverser {
             // Type s = sp.getSpecific();
             if (g == null) continue;
             if (g instanceof Feature) {
-                addContextForFeature((Feature) g);
+                addContextForFeature((Feature) g, sp instanceof Redefinition);
             }
             if (checkVisited(g)) continue;
             visit(g);


### PR DESCRIPTION
So far, redefinitions are handled with inherit key of redefined features but that did not work well in some cases such as that redefined target is missing. 

This PR enhances PC (PathContext) to properly handle redefinitions by differentiating the equivalence classes of redefinitions and non-redefinitions.  By this enhancement, we can use the same inherit key with non-redefinition cases.