### PR TITLE
ST6RI-778: Inherited elements of non-standard libraries are not shown (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -189,7 +189,7 @@ public abstract class VTraverser extends Visitor {
     }
 
     protected boolean isHidden(Element e) {
-        return !(showLib() && isModelLibrary(e));
+    	return !showLib() && isModelLibrary(e);
     }
 
     private static Set<Namespace> initVisited(Visitor prev) {


### PR DESCRIPTION
Because of my mistake in ST6RI-771 (PR #566), inherited features of non-standard library are wrongly hidden.  So the example below:
```
package TestStdLib {
	part def P1 {
		part p1;
	}
	
	part p : P1 {
		part p2;
		connect p1 to p2;
	}	
}
```
is wrongly rendered as:
![image](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/assets/10537/8b9326b7-9653-43d4-ac8b-61e75a3c7a8f)

