### PR TITLE
ST6RI-821 Transitivity for time/space relations where it is missing (KERML_-104)

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -152,13 +152,17 @@ standard library package Occurrences {
 			 * including at least this occurrence.
 			 */
 
-			/* timeCoincidentOccurrences occurrences happen during each other. */
 			feature thatOccurrence: Occurrence[1] subsets longerOccurrence;
 			feature thisOccurrence: Occurrence[1] subsets shorterOccurrence;
 
+			/* timeCoincidentOccurrences occurrences happen during each other. */
 			connector :HappensDuring
 				from [1] shorterOccurrence references thisOccurrence
 				to [1] longerOccurrence references thatOccurrence;
+
+			/* timeCoincidentOccurrences is transitive */
+			subset thatOccurrence.timeCoincidentOccurrences
+				subsets thisOccurrence.timeCoincidentOccurrences;
 		}
 
 		feature spaceEnclosedOccurrences: Occurrence[1..*] subsets occurrences {
@@ -168,10 +172,14 @@ standard library package Occurrences {
 			 * including this one.
 			 */
 
-			/* spaceEnclosedOccurrences is transitive. */
 			feature largerSpace: Occurrence[1] subsets that;
 			feature smallerSpace: Occurrence[1] subsets self;
+
+			/* spaceEnclosedOccurrences is transitive. */
 			subset smallerSpace.spaceEnclosedOccurrences subsets largerSpace.spaceEnclosedOccurrences;
+
+			/* smallerSpace are outside occurrences that are outside their largerSpace */
+			subset smallerSpace.outsideOfOccurrences subsets largerSpace.outsideOfOccurrences;
 		}
 
 		feature all spaceTimeEnclosedOccurrences: Occurrence[1..*] subsets timeEnclosedOccurrences, spaceEnclosedOccurrences
@@ -181,6 +189,9 @@ standard library package Occurrences {
 			 * Occurrences that this one completely includes in both space and time,
 			 * including this one.
 			 */
+
+			/* spaceTimeEnclosedOccurrences is transitive */
+			subset largerSpace.spaceTimeEnclosedOccurrences subsets smallerSpace.spaceTimeEnclosedOccurrences;
 		}
 
 		feature all spaceTimeEnclosedPoints : Occurrence[1..*] subsets spaceTimeEnclosedOccurrences {
@@ -202,13 +213,17 @@ standard library package Occurrences {
 			 * and vice-versa, including this one.
 			 */
 
-			/* spaceTimeCoincidentOccurrences occurrences are inside of each other. */
 			feature redefines thatOccurrence subsets largerSpace;
 			feature redefines thisOccurrence subsets smallerSpace;
 
+			/* spaceTimeCoincidentOccurrences occurrences are inside of each other. */
 			connector :InsideOf
 				from [1] largerSpace references thatOccurrence
 				to [1] smallerSpace references thisOccurrence;
+
+			/* spaceTimeCoincidentOccurrences is transitive */
+			subset thatOccurrence.spaceTimeCoincidentOccurrences
+				subsets thisOccurrence.spaceTimeCoincidentOccurrences;
 		}
 
 		feature outsideOfOccurrences: Occurrence[0..*] subsets withoutOccurrences inverse of outsideOfOccurrences {
@@ -288,6 +303,9 @@ standard library package Occurrences {
 			feature portionOccurrence: Occurrence[1] subsets that;
 			feature portionedOccurrence: Occurrence[1] subsets self;
 			binding [1] portionOccurrence.portionOfLife = [1] portionedOccurrence.portionOfLife;
+
+			/* portionOf is transitive */
+			subset portionedOccurrence.portionOf subsets portionOccurrence.portionOf;
 		}
 
 		portion feature timeSlices: Occurrence[1..*] subsets portions {
@@ -304,6 +322,12 @@ standard library package Occurrences {
 			 * Occurrences of which this occurrence is a time slice, including at least this
 			 * occurrence.
 			 */
+
+			feature timeSliceOccurrence: Occurrence[1] subsets that;
+			feature timeSlicedOccurrence: Occurrence[1] subsets self;
+
+			/* timeSliceOf is transitive */
+			subset timeSlicedOccurrence.timeSliceOf subsets timeSliceOccurrence.timeSliceOf;
 		}
 
 		portion feature all snapshots: Occurrence[1..*] subsets timeSlices {
@@ -383,6 +407,9 @@ standard library package Occurrences {
 			feature spaceSliceOccurrence: Occurrence[1] subsets that;
 			feature spaceSlicedOccurrence: Occurrence[1] subsets self;
 			inv { spaceSliceOccurrence.innerSpaceDimension <= spaceSlicedOccurrence.innerSpaceDimension }
+
+			/* spaceSliceOf is transitive */
+			subset spaceSlicedOccurrence.spaceSliceOf subsets spaceSliceOccurrence.spaceSliceOf;
 		}
 
 		portion feature spaceShots: Occurrence[1..*] subsets spaceSlices {
@@ -401,6 +428,9 @@ standard library package Occurrences {
 			feature spaceShotOccurrence: Occurrence[1] subsets that;
 			feature spaceShottedOccurrence: Occurrence[1] subsets self;
 			inv { spaceShotOccurrence.innerSpaceDimension < spaceShottedOccurrence.innerSpaceDimension }
+
+			/* spaceShotOf is transitive */
+			subset spaceShottedOccurrence.spaceShotOf subsets spaceShotOccurrence.spaceShotOf;
 		}
 
 		feature unionsOf: Set[0..*] {


### PR DESCRIPTION
Updates Kernel Semantic Library model `Occurrences.kerml` for the resolution to this SysML v2 FTF2 issue.

- [KERML_-104](https://issues.omg.org/issues/KERML_-104) Transitivity missing for some time/space associations

Specifically, these features of `Occurrence`: `timeCoincidentOccurrences`, `spaceEnclosedOccurrences`, `spaceTimeEnclosedOccurrences`, `spaceTimeCoincidentOccurrences`, `portionOf`, `timeSliceOf ` (ensures `spaceShotOf ` includes all `timeSliceOf` transitively, due to sufficiency of `snapshots`), `spaceSliceOf`, and `spaceShotOf`.

Also adds to `spaceEnclosedOccurrences` that "smaller" spaces are outside occurrences that are outside their "larger" spaces, similar to existing axioms for time ordering.