### PR TITLE
ST6RI-813 Transfers across interfaces (SYSML2_-39)

### DIFF
--- a/org.omg.sysml.xpect.tests/library.systems/Interfaces.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Interfaces.sysml
@@ -1,48 +1,89 @@
 standard library package Interfaces {
-	doc
-	/*
-	 * This package defines the base types for interfaces and related structural elements in the SysML language.
-	 */
-	 
-	private import Connections::Connection;
-	private import Connections::connections;
-	private import Connections::BinaryConnection;
-	private import Connections::binaryConnections;
-	private import Ports::Port;
-	
-	abstract interface def Interface :> Connection {
-		doc
-		/*
-		 * Interface is the most general class of links between Ports on Parts 
-		 * within some containing structure. Interface is the base type of all
-		 * InterfaceDefinitions.
-		 */
-	}
-	
-	abstract interface def BinaryInterface :> Interface, BinaryConnection {
-		doc
-		/*
-		 * BinaryInterface is the most general class of links between two Ports 
-		 * on Parts within some containing structure. BinaryInterface is the base 
-		 * type of all binary InterfaceDefinitions with exactly two ends.
-		 */
-	 
-		end source: Port :>> BinaryConnection::source; 
-		end target: Port :>> BinaryConnection::target;
-	}
-	
-	abstract interface interfaces: Interface[0..*] nonunique :> connections {
-		doc
-		/*
-		 * interfaces is the base feature of all InterfaceUsages.
-		 */
-	}
-	
-	abstract interface binaryInterfaces: BinaryInterface[0..*] nonunique :> interfaces, binaryConnections {
-		doc
-		/*
-		 * interfaces is the base feature of all binary InterfaceUsages.
-		 */
-	}
-	
+    doc
+    /*
+     * This package defines the base types for interfaces and related structural elements in the SysML language.
+     */
+     
+    private import Connections::Connection;
+    private import Connections::connections;
+    private import Connections::BinaryConnection;
+    private import Connections::binaryConnections;
+    private import Ports::Port;
+    
+    private import ScalarValues::Natural;
+    private import SequenceFunctions::size;
+    private import SequenceFunctions::excludingAt;
+    private import ControlFunctions::selectOne;
+    
+    private import SequenceFunctions::notEmpty;
+    
+    private calc def excludingOnce {
+        doc
+        /*
+         * Return a sequence that is the same as the input sequence, but with a single
+         * instance of a given value removed. The given value must be in the input sequence.
+         */
+        in seq[1..*] nonunique ordered; 
+        in value[1] :> seq;
+        
+        private attribute position : Natural[1] = (1..size(seq))->selectOne{in i; seq#(i) == value};
+        seq->excludingAt(position)
+    }
+    
+    abstract interface def Interface :> Connection {
+        doc
+        /*
+         * Interface is the most general class of links between Ports on Parts 
+         * within some containing structure. Interface is the base type of all
+         * InterfaceDefinitions. 
+         * 
+         * Transfers outgoing from any one of the participant Ports of an Interface 
+         * may be targeted to one of the other participant Ports (depending on any 
+         * other Interfaces in which the Port is also participating).
+         */
+         
+        ref port :>> participant : Port [2..*] nonunique ordered {
+             doc
+             /*
+              * The participants of an Interface must be Ports. The interfacingPorts of
+              * each participant Port include all the other participants in the Interface.
+              */
+              
+            protected ref thisParticipant :>> self;
+            protected ref otherParticipants : Port [1..*] nonunique :> interfacingPorts
+                default participant->excludingOnce(thisParticipant);            
+        }
+    }
+    
+    abstract interface def BinaryInterface :> Interface, BinaryConnection {
+        doc
+        /*
+         * BinaryInterface is the most general class of links between two Ports 
+         * on Parts within some containing structure. BinaryInterface is the base 
+         * type of all binary InterfaceDefinitions which have exactly two ends. 
+         * 
+         * Transfers outgoing from each participant Port of a BinaryInterface may be 
+         * targeted to the other participant Port (depending on any other Interfaces 
+         * in which the Port is also participating).
+         */
+        
+        ref port :>> Interface::participant, BinaryConnection::participant[2] nonunique ordered;
+     
+        end port source: Port :>> BinaryConnection::source; 
+        end port target: Port :>> BinaryConnection::target;
+    }
+    
+    abstract interface interfaces: Interface[0..*] nonunique :> connections {
+        doc
+        /*
+         * interfaces is the base feature of all InterfaceUsages.
+         */
+    }
+    
+    abstract interface binaryInterfaces: BinaryInterface[0..*] nonunique :> interfaces, binaryConnections {
+        doc
+        /*
+         * interfaces is the base feature of all binary InterfaceUsages.
+         */
+    }
 }

--- a/org.omg.sysml.xpect.tests/library.systems/Interfaces.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Interfaces.sysml
@@ -43,11 +43,11 @@ standard library package Interfaces {
          */
          
         ref port :>> participant : Port [2..*] nonunique ordered {
-             doc
-             /*
-              * The participants of an Interface must be Ports. The interfacingPorts of
-              * each participant Port include all the other participants in the Interface.
-              */
+            doc
+            /*
+             * The participants of an Interface must be Ports. The interfacingPorts of
+             * each participant Port include all the other participants in the Interface.
+             */
               
             protected ref thisParticipant :>> self;
             protected ref otherParticipants : Port [1..*] nonunique :> interfacingPorts

--- a/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
@@ -1,32 +1,32 @@
 standard library package Ports {
-	doc
-	/*
-	 * This package defines the base types for ports and related structural elements 
-	 * in the SysML language.
-	 */
+    doc
+    /*
+     * This package defines the base types for ports and related structural elements 
+     * in the SysML language.
+     */
 
-	private import Objects::Object;
-	private import Objects::objects;
-	
-	abstract port def Port :> Object {
-		doc
-		/*
-		 * Port is the most general class of objects that represent connection points
-		 * for interacting with a Part. Port is the base type of all PortDefinitions.
-		 * 
-		 * Transfers outgoing from a Port are always targeted to a Port connected to
-		 * the original Port by an Interface.
-		 */
-	
-		ref self: Port :>> Object::self;
-		
-		port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
-			doc
-			/*
-			 * The Ports that are subports of this Port.
-			 */
-		}
-		
+    private import Objects::Object;
+    private import Objects::objects;
+    
+    abstract port def Port :> Object {
+        doc
+        /*
+         * Port is the most general class of objects that represent connection points
+         * for interacting with a Part. Port is the base type of all PortDefinitions.
+         * 
+         * Transfers outgoing from a Port are always targeted to a Port connected to
+         * the original Port by an Interface.
+         */
+    
+        ref self: Port :>> Object::self;
+        
+        port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
+            doc
+            /*
+             * The Ports that are subports of this Port.
+             */
+        }
+        
         abstract ref port interfacingPorts : Port[0..*] nonunique :> ports {
             doc
             /*
@@ -34,18 +34,18 @@ standard library package Ports {
              */
         }
         
-        ref :>> outgoingTransfers :> interfacingPorts.incomingTransfersToSelf {
+        ref :>> outgoingTransfersFromSelf :> interfacingPorts.incomingTransfersToSelf {
             doc
             /* 
-             * The target of each outgoingTransfer of a Port must be an interfacingPort.
+             * The target of each of the outgoingTransfersFromSelf of a Port must be an interfacingPort.
              */
         }
-	}
-	
-	abstract port ports : Port[0..*] nonunique :> objects {
-		doc
-		/*
-		 * ports is the base feature of all PortUsages.
-		 */
-	}
+    }
+    
+    abstract port ports : Port[0..*] nonunique :> objects {
+        doc
+        /*
+         * ports is the base feature of all PortUsages.
+         */
+    }
 }

--- a/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
@@ -13,16 +13,33 @@ standard library package Ports {
 		/*
 		 * Port is the most general class of objects that represent connection points
 		 * for interacting with a Part. Port is the base type of all PortDefinitions.
+		 * 
+		 * Transfers outgoing from a Port are always targeted to a Port connected to
+		 * the original Port by an Interface.
 		 */
 	
 		ref self: Port :>> Object::self;
 		
-		port subports: Port :> timeEnclosedOccurrences {
+		port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
 			doc
 			/*
 			 * The Ports that are subports of this Port.
 			 */
 		}
+		
+        abstract ref port interfacingPorts : Port[0..*] nonunique :> ports {
+            doc
+            /*
+             * Ports that are connected to this Port by an Interface.
+             */
+        }
+        
+        ref :>> outgoingTransfers :> interfacingPorts.incomingTransfersToSelf {
+            doc
+            /* 
+             * The target of each outgoingTransfer of a Port must be an interfacingPort.
+             */
+        }
 	}
 	
 	abstract port ports : Port[0..*] nonunique :> objects {

--- a/sysml.library/Systems Library/Interfaces.sysml
+++ b/sysml.library/Systems Library/Interfaces.sysml
@@ -1,48 +1,89 @@
 standard library package Interfaces {
-	doc
-	/*
-	 * This package defines the base types for interfaces and related structural elements in the SysML language.
-	 */
-	 
-	private import Connections::Connection;
-	private import Connections::connections;
-	private import Connections::BinaryConnection;
-	private import Connections::binaryConnections;
-	private import Ports::Port;
-	
-	abstract interface def Interface :> Connection {
-		doc
-		/*
-		 * Interface is the most general class of links between Ports on Parts 
-		 * within some containing structure. Interface is the base type of all
-		 * InterfaceDefinitions.
-		 */
-	}
-	
-	abstract interface def BinaryInterface :> Interface, BinaryConnection {
-		doc
-		/*
-		 * BinaryInterface is the most general class of links between two Ports 
-		 * on Parts within some containing structure. BinaryInterface is the base 
-		 * type of all binary InterfaceDefinitions with exactly two ends.
-		 */
-	 
-		end source: Port :>> BinaryConnection::source; 
-		end target: Port :>> BinaryConnection::target;
-	}
-	
-	abstract interface interfaces: Interface[0..*] nonunique :> connections {
-		doc
-		/*
-		 * interfaces is the base feature of all InterfaceUsages.
-		 */
-	}
-	
-	abstract interface binaryInterfaces: BinaryInterface[0..*] nonunique :> interfaces, binaryConnections {
-		doc
-		/*
-		 * interfaces is the base feature of all binary InterfaceUsages.
-		 */
-	}
-	
+    doc
+    /*
+     * This package defines the base types for interfaces and related structural elements in the SysML language.
+     */
+     
+    private import Connections::Connection;
+    private import Connections::connections;
+    private import Connections::BinaryConnection;
+    private import Connections::binaryConnections;
+    private import Ports::Port;
+    
+    private import ScalarValues::Natural;
+    private import SequenceFunctions::size;
+    private import SequenceFunctions::excludingAt;
+    private import ControlFunctions::selectOne;
+    
+    private import SequenceFunctions::notEmpty;
+    
+    private calc def excludingOnce {
+        doc
+        /*
+         * Return a sequence that is the same as the input sequence, but with a single
+         * instance of a given value removed. The given value must be in the input sequence.
+         */
+        in seq[1..*] nonunique ordered; 
+        in value[1] :> seq;
+        
+        private attribute position : Natural[1] = (1..size(seq))->selectOne{in i; seq#(i) == value};
+        seq->excludingAt(position)
+    }
+    
+    abstract interface def Interface :> Connection {
+        doc
+        /*
+         * Interface is the most general class of links between Ports on Parts 
+         * within some containing structure. Interface is the base type of all
+         * InterfaceDefinitions. 
+         * 
+         * Transfers outgoing from any one of the participant Ports of an Interface 
+         * may be targeted to one of the other participant Ports (depending on any 
+         * other Interfaces in which the Port is also participating).
+         */
+         
+        ref port :>> participant : Port [2..*] nonunique ordered {
+             doc
+             /*
+              * The participants of an Interface must be Ports. The interfacingPorts of
+              * each participant Port include all the other participants in the Interface.
+              */
+              
+            protected ref thisParticipant :>> self;
+            protected ref otherParticipants : Port [1..*] nonunique :> interfacingPorts
+                default participant->excludingOnce(thisParticipant);            
+        }
+    }
+    
+    abstract interface def BinaryInterface :> Interface, BinaryConnection {
+        doc
+        /*
+         * BinaryInterface is the most general class of links between two Ports 
+         * on Parts within some containing structure. BinaryInterface is the base 
+         * type of all binary InterfaceDefinitions which have exactly two ends. 
+         * 
+         * Transfers outgoing from each participant Port of a BinaryInterface may be 
+         * targeted to the other participant Port (depending on any other Interfaces 
+         * in which the Port is also participating).
+         */
+        
+        ref port :>> Interface::participant, BinaryConnection::participant[2] nonunique ordered;
+     
+        end port source: Port :>> BinaryConnection::source; 
+        end port target: Port :>> BinaryConnection::target;
+    }
+    
+    abstract interface interfaces: Interface[0..*] nonunique :> connections {
+        doc
+        /*
+         * interfaces is the base feature of all InterfaceUsages.
+         */
+    }
+    
+    abstract interface binaryInterfaces: BinaryInterface[0..*] nonunique :> interfaces, binaryConnections {
+        doc
+        /*
+         * interfaces is the base feature of all binary InterfaceUsages.
+         */
+    }
 }

--- a/sysml.library/Systems Library/Interfaces.sysml
+++ b/sysml.library/Systems Library/Interfaces.sysml
@@ -43,11 +43,11 @@ standard library package Interfaces {
          */
          
         ref port :>> participant : Port [2..*] nonunique ordered {
-             doc
-             /*
-              * The participants of an Interface must be Ports. The interfacingPorts of
-              * each participant Port include all the other participants in the Interface.
-              */
+            doc
+            /*
+             * The participants of an Interface must be Ports. The interfacingPorts of
+             * each participant Port include all the other participants in the Interface.
+             */
               
             protected ref thisParticipant :>> self;
             protected ref otherParticipants : Port [1..*] nonunique :> interfacingPorts

--- a/sysml.library/Systems Library/Ports.sysml
+++ b/sysml.library/Systems Library/Ports.sysml
@@ -1,32 +1,32 @@
 standard library package Ports {
-	doc
-	/*
-	 * This package defines the base types for ports and related structural elements 
-	 * in the SysML language.
-	 */
+    doc
+    /*
+     * This package defines the base types for ports and related structural elements 
+     * in the SysML language.
+     */
 
-	private import Objects::Object;
-	private import Objects::objects;
-	
-	abstract port def Port :> Object {
-		doc
-		/*
-		 * Port is the most general class of objects that represent connection points
-		 * for interacting with a Part. Port is the base type of all PortDefinitions.
-		 * 
-		 * Transfers outgoing from a Port are always targeted to a Port connected to
-		 * the original Port by an Interface.
-		 */
-	
-		ref self: Port :>> Object::self;
-		
-		port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
-			doc
-			/*
-			 * The Ports that are subports of this Port.
-			 */
-		}
-		
+    private import Objects::Object;
+    private import Objects::objects;
+    
+    abstract port def Port :> Object {
+        doc
+        /*
+         * Port is the most general class of objects that represent connection points
+         * for interacting with a Part. Port is the base type of all PortDefinitions.
+         * 
+         * Transfers outgoing from a Port are always targeted to a Port connected to
+         * the original Port by an Interface.
+         */
+    
+        ref self: Port :>> Object::self;
+        
+        port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
+            doc
+            /*
+             * The Ports that are subports of this Port.
+             */
+        }
+        
         abstract ref port interfacingPorts : Port[0..*] nonunique :> ports {
             doc
             /*
@@ -34,18 +34,18 @@ standard library package Ports {
              */
         }
         
-        ref :>> outgoingTransfers :> interfacingPorts.incomingTransfersToSelf {
+        ref :>> outgoingTransfersFromSelf :> interfacingPorts.incomingTransfersToSelf {
             doc
             /* 
-             * The target of each outgoingTransfer of a Port must be an interfacingPort.
+             * The target of each of the outgoingTransfersFromSelf of a Port must be an interfacingPort.
              */
         }
-	}
-	
-	abstract port ports : Port[0..*] nonunique :> objects {
-		doc
-		/*
-		 * ports is the base feature of all PortUsages.
-		 */
-	}
+    }
+    
+    abstract port ports : Port[0..*] nonunique :> objects {
+        doc
+        /*
+         * ports is the base feature of all PortUsages.
+         */
+    }
 }

--- a/sysml.library/Systems Library/Ports.sysml
+++ b/sysml.library/Systems Library/Ports.sysml
@@ -13,16 +13,33 @@ standard library package Ports {
 		/*
 		 * Port is the most general class of objects that represent connection points
 		 * for interacting with a Part. Port is the base type of all PortDefinitions.
+		 * 
+		 * Transfers outgoing from a Port are always targeted to a Port connected to
+		 * the original Port by an Interface.
 		 */
 	
 		ref self: Port :>> Object::self;
 		
-		port subports: Port :> timeEnclosedOccurrences {
+		port subports: Port [0..*] :> ports, timeEnclosedOccurrences {
 			doc
 			/*
 			 * The Ports that are subports of this Port.
 			 */
 		}
+		
+        abstract ref port interfacingPorts : Port[0..*] nonunique :> ports {
+            doc
+            /*
+             * Ports that are connected to this Port by an Interface.
+             */
+        }
+        
+        ref :>> outgoingTransfers :> interfacingPorts.incomingTransfersToSelf {
+            doc
+            /* 
+             * The target of each outgoingTransfer of a Port must be an interfacingPort.
+             */
+        }
 	}
 	
 	abstract port ports : Port[0..*] nonunique :> objects {


### PR DESCRIPTION
This PR implements the resolution to the following issue, as approved in SysML v2 FTF2 Ballot 6.

- [SYSML2_-39](https://issues.omg.org/issues/SYSML2_-39) Semantics of transfers across interfaces

This resolution updates the Systems Library models `Ports.sysml` and `Interfaces.sysml` to specify the semantics of automatically targeting a transfer whose source is a `Port` at one end of an `Interface` to a `Port` at a different end of the `Interface`.