### PR TITLE
ST6RI-796 Leftover caches in InvocationDelegates

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -107,6 +107,24 @@ public class FeatureAdapter extends TypeAdapter {
 	// Caching
 	
 	EList<Type> types = null;
+	String storedEffectiveName = null;
+	String storedEffectiveShortName = null;
+	
+	public void storeEffectiveName(String effectiveName) {
+		storedEffectiveName = effectiveName;
+	}
+	
+	public String getEffectiveName() {
+		return storedEffectiveName;
+	}
+	
+	public void storeEffectiveShortName(String effectiveShortName) {
+		storedEffectiveShortName = effectiveShortName;
+	}
+	
+	public String getEffectiveShortName() {
+		return storedEffectiveShortName;
+	}
 	
 	public EList<Type> getTypes() {
 		return types;
@@ -124,6 +142,8 @@ public class FeatureAdapter extends TypeAdapter {
 		super.clearCaches();
 		types = null;
 		redefinedFeatures.clear();
+		storedEffectiveName = null;
+		storedEffectiveShortName = null;
 	}
 	
 	// Implicit Elements

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveName_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveName_InvocationDelegate.java
@@ -22,17 +22,13 @@
 package org.omg.sysml.delegate.invocation;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.BasicInvocationDelegate;
 import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.impl.FeatureImpl;
+import org.omg.sysml.util.FeatureUtil;
 
 public class Feature_effectiveName_InvocationDelegate extends BasicInvocationDelegate {
 
@@ -40,40 +36,9 @@ public class Feature_effectiveName_InvocationDelegate extends BasicInvocationDel
 		super(operation);
 	}
 	
-	private final Map<Feature, String> nameCache = new HashMap<>();
-	
 	@Override
 	public Object dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
 		Feature self = (Feature) target;
-		
-		return computeEffectiveName(self, new HashSet<>());
+		return FeatureUtil.computeEffectiveName(self);
 	}
-
-	private boolean isNameDefinite(Feature self) {
-		return self.getDeclaredName() != null || self.getDeclaredShortName() != null;
-	}
-	
-	
-	public String computeEffectiveName(Feature self, Set<Feature> visited) {		
-		if (isNameDefinite(self)) {
-			return self.getDeclaredName();
-		}
-		
-		String effectiveName = nameCache.get(self);
-		
-		if (effectiveName != null) {
-			return effectiveName;
-		}
-
-		visited.add(self);
-		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
-		
-		if (namingFeature != null && !visited.contains(namingFeature)) {
-			effectiveName = computeEffectiveName(namingFeature, visited);
-			nameCache.put(self, effectiveName);
-		}
-		
-		return effectiveName;
-	}
-
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveShortName_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveShortName_InvocationDelegate.java
@@ -22,17 +22,13 @@
 package org.omg.sysml.delegate.invocation;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.BasicInvocationDelegate;
 import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.impl.FeatureImpl;
+import org.omg.sysml.util.FeatureUtil;
 
 public class Feature_effectiveShortName_InvocationDelegate extends BasicInvocationDelegate {
 
@@ -40,39 +36,9 @@ public class Feature_effectiveShortName_InvocationDelegate extends BasicInvocati
 		super(operation);
 	}
 	
-	private final Map<Feature, String> nameCache = new HashMap<>();
-	
 	@Override
 	public Object dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
 		Feature self = (Feature) target;
-		
-		return computeEffectiveShortName(self, new HashSet<>());
+		return FeatureUtil.computeEffectiveShortName(self);
 	}
-	
-	private boolean isNameSet(Feature self) {
-		return self.getDeclaredName() != null || self.getDeclaredShortName() != null;
-	}
-	
-	public String computeEffectiveShortName(Feature self, Set<Feature> visited) {
-		if (isNameSet(self)) {
-			return self.getDeclaredShortName();
-		}
-		
-		String effectiveShortName = nameCache.get(self);
-		
-		if (effectiveShortName != null) {
-			return effectiveShortName;
-		}
-
-		visited.add(self);
-		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
-		
-		if (namingFeature != null && !visited.contains(namingFeature)) {
-			effectiveShortName = computeEffectiveShortName(namingFeature, visited);
-			nameCache.put(self, effectiveShortName);
-		}
-		
-		return effectiveShortName;
-	}
-
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -55,6 +55,7 @@ import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.TypeFeaturing;
+import org.omg.sysml.lang.sysml.impl.FeatureImpl;
 
 public class FeatureUtil {
 	
@@ -438,5 +439,63 @@ public class FeatureUtil {
 			}
 		}
 		return multiplicity;
+	}
+	
+	//Naming
+	
+	public static String computeEffectiveName(Feature self) {
+		return computeEffectiveName(self, new HashSet<>());
+	}
+	
+	private static String computeEffectiveName(Feature self, Set<Feature> visited) {
+		if (isNameSet(self)) {
+			return self.getDeclaredName();
+		}
+		
+		String effectiveName = getFeatureAdapter(self).getEffectiveName();
+		
+		if (effectiveName != null) {
+			return effectiveName;
+		}
+
+		visited.add(self);
+		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
+		
+		if (namingFeature != null && !visited.contains(namingFeature)) {
+			effectiveName = computeEffectiveName(namingFeature, visited);
+			getFeatureAdapter(self).storeEffectiveName(effectiveName);
+		}
+		
+		return effectiveName;
+	}
+	
+	public static String computeEffectiveShortName(Feature self) {
+		return computeEffectiveShortName(self, new HashSet<>());
+	}
+	
+	private static String computeEffectiveShortName(Feature self, Set<Feature> visited) {
+		if (isNameSet(self)) {
+			return self.getDeclaredShortName();
+		}
+		
+		String effectiveShortName = getFeatureAdapter(self).getEffectiveShortName();
+		
+		if (effectiveShortName != null) {
+			return effectiveShortName;
+		}
+
+		visited.add(self);
+		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
+		
+		if (namingFeature != null && !visited.contains(namingFeature)) {
+			effectiveShortName = computeEffectiveShortName(namingFeature, visited);
+			getFeatureAdapter(self).storeEffectiveShortName(effectiveShortName);
+		}
+		
+		return effectiveShortName;
+	}
+	
+	private static boolean isNameSet(Feature self) {
+		return self.getDeclaredName() != null || self.getDeclaredShortName() != null;
 	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -55,7 +55,6 @@ import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.TypeFeaturing;
-import org.omg.sysml.lang.sysml.impl.FeatureImpl;
 
 public class FeatureUtil {
 	
@@ -459,7 +458,7 @@ public class FeatureUtil {
 		}
 
 		visited.add(self);
-		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
+		Feature namingFeature = self.namingFeature();
 		
 		if (namingFeature != null && !visited.contains(namingFeature)) {
 			effectiveName = computeEffectiveName(namingFeature, visited);
@@ -485,7 +484,7 @@ public class FeatureUtil {
 		}
 
 		visited.add(self);
-		FeatureImpl namingFeature = (FeatureImpl) self.namingFeature();
+		Feature namingFeature = self.namingFeature();
 		
 		if (namingFeature != null && !visited.contains(namingFeature)) {
 			effectiveShortName = computeEffectiveShortName(namingFeature, visited);


### PR DESCRIPTION
[Feature_effectiveShortName_InvocationDelegate](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/d20a563968c7b78616ee80481829e0e4f6aee2e1/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveShortName_InvocationDelegate.java#L43) and [Feature_effectiveName_InvocationDelegate](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/blob/d20a563968c7b78616ee80481829e0e4f6aee2e1/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Feature_effectiveName_InvocationDelegate.java#L43) cache their result. The caches are stored by the Invocation Delegates and they are never invalideted. This can lead to values getting stuck or possibly even memory leaks.

- Moved `effectiveName` cache from `Feature_effectiveName_InvocationDelegate`to `FeatureAdapter`
- Moved `effectiveShortName` cache from `Feature_effectiveShortName_InvocationDelegate `to `FeatureAdapter`
- Added cache invalidation
- Moved calculation logic from the Invocation Delegates to `FeatureUtil`