### PR TITLE
ST6RI-793 Transition source cannot be a feature chain

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/TransitionUsage_source_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/TransitionUsage_source_SettingDelegate.java
@@ -22,15 +22,13 @@
 
 package org.omg.sysml.delegate.setting;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.ActionUsage;
-import org.omg.sysml.lang.sysml.Element;
-import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.TransitionUsage;
-import org.omg.sysml.util.NamespaceUtil;
+import org.omg.sysml.util.FeatureUtil;
+import org.omg.sysml.util.UsageUtil;
 
 public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -40,14 +38,8 @@ public class TransitionUsage_source_SettingDelegate extends BasicDerivedObjectSe
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		NamespaceUtil.addAdditionalMembersTo((TransitionUsage)owner);
-		EList<Membership> ownedMemberships = ((TransitionUsage)owner).getOwnedMembership();
-		if (ownedMemberships.isEmpty()) {
-			return null;
-		} else {
-			Element member = ownedMemberships.get(0).getMemberElement();
-			return member instanceof ActionUsage? (ActionUsage)member: null;
-		}
+		Feature source = UsageUtil.getSourceFeatureOf((TransitionUsage)owner);
+		return source == null? null: FeatureUtil.getBasicFeatureOf(source);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -199,7 +199,7 @@ public class UsageUtil {
 		if (owningNamespace instanceof TransitionUsage) {
 			TransitionUsage transition = (TransitionUsage)owningNamespace;
 			if (transition.getSuccession() == feature) {
-				return transition.getSource();
+				return getSourceFeatureOf(transition);
 			}
 		}
 		return getPreviousFeature(feature);
@@ -376,6 +376,17 @@ public class UsageUtil {
 	}
 	
 	// Transitions
+	
+	public static Feature getSourceFeatureOf(TransitionUsage transition) {
+		NamespaceUtil.addAdditionalMembersTo(transition);
+		return transition.getOwnedMembership().stream().
+				filter(mem->!(mem instanceof FeatureMembership)).
+				map(Membership::getMemberElement).
+				filter(Feature.class::isInstance).
+				map(Feature.class::cast).
+				filter(f->FeatureUtil.getBasicFeatureOf(f) instanceof ActionUsage).
+				findFirst().orElse(null);
+	}
 	
 	public static Feature getTransitionSourceOf(Feature transition) {
 		Feature source= transition instanceof TransitionUsage? ((TransitionUsage)transition).getSource():


### PR DESCRIPTION
As reported in OMG issue [SYSML2_-222](https://issues.omg.org/issues/SYSML2_-222), the derivations of the `TransitionUsage::source` and `target` properties given in the specification currently do not support the use of feature chains as the source or target of a transition. However, the derivation for `TransitionUsage::target` as implemented in the Pilot Implementation does already allow the use of feature chains as transition targets. Unfortunately, the implemented derivation of `TransitionUsage::source` did not allow feature chains to be used as transition sources, which was inconsistent.

This PR:
- Updates the implementated derivation of `TransitionUsage::source` so that it also consistently allows feature chains, presupposing the eventual resolution of SYSML2_-222.
- Updates the selection of the member action usage of the Transition from which the source is derived, to skip possible owned members that are features (like metadata usages) but are not action usages.