### PR TITLE
ST6RI-780: Nested inherited features are not correctly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -340,7 +340,8 @@ public class VPath extends VTraverser {
             if (ik != null) {
                 // Make the inherit key indirect in order to refer to redefined targets as well as inherited ones.
                 ik = InheritKey.makeIndirect(ik);
-                return InheritKey.findTop(ik, ref);
+                ik = InheritKey.findTop(ik, ref);
+                if (ik != null) return ik;
             }
         }
         if (ns instanceof Type) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSSRMembers.java
@@ -25,13 +25,12 @@
 package org.omg.sysml.plantuml;
 
 import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.FeatureUtil;
 
 public class VSSRMembers extends VStructure {
     private static boolean isRedefining(Feature f, String prefix) {
-        for (Redefinition rd: f.getOwnedRedefinition()) {
-            Feature rf = rd.getRedefinedFeature();
+        for (Feature rf: FeatureUtil.getAllRedefinedFeaturesOf(f)) {
             String qName = rf.getQualifiedName();
             if (qName != null) {
                 if (qName.startsWith(prefix)) return true;


### PR DESCRIPTION
When the visualizer renders a connector, it also renders inherited features referred by the connector.  However, it may fail to render nested features.  In the example below:
```
package TestInheritedPart2 {
    part def Vehicle {
        part powerTrain {
            part shaft {
                port rotation;
            }
        }
    }

    part vehicle : Vehicle {
        part :>> powerTrain {
            part motor {
                part shaft {
                    port rotation;
                }
            }
            bind motor.shaft.rotation = shaft.rotation;
        }
    }
}
```
rendering just part `vehicle` gives:
![image](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/assets/10537/936c9e1d-2de7-4fdc-8a1f-194df9427fb4)
which lacks `vehicle.powerTrain.shaft.rotation` even though it is referred to by the binding connector.

This PR also fixes `VSSRMember.isRedefining()` by using `FeatureUtil`.