### PR TITLE
ST6RI-775 LICENSE-GPL file needs to be packaged in the Jupyter kernel build

### DIFF
--- a/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.expressions.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.expressions.xtext,

--- a/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.expressions.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.expressions.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.expressions.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.owl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.owl,

--- a/org.omg.kerml.owl/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.owl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.owl
 Bundle-Vendor: My Company
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.owl;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xpect.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xpect.tests
 Bundle-SymbolicName: org.omg.kerml.xpect.tests;singleton:=true
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="[0.3.0,0.4.0)",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="[0.3.0,0.4.0)",

--- a/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.kerml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext.ui
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.kerml.xtext,

--- a/org.omg.kerml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.kerml.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.kerml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.kerml.xtext
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.kerml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml.edit/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.omg.sysml.edit;singleton:=true
 Automatic-Module-Name: org.omg.sysml.edit
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.omg.sysml.lang.sysml.provider.SysMLEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.omg.sysml.editor/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.omg.sysml.editor;singleton:=true
 Automatic-Module-Name: org.omg.sysml.editor
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.omg.sysml.lang.sysml.presentation.SysMLEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.omg.sysml.execution/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.execution/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.omg.sysml.execution;singleton:=true
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Automatic-Module-Name: org.omg.sysml.execution
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: org.omg.sysml.execution

--- a/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.omg.sysml.interactive.tests;singleton:=true
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Automatic-Module-Name: org.omg.sysml.interactive.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.interactive;bundle-version="0.3.2",

--- a/org.omg.sysml.interactive/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.interactive/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.interactive
 Bundle-SymbolicName: org.omg.sysml.interactive
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Export-Package: org.omg.sysml.interactive
 Require-Bundle: org.eclipse.emf.ecore,
  com.google.inject,

--- a/org.omg.sysml.jupyter.kernel/assembly.xml
+++ b/org.omg.sysml.jupyter.kernel/assembly.xml
@@ -13,6 +13,7 @@
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>LICENSE</include>
+                <include>LICENSE-GPL</include>
             </includes>
         </fileSet>
         <!-- zip the kernel -->

--- a/org.omg.sysml.jupyter.kernel/pom.xml
+++ b/org.omg.sysml.jupyter.kernel/pom.xml
@@ -111,8 +111,8 @@
               <attributes>
                 <source-highlighter>rogue</source-highlighter>
                 <icons>font</icons>
-								<pagenums />
-								<idprefix />
+                                <pagenums />
+                                <idprefix />
                 <idseparator>-</idseparator>
               </attributes>
             </configuration>
@@ -177,31 +177,31 @@
         </plugin>
         <!-- Clean old jars in the uzipped kernel. Jars with older version can get stuck in the target/kernel. -->
         <plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-clean-plugin</artifactId>
-			<executions>
-				<execution>
-					<id>clean-old-shaded-jar</id>
-					<phase>prepare-package</phase>
-					<goals>
-						<goal>clean</goal>
-					</goals>
-					<configuration>
-						<excludeDefaultDirectories>true</excludeDefaultDirectories>
-						<filesets>
-							<fileset>
-								<directory>target/kernel</directory>
-								<includes>
-									<include>*/**.jar</include>
-								</includes>
-							</fileset>
-						</filesets>
-					</configuration>
-				</execution>
-			</executions>
-		</plugin>
-		
-		<!-- Needed for updating the version number in the kernel.json. This is used to copy the resources to the unzipped kernel.-->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>clean-old-shaded-jar</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>clean</goal>
+                    </goals>
+                    <configuration>
+                        <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                        <filesets>
+                            <fileset>
+                                <directory>target/kernel</directory>
+                                <includes>
+                                    <include>*/**.jar</include>
+                                </includes>
+                            </fileset>
+                        </filesets>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+
+        <!-- Needed for updating the version number in the kernel.json. This is used to copy the resources to the unzipped kernel.-->
 		<plugin>
 			<groupId>org.codehaus.mojo</groupId>
 			<artifactId>templating-maven-plugin</artifactId>

--- a/org.omg.sysml.jupyter.kernel/pom.xml
+++ b/org.omg.sysml.jupyter.kernel/pom.xml
@@ -175,6 +175,31 @@
                 </execution>
             </executions>
         </plugin>
+        <!-- Clean old jars in the uzipped kernel. Jars with older version can get stuck in the target/kernel. -->
+        <plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-clean-plugin</artifactId>
+			<executions>
+				<execution>
+					<id>clean-old-shaded-jar</id>
+					<phase>prepare-package</phase>
+					<goals>
+						<goal>clean</goal>
+					</goals>
+					<configuration>
+						<excludeDefaultDirectories>true</excludeDefaultDirectories>
+						<filesets>
+							<fileset>
+								<directory>target/kernel</directory>
+								<includes>
+									<include>*/**.jar</include>
+								</includes>
+							</fileset>
+						</filesets>
+					</configuration>
+				</execution>
+			</executions>
+		</plugin>
 		
 		<!-- Needed for updating the version number in the kernel.json. This is used to copy the resources to the unzipped kernel.-->
 		<plugin>

--- a/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.plantuml
 Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization for Eclipse
 Bundle-SymbolicName: org.omg.sysml.plantuml.eclipse;singleton:=true
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Import-Package: net.sourceforge.plantuml.eclipse.utils;version="1.1.25.himi1",
  net.sourceforge.plantuml.ecore,
  net.sourceforge.plantuml.text,

--- a/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.plantuml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SysML 2 PlantUML visualization
 Bundle-SymbolicName: org.omg.sysml.plantuml
 Automatic-Module-Name: org.omg.sysml.plantuml
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Export-Package: org.omg.sysml.plantuml
 Import-Package: com.google.common.collect,
  com.google.inject;version="1.3.0",

--- a/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xpect.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xpect.tests
 Bundle-SymbolicName: org.omg.sysml.xpect.tests;singleton:=true
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xpect.xtext.lib;bundle-version="0.3.0",
  org.eclipse.xpect.xtext.xbase.lib;bundle-version="[0.3.0,0.4.0)",

--- a/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ide
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml.xtext,

--- a/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.omg.sysml.xtext.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext.ui
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.omg.sysml;bundle-version="0.2.0",

--- a/org.omg.sysml.xtext/META-INF/MANIFEST.MF
+++ b/org.omg.sysml.xtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.omg.sysml.xtext
 Bundle-ManifestVersion: 2
 Bundle-Name: org.omg.sysml.xtext
 Bundle-Vendor: SysML v2 Submission Team
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-SymbolicName: org.omg.sysml.xtext; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/org.omg.sysml/META-INF/MANIFEST.MF
+++ b/org.omg.sysml/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-Version: 0.42.0.qualifier
+Bundle-Version: 0.43.0.qualifier
 Bundle-ClassPath: .,
  lib/sysml-v2-api-client-all.jar
 Bundle-SymbolicName: org.omg.sysml;singleton:=true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <properties>
-	<revision>0.42.0-SNAPSHOT</revision>
+	<revision>0.43.0-SNAPSHOT</revision>
     <tycho-version>4.0.7</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>


### PR DESCRIPTION
This pull request updates the `jupyter-sysml-kernel` project to resolve some minor problems with the new build process introduced in PR #568:
- Modifies `assembly.xml` to incude the `LICENSE-GPL` file in the zipped kernel deployment package.
- Adds a clean step that removes `.jars` from the target/kernel before copying the new shaded `.jar`, preventing `.jars` getting "stuck" in the unzipped kernel directory resulting in multiple `.jars` with different versions in the zipped kernel package.