### PR TITLE
ST6RI-771 With `start` action, some flow connections are not rendered properly (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -76,6 +76,7 @@ import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.StakeholderMembership;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Succession;
+import org.omg.sysml.lang.sysml.SuccessionFlowConnectionUsage;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.TransitionUsage;
 import org.omg.sysml.lang.sysml.Usage;
@@ -430,6 +431,11 @@ public class SysML2PlantUMLStyle {
 		public String caseFlowConnectionUsage(FlowConnectionUsage fcu) {
             return " --> ";
 		}
+
+        @Override
+        public String caseSuccessionFlowConnectionUsage(SuccessionFlowConnectionUsage sfcu) {
+            return " ..> ";
+        }
 
 		@Override
 		public String caseAllocationUsage(AllocationUsage au) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -498,7 +498,7 @@ public class SysML2PlantUMLText {
         sb.append(v.getString());
 
         if (exceeds || exceedsTheLimit()) {
-            sb.insert(0, "title EXCEEDS THE LIMIT!!!  Since it exceeds the maximum number of model elements to be processed, the visualization results may be incomplete.\n");
+            sb.insert(0, "title EXCEEDS THE LIMIT!!!\\nSince it exceeds the maximum number of model elements to be processed,\\n the visualization result may be incomplete.\n");
             sb.insert(0, "skinparam titleBorderThickness 2\nskinparam titleBorderColor red\n");
         }
         

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -485,6 +485,8 @@ public class SysML2PlantUMLText {
         }
         vpath.init();
 
+        boolean exceeds = exceedsTheLimit();
+
         numVisits = 0;
         for (EObject eObj : eObjs) {
             if (eObj instanceof Element) {
@@ -494,6 +496,12 @@ public class SysML2PlantUMLText {
             }
         }
         sb.append(v.getString());
+
+        if (exceeds || exceedsTheLimit()) {
+            sb.insert(0, "title EXCEEDS THE LIMIT!!!  Since it exceeds the maximum number of model elements to be processed, the visualization results may be incomplete.\n");
+            sb.insert(0, "skinparam titleBorderThickness 2\nskinparam titleBorderColor red\n");
+        }
+        
         return sb.toString();
     }
 
@@ -615,8 +623,12 @@ public class SysML2PlantUMLText {
         numVisits++;
     }
 
+    private boolean exceedsTheLimit() {
+        return numVisits > MAX_VISITS;
+    }
+
     boolean pushNamespace(Namespace ns) {
-        if (numVisits > MAX_VISITS) return false;
+        if (exceedsTheLimit()) return false;
         if (namespaces.contains(ns)) return false;
         namespaces.add(ns);
         return true;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -646,6 +646,7 @@ public class VPath extends VTraverser {
             Type g = sp.getGeneral();
             // Type s = sp.getSpecific();
             if (g == null) continue;
+            if (isHidden(g)) continue;
             if (g instanceof Feature) {
                 addContextForFeature((Feature) g, sp instanceof Redefinition);
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -103,7 +103,7 @@ public abstract class VTraverser extends Visitor {
     private void traverseInherited(Type typ, Set<Element> covered) {
         for (Membership ms: typ.getInheritedMembership()) {
             Element e = ms.getMemberElement();
-            if (!showLib() && isModelLibrary(e)) continue;
+            if (isHidden(e)) continue;
             if (markRedefining(e, covered)) continue;
             setInherited(true);
             pushVisited();
@@ -114,7 +114,7 @@ public abstract class VTraverser extends Visitor {
 
     private void traverseRest(VPath vpath, Set<Element> covered) {
         for (Element e: vpath.rest()) {
-            if (!showLib() && isModelLibrary(e)) continue;
+            if (isHidden(e)) continue;
             if (markRedefining(e, covered)) continue;
             currentMembership = null;
             setInherited(true);
@@ -186,6 +186,10 @@ public abstract class VTraverser extends Visitor {
     private boolean showLib() {
         init();
         return showLib;
+    }
+
+    protected boolean isHidden(Element e) {
+        return !(showLib() && isModelLibrary(e));
     }
 
     private static Set<Namespace> initVisited(Visitor prev) {


### PR DESCRIPTION
Since `start` action is a standard library element having lots of features, the visualizer needed to process them, exceeding the limit of elements that can be processed, even though the `SHOWLIB` style is not selected.  This PR fixes the issue by preventing `VPath` from traversing standard library elements if `SHOWLIB` style is not specified.

This PR also adds a style configuration to `SuccessionFlowConnectionUsage` to properly render it and an error message shown in cases when the visualizer still hits the element limit.