### PR TITLE
ST6RI-832 Domain library models (SYSML2_-32/248)

### DIFF
--- a/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
@@ -58,7 +58,7 @@ standard library package TradeStudies {
 			 */
 		}
 		
-		in calc fn : EvaluationFunction {
+		in calc eval : EvaluationFunction {
 			doc
 			/*
 			 * The EvaluationFunction to be used in evaluating the given alternatives.
@@ -74,7 +74,7 @@ standard library package TradeStudies {
 			 */
 		}
 				
-		require constraint { fn(selectedAlternative) == best }
+		require constraint { eval(selectedAlternative) == best }
 	}
 	
 	requirement def MinimizeObjective :> TradeStudyObjective {
@@ -87,7 +87,7 @@ standard library package TradeStudies {
 		 
 		subject :>> selectedAlternative;
 		in ref :>> alternatives;
-		in calc :>>fn;
+		in calc :>> eval;
 	
 		out attribute :>> best = alternatives->minimize {
 			doc
@@ -109,7 +109,7 @@ standard library package TradeStudies {
 	
         subject :>> selectedAlternative;
         in ref :>> alternatives;
-        in calc :>>fn;
+        in calc :>> eval;
     
 		out attribute :>> best = alternatives->maximize {
 			doc
@@ -164,7 +164,7 @@ standard library package TradeStudies {
 		
             subject :>> selectedAlternative;
 			in ref :>> alternatives = studyAlternatives;
-			in calc :>> fn = evaluationFunction;
+			in calc :>> eval = evaluationFunction;
 		}
 		
 		return selectedAlternative : Anything = studyAlternatives->selectOne {in ref a {

--- a/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/Time.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/Time.sysml
@@ -195,8 +195,6 @@ standard library package Time {
 	     * 1969-07-20T20:17:00Z (UTC date and time with second precision)
 	     * 1969-07-20T15:17:00-05:00 (local date and time with second precision for a timezone 5 hour behind UTC)
 	     * 1969-07-20T22:17:00+02:00 (local date and time with second precision for a timezone 2 hour ahead of UTC)
-	     *
-	     * TODO: Add constraint to verify ISO 8691 extended string encoding.
 	     */
     }
 
@@ -222,9 +220,6 @@ standard library package Time {
 		/*
 	     * Representation of an ISO 8601 date and time with explicit date and time component attributes
 	     *
-	     * TO DO: Specify restrictions for attributes month (1 to 12), day (1 to 31), hour (0 to 23), minute (0 to 59), second (0 to 60), 
-	     * microsecond (0 to 999999), hourOffset (-12 to +12), minuteOffset (-59 to +59)
-	     * 
 	     * The total time offset is equal to the summation of hourOffset and minuteOffset.
 		 */
 	

--- a/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
+++ b/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
@@ -58,7 +58,7 @@ standard library package TradeStudies {
 			 */
 		}
 		
-		in calc fn : EvaluationFunction {
+		in calc eval : EvaluationFunction {
 			doc
 			/*
 			 * The EvaluationFunction to be used in evaluating the given alternatives.
@@ -74,7 +74,7 @@ standard library package TradeStudies {
 			 */
 		}
 				
-		require constraint { fn(selectedAlternative) == best }
+		require constraint { eval(selectedAlternative) == best }
 	}
 	
 	requirement def MinimizeObjective :> TradeStudyObjective {
@@ -87,7 +87,7 @@ standard library package TradeStudies {
 		 
 		subject :>> selectedAlternative;
 		in ref :>> alternatives;
-		in calc :>>fn;
+		in calc :>> eval;
 	
 		out attribute :>> best = alternatives->minimize {
 			doc
@@ -109,7 +109,7 @@ standard library package TradeStudies {
 	
         subject :>> selectedAlternative;
         in ref :>> alternatives;
-        in calc :>>fn;
+        in calc :>> eval;
     
 		out attribute :>> best = alternatives->maximize {
 			doc
@@ -164,7 +164,7 @@ standard library package TradeStudies {
 		
             subject :>> selectedAlternative;
 			in ref :>> alternatives = studyAlternatives;
-			in calc :>> fn = evaluationFunction;
+			in calc :>> eval = evaluationFunction;
 		}
 		
 		return selectedAlternative : Anything = studyAlternatives->selectOne {in ref a {

--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -195,8 +195,6 @@ standard library package Time {
 	     * 1969-07-20T20:17:00Z (UTC date and time with second precision)
 	     * 1969-07-20T15:17:00-05:00 (local date and time with second precision for a timezone 5 hour behind UTC)
 	     * 1969-07-20T22:17:00+02:00 (local date and time with second precision for a timezone 2 hour ahead of UTC)
-	     *
-	     * TODO: Add constraint to verify ISO 8691 extended string encoding.
 	     */
     }
 
@@ -222,9 +220,6 @@ standard library package Time {
 		/*
 	     * Representation of an ISO 8601 date and time with explicit date and time component attributes
 	     *
-	     * TO DO: Specify restrictions for attributes month (1 to 12), day (1 to 31), hour (0 to 23), minute (0 to 59), second (0 to 60), 
-	     * microsecond (0 to 999999), hourOffset (-12 to +12), minuteOffset (-59 to +59)
-	     * 
 	     * The total time offset is equal to the summation of hourOffset and minuteOffset.
 		 */
 	


### PR DESCRIPTION
This PR updates models from two domain libraries per the resolutions to the following issues approved on SysML v2 FTF2 Ballot 7.

- [SYSML2_-32](https://issues.omg.org/browse/SYSML2_-32) Resolve "TODO" in domain library model Time
- [SYSML2_-248](https://issues.omg.org/browse/SYSML2_-248) Evaluation problem with TradeStudyObjectives

<ins>Analysis Domain LIbrary</ins>
- `TradeStudies.sysml` – Renames the parameter `TradeStudyObjective::fn` to `eval` to avoid a name conflict.

<ins>Quantities and Units Domain Library</ins>
- `Time.sysml` – Removes two "TODO" comments.