### PR TITLE
ST6RI-782: Memberships of inherited features are not correctly rendered; and ST6RI-784:  Subsettings of inherited feature from nested type are not rendered(PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -199,10 +199,7 @@ class InheritKey {
     private static Type identifyRedefiningTargetOwner(Type redefinedOwner, Feature f) {
         for (Specialization sp: redefinedOwner.getOwnedSpecialization()) {
             Type g = sp.getGeneral();
-            for (FeatureMembership fm: Visitor.toOwnedFeatureMembershipArray(g)) {
-                Feature f2 = fm.getOwnedMemberFeature();
-                if (f.equals(f2)) return g;
-            }
+            if (isBelonging(g, f)) return g;
         }
         return null;
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/InheritKey.java
@@ -196,10 +196,14 @@ class InheritKey {
 
 
     // Identify what type owns redefining feature.
-    private static Type identifyRedefiningTargetOwner(Type redefinedOwner, Feature f) {
+    private static Type identifyRedefiningTargetOwner(Type redefinedOwner, Feature f, boolean showInherited) {
         for (Specialization sp: redefinedOwner.getOwnedSpecialization()) {
             Type g = sp.getGeneral();
-            if (isBelonging(g, f)) return g;
+            if (showInherited) {
+                if (isBelonging(g, f)) return g;
+            } else {
+                if (containsWithRedefined(belongingFeatures(g), f)) return g;
+            }
         }
         return null;
     }
@@ -217,12 +221,12 @@ class InheritKey {
         this.isDirect = false;
     }
     // Make an inherit key by identifying what type owns redefining feature.
-    public static InheritKey makeInheritKeyForRedefiningTarget(InheritKey ik, Feature f) {
+    public static InheritKey makeInheritKeyForRedefiningTarget(InheritKey ik, Feature f, boolean showInherited) {
         if (ik == null) return null; // It must be invalid model
         Type[] keys = ik.keys;
         for (int i = keys.length - 1; i >= 0; i--) {
             Type typ = keys[i];
-            Type tgt = identifyRedefiningTargetOwner(typ, f);
+            Type tgt = identifyRedefiningTargetOwner(typ, f, showInherited);
             if (tgt != null) {
                 return new InheritKey(ik, i, tgt);
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -534,9 +534,7 @@ public class SysML2PlantUMLText {
 
         Integer newId(Element e) {
             Integer ii = idCounter++;
-            if (!isInherited()) {
-                idMap.put(e, ii);
-            }
+            idMap.put(e, ii);
             if (vpath != null) {
                 vpath.setId(e, ii);
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -52,6 +52,7 @@ import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OwningMembership;
+import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;
@@ -126,7 +127,13 @@ public class VDefault extends VTraverser {
         for (Specialization s: typ.getOwnedSpecialization()) {
             Type gt = s.getGeneral();
             if (gt == null) continue;
-            PRelation pr = new PRelation(ik, typId, gt, s, null);
+            InheritKey ik2;
+            if (s instanceof Redefinition && gt instanceof Feature) {
+                ik2 = InheritKey.makeInheritKeyForRedefiningTarget(ik, (Feature) gt);
+            } else {
+                ik2 = ik;
+            }
+            PRelation pr = new PRelation(ik2, typId, gt, s, null);
             addPRelation(pr);
         }
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -129,7 +129,7 @@ public class VDefault extends VTraverser {
             if (gt == null) continue;
             InheritKey ik2;
             if (s instanceof Redefinition && gt instanceof Feature) {
-                ik2 = InheritKey.makeInheritKeyForRedefiningTarget(ik, (Feature) gt);
+                ik2 = InheritKey.makeInheritKeyForRedefiningTarget(ik, (Feature) gt, showInherited());
             } else {
                 ik2 = ik;
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -532,7 +532,7 @@ public class VPath extends VTraverser {
 
     private String addContextForFeature(Feature f, boolean isRedefinition) {
         PC pc = makeFeaturePC(f, f, isRedefinition);
-        InheritKey ik = makeInheritKeyForReferer(pc);
+        InheritKey ik = makeInheritKey(f);
         if (isRedefinition) {
             ik = InheritKey.makeInheritKeyForRedefiningTarget(ik, f, showInherited());
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -534,7 +534,7 @@ public class VPath extends VTraverser {
         PC pc = makeFeaturePC(f, f, isRedefinition);
         InheritKey ik = makeInheritKeyForReferer(pc);
         if (isRedefinition) {
-            ik = InheritKey.makeInheritKeyForRedefiningTarget(ik, f);
+            ik = InheritKey.makeInheritKeyForRedefiningTarget(ik, f, showInherited());
         }
         if (createRefPC(ik, pc) == null) return null;
         return "";

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -334,6 +334,8 @@ public class VPath extends VTraverser {
         Feature ref = (Feature) e;
 
         Namespace ns = getCurrentNamespace();
+        if (!(ns instanceof Type)) return null;
+
         if (ns instanceof Feature) {
             Feature tgt = (Feature) ns;
             InheritKey ik = makeInheritKey(tgt);
@@ -344,12 +346,10 @@ public class VPath extends VTraverser {
                 if (ik != null) return ik;
             }
         }
-        if (ns instanceof Type) {
-            // In case that tgt inherits ref, we need to make an InheritKey for tgt.
-            Type tgt = (Type) ns;
-            return InheritKey.makeTargetKey(tgt, ref);
-        }
-        return null;
+
+        // In case that tgt inherits ref, we need to make an InheritKey for tgt.
+        Type tgt = (Type) ns;
+        return InheritKey.makeTargetKey(tgt, ref);
     }
 
 
@@ -533,7 +533,9 @@ public class VPath extends VTraverser {
     private String addContextForFeature(Feature f, boolean isRedefinition) {
         PC pc = makeFeaturePC(f, f, isRedefinition);
         InheritKey ik = makeInheritKeyForReferer(pc);
-        // InheritKey ik = makeInheritKey(f);
+        if (isRedefinition) {
+            ik = InheritKey.makeInheritKeyForRedefiningTarget(ik, f);
+        }
         if (createRefPC(ik, pc) == null) return null;
         return "";
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTraverser.java
@@ -178,7 +178,7 @@ public abstract class VTraverser extends Visitor {
         this.inited = true;
     }
     
-    private boolean showInherited() {
+    protected boolean showInherited() {
         init();
         return showInherited;
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -770,8 +770,8 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return ms.toArray(array);
     }
 
-    public static FeatureMembership[] toOwnedFeatureMembershipArray(Feature f) {
-        List<FeatureMembership> fms = f.getOwnedFeatureMembership();
+    public static FeatureMembership[] toOwnedFeatureMembershipArray(Type typ) {
+        List<FeatureMembership> fms = typ.getOwnedFeatureMembership();
         FeatureMembership[] array = new FeatureMembership[fms.size()];
         return fms.toArray(array);
     }


### PR DESCRIPTION
Since the fix in ST6RI-767 has a problem to find a target of PRelation, the example below:
```
package TestInheritedPart1 {
    part def Vehicle {
        part powerTrain;
    }
    part vehicle : Vehicle;
}
```
is wrongly rendered with `SHOWINHERIT` style as below:
![image](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/assets/10537/4dd8bfab-baec-4346-a55f-ce7bd79b6d1f)


