### PR TITLE
ST6RI-794: Specify UTF-8 encoding to access index files.

### DIFF
--- a/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/library/DynamicLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/library/DynamicLibraryIndexProvider.java
@@ -24,6 +24,7 @@ package org.omg.kerml.xtext.ui.library;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -85,7 +86,7 @@ public class DynamicLibraryIndexProvider implements ILibraryIndexProvider {
 			LibraryIndex indexFromJson = LibraryIndex.EMPTY_INDEX;
 			
 			if (indexFile.exists()) {
-				try (var reader = new InputStreamReader(indexFile.getContents())){
+				try (var reader = new InputStreamReader(indexFile.getContents(), StandardCharsets.UTF_8)) {
 					 indexFromJson = LibraryIndex.fromJson(reader);
 				} catch (IOException e) {
 					//NOOP, return empty index

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/LibraryIndex.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/LibraryIndex.java
@@ -25,6 +25,7 @@ package org.omg.kerml.xtext.library;
 
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -141,8 +142,8 @@ public class LibraryIndex {
 	private String createChecksum(Map<String, Set<String>> index) {
 		 HashCode hashedIndex = Hashing.sha256().hashObject(index, (from, into) -> {
 			from.forEach((libFqn, shortNames) -> {
-				into.putBytes(libFqn.getBytes());
-				shortNames.forEach(shortName -> into.putBytes(shortName.getBytes()));
+				into.putBytes(libFqn.getBytes(StandardCharsets.UTF_8));
+				shortNames.forEach(shortName -> into.putBytes(shortName.getBytes(StandardCharsets.UTF_8)));
 			});
 		});
             

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -27,7 +27,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -61,7 +61,7 @@ public class PrecalculatedLibraryIndexProvider implements ILibraryIndexProvider 
 	@Override
 	public LibraryIndex getIndexFor(Resource resource) {
 		
-		if (disabled) {
+		if (disabled || resource == null) {
 			//return empty index
 			return LibraryIndex.EMPTY_INDEX;
 		}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -77,11 +77,10 @@ public class PrecalculatedLibraryIndexProvider implements ILibraryIndexProvider 
 			File indexFile = getIndexFile(resourceURI);
 			
 			if (indexFile == null || !indexFile.exists()) return LibraryIndex.EMPTY_INDEX;
-			
-			try {
-				FileInputStream fis = new FileInputStream(indexFile);
-				InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);				
-				index = LibraryIndex.fromJson(isr);
+
+            try (FileInputStream fis = new FileInputStream(indexFile);
+                 InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8)) {
+                index = LibraryIndex.fromJson(isr);
 			} catch (FileNotFoundException e) {
 				//NOOP, return empty index
 			} catch (Exception e) {

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -104,13 +104,12 @@ public class PrecalculatedLibraryIndexProvider implements ILibraryIndexProvider 
 	}
 	
 	private File getIndexFile(URI uri) {
-		var segments = Arrays.asList(uri.segments());
-		if (segments.contains(LIBRARY_FOLDER)) {
-			String pathString = uri.path();
-			String indexPath = pathString.split(LIBRARY_FOLDER)[0] + LIBRARY_FOLDER + File.separator + LibraryIndex.FILE_NAME;
-			return new File(indexPath);
-		}
-		return null;
+		String pathString = uri.path();
+		if (pathString == null) return null;
+		int idx = pathString.lastIndexOf(LIBRARY_FOLDER);
+		if (idx < 0) return null;
+		String parentPath = pathString.substring(0, idx + LIBRARY_FOLDER.length());
+		return new File(parentPath, LibraryIndex.FILE_NAME);
 	}
 	
 	public static synchronized PrecalculatedLibraryIndexProvider getInstance() {

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -23,9 +23,10 @@
 package org.omg.kerml.xtext.library;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.log4j.Logger;
@@ -78,13 +79,13 @@ public class PrecalculatedLibraryIndexProvider implements ILibraryIndexProvider 
 			
 			if (indexFile == null || !indexFile.exists()) return LibraryIndex.EMPTY_INDEX;
 			
-			try (FileReader fileReader = new FileReader(indexFile)){
-				
-				index = LibraryIndex.fromJson(fileReader);
-				
+			try {
+				FileInputStream fis = new FileInputStream(indexFile);
+				InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);				
+				index = LibraryIndex.fromJson(isr);
 			} catch (FileNotFoundException e) {
 				//NOOP, return empty index
-			} catch (IOException e) {
+			} catch (Exception e) {
 				if (log.isDebugEnabled()) {
 					log.debug(e.getMessage(), e);
 				}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/library/PrecalculatedLibraryIndexProvider.java
@@ -103,11 +103,11 @@ public class PrecalculatedLibraryIndexProvider implements ILibraryIndexProvider 
 	}
 	
 	private File getIndexFile(URI uri) {
-		String pathString = uri.path();
-		if (pathString == null) return null;
-		int idx = pathString.lastIndexOf(LIBRARY_FOLDER);
-		if (idx < 0) return null;
-		String parentPath = pathString.substring(0, idx + LIBRARY_FOLDER.length());
+		String fileString = uri.toFileString();
+		if (fileString == null) return null;
+		int idx = fileString.lastIndexOf(LIBRARY_FOLDER);
+ 		if (idx < 0) return null;
+		String parentPath = fileString.substring(0, idx + LIBRARY_FOLDER.length());
 		return new File(parentPath, LibraryIndex.FILE_NAME);
 	}
 	

--- a/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveLibraryIndexGenerator.java
+++ b/org.omg.sysml.interactive/src/org/omg/sysml/interactive/SysMLInteractiveLibraryIndexGenerator.java
@@ -25,6 +25,7 @@ package org.omg.sysml.interactive;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.EcoreUtil2;
@@ -74,7 +75,7 @@ public class SysMLInteractiveLibraryIndexGenerator {
 
 		System.out.println("Writing index");
 		try (FileOutputStream fileStream = new FileOutputStream(indexFile, false)) {
-			fileStream.write(json.getBytes());
+			fileStream.write(json.getBytes(StandardCharsets.UTF_8));
 		}
 		
 		System.out.println("Done.");

--- a/org.omg.sysml.xtext.ui/src/org/omg/sysml/xtext/ui/handlers/GenerateLibraryIndex.java
+++ b/org.omg.sysml.xtext.ui/src/org/omg/sysml/xtext/ui/handlers/GenerateLibraryIndex.java
@@ -25,6 +25,7 @@ package org.omg.sysml.xtext.ui.handlers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,7 +37,6 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
@@ -44,7 +44,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -152,7 +151,7 @@ public class GenerateLibraryIndex extends AbstractHandler {
 	private void writeIndex(IProject project, String json, IProgressMonitor monitor) throws CoreException {
 		IFile file = project.getFile(LibraryIndex.FILE_NAME);
 		
-		try (var inputStream = new ByteArrayInputStream(json.getBytes())){
+		try (var inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))){
 			if (file.exists()) {
 				file.setContents(inputStream, IFile.FORCE, monitor);
 			} else {


### PR DESCRIPTION
Previously, `LibraryIndex` read and wrote index files without specifying encoding. Therefore, if the default encoding of the JRE was not UTF-8, those files could be corrupted. In a Japanese Windows environment, the default encoding is CP932, and the library index was corrupted because it could not encode all of the Unicode characters used in the SysMLv2 libraries.

This PR updates `LibraryIndex` to use UTF-8 encoding. It also fixes an issue with constructing a proper index filename at PrecalculatedLibraryIndexProvider.getIndexFile(). To convert an EMF URI to a filename, `toFileString()` must be used.