### PR TITLE
ST6RI-820 ResultExpressionMembership validation is incorrect

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ResultExpressionMembership_Invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/ResultExpressionMembership_Invalid.kerml.xt
@@ -1,0 +1,35 @@
+//*
+XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+       	File {from ="/library/Occurrences.kerml"}
+       	File {from ="/library/Performances.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Occurrences.kerml"}
+       			File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+package ResultExpressionMembersio_invalid {
+	function F {
+		1
+	}
+	function G :> F {
+		//XPECT errors --> "Only one (owned or inherited) result expression is allowed" at "2"
+		2
+	}
+	
+	expr f : F {
+		//XPECT errors --> "Only one (owned or inherited) result expression is allowed" at "1"
+		1
+	}
+	//XPECT errors --> "Only one (owned or inherited) result expression is allowed" at "expr g :> f;"
+	expr g :> f;
+}

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -321,11 +321,9 @@ public class TypeUtil {
 		visited.add(type);
 		getTypeAdapter(type).addAdditionalMembers();
 		Set<ResultExpressionMembership> resultExpressions = new HashSet<>(getOwnedResultExpressionMembershipsOf(type));
-		if (resultExpressions.isEmpty()) {
-			for (Type general: getSupertypesOf(type)) {
-				if (general != null && !visited.contains(general)) {
-					resultExpressions.addAll(getResultExpressionMembershipsOf(general, visited));
-				}
+		for (Type general: getSupertypesOf(type)) {
+			if (general != null && !visited.contains(general)) {
+				resultExpressions.addAll(getResultExpressionMembershipsOf(general, visited));
 			}
 		}
 		return resultExpressions;


### PR DESCRIPTION
This PR corrects the checking of the `validateFunctionResultExpressionMembership` and `validateExpressionResultExpressionMembership` constraints. These constraints require that a `Function` or `Expression` have at most one owned or inherited `ResultExpressionMembership`. However, the implementation was allowing a `Function` or `Expression` to have inherited `ResultExpressionMemberships` if it had an owned `ResultExpressionMembership` (but it still only allowed one inherited `ResultExpressionMembership` if there was no owned `ResultExpressionMembership`).

The problem was with the utility method `TypeUtil.getResultExpressionMembershipsOf`, which is used to search the supertype hierarchy just for `ResultExpressionMemberships`. This had been implemented to stop searching when a `Type` was found with owned `ResultExpressionMemberships`. This PR changes `getResultExpressionMembershipsOf` so that it continues searching until all inherited `ResultExpressionMemberships` are found. (Note that result `Expressions` do not automatically override inherited result `Expressions`.)

For example, the following KerML model, which passed validation before, fails after the change in this PR.
```
function F {
  1
}
function G :> F {
  2 // Fails validateFunctionResultExpressionMembership here
}
```
(For a similar SysML example, replace `function` with `calc def`.)