### PR TITLE
ST6RI-730 Validation updates from KerML FTF1 Ballot #3

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
@@ -6,6 +6,7 @@ XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
 		File {from ="/library/Links.kerml"}
 		File {from ="/library/Occurrences.kerml"}
 		File {from ="/library/Objects.kerml"}
+		File {from ="/library/Performances.kerml"}
 	}
 	Workspace {
 		JavaProject {
@@ -15,6 +16,7 @@ XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
 				File {from ="/library/Links.kerml"}
 				File {from ="/library/Occurrences.kerml"}
 				File {from ="/library/Objects.kerml"}
+				File {from ="/library/Performances.kerml"}
 			}
 		}
 	}
@@ -47,4 +49,10 @@ package Specialization_invalid {
 	abstract assoc A1;
 	abstract assoc struct A2 specializes C2, A1;
 	abstract interaction A3 specializes C2, A1;
+	
+	// XPECT errors--->"Cannot specialize behavior" at "B1"
+	struct S specializes B1;
+
+	// XPECT errors--->"Cannot specialize structure" at "S"
+	behavior B1 specializes S;
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -90,6 +90,7 @@ import org.omg.sysml.lang.sysml.FeatureDirectionKind
 import org.omg.sysml.lang.sysml.Metaclass
 import org.omg.sysml.lang.sysml.Import
 import org.omg.sysml.lang.sysml.VisibilityKind
+import org.omg.sysml.lang.sysml.Structure
 
 /**
  * This class contains custom validation rules. 
@@ -180,6 +181,9 @@ class KerMLValidator extends AbstractKerMLValidator {
 	public static val INVALID_CLASS_SPECIALIZATION = "validateClassSpecialization"
 	public static val INVALID_CLASS_SPECIALIZATION_MSG = "Cannot specialize data type or association"    
 	
+	public static val INVALID_STRUCTURE_SPECIALIZATION = "validateStructureSpecialization"
+	public static val INVALID_STRUCTURE_SPECIALIZATION_MSG = "Cannot specialize behavior"    
+	
 	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION = "validateAssociationBinarySpecialization"
 	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG = "Cannot have more than two ends"
 	public static val INVALID_ASSOCIATION_RELATED_TYPES = "validateAssociationRelatedTypes"
@@ -202,6 +206,9 @@ class KerMLValidator extends AbstractKerMLValidator {
 	public static val INVALID_CONNECTOR_RELATED_FEATURES_MSG = "Must have at least two related elements"
 	public static val INVALID_CONNECTOR_TYPE_FEATURING = "validateConnectorTypeFeaturing"
 	public static val INVALID_CONNECTOR_TYPE_FEATURING_MSG = "Should be an accessible feature (use dot notation for nesting)"
+	
+	public static val INVALID_BEHAVIOR_SPECIALIZATION = "validateBehaviorSpecialization"
+	public static val INVALID_BEHAVIOR_SPECIALIZATION_MSG = "Cannot specialize structure"    
 	
 	public static val INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE = "validateParameterMembershipOwningType"
 	public static val INVALID_PARAMETER_MEMBERSHIP_OWNING_TYPE_MSG = "Parameter membership not allowed"	
@@ -599,6 +606,16 @@ class KerMLValidator extends AbstractKerMLValidator {
 	}
 	
 	@Check
+	def checkStructure(Structure c) {
+		// validateStructureSpecialization
+		for (s: c.ownedSpecialization) {
+			if (s.general instanceof Behavior) {
+				error(INVALID_STRUCTURE_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_STRUCTURE_SPECIALIZATION)
+			}
+		}
+	}
+	
+	@Check
 	def checkAssociation(Association a){
 		// validateAssociationBinarySpecialization
 		// NOTE: It is sufficient to check owned ends, since they will redefine ends from any supertypes.
@@ -729,6 +746,16 @@ class KerMLValidator extends AbstractKerMLValidator {
 				warning(INVALID_CONNECTOR_TYPE_FEATURING_MSG, 
 					if (location === c && i < connectorEnds.size) connectorEnds.get(i) else location, 
 					null, INVALID_CONNECTOR_TYPE_FEATURING)
+			}
+		}
+	}
+	
+	@Check
+	def checkBehavior(Behavior b) {
+		// validateStructureSpecialization
+		for (s: b.ownedSpecialization) {
+			if (s.general instanceof Structure) {
+				error(INVALID_BEHAVIOR_SPECIALIZATION_MSG, s, SysMLPackage.eINSTANCE.specialization_General, INVALID_BEHAVIOR_SPECIALIZATION)
 			}
 		}
 	}


### PR DESCRIPTION
This PR implements the resolution to the following issue that was approved in KerML FTF1 Ballot 3.

- [KERML-43](https://issues.omg.org/issues/KERML-43) Performances can be objects, behaviors can be structures

This resolution introduces two new validation constraints:

-  `validateStructureSpecialization`
-  `validateBehaviorSpecialization`

Together, these two constraints disallow a `Structure` from inheriting from a `Behavior`, and vice versa. However, these validations were not implemented at the time the resolution was approved because, at that time, in SysML v2, a `FlowConnectionDefinition` specialized both `PartDefinition` (a kind of `Structure`) and `ActionDefinition` (a kind of `Behavior`). The new validations would thus have make `FlowConnectionDefinition`.

Resolving this problem was deferred to FTF2 issue [SYSML2_-173](https://issues.omg.org/issues/SYSML2_-173), the resolution for which was approved in SysML v2 FTF2 Ballot 5 and implement in PR #607. Therefore, the above validation constraints can now be implemented.