### PR TITLE
ST6RI-826 isComposite semantics (KERML_-5)

### DIFF
--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -74,6 +74,9 @@ standard library package Occurrences {
 			 feature redefines incomingTransferSort default (that as Occurrence).incomingTransferSort;
 		}
 		
+		/* Occurrences may be suboccurrences of no more than one other occurrence. */		
+		feature superoccurrence: Occurrence[0..1] subsets occurrences inverse of suboccurrences;
+
 		feature withoutOccurrences: Occurrence[0..*] unions successors, predecessors, outsideOfOccurrences
 			inverse of withoutOccurrences {
 			doc
@@ -353,6 +356,11 @@ standard library package Occurrences {
 			/*
 			 * The snapshot at the end of the occurrence in time.
 			 */
+
+			/* suboccurrences at the end of an Occurrence must also end. */
+			feature subendshot : Occurrence [0..*] chains self.suboccurrences.endShot {
+				  feature superendshot : Occurrence [1] subsets that;
+				  subset superendshot subsets self.timeCoincidentOccurrences; }
 		}
 
 		 connector :HappensJustBefore
@@ -416,7 +424,7 @@ standard library package Occurrences {
 			feature union: Occurrence[0..1];
 
 			connector :Within
-				  from [0..*] smallerOccurrence references elements
+				  from [0..*] smallerOccurrence references elements 
 				  to [1] largerOccurrence references union;
 			connector :Within
 				  from [0..*] smallerOccurrence references union.spaceTimeEnclosedPoints


### PR DESCRIPTION
Updates Kernel Semantic Library model `Occurrences.kerml` for the resolution to this KerML FTF2 issue.

- [KERML_-5](https://issues.omg.org/issues/KERML_-5) isComposite, semantics?

Adds

- Informal semantics (in text) for single "ownership" via composite features (values of composite features cannot be values of other composite features that are not featured by the same composing instance).
- Modeled semantics for the above and for the existing informal "destruction" semantics (values of composite features at the time their composing occurrence end also end at that time):
   - Single ownership: Multiplicity [0..1] on a new inverse of `suboccurrences` (`superoccurrence`).
   - Destruction: Time coincidence of `endShot` and `endShots` of its `suboccurrences`.
