### PR TITLE
ST6RI-804 BindingConnctorAsUsages are not given the proper implicit subsetting

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -183,7 +183,7 @@ public class ImplicitGeneralizationMap {
 		put(AttributeDefinitionImpl.class, "base", "Base::DataValue");
 		put(AttributeUsageImpl.class, "base", "Base::dataValues");
 		
-		put(BindingConnectorAsUsageImpl.class, "base", "Links::links");
+		put(BindingConnectorAsUsageImpl.class, "base", "Links::selfLinks");
 		put(BindingConnectorAsUsageImpl.class, "binary", "Links::selfLinks");
 		
 		put(CalculationDefinitionImpl.class, "base", "Calculations::Calculation");
@@ -301,7 +301,7 @@ public class ImplicitGeneralizationMap {
 		put(StateUsageImpl.class, "exclusiveState", "States::StateAction::exclusiveStates");
 		put(StateUsageImpl.class, "ownedAction", "Parts::Part::ownedStates");
 		
-		put(SuccessionAsUsageImpl.class, "base", "Links::links");
+		put(SuccessionAsUsageImpl.class, "base", "Occurrences::happensBeforeLinks");
 		put(SuccessionAsUsageImpl.class, "binary", "Occurrences::happensBeforeLinks");
 		
 		put(SuccessionFlowConnectionUsageImpl.class, "base", "Connections::successionFlowConnections");


### PR DESCRIPTION
This PR fixes a bug that caused `BindingConnectorAsUsages` to get an implicit subsetting of _`Links::links`_ rather than _`Links::selfLinks`_, which is the correct subsetting for all kinds of `BindingConnectors`. 

`BindingConnectorAsUsage` specializes both `BindingConnector` and `Usage`, but it is the `UsageAdapter` that is selected for use for a `BindingConnectorAsUsage` (because there is no `BindingConnectorAsUsageAdapter` or `BindingConnectorAdapter`). As a result, the `base` value from the `ImplicitGeneralizationMap` is used for a `BindingConnectorAsUsage`, not the `binary` value. Unfortunately, only the `binary` value was set to _`Links::selfLinks`_ with the `base` value being `Links::links`. Since a `BindingConnectorAsUsage` must always be binary anyway, changing the `base` value to also be _`Links::selfLinks`_ corrected the bug.

`SuccessionAsUsage` did not have this problem, because there is a `SuccessionAdapter` that is used for it, and `SuccessionAdapter` inherits from `ConnectorAdapter` the use of the `binary` value from `ImplicitGeneralizationMap` for binary connectors. Nevertheless, for consistency and to avoid possible future problems, the `base` value for `SuccessionAsUsage` was also changed to be the same as the `binary` value.