### PR TITLE
ST6RI-797 PortConjugation elements have no elements listed in the JSON source field

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/PortConjugationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PortConjugationAdapter.java
@@ -41,6 +41,8 @@ public class PortConjugationAdapter extends ConjugationAdapter {
 	
 	@Override
 	public void postProcess() {
+		super.postProcess();
+		
 		PortConjugation obj = getTarget();
 		
 		// If the originalPortDefinition is empty, then set it to the owner of the conjugatedPortDefinition


### PR DESCRIPTION
This PR corrects a bug causing the `source` and `conjugatedType` fields of `PortConjugation` to not be set. This results int the JSON emitted by the `SysML2JSON` utility to produce empty values for these attributes. They should both be populated with the `conjugatedPortDefinition` of the `PortConjugation`. 

`PortConjugation` is a specialization of the KerML `Conjugation` relationship. The `Conjugation::conjugatedType` property redefines `Relationship::source`. In KerML, a `Conjugation` may or may not be owned by its `conjugatedType`. If it is owned, then its `owningType` must be the same as its `conjugatedType` – but these are still two separate properties. In SysML, `PortConjugation::conjugatedPortDefinition` redefines `Conjugation::owningType`, and a `PortConjugation` must be owned by its `conjugatedPortDefinition`. But `PortConjugation` also inherits `conjugatedType`, which should be the same as `conjugatedPortDefinition` (i.e., the `owningType`), and, therefore, the value of `source` should also be the same as `conjugatedPortDefinition`.

In the Pilot Implementation, the `Conjugation::getSource` operation calls `getConjugatedType` to get the `source` of a `Conjugation`. However, when a `Conjugation` is parsed with an `owningType`, the `conjugatedType` property is not set during parsing. Instead, it is set by `ConjugationAdapter::postProcess` to the value of `owningType`. In this way, `getSource`, `getConjugatedType` and `getOwningType` all return the same value for a `Conjugation` with an `owningType`.

For a `PortConjugation`, there is additional post-processing required to set the `originalPortDefinition` of the `PortConjugation` to the owner of the `conjugatedPortDefinition`. This is done in `PortConjugationAdapter::postProcess`, which overrides `ConjugationAdapter::postProcess`. Unfortunately, `PortConjugationAdapter::postProcess` was not calling `super.postProcess()`, so the base `Conjugation` post-processing was not being carried out for a `PortConjugation`. As a result, the `conjugatedType` property was never set for a `PortConjugation`, so `getConjugatedType` just returned null (and, hence, `getSource` returned the empty list), even though `conjugatedPortDefinition` is non-null.

Adding the `super.postProcess()` call fixes the bug.
