### PR TITLE
ST6RI-802: TransitionUsages may be wrongly rendered (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VPath.java
@@ -550,13 +550,6 @@ public class VPath extends VTraverser {
         return "";
     }
 
-    private String addContextForTransitionUsageEnd(Feature tu, Feature end) {
-        PC pc = makeEndFeaturePC(end);
-        InheritKey ik = makeInheritKey(tu);
-        if (createRefPC(ik, pc) == null) return null;
-        return "";
-    }
-
     private String addContextForItemFlowEnd(ItemFlowEnd ife) {
         PC pc = makeEndFeaturePC(ife);
         if (pc == null) return null;
@@ -689,9 +682,6 @@ public class VPath extends VTraverser {
     @Override
     public String caseTransitionUsage(TransitionUsage tu) {
         Succession su = tu.getSuccession();
-        for (Feature end: su.getConnectorEnd()) {
-            addContextForTransitionUsageEnd(tu, end);
-        }
-        return "";
+        return caseConnector(su);
     }
 }


### PR DESCRIPTION
When rendering `TransitionUsage`, the visualizer uses its `SucessionAsUsage` as a connector.  The code for TransitionUsage to resolve end features was not updated previously, even though the algorithm to resolve end features had been fixed and updated. This PR removed the wrong code that was only used for `TransitionUsage`.