### PR TITLE
ST6RI-760 Actor and stakeholder property derivations only return owned usages

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/CaseDefinition_actorParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/CaseDefinition_actorParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class CaseDefinition_actorParameter_SettingDelegate extends BasicDerivedL
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> actorParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((CaseDefinition)owner, ActorMembership.class, PartUsage.class, actorParameters);
+		TypeUtil.addFeaturesByMembership((CaseDefinition)owner, ActorMembership.class, PartUsage.class, actorParameters);
 		return actorParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/CaseUsage_actorParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/CaseUsage_actorParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class CaseUsage_actorParameter_SettingDelegate extends BasicDerivedListSe
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> actorParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((CaseUsage)owner, ActorMembership.class, PartUsage.class, actorParameters);
+		TypeUtil.addFeaturesByMembership((CaseUsage)owner, ActorMembership.class, PartUsage.class, actorParameters);
 		return actorParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementDefinition_actorParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementDefinition_actorParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class RequirementDefinition_actorParameter_SettingDelegate extends BasicD
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> actorParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((RequirementDefinition)owner, ActorMembership.class, PartUsage.class, actorParameters);
+		TypeUtil.addFeaturesByMembership((RequirementDefinition)owner, ActorMembership.class, PartUsage.class, actorParameters);
 		return actorParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementDefinition_stakeholderParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementDefinition_stakeholderParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class RequirementDefinition_stakeholderParameter_SettingDelegate extends 
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> stakeholderParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((RequirementDefinition)owner, StakeholderMembership.class, PartUsage.class, stakeholderParameters);
+		TypeUtil.addFeaturesByMembership((RequirementDefinition)owner, StakeholderMembership.class, PartUsage.class, stakeholderParameters);
 		return stakeholderParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementUsage_actorParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementUsage_actorParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class RequirementUsage_actorParameter_SettingDelegate extends BasicDerive
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> actorParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((RequirementUsage)owner, ActorMembership.class, PartUsage.class, actorParameters);
+		TypeUtil.addFeaturesByMembership((RequirementUsage)owner, ActorMembership.class, PartUsage.class, actorParameters);
 		return actorParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementUsage_stakeholderParameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/RequirementUsage_stakeholderParameter_SettingDelegate.java
@@ -40,7 +40,7 @@ public class RequirementUsage_stakeholderParameter_SettingDelegate extends Basic
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
 		EList<PartUsage> stakeholderParameters = new NonNotifyingEObjectEList<>(PartUsage.class, owner, eStructuralFeature.getFeatureID());
-		TypeUtil.addOwnedFeaturesByMembership((RequirementUsage)owner, StakeholderMembership.class, PartUsage.class, stakeholderParameters);
+		TypeUtil.addFeaturesByMembership((RequirementUsage)owner, StakeholderMembership.class, PartUsage.class, stakeholderParameters);
 		return stakeholderParameters;
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -296,6 +296,11 @@ public class TypeUtil {
 
 	public static <T extends Membership> Feature getFeatureByMembershipIn(Type type, Class<T> kind) {
 		return getFeaturesByMembershipIn(type, kind).findFirst().orElse(null);
+	}
+
+	public static <M extends Membership, E extends Element> void addFeaturesByMembership(Type type, 
+			Class<M> kind, Class<E> elementKind, List<E> list) {
+		getFeaturesByMembershipIn(type, kind).map(elementKind::cast).forEachOrdered(list::add);
 	}
 
 	public static <T extends Membership> Stream<Feature> getOwnedFeaturesByMembershipIn(Type type, Class<T> kind) {


### PR DESCRIPTION
According to the Beta 2 version of the SysML v2 specification, the derivations of the `actorParameter` and `stakeholderParameter` properties for `RequirementDefinitions` and `RequirementUsages` and of `actorParameter` for `CaseDefinitions` and `CaseUsages` are supposed to included both owned and inherited actors and stakeholders. Previously, however, the implementation only returned owned actors and stakeholders. This PR corrects the implementation to be conformant with the specification.