### PR TITLE
ST6RI-614 Redefinable shape attributes (SYSML2_-471)

### DIFF
--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -6,7 +6,8 @@ standard library package ShapeItems {
 
 	private import ScalarValues::Boolean;
 	private import ScalarValues::Positive;
-	private import ISQ::*;
+	private import ISQSpaceTime::*;
+	private import ISQBase::*;
 	private import SI::m;
 	private import Occurrences::MatesWith;
 	private import Objects::*;

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -110,8 +110,8 @@ standard library package ShapeItems {
 		 */
 	
 		attribute :>> radius [1];
-        attribute :>> semiMajorAxis [1] = radius;
-        attribute :>> semiMinorAxis [1] = radius;
+		attribute :>> semiMajorAxis [1] = radius;
+		attribute :>> semiMinorAxis [1] = radius;
 
 		item :>> edges {
 			attribute length [1] = Circle::radius * TrigFunctions::pi * 2;
@@ -260,7 +260,10 @@ standard library package ShapeItems {
 		 * A CircularDisc is a Disc bound by a Circle.
 		 */
 	
-		attribute :>> radius [1] = semiMajorAxis;
+		attribute :>> radius [1];
+		attribute :>> semiMajorAxis [1] = radius;
+		attribute :>> semiMinorAxis [1] = radius;
+
 		item :>> shape : Circle;
 		item :>> edges : Circle;
 	}
@@ -297,10 +300,10 @@ standard library package ShapeItems {
 		 * A Sphere is an Ellipsoid with all the same semiaxes.
 		 */	
 
-		attribute :>> radius [1] = semiAxis1;
-
-		assert constraint { ( semiAxis1 == semiAxis2 ) &
-						    ( semiAxis2 ==  semiAxis3 ) }
+		attribute :>> radius [1];
+		attribute :>> semiAxis1 [1] = radius;
+		attribute :>> semiAxis2 [1] = radius;
+		attribute :>> semiAxis3 [1] = radius;
 	}
 
 	item def Paraboloid :> ConicSurface {
@@ -444,9 +447,9 @@ standard library package ShapeItems {
 		 * A CircularCone is a Cone with a circular base.
 		 */	
 
-		attribute :>> radius [1] = semiMajorAxis;
-
-		assert constraint { semiMajorAxis == semiMinorAxis }
+		attribute :>> radius [1];
+		attribute :>> semiMajorAxis [1] = radius;
+		attribute :>> semiMinorAxis [1] = radius;
 
 		item :>> base : CircularDisc;
 	}
@@ -491,9 +494,9 @@ standard library package ShapeItems {
 		 * A CircularCylinder is a Cylinder with two circular sides.
 		 */
 	
-		attribute :>> radius [1] = semiMajorAxis;
-
-		assert constraint { semiMajorAxis == semiMinorAxis }
+		attribute :>> radius [1];
+		attribute :>> semiMajorAxis [1] = radius;
+		attribute :>> semiMinorAxis [1] = radius;
 
 		item :>> base : CircularDisc;
 		item :>> af : CircularDisc;

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -20,6 +20,7 @@ standard library package Items {
 	private import SequenceFunctions::includes;
 	private import SequenceFunctions::union;
 	private import ControlFunctions::forAll;
+	private import ScalarValues::Boolean;
 	
 	abstract item def Item :> Object {
 		doc
@@ -100,11 +101,12 @@ standard library package Items {
 			 */
 		}
 
-		attribute isSolid = isEmpty(voids) {
+		attribute isSolid: Boolean {
 			doc
 			/*
 			 * An Item is solid if it has no voids.
 			 */
+			attribute :>> self: Boolean = isEmpty((that as Item).voids);
 		}
 		
 		abstract item subitems: Item[0..*] :> items, subobjects {

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -20,7 +20,6 @@ standard library package Items {
 	private import SequenceFunctions::includes;
 	private import SequenceFunctions::union;
 	private import ControlFunctions::forAll;
-	private import ScalarValues::Boolean;
 	
 	abstract item def Item :> Object {
 		doc
@@ -101,12 +100,11 @@ standard library package Items {
 			 */
 		}
 
-		attribute isSolid: Boolean {
+		attribute isSolid = isEmpty(voids) {
 			doc
 			/*
 			 * An Item is solid if it has no voids.
 			 */
-			attribute :>> self: Boolean = isEmpty((that as Item).voids);
 		}
 		
 		abstract item subitems: Item[0..*] :> items, subobjects {


### PR DESCRIPTION
Updates the Geometry Domain Library model `ShapeItems.sysml` for the resolution to the following SysML v2 FTF2 issue.
- [SYSML2_-471](https://issues.omg.org/issues/SYSML2_-471) Unredefinable shape attributes

Specifically, `radius` on `Circle`, `CircularDisc`, `Sphere`, `CircularCone`, and `CircularCylinder` are made redefinable by moving their declaration bindings to the features they were bound to.  Also, asserted constraints on `Sphere`, `CircularCone`, and `CircularCylinder` are changed to equivalent declaration bindings.