### PR TITLE
ST6RI-781: Show multiplicities in nodes (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -189,6 +189,9 @@ public class SysML2PlantUMLStyle {
         add("HIDEMETADATA", "Hide metadata", " ", "hideMetadata", "true");
         add("SHOWMETACLASS", "Show metaclasses of metaobjects", " ", "showMetaclass", "true");
         add("EVAL", "Evaluate expressions", " ", "evalExp", "true");
+        add("NODEMULTIPLICITY", "Show multiplicities in nodes", " ", "nodeMultiplicity", "true");
+        add("EDGEMULTIPLICITY", "Show multiplicities on edges", " ", "edgeMultiplicity", "true");
+        add("IMPLICITMULTIPLICITY", "Show implicit multiplicities", " ", "implicitMultiplicity", "true");
     }
 
     public static class StyleSwitch {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VAction.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020-2023 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -77,10 +77,10 @@ public class VAction extends VDefault {
 
     public VAction(Visitor prev) {
     	super(prev);
-        setShowsMultiplicity(false);
+        setMultiplicityStyle(MultiplicityStyle.NONE);
     }
 
     public VAction() {
-        setShowsMultiplicity(false);
+    	setMultiplicityStyle(MultiplicityStyle.NONE);
     }
 }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -122,6 +122,11 @@ public class VMixed extends VTree {
 
     public VMixed(Visitor vt) {
         super(vt);
+    }
+
+    @Override
+    protected MultiplicityStyle getDefaultMultiplicityStyle() {
+        return MultiplicityStyle.DEFAULT;
     }
 
     public VMixed() {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VSequence.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2021-2022 Mgnite Inc.
+ * Copyright (c) 2021-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -488,7 +488,7 @@ public class VSequence extends VDefault {
     }
 
     public VSequence() {
-        setShowsMultiplicity(false);
+        setMultiplicityStyle(MultiplicityStyle.NONE);
         this.isInBox = false;
         this.messages = new ArrayList<Message>();
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStateMachine.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation, PlantUML Visualization
- * Copyright (c) 2020 Mgnite Inc.
+ * Copyright (c) 2020-2024 Mgnite Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -65,12 +65,12 @@ public class VStateMachine extends VDefault {
     
     public VStateMachine(Visitor prev) {
     	super(prev);
-        setShowsMultiplicity(false);
+        setMultiplicityStyle(MultiplicityStyle.NONE);
         this.showStereotype = true;
     }
 
     public VStateMachine() {
-        setShowsMultiplicity(false);
+        setMultiplicityStyle(MultiplicityStyle.NONE);
         this.showStereotype = false;
     }
 }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -244,12 +244,22 @@ public abstract class VStructure extends VDefault {
         if (e instanceof Feature) {
             Feature f = (Feature) e;
             boolean added = appendFeatureType(sb, ": ", f);
+            if (showsMultiplicity(true)) {
+                String str = getMultiplicityString(e);
+                if (str != null) {
+                    sb.append('[');
+                    sb.append(str);
+                    sb.append(']');
+                    added = true;
+                }
+            }
             sb.append(' ');
             added = appendSubsettings(sb, f) || added;
             if (!hasRefSubsettingWithoutDeclaredName(f)) {
                 sb.append(' ');
                 added = appendReferenceSubsetting(sb, f) || added;
             }
+
             sb.insert(0, name);
             /*
               if (f instanceof Usage) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -284,6 +284,11 @@ public class VTree extends VStructure {
     	super(vt);
     }
 
+    @Override
+    protected MultiplicityStyle getDefaultMultiplicityStyle() {
+        return MultiplicityStyle.NODE;
+    }
+
     public VTree() {
         super();
         this.namespace = null;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -57,9 +57,62 @@ public abstract class Visitor extends SysMLSwitch<String> {
         this.s2p = s2p;
     }
 
-    private boolean showsMultiplicity = true;
-    public void setShowsMultiplicity(boolean flag) {
-        this.showsMultiplicity = flag;
+    public enum MultiplicityStyle {
+        NONE,
+        DEFAULT,
+
+        EDGE,
+        NODE,
+        BOTH,
+    }
+
+    private boolean showImplicitMultiplicity = false;
+    private MultiplicityStyle multiplicityStyle = null;
+    public void setMultiplicityStyle(MultiplicityStyle style) {
+        this.multiplicityStyle = style;
+    }
+
+    protected MultiplicityStyle getDefaultMultiplicityStyle() {
+        return MultiplicityStyle.DEFAULT;
+    }
+
+    private MultiplicityStyle getMultiplicityStyle() {
+        if (multiplicityStyle != null) return multiplicityStyle;
+        boolean em = styleBooleanValue("edgeMultiplicity");
+        boolean nm = styleBooleanValue("nodeMultiplicity");
+        if (em) {
+            if (nm) {
+                this.multiplicityStyle = MultiplicityStyle.BOTH;
+            } else {
+                this.multiplicityStyle = MultiplicityStyle.EDGE;
+            }
+        } else if (nm) {
+            this.multiplicityStyle = MultiplicityStyle.NODE;
+        } else {
+            this.multiplicityStyle = getDefaultMultiplicityStyle();
+        }
+        if (styleBooleanValue("implicitMultiplicity")) {
+            this.showImplicitMultiplicity = true;
+        }
+
+        return multiplicityStyle;
+    }
+
+    protected boolean showsMultiplicity(boolean node) {
+        switch (getMultiplicityStyle()) {
+        case DEFAULT:
+            return !node;
+        case EDGE:
+            return !node;
+        case NODE:
+            return node;
+        case BOTH:
+            return true;
+
+        case NONE:
+        default:
+            return false;
+        }
     }
 
     protected SysML2PlantUMLStyle getStyle() {
@@ -353,42 +406,46 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return addPRelation(src, dest, rel, null);
     }
 
-    private MultiplicityRange getEffectiveMultiplicityRange(Element e) {
+    private MultiplicityRange getMultiplicityRange(Element e) {
         if (!(e instanceof Type)) return null;
         Type typ = (Type) e;
-        Multiplicity m = FeatureUtil.getMultiplicityOf(typ);
-        return FeatureUtil.getMultiplicityRangeOf(m);
+        if (showImplicitMultiplicity) {
+            Multiplicity m = FeatureUtil.getMultiplicityOf(typ);
+            return FeatureUtil.getMultiplicityRangeOf(m);
+        } else {
+            Multiplicity m = typ.getMultiplicity();
+            if (m instanceof MultiplicityRange) {
+                return (MultiplicityRange) m;
+            }
+        }
+        return null;
     }
 
-    private void addMultiplicityString(StringBuilder ss, Element e) {
-        if (!showsMultiplicity) return;
-        MultiplicityRange mr = getEffectiveMultiplicityRange(e);
-        if (mr == null) return;
+    protected String getMultiplicityString(Element e) {
+        MultiplicityRange mr = getMultiplicityRange(e);
+        if (mr == null) return null;
 
         String exl = getText(mr.getLowerBound());
         String exu = getText(mr.getUpperBound());
+
         if (exl == null) {
-            if (exu == null) return;
-            ss.append('"');
-            ss.append(quote0Str(exu));
-            ss.append('"');
-            return;
+            if (exu == null) return null;
+            return exu;
         }
         if ((exu == null) || (exl.equals(exu))) {
-            ss.append('"');
-            ss.append(quote0Str(exl));
-            ss.append('"');
-            return;
+            return exl;
         }
-        if ("0".equals(exl) && "*".equals(exu)) {
-            ss.append("\"*\"");
-        } else {
-            ss.append('"');
-            ss.append(quote0Str(exl));
-            ss.append("..");
-            ss.append(quote0Str(exu));
-            ss.append('"');
-        }
+        if ("0".equals(exl) && "*".equals(exu)) return "*";
+        return exl + ".." + exu;
+    }
+
+    private void addMultiplicityStringOnEdge(StringBuilder ss, Element e) {
+        if (!showsMultiplicity(false)) return;
+        String str = getMultiplicityString(e);
+        if (str == null) return;
+        ss.append('"');
+        ss.append(quote0Str(str));
+        ss.append('"');
     }
 
     protected static String getFeatureName(Feature f) {
@@ -661,10 +718,10 @@ public abstract class Visitor extends SysMLSwitch<String> {
         if (pr.rel instanceof Membership) {
             Element dest = pr.getDestElement();
             if (dest != null) {
-                addMultiplicityString(ss, dest);
+                addMultiplicityStringOnEdge(ss, dest);
             }
         } else {
-            addMultiplicityString(ss, pr.rel);
+            addMultiplicityStringOnEdge(ss, pr.rel);
         }
 
         ss.append(destId);
@@ -737,7 +794,8 @@ public abstract class Visitor extends SysMLSwitch<String> {
             this.pRelations = parent.pRelations;
             this.pRelationsSB = parent.pRelationsSB;
             this.s2p = parent.s2p;
-            this.showsMultiplicity = parent.showsMultiplicity;
+            this.multiplicityStyle = parent.multiplicityStyle;
+            this.showImplicitMultiplicity = parent.showImplicitMultiplicity;
         }
     }
 


### PR DESCRIPTION
This PR supports rendering multiplicities in nodes.  So far the visualizer renders multiplicities in edges only.  I added three new styles:

- NODEMULTIPLICITY
    Show multiplicities in nodes.
- EDGEMULTIPLICITY
   Show multiplicities in edges.
- IMPLICITMULTIPLICITY
   Show implicit multiplicities as well.  That means even if you do not explicitly specify multiplicities, the visualizer renders default multiplicities.

If you do not specify any styles, view choose proper multiplicity rendering.  For example, `Tree` view shows multiplicities in nodes by default.