### PR TITLE
ST6RI-765 Update to JupyterLab version 3.x in the Jupyter deployment

### DIFF
--- a/org.omg.sysml.jupyter.installer/.classpath
+++ b/org.omg.sysml.jupyter.installer/.classpath
@@ -13,7 +13,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -21,6 +21,19 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/org.omg.sysml.jupyter.installer/.settings/org.eclipse.jdt.core.prefs
+++ b/org.omg.sysml.jupyter.installer/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/org.omg.sysml.jupyter.installer/install.bat
+++ b/org.omg.sysml.jupyter.installer/install.bat
@@ -41,7 +41,7 @@ call java -version || goto :error
 
 echo --- Step 3: Installing Jupyter SysML kernel and dependencies ---
 call jupyter kernelspec remove sysml -f >nul 2>&1
-call conda install "jupyter-sysml-kernel=%SYSML_VERSION%" python=3.* jupyterlab=2.* graphviz=2.* nodejs=14.* -c conda-forge -y || goto:error
+call conda install "jupyter-sysml-kernel=%SYSML_VERSION%" python=3.* jupyterlab=3.* graphviz=2.* nodejs="<17" -c conda-forge -y || goto:error
 
 echo --- Step 4: Installing JupyterLab SysML extension ---
 call jupyter labextension uninstall @systems-modeling/jupyterlab-sysml

--- a/org.omg.sysml.jupyter.installer/install.sh
+++ b/org.omg.sysml.jupyter.installer/install.sh
@@ -34,7 +34,7 @@ java -version
 
 echo "--- Step 3: Installing Jupyter SysML kernel and dependencies ---"
 jupyter kernelspec remove sysml -f > /dev/null 2>&1 || true
-conda install "jupyter-sysml-kernel=$SYSML_VERSION" python=3.* jupyterlab=3.* graphviz=2.* nodejs=16.20.2 -c conda-forge -y
+conda install "jupyter-sysml-kernel=$SYSML_VERSION" python=3.* jupyterlab=3.* graphviz=2.* nodejs="<17" -c conda-forge -y
 
 echo "--- Step 4: Installing JupyterLab SysML extension ---"
 jupyter labextension uninstall @systems-modeling/jupyterlab-sysml > /dev/null 2>&1 || true

--- a/org.omg.sysml.jupyter.installer/install.sh
+++ b/org.omg.sysml.jupyter.installer/install.sh
@@ -34,7 +34,7 @@ java -version
 
 echo "--- Step 3: Installing Jupyter SysML kernel and dependencies ---"
 jupyter kernelspec remove sysml -f > /dev/null 2>&1 || true
-conda install "jupyter-sysml-kernel=$SYSML_VERSION" python=3.* jupyterlab=2.* graphviz=2.* nodejs=15.* -c conda-forge -y
+conda install "jupyter-sysml-kernel=$SYSML_VERSION" python=3.* jupyterlab=3.* graphviz=2.* nodejs=16.20.2 -c conda-forge -y
 
 echo "--- Step 4: Installing JupyterLab SysML extension ---"
 jupyter labextension uninstall @systems-modeling/jupyterlab-sysml > /dev/null 2>&1 || true

--- a/org.omg.sysml.jupyter.jupyterlab/.classpath
+++ b/org.omg.sysml.jupyter.jupyterlab/.classpath
@@ -13,7 +13,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -21,6 +21,19 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/org.omg.sysml.jupyter.jupyterlab/.settings/org.eclipse.jdt.core.prefs
+++ b/org.omg.sysml.jupyter.jupyterlab/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/org.omg.sysml.jupyter.jupyterlab/package.json
+++ b/org.omg.sysml.jupyter.jupyterlab/package.json
@@ -11,12 +11,16 @@
     "jupyterlab-extension"
   ],
   "dependencies": {
-    "@jupyterlab/application": "2.x"
+    "@jupyterlab/application": "3.x"
   },
   "devDependencies": {
     "@types/codemirror": "^0.0.98",
     "@types/json-schema": "*",
     "typescript": "<4.4.0"
+  },
+  "resolutions": {
+    "@lumino/coreutils": "^1.11.0",
+    "@lumino/widgets": "^1.37.2"
   },
   "peerDependencies": {
     "codemirror": "^5.58.1"


### PR DESCRIPTION
This PR updates the Jupyter deployment to upgrade the version of JupyterLab from 2.x to 3.x, which allows the use of Node.js version 16.x. This is then consistent with the setting of Node.js version 16.20.1 in Maven build script. This only affects the installation of the JupyterLab extension for SysML, not the kernel, via the following changes:

1. `org.omg.sysml.jupyter.jupyterlab/package.json` – The version for the dependency on `jupyterlab/application` changes from `2.x` to `3.x`.
2. `org.omg.sysml.jupyter.installer/install.sh` and `install.bat` – In the `conda install` command, the version for `jupyterlab` changes from `2.*` to `3.*` and the version for `nodejs` changes from `15.*` to `<17`.

**Note.** The Jupyter extension installation still uses `jupyterlab labextension`, which is deprecated but still functional for JupyterLab 3.x. This will be replaced in a future upgrade to JupyterLab 4.x.