### PR TITLE
ST6RI-819 Association end type constraint (KERML_-32)

### DIFF
--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-5-TimingForStructures.kerml
@@ -62,12 +62,13 @@ package TimingForStructuresExecution2 {
 	private import Atoms::*;
 	private import TimingForStructuresModelToBeExecuted2::*;
 	private import Occurrences::HappensDuring;
-	private import OneToOneConnectorsExecution::MyWheel1;
-	private import OneToOneConnectorsExecution::MyWheel2;
 	private import OneToOneConnectorsExecution::MyWheel;
-	private import OneToOneConnectorsExecution::MyBikeFork1;
-	private import OneToOneConnectorsExecution::MyBikeFork2;
 	private import OneToOneConnectorsExecution::MyBikeFork;
+	
+	struct MyWheel1 specializes OneToOneConnectorsExecution::MyWheel1;
+	struct MyWheel2 specializes OneToOneConnectorsExecution::MyWheel2;
+    struct MyBikeFork1 specializes OneToOneConnectorsExecution::MyBikeFork1;
+    struct MyBikeFork2 specializes OneToOneConnectorsExecution::MyBikeFork2;
 
 	#atom
 	assoc MyBike_During_Wheel1_Link specializes HappensDuring {

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_EndTypes_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_EndTypes_invalid.kerml.xt
@@ -1,0 +1,45 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+		ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+		File {from ="/library/Occurrences.kerml"}
+		File {from ="/library/Objects.kerml"}
+		File {from ="/library/Performances.kerml"}
+	}
+	Workspace {
+		JavaProject {
+			SrcFolder {
+				ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+				File {from ="/library/Objects.kerml"}
+				File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+package AssociationTest_EndTypes_invalid {
+	class C1;	
+	class C2;
+	class C3 specializes C1;
+	
+	assoc A1 {
+		end x : C1;
+		// XPECT errors --> "An association end must have exactly one type" at "end y : C1, C2;"
+		end y : C1, C2;
+	}
+	
+	assoc A2 specializes A1 {
+		// XPECT errors --> "An association end must have exactly one type" at "end x : C2;"
+		end x : C2;
+	}
+	
+	assoc A3 specializes A1 {
+		end x : C3;
+	}
+	
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -211,6 +211,8 @@ class KerMLValidator extends AbstractKerMLValidator {
 	
 	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION = "validateAssociationBinarySpecialization"
 	public static val INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG = "Cannot have more than two ends"
+	public static val INVALID_ASSOCIATION_END_TYPES = "validateAssociationEndTypes"
+	public static val INVALID_ASSOCIATION_END_TYPES_MSG = "An association end must have exactly one type"
 	public static val INVALID_ASSOCIATION_RELATED_TYPES = "validateAssociationRelatedTypes"
 	public static val INVALID_ASSOCIATION_RELATED_TYPES_MSG = "Must have at least two related elements"
 	public static val INVALID_ASSOCIATION_STRUCTURE_INTERSECTION = "validateAssociationStructureIntersection"
@@ -767,12 +769,12 @@ class KerMLValidator extends AbstractKerMLValidator {
 	def checkAssociation(Association a){
 		// validateAssociationBinarySpecialization
 		// NOTE: It is sufficient to check owned ends, since they will redefine ends from any supertypes.
-		val associationEnds = TypeUtil.getOwnedEndFeaturesOf(a);
-		if (associationEnds.size() > 2) {
+		val ownedEndFeatures = TypeUtil.getOwnedEndFeaturesOf(a);
+		if (ownedEndFeatures.size() > 2) {
 			val binaryLinkType = SysMLLibraryUtil.getLibraryElement(a, "Links::BinaryLink") as Type
 			if (a.conformsTo(binaryLinkType)) {
-				for (var i = 2; i < associationEnds.size(); i++) {
-					error(INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG, associationEnds.get(i), null, INVALID_ASSOCIATION_BINARY_SPECIALIZATION)	
+				for (var i = 2; i < ownedEndFeatures.size(); i++) {
+					error(INVALID_ASSOCIATION_BINARY_SPECIALIZATION_MSG, ownedEndFeatures.get(i), null, INVALID_ASSOCIATION_BINARY_SPECIALIZATION)	
 				}
 			}
 		}
@@ -782,6 +784,13 @@ class KerMLValidator extends AbstractKerMLValidator {
 			val relatedElements = a.getRelatedElement
 			if (relatedElements !== null && relatedElements.size < 2)
 				error(INVALID_ASSOCIATION_RELATED_TYPES_MSG, a, SysMLPackage.eINSTANCE.relationship_RelatedElement, INVALID_ASSOCIATION_RELATED_TYPES)	
+		}
+		
+		// validateAssociationEndTypes
+		for (end: ownedEndFeatures) {
+			if (end.type.size != 1) {
+				error(INVALID_ASSOCIATION_END_TYPES_MSG, end, null, INVALID_ASSOCIATION_END_TYPES)
+			}
 		}
 		
 		// validateAssociationStructureIntersection is automatically satisfied


### PR DESCRIPTION
This PR implements the resolution to the following issue from KerML FTF2 Ballot 2:

- [KERML_-32](http://issues.omg.org/issues/KERML_-32) Association ends can have more than one type

(This resolution should have been implemented in the 2024-12 release, but it was missed.)

The resolution to this issue adds a new `validateAssociationEndTypes` constraint that requires association end features (or connection end features in SysML) to have exactly one type.