### PR TITLE
ST6RI-752 Reimplement Xtext workarounds using Xtext parse postprocessing

### DIFF
--- a/kerml/src/examples/Simple Tests/Dependencies.kerml
+++ b/kerml/src/examples/Simple Tests/Dependencies.kerml
@@ -8,8 +8,8 @@ package Dependencies {
 	
 	import System::*;
 	
-//	dependency Use from 'Application Layer' to 'Service Layer';
-//	dependency from 'Service Layer' to 'Data Layer';
+	dependency Use from 'Application Layer' to 'Service Layer';
+	dependency from 'Service Layer' to 'Data Layer';
 	
 	feature x;
 	feature y;

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
@@ -26,14 +26,42 @@ package org.omg.kerml.xtext.scoping;
 
 import java.util.Objects;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature.Setting;
+import org.eclipse.xtext.diagnostics.IDiagnosticProducer;
 import org.eclipse.xtext.linking.lazy.LazyLinker;
+import org.eclipse.xtext.nodemodel.INode;
+import org.omg.sysml.lang.sysml.AnnotatingElement;
+import org.omg.sysml.lang.sysml.Annotation;
+import org.omg.sysml.lang.sysml.Classifier;
 import org.omg.sysml.lang.sysml.Comment;
+import org.omg.sysml.lang.sysml.ConjugatedPortDefinition;
+import org.omg.sysml.lang.sysml.Conjugation;
+import org.omg.sysml.lang.sysml.Differencing;
+import org.omg.sysml.lang.sysml.Disjoining;
 import org.omg.sysml.lang.sysml.Documentation;
-import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureInverting;
+import org.omg.sysml.lang.sysml.FeatureTyping;
+import org.omg.sysml.lang.sysml.Intersecting;
+import org.omg.sysml.lang.sysml.Namespace;
+import org.omg.sysml.lang.sysml.NamespaceImport;
+import org.omg.sysml.lang.sysml.PortConjugation;
+import org.omg.sysml.lang.sysml.PortDefinition;
+import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.Specialization;
+import org.omg.sysml.lang.sysml.Subclassification;
+import org.omg.sysml.lang.sysml.Subsetting;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.lang.sysml.TypeFeaturing;
+import org.omg.sysml.lang.sysml.Unioning;
 import org.omg.sysml.util.ElementUtil;
+
+import com.google.common.collect.Multimap;
 
 public class KerMLLinker extends LazyLinker {
 
@@ -75,5 +103,366 @@ public class KerMLLinker extends LazyLinker {
 			return;
 		}
 		super.clearReference(obj, ref);
+	}
+	
+	@Override
+	protected void installProxies(EObject obj, IDiagnosticProducer producer, Multimap<Setting, INode> settingsToLink) {
+		super.installProxies(obj, producer, settingsToLink);
+		postProcessCrossReferences(obj);
+	}
+	
+	protected void postProcessCrossReferences(EObject obj) {
+		if (obj instanceof Annotation) {
+			postProcessCrossReferences((Annotation) obj);
+		}
+		if (obj instanceof Conjugation) {
+			postProcessCrossReferences((Conjugation) obj);
+		}
+		if (obj instanceof Differencing) {
+			postProcessCrossReferences((Differencing) obj);
+		}
+		if (obj instanceof Disjoining) {
+			postProcessCrossReferences((Disjoining) obj);
+		}
+		if (obj instanceof FeatureInverting) {
+			postProcessCrossReferences((FeatureInverting) obj);
+		}
+		if (obj instanceof FeatureTyping) {
+			postProcessCrossReferences((FeatureTyping) obj);
+		}
+		if (obj instanceof Intersecting) {
+			postProcessCrossReferences((Intersecting) obj);
+		}
+		if (obj instanceof NamespaceImport) {
+			postProcessCrossReferences((NamespaceImport) obj);
+		}
+		if (obj instanceof PortConjugation) {
+			postProcessCrossReferences((PortConjugation) obj);
+		}
+		if (obj instanceof Redefinition) {
+			postProcessCrossReferences((Redefinition) obj);
+		}
+		if (obj instanceof Specialization) {
+			postProcessCrossReferences((Specialization) obj);
+		}
+		if (obj instanceof Subclassification) {
+			postProcessCrossReferences((Subclassification) obj);
+		}
+		if (obj instanceof Subsetting) {
+			postProcessCrossReferences((Subsetting) obj);
+		}
+		if (obj instanceof TypeFeaturing) {
+			postProcessCrossReferences((TypeFeaturing) obj);
+		}
+		if (obj instanceof Unioning) {
+			postProcessCrossReferences((Unioning) obj);
+		}
+	}
+	
+	protected void postProcessCrossReferences(Annotation obj) {
+		// If the Annotation is not owned by an AnnotatingElement, then the annotatedElement is the owningRelatedElement.
+		Object annotatedElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATED_ELEMENT, false);
+		if (annotatedElement == null) {
+			Element owningRelatedElement = obj.getOwningRelatedElement();
+			if (!(owningRelatedElement instanceof AnnotatingElement)) {
+				obj.setAnnotatedElement(owningRelatedElement);
+			}
+		}
+		
+		// If there is no annotatingElement set, then set the AnnotatingElement to the owningRelatedElement,
+		// if it is an AnnotatingElement, otherwise set it to the first ownedRelatedElement that is an
+		// AnnotatingElement (if any).
+		Object annotatingElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATING_ELEMENT, false);
+		if (annotatingElement == null) {
+			Element owner = obj.getOwningRelatedElement();
+			obj.setAnnotatingElement((AnnotatingElement)
+					(owner instanceof AnnotatingElement? owner: 
+						obj.getOwnedRelatedElement().stream().
+							filter(AnnotatingElement.class::isInstance).
+							findFirst().orElse(null)));
+		}
+	}
+	
+	protected void postProcessCrossReferences(Conjugation obj) {
+		// If the conjugatedType is not set, then set it to the owningRelatedElement, if this is a Type,
+		// otherwise set it to the first ownedRelatedElement.
+		Object conjugatedType = obj.eGet(SysMLPackage.Literals.CONJUGATION__CONJUGATED_TYPE, false);
+		if (conjugatedType == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				obj.setConjugatedType((Type)owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setConjugatedType((Type)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		// If the originalType is not set, set it to the last ownedRelatedElement.
+		Object originalType = obj.eGet(SysMLPackage.Literals.CONJUGATION__ORIGINAL_TYPE, false);
+		if (originalType == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setOriginalType((Type)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Differencing obj) {
+		// If a Differencing is parsed targeting a Feature chain, then the differencingType will be empty,
+		// but the Differencing will own the differencingType. So, in this case, the differencingType should
+		// be set to the (last) ownedRelatedelement.
+		Object differencingType = obj.eGet(SysMLPackage.Literals.DIFFERENCING__DIFFERENCING_TYPE, false);
+		if (differencingType == null) {
+			// Handle a differencingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setDifferencingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Disjoining obj) {
+		// If a Disjoining is parsed targeting a Feature chain, then the disjoiningType will be empty,
+		// but the Disjoining will own the disjoiningType. So, in this case, the disjoiningType should
+		// be set to the (last) ownedRelatedelement.
+		Object disjoiningType = obj.eGet(SysMLPackage.Literals.DISJOINING__DISJOINING_TYPE, false);
+		if (disjoiningType == null) {
+			// Handle a disjoiningType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setDisjoiningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If the typedDisjoined (source) is empty, set it to the owningRelatedElement, if it is a Type.
+		// Otherwise, set it to the first ownedRelatedElement, to the first ownedRelatedElement,
+		// which will be a Feature chain.
+		Object typeDisjoined = obj.eGet(SysMLPackage.Literals.DISJOINING__TYPE_DISJOINED, false);
+		if (typeDisjoined == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				// Handle a Disjoining owned by the typeDisjoined.
+				obj.setTypeDisjoined((Type)owner);
+			} else {
+				// Handle a typeDisjoined that is a Feature chain.
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setTypeDisjoined((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(FeatureInverting obj) {
+		// If the featureInverted is empty, then set it to the owningRelatedElement of the FeatureInverting,
+		// if that is a Feature, otherwise set it to the first ownedRelatedElement (which will be a
+		// Feature chain).
+		Object featureInverted = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__FEATURE_INVERTED, false);
+		if (featureInverted == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				// Handle FeatureInverting owned by the featureInverted.
+				obj.setFeatureInverted((Feature)owner);
+			} else {
+				// Handle featureInverted that is a Feature chain.
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setFeatureInverted((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		// If the invertingFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object invertingFeature = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__INVERTING_FEATURE, false);
+		if (invertingFeature == null) {
+			// Handle invertingFeature that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setInvertingFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(FeatureTyping obj) {
+		// If the type is empty, then set it to the first owned related element
+		// (which will be a Feature chain).
+		Object type = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPE, false);
+		if (type == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setType((Feature)ownedRelatedElements.get(0));
+			}
+		}
+		
+		// If the typedFeature is empty, then set it to the owningRelatedElement (if that is a Feature).
+		Object typedFeature = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPED_FEATURE, false);
+		if (typedFeature == null) {
+			Element owningRelatedElement = obj.getOwningRelatedElement();
+			if (owningRelatedElement instanceof Feature) {
+				obj.setTypedFeature((Feature) owningRelatedElement);
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Intersecting obj) {
+		// If a Intersecting is parsed targeting a Feature chain, then the intersectingType will be empty,
+		// but the Intersecting will own the intersectingType. So, in this case, the intersectingType should
+		// be set to the (last) ownedRelatedelement.
+		Object intersectingType = obj.eGet(SysMLPackage.Literals.INTERSECTING__INTERSECTING_TYPE, false);
+		if (intersectingType == null) {
+			// Handle a intersectingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setIntersectingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(NamespaceImport obj) {
+		// If importedNamespace is empty, then set it to the first ownedRelatedElement, if this is a namespace
+		// (filling in the implicit import for a filter package). Otherwise, set it to the importOwningNamspace.
+		Object importedNamespace = obj.eGet(SysMLPackage.Literals.NAMESPACE_IMPORT__IMPORTED_NAMESPACE, false);
+		if (importedNamespace == null) {
+			EList<Element> ownedRelatedElement = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElement.isEmpty() && ownedRelatedElement.get(0) instanceof Namespace) {
+				// Fill in the implicit import for a filter package.
+				obj.setImportedNamespace((Namespace)ownedRelatedElement.get(0));
+			} else {
+				obj.setImportedNamespace(obj.getImportOwningNamespace());
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(PortConjugation obj) {
+		// If the originalPortDefinition is empty, then set it to the owner of the conjugatedPortDefinition
+		// (if that is a PortDefinition).
+		Object originalPortDefinition = obj.eGet(SysMLPackage.Literals.PORT_CONJUGATION__ORIGINAL_PORT_DEFINITION, false);
+		if (originalPortDefinition == null) {
+			ConjugatedPortDefinition conjugatedPortDefinition = obj.getConjugatedPortDefinition();
+			if (conjugatedPortDefinition != null) {
+				Element conjugatedPortDefinitionOwner = conjugatedPortDefinition.getOwner();
+				if (conjugatedPortDefinitionOwner instanceof PortDefinition) {
+					obj.setOriginalPortDefinition((PortDefinition)conjugatedPortDefinitionOwner);
+				}
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Redefinition obj) {
+		// If the redefiningFeature is empty, then set it to the owningRelatedElement, if that is a Feature.
+		// Otherwise, set it to the first ownedRelatedElement (which will be a Feature chain).
+		Object redefiningFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINING_FEATURE, false);
+		if (redefiningFeature == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setRedefiningFeature((Feature) owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setRedefiningFeature((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		Object redefinedFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINED_FEATURE, false);
+		if (redefinedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setRedefinedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Specialization obj) {
+		// If general is empty, then set it to the last ownedRelatedElement (which will be a Feature chain).
+		Object general = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__GENERAL, false);
+		if (general == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setGeneral((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If specific is empty, then set it to the owningRelatedElement, if that is a Type.
+		// Otherwise set it to the first ownedRelatedElement (which will be a FeatureChain).
+		Object specific = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__SPECIFIC, false);
+		if (specific == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				obj.setSpecific((Type)owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setSpecific((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Subclassification obj) {
+		// If the subclassifier is empty, then set it to the owningRelatedElement,
+		// if this is a Classifier.
+		Object subclassifier = obj.eGet(SysMLPackage.Literals.SUBCLASSIFICATION__SUBCLASSIFIER, false);
+		if (subclassifier == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Classifier) {
+				obj.setSubclassifier((Classifier) owner);
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Subsetting obj) {
+		// If the subsettedFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object subsettedFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTED_FEATURE, false);
+		if (subsettedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setSubsettedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If the subsettingFeature is empty, then set it to the owningRelatedFeature, if this is a Feature.
+		// Otherwise set it to the first ownedRelatedElement (which will be a Feature chain).
+		Object subsettingFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTING_FEATURE, false);
+		if (subsettingFeature == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setSubsettingFeature((Feature) owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setSubsettingFeature((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(TypeFeaturing obj) {
+		// If the featureOfType is empty, then set it to the owningRelatedElement (if this is a Feature).
+		Object featureOfType = obj.eGet(SysMLPackage.Literals.TYPE_FEATURING__FEATURE_OF_TYPE, false);
+		if (featureOfType == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setFeatureOfType((Feature)owner);
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(Unioning obj) {
+		// If a Unioning is parsed targeting a Feature chain, then the unioningType will be empty,
+		// but the Unioning will own the unioningType. So, in this case, the unioningType should
+		// be set to the (last) ownedRelatedelement.
+		Object unioningType = obj.eGet(SysMLPackage.Literals.UNIONING__UNIONING_TYPE, false);
+		if (unioningType == null) {
+			// Handle a intersectingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setUnioningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
 	}
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
@@ -54,6 +54,7 @@ import org.omg.sysml.lang.sysml.NamespaceImport;
 import org.omg.sysml.lang.sysml.PortConjugation;
 import org.omg.sysml.lang.sysml.PortDefinition;
 import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.ReferenceSubsetting;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subclassification;
 import org.omg.sysml.lang.sysml.Subsetting;
@@ -168,6 +169,8 @@ public class KerMLLinker extends LazyLinker {
 		// for overridden features.
 		if (obj instanceof Redefinition) {
 			postProcessCrossReferences((Redefinition) obj);
+		} else if (obj instanceof ReferenceSubsetting) {
+			postProcessCrossReferences((ReferenceSubsetting) obj);
 		} else if (obj instanceof Subsetting) {
 			postProcessCrossReferences((Subsetting) obj);
 		} else if (obj instanceof Subclassification) {
@@ -400,6 +403,18 @@ public class KerMLLinker extends LazyLinker {
 			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
 			if (!ownedRelatedElements.isEmpty()) {
 				obj.setRedefinedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+	protected void postProcessCrossReferences(ReferenceSubsetting obj) {
+		// If the referencedFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object referencedFeature = obj.eGet(SysMLPackage.Literals.REFERENCE_SUBSETTING__REFERENCED_FEATURE, false);
+		if (referencedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setReferencedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
 			}
 		}
 	}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
@@ -1,6 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2021, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,13 +21,13 @@
  * Contributors:
  *  Zoltan Ujhelyi, MDS
  *  Ed Seidewitz, MDS
+ *  Kristóf Marussy, BME
  * 
  *****************************************************************************/
 package org.omg.kerml.xtext.scoping;
 
 import java.util.Objects;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -35,33 +36,10 @@ import org.eclipse.xtext.diagnostics.IDiagnosticConsumer;
 import org.eclipse.xtext.linking.lazy.LazyLinker;
 import org.eclipse.xtext.util.OnChangeEvictingCache;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
-import org.omg.sysml.lang.sysml.AnnotatingElement;
-import org.omg.sysml.lang.sysml.Annotation;
-import org.omg.sysml.lang.sysml.Classifier;
 import org.omg.sysml.lang.sysml.Comment;
-import org.omg.sysml.lang.sysml.ConjugatedPortDefinition;
-import org.omg.sysml.lang.sysml.Conjugation;
-import org.omg.sysml.lang.sysml.Differencing;
-import org.omg.sysml.lang.sysml.Disjoining;
 import org.omg.sysml.lang.sysml.Documentation;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.FeatureInverting;
-import org.omg.sysml.lang.sysml.FeatureTyping;
-import org.omg.sysml.lang.sysml.Intersecting;
-import org.omg.sysml.lang.sysml.Namespace;
-import org.omg.sysml.lang.sysml.NamespaceImport;
-import org.omg.sysml.lang.sysml.PortConjugation;
-import org.omg.sysml.lang.sysml.PortDefinition;
-import org.omg.sysml.lang.sysml.Redefinition;
-import org.omg.sysml.lang.sysml.ReferenceSubsetting;
-import org.omg.sysml.lang.sysml.Specialization;
-import org.omg.sysml.lang.sysml.Subclassification;
-import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.SysMLPackage;
-import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.TypeFeaturing;
-import org.omg.sysml.lang.sysml.Unioning;
 import org.omg.sysml.util.ElementUtil;
 
 import com.google.inject.Inject;
@@ -124,388 +102,11 @@ public class KerMLLinker extends LazyLinker {
 				TreeIterator<EObject> iterator = getAllLinkableContents(model);
 				while (iterator.hasNext()) {
 					EObject obj = iterator.next();
-					postProcessCrossReferences(obj);
+					if (obj instanceof Element) {
+						ElementUtil.postProcess((Element)obj);
+					}
 				}
 			}
 		});
-	}
-	
-	protected void postProcessCrossReferences(EObject obj) {
-		if (obj instanceof Annotation) {
-			postProcessCrossReferences((Annotation) obj);
-		}
-		
-		if (obj instanceof Differencing) {
-			postProcessCrossReferences((Differencing) obj);
-		}
-		
-		if (obj instanceof Disjoining) {
-			postProcessCrossReferences((Disjoining) obj);
-		}
-		
-		if (obj instanceof FeatureInverting) {
-			postProcessCrossReferences((FeatureInverting) obj);
-		}
-		
-		if (obj instanceof Intersecting) {
-			postProcessCrossReferences((Intersecting) obj);
-		}
-		
-		if (obj instanceof NamespaceImport) {
-			postProcessCrossReferences((NamespaceImport) obj);
-		}
-		
-		// We must process Conjugation subclasses in order from the most specific
-		// to the most generic so that we only apply the appropriate post-processing
-		// for overridden features.
-		if (obj instanceof PortConjugation) {
-			postProcessCrossReferences((PortConjugation) obj);
-		} else if (obj instanceof Conjugation) {
-			postProcessCrossReferences((Conjugation) obj);
-		}
-		
-		// We must process Specialization subclasses in order from the most specific
-		// to the most generic so that we only apply the appropriate post-processing
-		// for overridden features.
-		if (obj instanceof Redefinition) {
-			postProcessCrossReferences((Redefinition) obj);
-		} else if (obj instanceof ReferenceSubsetting) {
-			postProcessCrossReferences((ReferenceSubsetting) obj);
-		} else if (obj instanceof Subsetting) {
-			postProcessCrossReferences((Subsetting) obj);
-		} else if (obj instanceof Subclassification) {
-			postProcessCrossReferences((Subclassification) obj);
-		} else if (obj instanceof FeatureTyping) {
-			postProcessCrossReferences((FeatureTyping) obj);
-		} else if (obj instanceof Specialization) {
-			postProcessCrossReferences((Specialization) obj);
-		}
-		
-		if (obj instanceof TypeFeaturing) {
-			postProcessCrossReferences((TypeFeaturing) obj);
-		}
-		
-		if (obj instanceof Unioning) {
-			postProcessCrossReferences((Unioning) obj);
-		}
-	}
-	
-	protected void postProcessCrossReferences(Annotation obj) {
-		// If the Annotation is not owned by an AnnotatingElement, then the annotatedElement is the owningRelatedElement.
-		Object annotatedElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATED_ELEMENT, false);
-		if (annotatedElement == null) {
-			Element owningRelatedElement = obj.getOwningRelatedElement();
-			if (!(owningRelatedElement instanceof AnnotatingElement)) {
-				obj.setAnnotatedElement(owningRelatedElement);
-			}
-		}
-		
-		// If there is no annotatingElement set, then set the AnnotatingElement to the owningRelatedElement,
-		// if it is an AnnotatingElement, otherwise set it to the first ownedRelatedElement that is an
-		// AnnotatingElement (if any).
-		Object annotatingElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATING_ELEMENT, false);
-		if (annotatingElement == null) {
-			Element owner = obj.getOwningRelatedElement();
-			obj.setAnnotatingElement((AnnotatingElement)
-					(owner instanceof AnnotatingElement? owner: 
-						obj.getOwnedRelatedElement().stream().
-							filter(AnnotatingElement.class::isInstance).
-							findFirst().orElse(null)));
-		}
-	}
-	
-	protected void postProcessCrossReferences(Conjugation obj) {
-		// If the conjugatedType is not set, then set it to the owningRelatedElement, if this is a Type,
-		// otherwise set it to the first ownedRelatedElement.
-		Object conjugatedType = obj.eGet(SysMLPackage.Literals.CONJUGATION__CONJUGATED_TYPE, false);
-		if (conjugatedType == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Type) {
-				obj.setConjugatedType((Type)owner);
-			} else {
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setConjugatedType((Type)ownedRelatedElements.get(0));
-				}
-			}
-		}
-		
-		// If the originalType is not set, set it to the last ownedRelatedElement.
-		Object originalType = obj.eGet(SysMLPackage.Literals.CONJUGATION__ORIGINAL_TYPE, false);
-		if (originalType == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setOriginalType((Type)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Differencing obj) {
-		// If a Differencing is parsed targeting a Feature chain, then the differencingType will be empty,
-		// but the Differencing will own the differencingType. So, in this case, the differencingType should
-		// be set to the (last) ownedRelatedelement.
-		Object differencingType = obj.eGet(SysMLPackage.Literals.DIFFERENCING__DIFFERENCING_TYPE, false);
-		if (differencingType == null) {
-			// Handle a differencingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setDifferencingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Disjoining obj) {
-		// If a Disjoining is parsed targeting a Feature chain, then the disjoiningType will be empty,
-		// but the Disjoining will own the disjoiningType. So, in this case, the disjoiningType should
-		// be set to the (last) ownedRelatedelement.
-		Object disjoiningType = obj.eGet(SysMLPackage.Literals.DISJOINING__DISJOINING_TYPE, false);
-		if (disjoiningType == null) {
-			// Handle a disjoiningType that is a Feature chain.
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setDisjoiningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-		
-		// If the typedDisjoined (source) is empty, set it to the owningRelatedElement, if it is a Type.
-		// Otherwise, set it to the first ownedRelatedElement, to the first ownedRelatedElement,
-		// which will be a Feature chain.
-		Object typeDisjoined = obj.eGet(SysMLPackage.Literals.DISJOINING__TYPE_DISJOINED, false);
-		if (typeDisjoined == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Type) {
-				// Handle a Disjoining owned by the typeDisjoined.
-				obj.setTypeDisjoined((Type)owner);
-			} else {
-				// Handle a typeDisjoined that is a Feature chain.
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setTypeDisjoined((Feature)ownedRelatedElements.get(0));
-				}
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(FeatureInverting obj) {
-		// If the featureInverted is empty, then set it to the owningRelatedElement of the FeatureInverting,
-		// if that is a Feature, otherwise set it to the first ownedRelatedElement (which will be a
-		// Feature chain).
-		Object featureInverted = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__FEATURE_INVERTED, false);
-		if (featureInverted == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				// Handle FeatureInverting owned by the featureInverted.
-				obj.setFeatureInverted((Feature)owner);
-			} else {
-				// Handle featureInverted that is a Feature chain.
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setFeatureInverted((Feature)ownedRelatedElements.get(0));
-				}
-			}
-		}
-		
-		// If the invertingFeature is empty, then set it to the last ownedRelatedElement
-		// (which will be a Feature chain).
-		Object invertingFeature = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__INVERTING_FEATURE, false);
-		if (invertingFeature == null) {
-			// Handle invertingFeature that is a Feature chain.
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setInvertingFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(FeatureTyping obj) {
-		// If the type is empty, then set it to the first owned related element
-		// (which will be a Feature chain).
-		Object type = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPE, false);
-		if (type == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setType((Feature)ownedRelatedElements.get(0));
-			}
-		}
-		
-		// If the typedFeature is empty, then set it to the owningRelatedElement (if that is a Feature).
-		Object typedFeature = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPED_FEATURE, false);
-		if (typedFeature == null) {
-			Element owningRelatedElement = obj.getOwningRelatedElement();
-			if (owningRelatedElement instanceof Feature) {
-				obj.setTypedFeature((Feature) owningRelatedElement);
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Intersecting obj) {
-		// If a Intersecting is parsed targeting a Feature chain, then the intersectingType will be empty,
-		// but the Intersecting will own the intersectingType. So, in this case, the intersectingType should
-		// be set to the (last) ownedRelatedelement.
-		Object intersectingType = obj.eGet(SysMLPackage.Literals.INTERSECTING__INTERSECTING_TYPE, false);
-		if (intersectingType == null) {
-			// Handle a intersectingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setIntersectingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(NamespaceImport obj) {
-		// If importedNamespace is empty, then set it to the first ownedRelatedElement, if this is a namespace
-		// (filling in the implicit import for a filter package). Otherwise, set it to the importOwningNamspace.
-		Object importedNamespace = obj.eGet(SysMLPackage.Literals.NAMESPACE_IMPORT__IMPORTED_NAMESPACE, false);
-		if (importedNamespace == null) {
-			EList<Element> ownedRelatedElement = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElement.isEmpty() && ownedRelatedElement.get(0) instanceof Namespace) {
-				// Fill in the implicit import for a filter package.
-				obj.setImportedNamespace((Namespace)ownedRelatedElement.get(0));
-			} else {
-				obj.setImportedNamespace(obj.getImportOwningNamespace());
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(PortConjugation obj) {
-		// If the originalPortDefinition is empty, then set it to the owner of the conjugatedPortDefinition
-		// (if that is a PortDefinition).
-		Object originalPortDefinition = obj.eGet(SysMLPackage.Literals.PORT_CONJUGATION__ORIGINAL_PORT_DEFINITION, false);
-		if (originalPortDefinition == null) {
-			ConjugatedPortDefinition conjugatedPortDefinition = obj.getConjugatedPortDefinition();
-			if (conjugatedPortDefinition != null) {
-				Element conjugatedPortDefinitionOwner = conjugatedPortDefinition.getOwner();
-				if (conjugatedPortDefinitionOwner instanceof PortDefinition) {
-					obj.setOriginalPortDefinition((PortDefinition)conjugatedPortDefinitionOwner);
-				}
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Redefinition obj) {
-		// If the redefiningFeature is empty, then set it to the owningRelatedElement, if that is a Feature.
-		// Otherwise, set it to the first ownedRelatedElement (which will be a Feature chain).
-		Object redefiningFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINING_FEATURE, false);
-		if (redefiningFeature == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				obj.setRedefiningFeature((Feature) owner);
-			} else {
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setRedefiningFeature((Feature)ownedRelatedElements.get(0));
-				}
-			}
-		}
-		
-		Object redefinedFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINED_FEATURE, false);
-		if (redefinedFeature == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setRedefinedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(ReferenceSubsetting obj) {
-		// If the referencedFeature is empty, then set it to the last ownedRelatedElement
-		// (which will be a Feature chain).
-		Object referencedFeature = obj.eGet(SysMLPackage.Literals.REFERENCE_SUBSETTING__REFERENCED_FEATURE, false);
-		if (referencedFeature == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setReferencedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Specialization obj) {
-		// If general is empty, then set it to the last ownedRelatedElement (which will be a Feature chain).
-		Object general = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__GENERAL, false);
-		if (general == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setGeneral((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-		
-		// If specific is empty, then set it to the owningRelatedElement, if that is a Type.
-		// Otherwise set it to the first ownedRelatedElement (which will be a FeatureChain).
-		Object specific = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__SPECIFIC, false);
-		if (specific == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Type) {
-				obj.setSpecific((Type)owner);
-			} else {
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setSpecific((Feature)ownedRelatedElements.get(0));
-				}
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Subclassification obj) {
-		// If the subclassifier is empty, then set it to the owningRelatedElement,
-		// if this is a Classifier.
-		Object subclassifier = obj.eGet(SysMLPackage.Literals.SUBCLASSIFICATION__SUBCLASSIFIER, false);
-		if (subclassifier == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Classifier) {
-				obj.setSubclassifier((Classifier) owner);
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Subsetting obj) {
-		// If the subsettedFeature is empty, then set it to the last ownedRelatedElement
-		// (which will be a Feature chain).
-		Object subsettedFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTED_FEATURE, false);
-		if (subsettedFeature == null) {
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setSubsettedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
-		
-		// If the subsettingFeature is empty, then set it to the owningRelatedFeature, if this is a Feature.
-		// Otherwise set it to the first ownedRelatedElement (which will be a Feature chain).
-		Object subsettingFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTING_FEATURE, false);
-		if (subsettingFeature == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				obj.setSubsettingFeature((Feature) owner);
-			} else {
-				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					obj.setSubsettingFeature((Feature)ownedRelatedElements.get(0));
-				}
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(TypeFeaturing obj) {
-		// If the featureOfType is empty, then set it to the owningRelatedElement (if this is a Feature).
-		Object featureOfType = obj.eGet(SysMLPackage.Literals.TYPE_FEATURING__FEATURE_OF_TYPE, false);
-		if (featureOfType == null) {
-			Element owner = obj.getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				obj.setFeatureOfType((Feature)owner);
-			}
-		}
-	}
-	
-	protected void postProcessCrossReferences(Unioning obj) {
-		// If a Unioning is parsed targeting a Feature chain, then the unioningType will be empty,
-		// but the Unioning will own the unioningType. So, in this case, the unioningType should
-		// be set to the (last) ownedRelatedelement.
-		Object unioningType = obj.eGet(SysMLPackage.Literals.UNIONING__UNIONING_TYPE, false);
-		if (unioningType == null) {
-			// Handle a intersectingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				obj.setUnioningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
-			}
-		}
 	}
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLLinker.java
@@ -36,8 +36,6 @@ import org.eclipse.xtext.diagnostics.IDiagnosticConsumer;
 import org.eclipse.xtext.linking.lazy.LazyLinker;
 import org.eclipse.xtext.util.OnChangeEvictingCache;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
-import org.omg.sysml.lang.sysml.Comment;
-import org.omg.sysml.lang.sysml.Documentation;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.util.ElementUtil;
@@ -62,27 +60,9 @@ public class KerMLLinker extends LazyLinker {
 		if (
 			// The Relationship#source and #target features are overridden
 			// in each subtype to provide specific derived implementations that
-			// are regenerated each time they are accessed so there is no need to
-			// delete them; and as of May 2020, generic references are not supported
-			// in concrete syntax, making it a safe to not clear them during linking.
+			// are recomputed when accessed so they should not be cleared.
 			Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__SOURCE) || 
-			Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__TARGET) ||
-			
-			// The Relationship#relatedElement feature is a derived union in the
-			// abstract syntax model, but it is implemented as a manual derivation,
-			// which is overridden as necessary in subtypes, so there is no need to
-			// delete it.
-			Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__RELATED_ELEMENT) ||
-			
-			// The Annotation#annotatingElement feature, which is not composite, is
-			// redefined by Documentation#documentingComment, which is composite. 
-			// Clearing annotedElement spuriously clears the documentedElement, which
-			// then does not get a proxy because it is composite (containment).
-			// Annotation#annotatingElement has the opposite feature 
-			// AnnotatingElement#Annotation, which also should not be cleared.
-			obj instanceof Documentation && Objects.equals(ref, SysMLPackage.Literals.ANNOTATION__ANNOTATING_ELEMENT) ||
-			obj instanceof Comment && obj.eContainer() instanceof Documentation && 
-				Objects.equals(ref, SysMLPackage.Literals.ANNOTATING_ELEMENT__ANNOTATION)
+			Objects.equals(ref, SysMLPackage.Literals.RELATIONSHIP__TARGET)			
 		 ) {
 			return;
 		}

--- a/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
+++ b/org.omg.sysml.execution/src/org/omg/sysml/execution/expressions/ExpressionEvaluator.java
@@ -81,6 +81,7 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 		for (FeatureTyping typing: expression.getOwnedTyping()) {
 			FeatureTyping newTyping = SysMLFactory.eINSTANCE.createFeatureTyping();
 			newTyping.setType(typing.getType());
+			newTyping.setTypedFeature(instantiation);
 			instantiation.getOwnedRelationship().add(newTyping);
 		}
 		
@@ -99,6 +100,7 @@ public class ExpressionEvaluator extends ModelLevelExpressionEvaluator {
 				for (Feature redefinedFeature: FeatureUtil.getRedefinedFeaturesWithComputedOf(parameter, null)) {
 					Redefinition newRedefinition = SysMLFactory.eINSTANCE.createRedefinition();
 					newRedefinition.setRedefinedFeature(redefinedFeature);
+					newRedefinition.setRedefiningFeature(newParameter);
 					newParameter.getOwnedRelationship().add(newRedefinition);
 				}				
 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AnnotationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AnnotationAdapter.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.omg.sysml.lang.sysml.AnnotatingElement;
+import org.omg.sysml.lang.sysml.Annotation;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class AnnotationAdapter extends RelationshipAdapter {
+
+	public AnnotationAdapter(Annotation element) {
+		super(element);
+	}
+	
+	@Override
+	public Annotation getTarget() {
+		return (Annotation)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Annotation obj = getTarget();
+		
+		// If the Annotation is not owned by an AnnotatingElement, then the annotatedElement is the owningRelatedElement.
+		Object annotatedElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATED_ELEMENT, false);
+		if (annotatedElement == null) {
+			Element owningRelatedElement = obj.getOwningRelatedElement();
+			if (!(owningRelatedElement instanceof AnnotatingElement)) {
+				obj.setAnnotatedElement(owningRelatedElement);
+			}
+		}
+		
+		// If there is no annotatingElement set, then set the AnnotatingElement to the owningRelatedElement,
+		// if it is an AnnotatingElement, otherwise set it to the first ownedRelatedElement that is an
+		// AnnotatingElement (if any).
+		Object annotatingElement = obj.eGet(SysMLPackage.Literals.ANNOTATION__ANNOTATING_ELEMENT, false);
+		if (annotatingElement == null) {
+			Element owner = obj.getOwningRelatedElement();
+			obj.setAnnotatingElement((AnnotatingElement)
+					(owner instanceof AnnotatingElement? owner: 
+						obj.getOwnedRelatedElement().stream().
+							filter(AnnotatingElement.class::isInstance).
+							findFirst().orElse(null)));
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConjugationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConjugationAdapter.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Conjugation;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
+
+public class ConjugationAdapter extends RelationshipAdapter {
+
+	public ConjugationAdapter(Conjugation element) {
+		super(element);
+	}
+	
+	@Override
+	public Conjugation getTarget() {
+		return (Conjugation)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Conjugation obj = getTarget();
+		
+		// If the conjugatedType is not set, then set it to the owningRelatedElement, if this is a Type,
+		// otherwise set it to the first ownedRelatedElement.
+		Object conjugatedType = obj.eGet(SysMLPackage.Literals.CONJUGATION__CONJUGATED_TYPE, false);
+		if (conjugatedType == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				obj.setConjugatedType((Type)owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setConjugatedType((Type)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		// If the originalType is not set, set it to the last ownedRelatedElement.
+		Object originalType = obj.eGet(SysMLPackage.Literals.CONJUGATION__ORIGINAL_TYPE, false);
+		if (originalType == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setOriginalType((Type)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/DependencyAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/DependencyAdapter.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.EObjectResolvingEList;
+import org.omg.sysml.lang.sysml.Dependency;
+import org.omg.sysml.lang.sysml.Element;
+
+public class DependencyAdapter extends RelationshipAdapter {
+
+	public DependencyAdapter(Dependency element) {
+		super(element);
+	}
+	
+	public Dependency getTarget() {
+		return (Dependency)super.getTarget();
+	}
+	
+	public void postProcess() {
+		Dependency target = getTarget();
+		
+		// Add all ownedRelatedElements to supplier.
+		EObjectResolvingEList<Element> suppliers = (EObjectResolvingEList<Element>)target.getSupplier();
+		EList<Element> ownedRelatedElements = target.getOwnedRelatedElement();
+		ownedRelatedElements.stream().forEachOrdered(suppliers::addUnique);
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/DifferencingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/DifferencingAdapter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Differencing;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class DifferencingAdapter extends RelationshipAdapter {
+
+	public DifferencingAdapter(Differencing element) {
+		super(element);
+	}
+	
+	@Override
+	public Differencing getTarget() {
+		return (Differencing)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Differencing obj = getTarget();
+		
+		// If a Differencing is parsed targeting a Feature chain, then the differencingType will be empty,
+		// but the Differencing will own the differencingType. So, in this case, the differencingType should
+		// be set to the (last) ownedRelatedelement.
+		Object differencingType = obj.eGet(SysMLPackage.Literals.DIFFERENCING__DIFFERENCING_TYPE, false);
+		if (differencingType == null) {
+			// Handle a differencingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setDifferencingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/DisjoiningAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/DisjoiningAdapter.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Disjoining;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
+
+public class DisjoiningAdapter extends RelationshipAdapter {
+
+	public DisjoiningAdapter(Disjoining element) {
+		super(element);
+	}
+	
+	@Override
+	public Disjoining getTarget() {
+		return (Disjoining)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Disjoining obj = getTarget();
+		
+		// If a Disjoining is parsed targeting a Feature chain, then the disjoiningType will be empty,
+		// but the Disjoining will own the disjoiningType. So, in this case, the disjoiningType should
+		// be set to the (last) ownedRelatedelement.
+		Object disjoiningType = obj.eGet(SysMLPackage.Literals.DISJOINING__DISJOINING_TYPE, false);
+		if (disjoiningType == null) {
+			// Handle a disjoiningType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setDisjoiningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If the typedDisjoined (source) is empty, set it to the owningRelatedElement, if it is a Type.
+		// Otherwise, set it to the first ownedRelatedElement, to the first ownedRelatedElement,
+		// which will be a Feature chain.
+		Object typeDisjoined = obj.eGet(SysMLPackage.Literals.DISJOINING__TYPE_DISJOINED, false);
+		if (typeDisjoined == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				// Handle a Disjoining owned by the typeDisjoined.
+				obj.setTypeDisjoined((Type)owner);
+			} else {
+				// Handle a typeDisjoined that is a Feature chain.
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setTypeDisjoined((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
@@ -71,6 +71,12 @@ public class ElementAdapter extends AdapterImpl {
 		}
 		return metaclassFeature;
 	}
+	
+	// Parse post-processing
+	
+	public void postProcess() {
+		
+	}
 		
 	// Transformation
 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapter.java
@@ -61,6 +61,7 @@ public class ElementAdapter extends AdapterImpl {
 				metaclassFeature = SysMLFactory.eINSTANCE.createMetadataFeature();
 				FeatureTyping typing = SysMLFactory.eINSTANCE.createFeatureTyping();
 				typing.setType(metaclass);
+				typing.setTypedFeature(metaclassFeature);
 				Annotation annotation = SysMLFactory.eINSTANCE.createAnnotation();
 				annotation.setAnnotatingElement(metaclassFeature);
 				annotation.setAnnotatedElement(element);

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
@@ -193,6 +193,11 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseDependency(Dependency element) {
+			return new DependencyAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseDifferencing(Differencing element) {
 			return new DifferencingAdapter(element);
 		}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ElementAdapterFactory.java
@@ -68,6 +68,11 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseAnnotation(Annotation element) {
+			return new AnnotationAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseActionDefinition(ActionDefinition element) {
 			return new ActionDefinitionAdapter(element);
 		}
@@ -148,6 +153,11 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseConjugation(Conjugation element) {
+			return new ConjugationAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseConnectionDefinition(ConnectionDefinition element) {
 			return new ConnectionDefinitionAdapter(element);
 		}
@@ -183,6 +193,16 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseDifferencing(Differencing element) {
+			return new DifferencingAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseDisjoining(Disjoining element) {
+			return new DisjoiningAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseElement(Element element) {
 			return new ElementAdapter(element);
 		}
@@ -213,8 +233,18 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter caseFeatureInverting(FeatureInverting element) {
+			return new FeatureInvertingAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter caseFeatureReferenceExpression(FeatureReferenceExpression element) {
 			return new FeatureReferenceExpressionAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseFeatureTyping(FeatureTyping element) {
+			return new FeatureTypingAdapter(element);
 		}
 		
 		@Override
@@ -240,6 +270,11 @@ public class ElementAdapterFactory {
 		@Override
 		public ElementAdapter caseIncludeUseCaseUsage(IncludeUseCaseUsage element) {
 			return new IncludeUseCaseUsageAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseIntersecting(Intersecting element) {
+			return new IntersectingAdapter(element);
 		}
 		
 		@Override
@@ -353,6 +388,11 @@ public class ElementAdapterFactory {
 		}
 		
 		@Override
+		public ElementAdapter casePortConjugation(PortConjugation element) {
+			return new PortConjugationAdapter(element);
+		}
+		
+		@Override
 		public ElementAdapter casePortDefinition(PortDefinition element) {
 			return new PortDefinitionAdapter(element);
 		}
@@ -360,6 +400,16 @@ public class ElementAdapterFactory {
 		@Override
 		public ElementAdapter casePortUsage(PortUsage element) {
 			return new PortUsageAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseRedefinition(Redefinition element) {
+			return new RedefinitionAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseReferenceSubsetting(ReferenceSubsetting element) {
+			return new ReferenceSubsettingAdapter(element);
 		}
 		
 		@Override
@@ -395,6 +445,21 @@ public class ElementAdapterFactory {
 		@Override
 		public ElementAdapter caseSendActionUsage(SendActionUsage element) {
 			return new SendActionUsageAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseSpecialization(Specialization element) {
+			return new SpecializationAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseSubclassification(Subclassification element) {
+			return new SubclassificationAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseSubsetting(Subsetting element) {
+			return new SubsettingAdapter(element);
 		}
 		
 		@Override
@@ -435,6 +500,16 @@ public class ElementAdapterFactory {
 		@Override
 		public ElementAdapter caseType(Type element) {
 			return new TypeAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseTypeFeaturing(TypeFeaturing element) {
+			return new TypeFeaturingAdapter(element);
+		}
+		
+		@Override
+		public ElementAdapter caseUnioning(Unioning element) {
+			return new UnioningAdapter(element);
 		}
 		
 		@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureInvertingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureInvertingAdapter.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.FeatureInverting;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class FeatureInvertingAdapter extends RelationshipAdapter {
+
+	public FeatureInvertingAdapter(FeatureInverting element) {
+		super(element);
+	}
+	
+	@Override
+	public FeatureInverting getTarget() {
+		return (FeatureInverting)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		FeatureInverting obj = getTarget();
+		
+		// If the featureInverted is empty, then set it to the owningRelatedElement of the FeatureInverting,
+		// if that is a Feature, otherwise set it to the first ownedRelatedElement (which will be a
+		// Feature chain).
+		Object featureInverted = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__FEATURE_INVERTED, false);
+		if (featureInverted == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				// Handle FeatureInverting owned by the featureInverted.
+				obj.setFeatureInverted((Feature)owner);
+			} else {
+				// Handle featureInverted that is a Feature chain.
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setFeatureInverted((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		// If the invertingFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object invertingFeature = obj.eGet(SysMLPackage.Literals.FEATURE_INVERTING__INVERTING_FEATURE, false);
+		if (invertingFeature == null) {
+			// Handle invertingFeature that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setInvertingFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureTypingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureTypingAdapter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.FeatureTyping;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class FeatureTypingAdapter extends SpecializationAdapter {
+
+	public FeatureTypingAdapter(FeatureTyping element) {
+		super(element);
+	}
+	
+	@Override
+	public FeatureTyping getTarget() {
+		return (FeatureTyping)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		FeatureTyping obj = getTarget();
+		
+		// If the type is empty, then set it to the first owned related element
+		// (which will be a Feature chain).
+		Object type = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPE, false);
+		if (type == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setType((Feature)ownedRelatedElements.get(0));
+			}
+		}
+		
+		// If the typedFeature is empty, then set it to the owningRelatedElement (if that is a Feature).
+		Object typedFeature = obj.eGet(SysMLPackage.Literals.FEATURE_TYPING__TYPED_FEATURE, false);
+		if (typedFeature == null) {
+			Element owningRelatedElement = obj.getOwningRelatedElement();
+			if (owningRelatedElement instanceof Feature) {
+				obj.setTypedFeature((Feature) owningRelatedElement);
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IntersectingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IntersectingAdapter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Intersecting;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class IntersectingAdapter extends RelationshipAdapter {
+
+	public IntersectingAdapter(Intersecting element) {
+		super(element);
+	}
+	
+	@Override
+	public Intersecting getTarget() {
+		return (Intersecting)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Intersecting obj = getTarget();
+		
+		// If a Intersecting is parsed targeting a Feature chain, then the intersectingType will be empty,
+		// but the Intersecting will own the intersectingType. So, in this case, the intersectingType should
+		// be set to the (last) ownedRelatedelement.
+		Object intersectingType = obj.eGet(SysMLPackage.Literals.INTERSECTING__INTERSECTING_TYPE, false);
+		if (intersectingType == null) {
+			// Handle a intersectingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setIntersectingType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/NamespaceImportAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/NamespaceImportAdapter.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,8 +25,10 @@ package org.omg.sysml.adapter;
 import java.util.Collection;
 
 import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.NamespaceImport;
+import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Type;
 
@@ -37,6 +40,24 @@ public class NamespaceImportAdapter extends ImportAdapter {
 	
 	public NamespaceImport getTarget() {
 		return (NamespaceImport)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		NamespaceImport obj = getTarget();
+		
+		// If importedNamespace is empty, then set it to the first ownedRelatedElement, if this is a namespace
+		// (filling in the implicit import for a filter package). Otherwise, set it to the importOwningNamspace.
+		Object importedNamespace = obj.eGet(SysMLPackage.Literals.NAMESPACE_IMPORT__IMPORTED_NAMESPACE, false);
+		if (importedNamespace == null) {
+			EList<Element> ownedRelatedElement = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElement.isEmpty() && ownedRelatedElement.get(0) instanceof Namespace) {
+				// Fill in the implicit import for a filter package.
+				obj.setImportedNamespace((Namespace)ownedRelatedElement.get(0));
+			} else {
+				obj.setImportedNamespace(obj.getImportOwningNamespace());
+			}
+		}
 	}
 	
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PortConjugationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PortConjugationAdapter.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.omg.sysml.lang.sysml.PortConjugation;
+import org.omg.sysml.lang.sysml.PortDefinition;
+import org.omg.sysml.lang.sysml.ConjugatedPortDefinition;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class PortConjugationAdapter extends ConjugationAdapter {
+
+	public PortConjugationAdapter(PortConjugation element) {
+		super(element);
+	}
+	
+	@Override
+	public PortConjugation getTarget() {
+		return (PortConjugation)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		PortConjugation obj = getTarget();
+		
+		// If the originalPortDefinition is empty, then set it to the owner of the conjugatedPortDefinition
+		// (if that is a PortDefinition).
+		Object originalPortDefinition = obj.eGet(SysMLPackage.Literals.PORT_CONJUGATION__ORIGINAL_PORT_DEFINITION, false);
+		if (originalPortDefinition == null) {
+			ConjugatedPortDefinition conjugatedPortDefinition = obj.getConjugatedPortDefinition();
+			if (conjugatedPortDefinition != null) {
+				Element conjugatedPortDefinitionOwner = conjugatedPortDefinition.getOwner();
+				if (conjugatedPortDefinitionOwner instanceof PortDefinition) {
+					obj.setOriginalPortDefinition((PortDefinition)conjugatedPortDefinitionOwner);
+				}
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RedefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RedefinitionAdapter.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class RedefinitionAdapter extends SubsettingAdapter {
+
+	public RedefinitionAdapter(Redefinition element) {
+		super(element);
+	}
+	
+	@Override
+	public Redefinition getTarget() {
+		return (Redefinition)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Redefinition obj = getTarget();
+		
+		// If the redefiningFeature is empty, then set it to the owningRelatedElement, if that is a Feature.
+		// Otherwise, set it to the first ownedRelatedElement (which will be a Feature chain).
+		Object redefiningFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINING_FEATURE, false);
+		if (redefiningFeature == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setRedefiningFeature((Feature) owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setRedefiningFeature((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+		
+		Object redefinedFeature = obj.eGet(SysMLPackage.Literals.REDEFINITION__REDEFINED_FEATURE, false);
+		if (redefinedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setRedefinedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceSubsettingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceSubsettingAdapter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.ReferenceSubsetting;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class ReferenceSubsettingAdapter extends SubsettingAdapter {
+
+	public ReferenceSubsettingAdapter(ReferenceSubsetting element) {
+		super(element);
+	}
+	
+	@Override
+	public ReferenceSubsetting getTarget() {
+		return (ReferenceSubsetting)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		ReferenceSubsetting obj = getTarget();
+		
+		// If the referencedFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object referencedFeature = obj.eGet(SysMLPackage.Literals.REFERENCE_SUBSETTING__REFERENCED_FEATURE, false);
+		if (referencedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setReferencedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SpecializationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SpecializationAdapter.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Specialization;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.Type;
+
+public class SpecializationAdapter extends RelationshipAdapter {
+
+	public SpecializationAdapter(Specialization element) {
+		super(element);
+	}
+	
+	@Override
+	public Specialization getTarget() {
+		return (Specialization)super.getTarget();
+	}
+	
+	public void postProcess() {
+		Specialization obj = getTarget();
+		
+		// If general is empty, then set it to the last ownedRelatedElement (which will be a Feature chain).
+		Object general = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__GENERAL, false);
+		if (general == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setGeneral((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If specific is empty, then set it to the owningRelatedElement, if that is a Type.
+		// Otherwise set it to the first ownedRelatedElement (which will be a FeatureChain).
+		Object specific = obj.eGet(SysMLPackage.Literals.SPECIALIZATION__SPECIFIC, false);
+		if (specific == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Type) {
+				obj.setSpecific((Type)owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setSpecific((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SubclassificationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SubclassificationAdapter.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,17 +22,35 @@
 
 package org.omg.sysml.adapter;
 
-import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Classifier;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Subclassification;
+import org.omg.sysml.lang.sysml.SysMLPackage;
 
-public class MembershipAdapter extends RelationshipAdapter {
+public class SubclassificationAdapter extends SpecializationAdapter {
 
-	public MembershipAdapter(Membership element) {
+	public SubclassificationAdapter(Subclassification element) {
 		super(element);
 	}
 	
 	@Override
-	public Membership getTarget() {
-		return (Membership)super.getTarget();
+	public Subclassification getTarget() {
+		return (Subclassification)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Subclassification obj = getTarget();
+		
+		// If the subclassifier is empty, then set it to the owningRelatedElement,
+		// if this is a Classifier.
+		Object subclassifier = obj.eGet(SysMLPackage.Literals.SUBCLASSIFICATION__SUBCLASSIFIER, false);
+		if (subclassifier == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Classifier) {
+				obj.setSubclassifier((Classifier) owner);
+			}
+		}
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SubsettingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SubsettingAdapter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Subsetting;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class SubsettingAdapter extends SpecializationAdapter {
+
+	public SubsettingAdapter(Subsetting element) {
+		super(element);
+	}
+	
+	@Override
+	public Subsetting getTarget() {
+		return (Subsetting)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Subsetting obj = getTarget();
+		
+		// If the subsettedFeature is empty, then set it to the last ownedRelatedElement
+		// (which will be a Feature chain).
+		Object subsettedFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTED_FEATURE, false);
+		if (subsettedFeature == null) {
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setSubsettedFeature((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+		
+		// If the subsettingFeature is empty, then set it to the owningRelatedFeature, if this is a Feature.
+		// Otherwise set it to the first ownedRelatedElement (which will be a Feature chain).
+		Object subsettingFeature = obj.eGet(SysMLPackage.Literals.SUBSETTING__SUBSETTING_FEATURE, false);
+		if (subsettingFeature == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setSubsettingFeature((Feature) owner);
+			} else {
+				EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+				if (!ownedRelatedElements.isEmpty()) {
+					obj.setSubsettingFeature((Feature)ownedRelatedElements.get(0));
+				}
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeFeaturingAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeFeaturingAdapter.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,17 +22,34 @@
 
 package org.omg.sysml.adapter;
 
-import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.TypeFeaturing;
+import org.omg.sysml.lang.sysml.SysMLPackage;
 
-public class MembershipAdapter extends RelationshipAdapter {
+public class TypeFeaturingAdapter extends RelationshipAdapter {
 
-	public MembershipAdapter(Membership element) {
+	public TypeFeaturingAdapter(TypeFeaturing element) {
 		super(element);
 	}
 	
 	@Override
-	public Membership getTarget() {
-		return (Membership)super.getTarget();
+	public TypeFeaturing getTarget() {
+		return (TypeFeaturing)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		TypeFeaturing obj = getTarget();
+		
+		// If the featureOfType is empty, then set it to the owningRelatedElement (if this is a Feature).
+		Object featureOfType = obj.eGet(SysMLPackage.Literals.TYPE_FEATURING__FEATURE_OF_TYPE, false);
+		if (featureOfType == null) {
+			Element owner = obj.getOwningRelatedElement();
+			if (owner instanceof Feature) {
+				obj.setFeatureOfType((Feature)owner);
+			}
+		}
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UnioningAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UnioningAdapter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024 Budapest University of Technology and Economics
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of theGNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.adapter;
+
+import org.eclipse.emf.common.util.EList;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.Unioning;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class UnioningAdapter extends RelationshipAdapter {
+
+	public UnioningAdapter(Unioning element) {
+		super(element);
+	}
+	
+	@Override
+	public Unioning getTarget() {
+		return (Unioning)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		Unioning obj = getTarget();
+		
+		// If a Unioning is parsed targeting a Feature chain, then the unioningType will be empty,
+		// but the Unioning will own the unioningType. So, in this case, the unioningType should
+		// be set to the (last) ownedRelatedelement.
+		Object unioningType = obj.eGet(SysMLPackage.Literals.UNIONING__UNIONING_TYPE, false);
+		if (unioningType == null) {
+			// Handle a intersectingType that is a Feature chain.
+			EList<Element> ownedRelatedElements = obj.getOwnedRelatedElement();
+			if (!ownedRelatedElements.isEmpty()) {
+				obj.setUnioningType((Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1));
+			}
+		}
+	}
+	
+}

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -300,6 +300,12 @@ public class ElementUtil {
 	public static MetadataFeature getMetaclassFeatureFor(Element element) {
 		return element == null? null: getElementAdapter(element).getMetaclassFeature();
 	}
+	
+	// Parse post-processing
+	
+	public static void postProcess(Element element) {
+		getElementAdapter(element).postProcess();
+	}
 
 	// Transformation 
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -96,7 +96,22 @@ public class FeatureUtil {
 		}
 	}	
 	
-	// Typing
+	public static boolean checkIsOrdered(Feature feature, Set<Feature> visited) {
+		if (feature.isOrdered()) {
+			return feature.isOrdered();
+		} else {
+			visited.add(feature);
+			for (Feature subsettedFeature: FeatureUtil.getSubsettedFeaturesOf(feature)) {
+				if (subsettedFeature != null && !visited.contains(subsettedFeature) && 
+						checkIsOrdered(subsettedFeature, visited)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+// Typing
 	
 	public static EList<Type> cacheTypesOf(Feature feature, Supplier<EList<Type>> supplier) {	
 		FeatureAdapter adapter = getFeatureAdapter(feature);

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/AnnotationImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/AnnotationImpl.java
@@ -117,23 +117,13 @@ public class AnnotationImpl extends RelationshipImpl implements Annotation {
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.ANNOTATION;
 	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	public Element getAnnotatedElement() {
-		return annotatedElement == null? basicGetAnnotatedElement(): getAnnotatedElementGen();
-	}
 	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Element getAnnotatedElementGen() {
+	public Element getAnnotatedElement() {
 		if (annotatedElement != null && annotatedElement.eIsProxy()) {
 			InternalEObject oldAnnotatedElement = (InternalEObject)annotatedElement;
 			annotatedElement = (Element)eResolveProxy(oldAnnotatedElement);
@@ -147,18 +137,10 @@ public class AnnotationImpl extends RelationshipImpl implements Annotation {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the Annotation is not owned by an AnnotatingElement, then the annotatedElement is the owningRelatedElement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Element basicGetAnnotatedElement() {
-		if (annotatedElement == null) {
-			Element owningRelatedElement = getOwningRelatedElement();
-			if (!(owningRelatedElement instanceof AnnotatingElement)) {
-				annotatedElement = owningRelatedElement;
-			}
-		}
 		return annotatedElement;
 	}
 
@@ -237,21 +219,10 @@ public class AnnotationImpl extends RelationshipImpl implements Annotation {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public AnnotatingElement getAnnotatingElement() {
-		return annotatingElement == null? basicGetAnnotatingElement(): getAnnotatingElementGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public AnnotatingElement getAnnotatingElementGen() {
+	public AnnotatingElement getAnnotatingElement() {
 		if (annotatingElement != null && annotatingElement.eIsProxy()) {
 			InternalEObject oldAnnotatingElement = (InternalEObject)annotatingElement;
 			annotatingElement = (AnnotatingElement)eResolveProxy(oldAnnotatingElement);
@@ -265,22 +236,10 @@ public class AnnotationImpl extends RelationshipImpl implements Annotation {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If there is no annotatingElement set, then set the AnnotatingElement to the owningRelatedElement,
-	 * if it is an AnnotatingElement, otherwise set it to the first ownedRelatedElement that is an
-	 * AnnotatingElement (if any).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public AnnotatingElement basicGetAnnotatingElement() {
-		if (annotatingElement == null) {
-			Element owner = getOwningRelatedElement();
-			annotatingElement = (AnnotatingElement)
-					(owner instanceof AnnotatingElement? owner: 
-						getOwnedRelatedElement().stream().
-							filter(AnnotatingElement.class::isInstance).
-							findFirst().orElse(null));
-		}
 		return annotatingElement;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/CaseUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/CaseUsageImpl.java
@@ -132,11 +132,11 @@ public class CaseUsageImpl extends CalculationUsageImpl implements CaseUsage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	@Override
 	public void setObjectiveRequirement(RequirementUsage newObjectiveRequirement) {
-		throw new UnsupportedOperationException();
+		OBJECTIVE_REQUIREMENT__ESETTING_DELEGATE.dynamicSet(this, null, 0, newObjectiveRequirement);
 	}
 
 	/**

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ConjugationImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ConjugationImpl.java
@@ -106,24 +106,13 @@ public class ConjugationImpl extends RelationshipImpl implements Conjugation {
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.CONJUGATION;
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getConjugatedType() {
-		return conjugatedType == null? basicGetConjugatedType(): getConjugatedTypeGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getConjugatedTypeGen() {
+	public Type getConjugatedType() {
 		if (conjugatedType != null && conjugatedType.eIsProxy()) {
 			InternalEObject oldConjugatedType = (InternalEObject)conjugatedType;
 			conjugatedType = (Type)eResolveProxy(oldConjugatedType);
@@ -137,24 +126,10 @@ public class ConjugationImpl extends RelationshipImpl implements Conjugation {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the conjugatedType is not set, then set it to the owningRelatedElement, if this is a Type,
-	 * otherwise set it to the first ownedRelatedElement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetConjugatedType() {
-		if (conjugatedType == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Type) {
-				conjugatedType = (Type)owner;
-			} else {
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					conjugatedType = (Type)ownedRelatedElements.get(0);
-				}
-			}
-		}
 		return conjugatedType;
 	}
 
@@ -222,24 +197,13 @@ public class ConjugationImpl extends RelationshipImpl implements Conjugation {
 		else if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SysMLPackage.CONJUGATION__OWNING_RELATED_ELEMENT, newOwningRelatedElement, newOwningRelatedElement));
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getOriginalType() {
-		return originalType == null? basicGetOriginalType(): getOriginalTypeGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getOriginalTypeGen() {
+	public Type getOriginalType() {
 		if (originalType != null && originalType.eIsProxy()) {
 			InternalEObject oldOriginalType = (InternalEObject)originalType;
 			originalType = (Type)eResolveProxy(oldOriginalType);
@@ -253,18 +217,10 @@ public class ConjugationImpl extends RelationshipImpl implements Conjugation {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the originalType is not set, set it to the last ownedRelatedElement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetOriginalType() {
-		if (originalType == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				originalType = (Type)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return originalType;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DependencyImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DependencyImpl.java
@@ -153,12 +153,11 @@ public class DependencyImpl extends RelationshipImpl implements Dependency {
 	/**
 	 * <!-- begin-user-doc -->
 	 * Xtext workaround:
-	 * getTarget() is inherited from Relationship.
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
-	public EList<Element> getTargetGen() {
+	public EList<Element> getTarget() {
 		return getSupplier();
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DifferencingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DifferencingImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.uml2.common.util.UnionEObjectEList;
 
 import org.omg.sysml.lang.sysml.Differencing;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 
@@ -124,21 +123,10 @@ public class DifferencingImpl extends RelationshipImpl implements Differencing {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getDifferencingType() {
-		return differencingType == null? basicGetDifferencingType(): getDifferencingTypeGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getDifferencingTypeGen() {
+	public Type getDifferencingType() {
 		if (differencingType != null && differencingType.eIsProxy()) {
 			InternalEObject oldDifferencingType = (InternalEObject)differencingType;
 			differencingType = (Type)eResolveProxy(oldDifferencingType);
@@ -152,21 +140,10 @@ public class DifferencingImpl extends RelationshipImpl implements Differencing {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If a Differencing is parsed targeting a Feature chain, then the differencingType will be empty,
-	 * but the Differencing will own the differencingType. So, in this case, the differencingType should
-	 * be set to the (last) ownedRelatedelement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetDifferencingType() {
-		if (differencingType == null) {
-			// Handle a differencingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				differencingType = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return differencingType;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DisjoiningImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DisjoiningImpl.java
@@ -23,22 +23,16 @@ package org.omg.sysml.lang.sysml.impl;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
-
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.UniqueEList;
-
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
-
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
-
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.uml2.common.util.UnionEObjectEList;
-
 import org.omg.sysml.lang.sysml.Disjoining;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 
@@ -110,21 +104,10 @@ public class DisjoiningImpl extends RelationshipImpl implements Disjoining {
 	
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getDisjoiningType() {
-		return disjoiningType == null? basicGetDisjoiningType(): getDisjoiningTypeGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getDisjoiningTypeGen() {
+	public Type getDisjoiningType() {
 		if (disjoiningType != null && disjoiningType.eIsProxy()) {
 			InternalEObject oldDisjoiningType = (InternalEObject)disjoiningType;
 			disjoiningType = (Type)eResolveProxy(oldDisjoiningType);
@@ -138,22 +121,10 @@ public class DisjoiningImpl extends RelationshipImpl implements Disjoining {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If a Disjoining is parsed targeting a Feature chain, then the disjoiningType will be empty,
-	 * but the Disjoining will own the disjoiningType. So, in this case, the disjoiningType should
-	 * be set to the (last) ownedRelatedelement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetDisjoiningType() {
-		if (disjoiningType == null) {
-			// Handle a disjoiningType that is a Feature chain.
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				disjoiningType = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
-		
 		return disjoiningType;
 	}
 
@@ -255,19 +226,9 @@ public class DisjoiningImpl extends RelationshipImpl implements Disjoining {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getTypeDisjoined() {
-		return typeDisjoined == null? basicGetTypeDisjoined(): getTypeDisjoinedGen();
-	}	
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getTypeDisjoinedGen() {
+	public Type getTypeDisjoined() {
 		if (typeDisjoined != null && typeDisjoined.eIsProxy()) {
 			InternalEObject oldTypeDisjoined = (InternalEObject)typeDisjoined;
 			typeDisjoined = (Type)eResolveProxy(oldTypeDisjoined);
@@ -281,28 +242,10 @@ public class DisjoiningImpl extends RelationshipImpl implements Disjoining {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the typedDisjoined (source) is empty, set it to the owningRelatedElement, if it is a Type.
-	 * Otherwise, set it to the first ownedRelatedElement, to the first ownedRelatedElement,
-	 * which will be a Feature chain.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetTypeDisjoined() {
-		if (typeDisjoined == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Type) {
-				// Handle a Disjoining owned by the typeDisjoined.
-				typeDisjoined = (Type)owner;
-			} else {
-				// Handle a typeDisjoined that is a Feature chain.
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					typeDisjoined = (Feature)ownedRelatedElements.get(0);
-				}
-			}
-		}
-		
 		return typeDisjoined;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureImpl.java
@@ -24,9 +24,6 @@ package org.omg.sysml.lang.sysml.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.BasicEList;
@@ -42,7 +39,6 @@ import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.TypeFeaturing;
-import org.omg.sysml.util.FeatureUtil;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureChaining;
 import org.omg.sysml.lang.sysml.FeatureDirectionKind;
@@ -456,24 +452,9 @@ public class FeatureImpl extends TypeImpl implements Feature {
 	 */
 	@Override
 	public boolean isOrdered() {
-		return checkIsOrdered(this, new HashSet<Feature>());
+		return isOrdered;
 	}
 	
-	public static boolean checkIsOrdered(FeatureImpl feature, Set<Feature> visited) {
-		if (feature.isOrdered) {
-			return feature.isOrdered;
-		} else {
-			visited.add(feature);
-			for (Feature subsettedFeature: FeatureUtil.getSubsettedFeaturesOf(feature)) {
-				if (subsettedFeature != null && !visited.contains(subsettedFeature) && 
-						checkIsOrdered(((FeatureImpl)subsettedFeature), visited)) {
-					return true;
-				}
-			}
-			return false;
-		}
-	}
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureInvertingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureInvertingImpl.java
@@ -110,21 +110,10 @@ public class FeatureInvertingImpl extends RelationshipImpl implements FeatureInv
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getFeatureInverted() {
-		return featureInverted == null? basicGetFeatureInverted(): getFeatureInvertedGen();
-	}	
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getFeatureInvertedGen() {
+	public Feature getFeatureInverted() {
 		if (featureInverted != null && featureInverted.eIsProxy()) {
 			InternalEObject oldFeatureInverted = (InternalEObject)featureInverted;
 			featureInverted = (Feature)eResolveProxy(oldFeatureInverted);
@@ -138,28 +127,10 @@ public class FeatureInvertingImpl extends RelationshipImpl implements FeatureInv
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the featureInverted is empty, then set it to the owningRelatedElement of the FeatureInverting,
-	 * if that is a Feature, otherwise set it to the first ownedRelatedElement (which will be a
-	 * Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetFeatureInverted() {
-		if (featureInverted == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				// Handle FeatureInverting owned by the featureInverted.
-				featureInverted = (Feature)owner;
-			} else {
-				// Handle featureInverted that is a Feature chain.
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					featureInverted = (Feature)ownedRelatedElements.get(0);
-				}
-			}
-		}
-		
 		return featureInverted;
 	}
 
@@ -230,21 +201,10 @@ public class FeatureInvertingImpl extends RelationshipImpl implements FeatureInv
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getInvertingFeature() {
-		return invertingFeature == null? basicGetInvertingFeature(): getInvertingFeatureGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getInvertingFeatureGen() {
+	public Feature getInvertingFeature() {
 		if (invertingFeature != null && invertingFeature.eIsProxy()) {
 			InternalEObject oldInvertingFeature = (InternalEObject)invertingFeature;
 			invertingFeature = (Feature)eResolveProxy(oldInvertingFeature);
@@ -258,21 +218,10 @@ public class FeatureInvertingImpl extends RelationshipImpl implements FeatureInv
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the invertingFeature is empty, then set it to the last ownedRelatedElement
-	 * (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetInvertingFeature() {
-		if (invertingFeature == null) {
-			// Handle invertingFeature that is a Feature chain.
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				invertingFeature = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
-		
 		return invertingFeature;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureTypingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FeatureTypingImpl.java
@@ -23,14 +23,12 @@
 package org.omg.sysml.lang.sysml.impl;
 
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -97,22 +95,11 @@ public class FeatureTypingImpl extends SpecializationImpl implements FeatureTypi
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getType() {
-		return type == null? basicGetType(): getTypeGen();
-	}
-
-	/**
 	 * <!-- begin-user-doc --> 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getTypeGen() {
+	public Type getType() {
 		if (type != null && type.eIsProxy()) {
 			InternalEObject oldType = (InternalEObject)type;
 			type = (Type)eResolveProxy(oldType);
@@ -126,19 +113,10 @@ public class FeatureTypingImpl extends SpecializationImpl implements FeatureTypi
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the type is empty, then set it to the first owned related element
-	 * (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetType() {
-		if (type == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				type = (Feature)ownedRelatedElements.get(0);
-			}
-		}
 		return type;
 	}
 
@@ -202,21 +180,10 @@ public class FeatureTypingImpl extends SpecializationImpl implements FeatureTypi
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getTypedFeature() {
-		return typedFeature == null ? basicGetTypedFeature() : getTypedFeatureGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc --> 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getTypedFeatureGen() {
+	public Feature getTypedFeature() {
 		if (typedFeature != null && typedFeature.eIsProxy()) {
 			InternalEObject oldTypedFeature = (InternalEObject)typedFeature;
 			typedFeature = (Feature)eResolveProxy(oldTypedFeature);
@@ -230,19 +197,10 @@ public class FeatureTypingImpl extends SpecializationImpl implements FeatureTypi
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the typedFeature is empty, then set it to the owningRelatedElement (if that is a Feature).
 	 * <!-- end-user-doc -->
-	 * 
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetTypedFeature() {
-		if (typedFeature == null) {
-			Element owningRelatedElement = getOwningRelatedElement();
-			if (owningRelatedElement instanceof Feature) {
-				typedFeature = (Feature) owningRelatedElement;
-			}
-		}
 		return typedFeature;
 	}
 
@@ -260,10 +218,10 @@ public class FeatureTypingImpl extends SpecializationImpl implements FeatureTypi
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public boolean isSetTypedFeature() {
-		return basicGetTypedFeature() != null;
+		return typedFeature != null;
 	}
 
 	/**

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FlowConnectionUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/FlowConnectionUsageImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2024 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -23,12 +23,12 @@ package org.omg.sysml.lang.sysml.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Association;
 import org.omg.sysml.lang.sysml.AssociationStructure;
@@ -36,18 +36,13 @@ import org.omg.sysml.lang.sysml.Behavior;
 import org.omg.sysml.lang.sysml.Classifier;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FlowConnectionUsage;
 import org.omg.sysml.lang.sysml.Interaction;
 import org.omg.sysml.lang.sysml.ItemFeature;
 import org.omg.sysml.lang.sysml.ItemFlow;
 import org.omg.sysml.lang.sysml.ItemFlowEnd;
-import org.omg.sysml.lang.sysml.StateSubactionKind;
-import org.omg.sysml.lang.sysml.StateSubactionMembership;
 import org.omg.sysml.lang.sysml.Step;
 import org.omg.sysml.lang.sysml.SysMLPackage;
-import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.util.UsageUtil;
 
 /**
  * <!-- begin-user-doc -->
@@ -478,11 +473,15 @@ public class FlowConnectionUsageImpl extends ConnectionUsageImpl implements Flow
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature inputParameter(int i) {
-		EList<Feature> parameters = inputParameters();
-		return parameters.size() > i? null: parameters.get(i-1);
+		try {
+			return (Feature)INPUT_PARAMETER_INT__EINVOCATION_DELEGATE.dynamicInvoke(this, new BasicEList.UnmodifiableEList<Object>(1, new Object[]{i}));
+		}
+		catch (InvocationTargetException ite) {
+			throw new WrappedException(ite);
+		}
 	}
 
 	/**
@@ -498,10 +497,15 @@ public class FlowConnectionUsageImpl extends ConnectionUsageImpl implements Flow
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Expression argument(int i) {
-		return UsageUtil.getArgumentOf(this, i);
+		try {
+			return (Expression)ARGUMENT_INT__EINVOCATION_DELEGATE.dynamicInvoke(this, new BasicEList.UnmodifiableEList<Object>(1, new Object[]{i}));
+		}
+		catch (InvocationTargetException ite) {
+			throw new WrappedException(ite);
+		}
 	}
 
 	/**
@@ -517,15 +521,15 @@ public class FlowConnectionUsageImpl extends ConnectionUsageImpl implements Flow
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public boolean isSubactionUsage() {
-		Type owningType = getOwningType();
-		FeatureMembership owningMembership = getOwningFeatureMembership();
-		return isComposite() && 
-			   (owningType instanceof ActionDefinition || owningType instanceof ActionUsage) &&
-			    (!(owningMembership instanceof StateSubactionMembership) ||
-			     ((StateSubactionMembership)owningMembership).getKind() == StateSubactionKind.DO);
+		try {
+			return (Boolean)IS_SUBACTION_USAGE__EINVOCATION_DELEGATE.dynamicInvoke(this, null);
+		}
+		catch (InvocationTargetException ite) {
+			throw new WrappedException(ite);
+		}
 	}
 
 	// Additional overrides

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/IntersectingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/IntersectingImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.uml2.common.util.UnionEObjectEList;
 
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Intersecting;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
@@ -124,21 +123,10 @@ public class IntersectingImpl extends RelationshipImpl implements Intersecting {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getIntersectingType() {
-		return intersectingType == null? basicGetIntersectingType(): getIntersectingTypeGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getIntersectingTypeGen() {
+	public Type getIntersectingType() {
 		if (intersectingType != null && intersectingType.eIsProxy()) {
 			InternalEObject oldIntersectingType = (InternalEObject)intersectingType;
 			intersectingType = (Type)eResolveProxy(oldIntersectingType);
@@ -152,21 +140,10 @@ public class IntersectingImpl extends RelationshipImpl implements Intersecting {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If a Intersecting is parsed targeting a Feature chain, then the intersectingType will be empty,
-	 * but the Intersecting will own the intersectingType. So, in this case, the intersectingType should
-	 * be set to the (last) ownedRelatedelement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetIntersectingType() {
-		if (intersectingType == null) {
-			// Handle a intersectingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				intersectingType = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return intersectingType;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/NamespaceImportImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/NamespaceImportImpl.java
@@ -65,19 +65,9 @@ public class NamespaceImportImpl extends ImportImpl implements NamespaceImport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Namespace getImportedNamespace() {
-		return importedNamespace == null? basicGetImportedNamespace(): getImportedNamespaceGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Namespace getImportedNamespaceGen() {
+	public Namespace getImportedNamespace() {
 		if (importedNamespace != null && importedNamespace.eIsProxy()) {
 			InternalEObject oldImportedNamespace = (InternalEObject)importedNamespace;
 			importedNamespace = (Namespace)eResolveProxy(oldImportedNamespace);
@@ -91,22 +81,10 @@ public class NamespaceImportImpl extends ImportImpl implements NamespaceImport {
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If importedNamespace is empty, then set it to the first ownedRelatedElement, if this is a namespace
-	 * (filling in the implicit import for a filter package). Otherwise, set it to the importOwningNamspace.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Namespace basicGetImportedNamespace() {
-		if (importedNamespace == null) {
-			EList<Element> ownedRelatedElement = getOwnedRelatedElement();
-			if (!ownedRelatedElement.isEmpty() && ownedRelatedElement.get(0) instanceof Namespace) {
-				// Fill in the implicit import for a filter package.
-				importedNamespace = (Namespace)ownedRelatedElement.get(0);
-			} else {
-				importedNamespace = getImportOwningNamespace();
-			}
-		}
 		return importedNamespace;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/PortConjugationImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/PortConjugationImpl.java
@@ -30,7 +30,6 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.omg.sysml.lang.sysml.ConjugatedPortDefinition;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.PortConjugation;
 import org.omg.sysml.lang.sysml.PortDefinition;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -89,24 +88,13 @@ public class PortConjugationImpl extends ConjugationImpl implements PortConjugat
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.PORT_CONJUGATION;
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public PortDefinition getOriginalPortDefinition() {
-		return originalPortDefinition == null? basicGetOriginalPortDefinition(): getOriginalPortDefinitionGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public PortDefinition getOriginalPortDefinitionGen() {
+	public PortDefinition getOriginalPortDefinition() {
 		if (originalPortDefinition != null && originalPortDefinition.eIsProxy()) {
 			InternalEObject oldOriginalPortDefinition = (InternalEObject)originalPortDefinition;
 			originalPortDefinition = (PortDefinition)eResolveProxy(oldOriginalPortDefinition);
@@ -120,22 +108,10 @@ public class PortConjugationImpl extends ConjugationImpl implements PortConjugat
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the originalPortDefinition is empty, then set it to the owner of the conjugatedPortDefinition
-	 * (if that is a PortDefinition).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public PortDefinition basicGetOriginalPortDefinition() {
-		if (originalPortDefinition == null) {
-			ConjugatedPortDefinition conjugatedPortDefinition = getConjugatedPortDefinition();
-			if (conjugatedPortDefinition != null) {
-				Element conjugatedPortDefinitionOwner = conjugatedPortDefinition.getOwner();
-				if (conjugatedPortDefinitionOwner instanceof PortDefinition) {
-					originalPortDefinition = (PortDefinition)conjugatedPortDefinitionOwner;
-				}
-			}
-		}
 		return originalPortDefinition;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RedefinitionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RedefinitionImpl.java
@@ -23,12 +23,10 @@
 package org.omg.sysml.lang.sysml.impl;
 
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -83,20 +81,10 @@ public class RedefinitionImpl extends SubsettingImpl implements Redefinition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	public Feature getRedefiningFeature() {
-		return redefiningFeature == null ? basicGetRedefiningFeature() : getRedefiningFeatureGen();
-	}
-
-	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getRedefiningFeatureGen() {
+	public Feature getRedefiningFeature() {
 		if (redefiningFeature != null && redefiningFeature.eIsProxy()) {
 			InternalEObject oldRedefiningFeature = (InternalEObject)redefiningFeature;
 			redefiningFeature = (Feature)eResolveProxy(oldRedefiningFeature);
@@ -110,25 +98,10 @@ public class RedefinitionImpl extends SubsettingImpl implements Redefinition {
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the redefiningFeature is empty, then set it to the owningRelatedElement, if that is a Feature.
-	 * Otherwise, set it to the first ownedRelatedElement (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * 
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetRedefiningFeature() {
-		if (redefiningFeature == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				redefiningFeature = (Feature) owner;
-			} else {
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					redefiningFeature = (Feature)ownedRelatedElements.get(0);
-				}
-			}
-		}
 		return redefiningFeature;
 	}
 
@@ -152,19 +125,14 @@ public class RedefinitionImpl extends SubsettingImpl implements Redefinition {
 	 * @generated NOT
 	 */
 	public boolean isSetRedefiningFeature() {
-		return basicGetRedefiningFeature() != null;
-	}
-
-	@Override
-	public Feature getRedefinedFeature() {
-		return redefinedFeature == null? basicGetRedefinedFeature(): getRedefinedFeatureGen();
+		return redefiningFeature != null;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getRedefinedFeatureGen() {
+	public Feature getRedefinedFeature() {
 		if (redefinedFeature != null && redefinedFeature.eIsProxy()) {
 			InternalEObject oldRedefinedFeature = (InternalEObject)redefinedFeature;
 			redefinedFeature = (Feature)eResolveProxy(oldRedefinedFeature);
@@ -178,15 +146,9 @@ public class RedefinitionImpl extends SubsettingImpl implements Redefinition {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetRedefinedFeature() {
-		if (redefinedFeature == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				redefinedFeature = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return redefinedFeature;
 	}
 
@@ -204,10 +166,10 @@ public class RedefinitionImpl extends SubsettingImpl implements Redefinition {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public boolean isSetRedefinedFeature() {
-		return basicGetRedefinedFeature() != null;
+		return redefinedFeature != null;
 	}
 
 	/**

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ReferenceSubsettingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ReferenceSubsettingImpl.java
@@ -3,13 +3,11 @@
 package org.omg.sysml.lang.sysml.impl;
 
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.ReferenceSubsetting;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -70,21 +68,10 @@ public class ReferenceSubsettingImpl extends SubsettingImpl implements Reference
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getReferencedFeature() {
-		return referencedFeature == null? basicGetReferencedFeature(): getReferencedFeatureGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getReferencedFeatureGen() {
+	public Feature getReferencedFeature() {
 		if (referencedFeature != null && referencedFeature.eIsProxy()) {
 			InternalEObject oldReferencedFeature = (InternalEObject)referencedFeature;
 			referencedFeature = (Feature)eResolveProxy(oldReferencedFeature);
@@ -98,19 +85,10 @@ public class ReferenceSubsettingImpl extends SubsettingImpl implements Reference
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the referencedFeature is empty, then set it to the last ownedRelatedElement
-	 * (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetReferencedFeature() {
-		if (referencedFeature == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				referencedFeature = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return referencedFeature;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RelationshipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RelationshipImpl.java
@@ -238,25 +238,11 @@ public abstract class RelationshipImpl extends ElementImpl implements Relationsh
 	
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * Add all ownedRelatedElements to target.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public EList<Element> getTarget() {
-		EList<Element> targets = getTargetGen();
-		EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-		ownedRelatedElements.stream().filter(e->!targets.contains(e)).forEachOrdered(targets::add);
-		return targets;
-	}	
-
-	/**
-	 * <!-- begin-user-doc --> 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<Element> getTargetGen() {
+	@Override
+	public EList<Element> getTarget() {
 		if (target == null) {
 			target = new EObjectResolvingEList<Element>(Element.class, this, SysMLPackage.RELATIONSHIP__TARGET);
 		}
@@ -265,27 +251,11 @@ public abstract class RelationshipImpl extends ElementImpl implements Relationsh
 	
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If source is empty, then add all owningRelatedElements to it.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public EList<Element> getSource() {
-		EList<Element> sources = getSourceGen();
-		Element owningRelatedElement = getOwningRelatedElement();
-		if (sources.isEmpty() && owningRelatedElement != null && !getTarget().contains(owningRelatedElement)) {
-			sources.add(owningRelatedElement);
-		}
-		return sources;
-	}
-
-	/**
-	 * <!-- begin-user-doc --> 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<Element> getSourceGen() {
+	@Override
+	public EList<Element> getSource() {
 		if (source == null) {
 			source = new EObjectResolvingEList<Element>(Element.class, this, SysMLPackage.RELATIONSHIP__SOURCE);
 		}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SpecializationImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SpecializationImpl.java
@@ -35,7 +35,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.uml2.common.util.UnionEObjectEList;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 
@@ -107,21 +106,10 @@ public class SpecializationImpl extends RelationshipImpl implements Specializati
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getGeneral() {
-		return general == null? basicGetGeneral(): getGeneralGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getGeneralGen() {
+	public Type getGeneral() {
 		if (general != null && general.eIsProxy()) {
 			InternalEObject oldGeneral = (InternalEObject)general;
 			general = (Type)eResolveProxy(oldGeneral);
@@ -135,18 +123,10 @@ public class SpecializationImpl extends RelationshipImpl implements Specializati
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If general is empty, then set it to the last ownedRelatedElement (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetGeneral() {
-		if (general == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				general = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return general;
 	}
 
@@ -171,24 +151,13 @@ public class SpecializationImpl extends RelationshipImpl implements Specializati
 	public boolean isSetGeneral() {
 		return general != null;
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getSpecific() {
-		return specific == null? basicGetSpecific(): getSpecificGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getSpecificGen() {
+	public Type getSpecific() {
 		if (specific != null && specific.eIsProxy()) {
 			InternalEObject oldSpecific = (InternalEObject)specific;
 			specific = (Type)eResolveProxy(oldSpecific);
@@ -202,24 +171,10 @@ public class SpecializationImpl extends RelationshipImpl implements Specializati
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If specific is empty, then set it to the owningRelatedElement, if that is a Type.
-	 * Otherwise set it to the first ownedRelatedElement (which will be a FeatureChain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetSpecific() {
-		if (specific == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Type) {
-				specific = (Type)owner;
-			} else {
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					specific = (Feature)ownedRelatedElements.get(0);
-				}
-			}
-		}
 		return specific;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SubclassificationImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SubclassificationImpl.java
@@ -31,7 +31,6 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.omg.sysml.lang.sysml.Classifier;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Subclassification;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 
@@ -183,21 +182,10 @@ public class SubclassificationImpl extends SpecializationImpl implements Subclas
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public org.omg.sysml.lang.sysml.Classifier getSubclassifier() {
-		return subclassifier == null ? basicGetSubclassifier() : getSubclassifierGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Classifier getSubclassifierGen() {
+	public Classifier getSubclassifier() {
 		if (subclassifier != null && subclassifier.eIsProxy()) {
 			InternalEObject oldSubclassifier = (InternalEObject)subclassifier;
 			subclassifier = (Classifier)eResolveProxy(oldSubclassifier);
@@ -210,21 +198,11 @@ public class SubclassificationImpl extends SpecializationImpl implements Subclas
 	}
 
 	/**
-	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the subclassifier is empty, then set it to the owningRelatedElement,
-	 * if this is a Classifier.
+	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @generated NOT
+	 * @generated
 	 */
 	public org.omg.sysml.lang.sysml.Classifier basicGetSubclassifier() {
-		if (subclassifier == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Classifier) {
-				subclassifier = (Classifier) owner;
-			}
-		}
 		return subclassifier;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SubsettingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SubsettingImpl.java
@@ -23,7 +23,6 @@
 package org.omg.sysml.lang.sysml.impl;
 
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -31,7 +30,6 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Subsetting;
 import org.omg.sysml.lang.sysml.SysMLPackage;
@@ -95,24 +93,13 @@ public class SubsettingImpl extends SpecializationImpl implements Subsetting {
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.SUBSETTING;
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getSubsettedFeature() {
-		return subsettedFeature == null? basicGetSubsettedFeature(): getSubsettedFeatureGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc --> 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getSubsettedFeatureGen() {
+	public Feature getSubsettedFeature() {
 		if (subsettedFeature != null && subsettedFeature.eIsProxy()) {
 			InternalEObject oldSubsettedFeature = (InternalEObject)subsettedFeature;
 			subsettedFeature = (Feature)eResolveProxy(oldSubsettedFeature);
@@ -126,19 +113,10 @@ public class SubsettingImpl extends SpecializationImpl implements Subsetting {
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the subsettedFeature is empty, then set it to the last ownedRelatedElement
-	 * (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetSubsettedFeature() {
-		if (subsettedFeature == null) {
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				subsettedFeature = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return subsettedFeature;
 	}
 
@@ -156,20 +134,10 @@ public class SubsettingImpl extends SpecializationImpl implements Subsetting {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public boolean isSetSubsettedFeature() {
-		return basicGetSubsettedFeature() != null;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	public Feature getSubsettingFeature() {
-		return subsettingFeature == null ? basicGetSubsettingFeature() : getSubsettingFeatureGen();
+		return subsettedFeature != null;
 	}
 
 	/**
@@ -177,7 +145,7 @@ public class SubsettingImpl extends SpecializationImpl implements Subsetting {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getSubsettingFeatureGen() {
+	public Feature getSubsettingFeature() {
 		if (subsettingFeature != null && subsettingFeature.eIsProxy()) {
 			InternalEObject oldSubsettingFeature = (InternalEObject)subsettingFeature;
 			subsettingFeature = (Feature)eResolveProxy(oldSubsettingFeature);
@@ -191,25 +159,10 @@ public class SubsettingImpl extends SpecializationImpl implements Subsetting {
 
 	/**
 	 * <!-- begin-user-doc --> 
-	 * Xtext workaround:
-	 * If the subsettingFeature is empty, then set it to the owningRelatedFeature, if this is a Feature.
-	 * Otherwise set it to the first ownedRelatedElement (which will be a Feature chain).
 	 * <!-- end-user-doc -->
-	 * 
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetSubsettingFeature() {
-		if (subsettingFeature == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				subsettingFeature = (Feature) owner;
-			} else {
-				EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-				if (!ownedRelatedElements.isEmpty()) {
-					subsettingFeature = (Feature)ownedRelatedElements.get(0);
-				}
-			}
-		}
 		return subsettingFeature;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeFeaturingImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeFeaturingImpl.java
@@ -108,24 +108,13 @@ public class TypeFeaturingImpl extends FeaturingImpl implements TypeFeaturing {
 	protected EClass eStaticClass() {
 		return SysMLPackage.Literals.TYPE_FEATURING;
 	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * Xtext workaround.
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Feature getFeatureOfType() {
-		return featureOfType == null? basicGetFeatureOfType(): getFeatureOfTypeGen();
-	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Feature getFeatureOfTypeGen() {
+	public Feature getFeatureOfType() {
 		if (featureOfType != null && featureOfType.eIsProxy()) {
 			InternalEObject oldFeatureOfType = (InternalEObject)featureOfType;
 			featureOfType = (Feature)eResolveProxy(oldFeatureOfType);
@@ -139,18 +128,10 @@ public class TypeFeaturingImpl extends FeaturingImpl implements TypeFeaturing {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If the featureOfType is empty, then set it to the owningRelatedElement (if this is a Feature).
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Feature basicGetFeatureOfType() {
-		if (featureOfType == null) {
-			Element owner = getOwningRelatedElement();
-			if (owner instanceof Feature) {
-				featureOfType = (Feature)owner;
-			}
-		}
 		return featureOfType;
 	}
 

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UnioningImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UnioningImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.uml2.common.util.UnionEObjectEList;
 
 import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Unioning;
@@ -124,21 +123,10 @@ public class UnioningImpl extends RelationshipImpl implements Unioning {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround
-	 * <!-- end-user-doc -->
-	 * @generated NOT
-	 */
-	@Override
-	public Type getUnioningType() {
-		return unioningType == null? basicGetUnioningType(): getUnioningTypeGen();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public Type getUnioningTypeGen() {
+	public Type getUnioningType() {
 		if (unioningType != null && unioningType.eIsProxy()) {
 			InternalEObject oldUnioningType = (InternalEObject)unioningType;
 			unioningType = (Type)eResolveProxy(oldUnioningType);
@@ -152,21 +140,10 @@ public class UnioningImpl extends RelationshipImpl implements Unioning {
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Xtext workaround:
-	 * If a Unioning is parsed targeting a Feature chain, then the unioningType will be empty,
-	 * but the Unioning will own the unioningType. So, in this case, the unioningType should
-	 * be set to the (last) ownedRelatedelement.
 	 * <!-- end-user-doc -->
-	 * @generated NOT
+	 * @generated
 	 */
 	public Type basicGetUnioningType() {
-		if (unioningType == null) {
-			// Handle a intersectingType that is a Feature chain.
-			EList<Element> ownedRelatedElements = getOwnedRelatedElement();
-			if (!ownedRelatedElements.isEmpty()) {
-				unioningType = (Feature)ownedRelatedElements.get(ownedRelatedElements.size() - 1);
-			}
-		}
 		return unioningType;
 	}
 


### PR DESCRIPTION
**Background**

There is non-generated code in the `Impl` classes (in package `org.omg.sysml.impl`), inserted to work around limitations in parsing using Xtext. In particular, there were previously a number of methods that were specifically commented as “Xtext workarounds”. Ideally, these would be better handled as actions taken when constructing the abstract syntax tree during parsing, but that is not supported in the Xtext grammar language. Instead, this PR implements a mechanism that makes the necessary changes after the construction of the syntax tree, but before other processing is done on it, so this code no longer needs to be inserted into the `Impl` classes.

Note, however, that it does _not_ replace the following mechanisms:
- The use of the `Feature::isNonunique` property to parse the **`nonunique`** keyword.
- The use of the `Expression::operand` property to parse the KerML expression notation.

It also does not remove a number other cases of handwritten code, mostly related to property default values and additional method overrides, which may be addressed in a future PR.

**Changes**

* Moves post-processing code marked as an "Xtext workaround" (from `Relationship` implementations) to `ElementAdapter::postProcess`.
* Remove ssome special checks in `clearReference` that are not longer required.
* Removes non-generated code for `Relationship::source` and `target`, since this is obsoleted by the post-processing code for `Relationship` subclasses.
* Re-generates some methods incorrectly tagged as `@generated NOT` previously.