### PR TITLE
ST6RI-801 SuccessionAsUsage of TransitionUsage seems incorrect

### DIFF
--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/StateTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/StateTest.sysml.xt
@@ -88,6 +88,16 @@ package StateTest {
 		exit act;
 	}
 	
+	state s0 {
+  		state s1 {
+    		state s2;
+  		}
+  		state s3 {
+  			state s4;
+  		}
+  		transition t1 first s1.s2 then s3.s4;
+	}
+	
 	state s parallel {
 		state s1;
 		state s2;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -27,7 +27,7 @@ import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Membership;
-import org.omg.sysml.lang.sysml.OwningMembership;
+import org.omg.sysml.lang.sysml.ParameterMembership;
 import org.omg.sysml.lang.sysml.StateDefinition;
 import org.omg.sysml.lang.sysml.StateUsage;
 import org.omg.sysml.lang.sysml.Succession;
@@ -76,7 +76,7 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	protected void computeSource() {
 		TransitionUsage target = getTarget();
 		List<Membership> ownedMemberships = target.getOwnedMembership();
-		if (ownedMemberships.isEmpty() || ownedMemberships.get(0) instanceof OwningMembership) {
+		if (ownedMemberships.isEmpty() || ownedMemberships.get(0) instanceof ParameterMembership) {
 			Feature source = UsageUtil.getPreviousFeature(target);
 			Membership membership = SysMLFactory.eINSTANCE.createMembership();
 			membership.setMemberElement(source);

--- a/sysml/src/examples/Simple Tests/StateTest.sysml
+++ b/sysml/src/examples/Simple Tests/StateTest.sysml
@@ -37,6 +37,22 @@ package StateTest {
 			then S1;
 			
 		exit act;
+		
+		state S3 {
+			state S3a;
+		}
+		
+		transition first S3.S3a then S1; 
+	}
+	
+	state s0 {
+  		state s1 {
+    		state s2;
+  		}
+  		state s3 {
+  			state s4;
+  		}
+  		transition t1 first s1.s2 then s3.s4;
 	}
 	
 	state s parallel {


### PR DESCRIPTION
This pull request fixes a bug in which a `TransitionUsage` parsed with a feature chain did not correctly reflect this when `getSource` was called on it. This was because the `TransitionUsageAdapter::computeSource` method assumed that a source parsed for a `TransitionUsage` would be referenced by a non-owning `Membership`, while a feature chain is owned using an `OwnedMembership`. Therefore, `computeSource` used the shorthand rule to fill in the source as the lexically immmediately preceding state.

For example, the model 
```
state s0 {
	state s1 {
		state s2;
	}
	transition t1 first s1.s2 then s3.s4;
	state s3 {
		state s4;
	}
}
```
was previously rendered by PlantUML as
![image](https://github.com/user-attachments/assets/94794635-f3ae-4a93-a8fe-5b72264f095c)
because the transition source has been set to `s1`, the state lexically previous to `t1`.

This PR changes the condition in `computeSource`to assume that no source has been parsed for the `TransitionUsage` if the first `ownedMembership` is a `ParameterMembership`, because in the shorthand notation without a source, a `TransitionUsage` is always parsed with an initial empty parameter. With this change, the above model renders properly as
![image](https://github.com/user-attachments/assets/b2aba549-45d6-41d0-9787-77c4b1d9d878)
