### PR TITLE
ST6RI-828 Operation and Constraint Updates for 2025-02/Beta 3

### DIFF
--- a/kerml/src/examples/Behavior Examples/TakePicture.kerml
+++ b/kerml/src/examples/Behavior Examples/TakePicture.kerml
@@ -11,7 +11,7 @@ behavior TakePicture {
 	step step1: Focus[1];	
 	step step2: Shoot[1];
 	
-	succession flow exposure[1] from step1.xrsl to step2.xsf;
+	succession flow exposure[1] of Exposure from step1.xrsl to step2.xsf;
 
 	succession step1 then camera.focusedState;
 	succession step2 then camera.shotState;

--- a/kerml/src/examples/Simple Tests/Expressions.kerml
+++ b/kerml/src/examples/Simple Tests/Expressions.kerml
@@ -21,14 +21,13 @@ package Expressions {
 	behavior w { inout v : Integer;
 	    step : ControlPerformances::LoopPerformance {
     		in expr whileTest {v > 3}
-    		in expr untilTest;
     		in step body {
     			step decrement {
     				out v_decr : Integer = v - 1;			
     			}
     			succession decrement then update;
     			step update : FeatureReferencingPerformances::FeatureWritePerformance {
-    				in redefines onOccurrence = w::self {
+    				in onOccurrence = w::self {
     					feature redefines startingAt : w {
     						inout feature redefines accessedFeature redefines v;
     					}

--- a/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
@@ -116,8 +116,8 @@ standard library package ControlPerformances {
 		 */
 		 
 		in whileTest : BooleanEvaluation[1..*];
-		in untilTest : BooleanEvaluation[0..*];
 		in body : Occurrence[0..*];
+        in untilTest : BooleanEvaluation[0..*];
 		
 		step whileDecision : IfThenPerformance[1..*];
 		step untilDecision : IfElsePerformance[0..*];

--- a/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/ControlPerformances.kerml
@@ -31,7 +31,7 @@ standard library package ControlPerformances {
 			 * successions going out of a decision step.
 			 */
 
-			 feature redefines earlierOccurrence subsets that;
+			 end feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -52,7 +52,7 @@ standard library package ControlPerformances {
 			 * successions coming into a merge step.
 			 */
 
-			 feature redefines laterOccurrence subsets that;
+			 end feature redefines laterOccurrence subsets that;
 		}
 	}
 

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Expressions.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Expressions.kerml.xt
@@ -62,14 +62,13 @@ package Expressions {
 		inout v : Integer;
 	    step : ControlPerformances::LoopPerformance {
     		in expr whileTest {v > 3}
-    		in expr untilTest;
     		in step body {
     			step decrement {
     				out v_decr : Integer = v - 1;			
     			}
     			succession decrement then update;
     			step update : FeatureReferencingPerformances::FeatureWritePerformance {
-    				in redefines onOccurrence = w::self {
+    				in onOccurrence = w::self {
     					feature redefines startingAt : w {
     						inout feature redefines accessedFeature redefines v;
     					}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_End_Invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_End_Invalid.kerml.xt
@@ -1,0 +1,33 @@
+//* 
+XPECT_SETUP org.omg.kerml.xpect.tests.validation.KerMLValidationTest
+	ResourceSet {
+       ThisFile {}
+        File {from ="/library/Base.kerml"}
+        File {from ="/library/Occurrences.kerml"}
+        File {from ="/library/Objects.kerml"}
+        File {from ="/library/Performances.kerml"}
+    }
+    Workspace {
+        JavaProject {
+            SrcFolder {
+                ThisFile {}
+		            File {from ="/library/Base.kerml"}
+		            File {from ="/library/Occurrences.kerml"}
+		            File {from ="/library/Objects.kerml"}
+		            File {from ="/library/Performances.kerml"}
+			}
+		}
+	}
+END_SETUP 
+*/
+package RedefinitionEnd {
+	classifier A {
+		end feature e[1];
+	}
+	
+	classifier B :> A {
+		// XPECT errors ---> "Redefining feature must be an end feature" at "e"
+		feature :>> e;
+	}
+
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -180,6 +180,8 @@ class KerMLValidator extends AbstractKerMLValidator {
 
 	public static val INVALID_REDEFINITION_DIRECTION_CONFORMANCE = "validateRedefinitionDirectionConformance"
 	public static val INVALID_REDEFINITION_DIRECTION_CONFORMANCE_MSG = "Redefining feature must have a compatible direction"
+	public static val INVALID_REDEFINITION_END_CONFORMANCE = "validateRedefinitionEndConformance"
+	public static val INVALID_REDEFINITION_END_CONFORMANCE_MSG = "Redefining feature must be an end feature"
 	public static val INVALID_REDEFINITION_FEATURING_TYPES = 'validateRedefinitionFeaturingTypes'
 	public static val INVALID_REDEFINITION_FEATURING_TYPES_MSG_1 = "A package-level feature cannot be redefined"
 	public static val INVALID_REDEFINITION_FEATURING_TYPES_MSG_2 = "Owner of redefining feature cannot be the same as owner of redefined feature"
@@ -600,6 +602,13 @@ class KerMLValidator extends AbstractKerMLValidator {
 					error(INVALID_REDEFINITION_FEATURING_TYPES_MSG_2, redef, 
 						SysMLPackage.eINSTANCE.redefinition_RedefinedFeature, INVALID_REDEFINITION_FEATURING_TYPES)
 				}
+			}
+			
+			// validatRedefinitionEndConformance
+			
+			if (redefinedFeature.isEnd && !redefiningFeature.isEnd) {
+				error(INVALID_REDEFINITION_END_CONFORMANCE_MSG, redef, 
+						SysMLPackage.eINSTANCE.redefinition_RedefinedFeature, INVALID_REDEFINITION_END_CONFORMANCE)
 			}
 		}		
 	}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -365,6 +365,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 				checkDistinguishibility(mem, aliasMemberships, INVALID_NAMESPACE_DISTINGUISHABILITY_MSG_1)
 			}
 			if (namesp instanceof Type) {
+				ElementUtil.clearCachesOf(namesp)
 				val inheritedMemberships = namesp.inheritedMembership
 				for (mem: ownedMemberships) {
 					checkDistinguishibility(mem, inheritedMemberships, INVALID_NAMESPACE_DISTINGUISHABILITY_MSG_2)

--- a/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/ControlPerformances.kerml
@@ -31,7 +31,7 @@ standard library package ControlPerformances {
 			 * successions going out of a decision step.
 			 */
 
-			 feature redefines earlierOccurrence subsets that;
+			 end feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -52,7 +52,7 @@ standard library package ControlPerformances {
 			 * successions coming into a merge step.
 			 */
 
-			 feature redefines laterOccurrence subsets that;
+			 end feature redefines laterOccurrence subsets that;
 		}
 	}
 
@@ -116,8 +116,8 @@ standard library package ControlPerformances {
 		 */
 		 
 		in whileTest : BooleanEvaluation[1..*];
-		in untilTest : BooleanEvaluation[0..*];
 		in body : Occurrence[0..*];
+        in untilTest : BooleanEvaluation[0..*];
 		
 		step whileDecision : IfThenPerformance[1..*];
 		step untilDecision : IfElsePerformance[0..*];

--- a/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
@@ -431,6 +431,7 @@ standard library package Actions {
 		 * A LoopAction is the base type for all LoopActionUsages.
 		 */
 	
+        in ref iterator;
 		
 		in action body[0..*] {
 			doc
@@ -447,7 +448,7 @@ standard library package Actions {
 		 * It is the base type for all WhileLoopActionUsages.
 		 */
 	
-		in :>> whileTest default {true} {
+		in whileTest default {true} {
 			doc
 			/*
 			 * A Boolean expression that must be true for the loop to continue.
@@ -456,7 +457,7 @@ standard library package Actions {
 			 */
 		}
 		
-		in action body :>> LoopAction::body, LoopPerformance::body {
+		in action body {
 			doc
 			/*
 			 * The action that is performed while the whileTest is true and the
@@ -464,7 +465,7 @@ standard library package Actions {
 			 */
 		}
 		
-		in :>> untilTest default {false} {
+		in untilTest default {false} {
 			doc
 			/*
 			 * A Boolean expression that must be false for the loop to continue.
@@ -473,12 +474,7 @@ standard library package Actions {
 		}
 	}
 	
-	private abstract action def ForLoopActionBase :> LoopAction {
-		in action body;
-		in ref seq[0..*] ordered nonunique;
-	}
-	
-	action def ForLoopAction :> ForLoopActionBase {
+	action def ForLoopAction :> LoopAction {
 		doc
 		/*
 		 * A ForLoopAction is a LoopAction that iterates over an ordered sequence of values.
@@ -493,14 +489,14 @@ standard library package Actions {
 			 */
 		}
 		
-		in ref :>> seq {
+		in ref seq {
 			doc
 			/*
 			 * The sequence of values over which the loop iterates.
 			 */
 		}
 		
-		in action :>> body {
+		in action body {
 			doc
 			/*
 			 * The action that is performed on each iteration of the loop.

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -1352,7 +1352,6 @@ class SysMLValidator extends KerMLValidator {
 	protected def boolean checkReferenceType(Feature feature, Class<?> type, String msg, String eId) {
 		val subsetting = feature.ownedReferenceSubsetting
 		
-		// NOTE: This is implemented using getBasicFeatureOf to account for feature chaining. (See SYSML2-307.)
 		if (subsetting !== null && !type.isInstance(FeatureUtil.getBasicFeatureOf(subsetting.referencedFeature))) {
 			error(msg, subsetting, null, eId)
 			return false

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionDefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,11 +21,7 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.omg.sysml.lang.sysml.ActionDefinition;
-import org.omg.sysml.lang.sysml.Feature;
 
 public class ActionDefinitionAdapter extends OccurrenceDefinitionAdapter {
 	
@@ -36,11 +32,6 @@ public class ActionDefinitionAdapter extends OccurrenceDefinitionAdapter {
 	@Override
 	public ActionDefinition getTarget() {
 		return (ActionDefinition)super.getTarget();
-	}
-
-	@Override
-	public List<Feature> getRelevantFeatures() {
-		return Collections.emptyList();
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -34,7 +34,6 @@ import org.omg.sysml.lang.sysml.StateSubactionMembership;
 import org.omg.sysml.lang.sysml.TransitionFeatureMembership;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.ImplicitGeneralizationMap;
-import org.omg.sysml.util.TypeUtil;
 
 public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	
@@ -101,11 +100,6 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 		return redefinedFeature != null? isComputeRedefinitions:
 				super.isComputeRedefinitions();
 	}
-	
-	@Override
-	public List<? extends Feature> getRelevantFeatures() {
-		return TypeUtil.getItemFeaturesOf(getTarget());
-	}	
 	
 	@Override
 	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/BehaviorAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/BehaviorAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,11 +21,7 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.List;
-
 import org.omg.sysml.lang.sysml.Behavior;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.util.TypeUtil;
 
 public class BehaviorAdapter extends ClassAdapter {
 
@@ -38,12 +34,4 @@ public class BehaviorAdapter extends ClassAdapter {
 		return (Behavior)super.getTarget();
 	}
 
-	/**
-	 * Return the non-parameter abstract features of the Behavior.
-	 */
-	@Override
-	public List<Feature> getRelevantFeatures() {
-		return TypeUtil.getNonParameterAbstractFeaturesFor(getTarget());
-	}
-	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -561,7 +561,7 @@ public class FeatureAdapter extends TypeAdapter {
 		return type == null? Collections.emptyList():
 			   target.isEnd()? TypeUtil.getAllEndFeaturesOf(type):
 			   FeatureUtil.isParameter(target)? getParameterRelevantFeatures(type, skip):
-			   TypeUtil.getRelevantFeaturesOf(type);
+			   Collections.emptyList();
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -494,9 +494,8 @@ public class FeatureAdapter extends TypeAdapter {
 	public boolean isComputeRedefinitions() {
 		Feature target = getTarget();
 		return isAddImplicitGeneralTypes && isComputeRedefinitions &&
-				(!FeatureUtil.isParameter(target) || 
-				 FeatureUtil.isResultParameter(target) ||
-				 target.getOwnedRedefinition().isEmpty());
+				(!(target.getOwningType() instanceof InvocationExpression) ||
+				  target.getOwnedRedefinition().isEmpty());
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,12 +21,8 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.List;
-
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Flow;
 import org.omg.sysml.util.ConnectorUtil;
-import org.omg.sysml.util.TypeUtil;
 
 public class FlowAdapter extends ConnectorAdapter {
 
@@ -57,12 +53,7 @@ public class FlowAdapter extends ConnectorAdapter {
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
 	}
-	
-	@Override
-	public List<? extends Feature> getRelevantFeatures() {
-		return TypeUtil.getItemFeaturesOf(getTarget());
-	}
-	
+		
 	@Override
 	public void doTransform() {
 		ConnectorUtil.transformConnectorEndsOf(getTarget());

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,14 +21,10 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.List;
-
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FlowUsage;
 import org.omg.sysml.lang.sysml.OccurrenceUsage;
 import org.omg.sysml.lang.sysml.PortionKind;
 import org.omg.sysml.util.ConnectorUtil;
-import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
 public class FlowUsageAdapter extends ConnectorAsUsageAdapter {
@@ -88,12 +84,7 @@ public class FlowUsageAdapter extends ConnectorAsUsageAdapter {
 				getDefaultSupertype("message"):
 				getDefaultSupertype("base");
 	}
-	
-	@Override
-	public List<? extends Feature> getRelevantFeatures() {
-		return TypeUtil.getItemFeaturesOf(getTarget());
-	}
-	
+		
 	@Override
 	public void doTransform() {
 		ConnectorUtil.transformConnectorEndsOf(getTarget());

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -33,6 +33,7 @@ import org.omg.sysml.util.TypeUtil;
 public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 
 	public static final String ARRAY_TYPE = "Collections::Array";
+	public static final String SCALAR_VALUE_TYPE = "ScalarValues::ScalarValue";
 
 	public IndexExpressionAdapter(IndexExpression element) {
 		super(element);
@@ -51,7 +52,9 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 			Expression seqArgument = arguments.get(0);
 			ElementUtil.transform(seqArgument);
 			Feature seqResult = seqArgument.getResult();
-			if (!hasArrayType(seqResult)) {
+			Type arrayType = getLibraryType(ARRAY_TYPE);
+			Type scalarValueType = getLibraryType(SCALAR_VALUE_TYPE);
+			if (!TypeUtil.conforms(target, arrayType) || TypeUtil.conforms(target, scalarValueType)) {
 				Feature resultFeature = target.getResult();
 				if (resultFeature != null && seqResult != null) {
 					TypeUtil.addImplicitGeneralTypeTo(resultFeature, SysMLPackage.eINSTANCE.getSubsetting(), seqResult);
@@ -60,10 +63,4 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 		}
 	}
 	
-	protected boolean hasArrayType(Feature feature) {
-		Type arrayType = getLibraryType(ARRAY_TYPE);
-		return arrayType != null && 
-			   feature.getType().stream().anyMatch(t->TypeUtil.conforms(t, arrayType));
-	}
-
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,12 +21,8 @@
 
 package org.omg.sysml.adapter;
 
-import java.util.List;
-
-import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.PayloadFeature;
 import org.omg.sysml.lang.sysml.Step;
-import org.omg.sysml.util.TypeUtil;
 
 public class StepAdapter extends FeatureAdapter {
 	
@@ -57,9 +53,4 @@ public class StepAdapter extends FeatureAdapter {
 		return getTarget().getOwnedFeature().stream().anyMatch(PayloadFeature.class::isInstance);
 	}
 
-	@Override
-	public List<? extends Feature> getRelevantFeatures() {
-		return TypeUtil.getItemFeaturesOf(getTarget());
-	}	
-	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -425,18 +425,6 @@ public class TypeAdapter extends NamespaceAdapter {
 		return SysMLLibraryUtil.getLibraryType(getTarget(), defaultNames);
 	}
 	
-	// Computed Redefinitions
-	
-	/**
-	 * This method returns those features from the target type that should be automatically overridden in its usages.
-	 * By default, there are none.
-	 * 
-	 * @return	Relevant features from the target type that should be redefined in usages.
-	 */
-	public List<? extends Feature> getRelevantFeatures() {
-		return Collections.emptyList();
-	}
-	
 	// Extension
 	
 	private boolean isGetBaseTypes = true;

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Type_allRedefinedFeaturesOf_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Type_allRedefinedFeaturesOf_InvocationDelegate.java
@@ -32,16 +32,16 @@ import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.Membership;
 
-public class Membership_allRedefinedFeatures_InvocationDelegate extends BasicInvocationDelegate {
+public class Type_allRedefinedFeaturesOf_InvocationDelegate extends BasicInvocationDelegate {
 
-	public Membership_allRedefinedFeatures_InvocationDelegate(EOperation operation) {
+	public Type_allRedefinedFeaturesOf_InvocationDelegate(EOperation operation) {
 		super(operation);
 	}
 	
 	@Override
 	public Object dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
-		Membership self = (Membership)target;
-		Element memberElement = self.getMemberElement();
+		Membership membership = (Membership)arguments.get(0);
+		Element memberElement = membership.getMemberElement();
 		return memberElement instanceof Feature? ((Feature)memberElement).allRedefinedFeatures():
 			new BasicEList<>();
 	}

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -43,7 +43,6 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureChaining;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.Specialization;
-import org.omg.sysml.lang.sysml.PayloadFeature;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Multiplicity;
 import org.omg.sysml.lang.sysml.Namespace;
@@ -489,30 +488,6 @@ public class TypeUtil {
 		}
 	}
 	
-	// Relevant features
-	
-	public static List<? extends Feature> getRelevantFeaturesOf(Type type) {
-		return getTypeAdapter(type).getRelevantFeatures();
-	}
-	
-	/**
-	 * Get the non-parameter abstract Features. (For use with Behaviors.)
-	 */
-	public static List<Feature> getNonParameterAbstractFeaturesFor(Type type) {
-		return type.getOwnedFeature().stream().
-				filter(feature -> !FeatureUtil.isParameter(feature) && feature.isAbstract()).
-				collect(Collectors.toList());
-	}
-	
-	/**
-	 * Get ItemFeatures. (For use with Steps.)
-	 */
-	public static List<? extends Feature> getItemFeaturesOf(Type type) {
-		return type.getOwnedFeature().stream().
-				filter(PayloadFeature.class::isInstance).
-				collect(Collectors.toList());
-	}
-
 	// Associations
 
 	public static Type getSourceTypeOf(Association association) {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
@@ -116,8 +116,8 @@ standard library package ControlPerformances {
 		 */
 		 
 		in whileTest : BooleanEvaluation[1..*];
-		in untilTest : BooleanEvaluation[0..*];
 		in body : Occurrence[0..*];
+        in untilTest : BooleanEvaluation[0..*];
 		
 		step whileDecision : IfThenPerformance[1..*];
 		step untilDecision : IfElsePerformance[0..*];

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/ControlPerformances.kerml
@@ -31,7 +31,7 @@ standard library package ControlPerformances {
 			 * successions going out of a decision step.
 			 */
 
-			 feature redefines earlierOccurrence subsets that;
+			 end feature redefines earlierOccurrence subsets that;
 		}
 	}
 	
@@ -52,7 +52,7 @@ standard library package ControlPerformances {
 			 * successions coming into a merge step.
 			 */
 
-			 feature redefines laterOccurrence subsets that;
+			 end feature redefines laterOccurrence subsets that;
 		}
 	}
 

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -431,6 +431,7 @@ standard library package Actions {
 		 * A LoopAction is the base type for all LoopActionUsages.
 		 */
 	
+        in ref iterator;
 		
 		in action body[0..*] {
 			doc
@@ -447,7 +448,7 @@ standard library package Actions {
 		 * It is the base type for all WhileLoopActionUsages.
 		 */
 	
-		in :>> whileTest default {true} {
+		in whileTest default {true} {
 			doc
 			/*
 			 * A Boolean expression that must be true for the loop to continue.
@@ -456,7 +457,7 @@ standard library package Actions {
 			 */
 		}
 		
-		in action body :>> LoopAction::body, LoopPerformance::body {
+		in action body {
 			doc
 			/*
 			 * The action that is performed while the whileTest is true and the
@@ -464,7 +465,7 @@ standard library package Actions {
 			 */
 		}
 		
-		in :>> untilTest default {false} {
+		in untilTest default {false} {
 			doc
 			/*
 			 * A Boolean expression that must be false for the loop to continue.
@@ -473,12 +474,7 @@ standard library package Actions {
 		}
 	}
 	
-	private abstract action def ForLoopActionBase :> LoopAction {
-		in action body;
-		in ref seq[0..*] ordered nonunique;
-	}
-	
-	action def ForLoopAction :> ForLoopActionBase {
+	action def ForLoopAction :> LoopAction {
 		doc
 		/*
 		 * A ForLoopAction is a LoopAction that iterates over an ordered sequence of values.
@@ -493,14 +489,14 @@ standard library package Actions {
 			 */
 		}
 		
-		in ref :>> seq {
+		in ref seq {
 			doc
 			/*
 			 * The sequence of values over which the loop iterates.
 			 */
 		}
 		
-		in action :>> body {
+		in action body {
 			doc
 			/*
 			 * The action that is performed on each iteration of the loop.

--- a/sysml/src/examples/Camera Example/PictureTaking.sysml
+++ b/sysml/src/examples/Camera Example/PictureTaking.sysml
@@ -6,7 +6,7 @@ package PictureTaking {
 		
 	action takePicture {		
 		action focus: Focus[1];
-		flow focus.xrsl to shoot.xsf;
+		flow of Exposure from focus.xrsl to shoot.xsf;
 		action shoot: Shoot[1];
 	}
 }

--- a/sysml/src/training/20. Assignment Actions/Assignment Example.sysml
+++ b/sysml/src/training/20. Assignment Actions/Assignment Example.sysml
@@ -22,9 +22,9 @@ package 'For Loop Example' {
 		private attribute position := initialPosition;
 		private attribute speed := initialSpeed;
 		
-		for i in 1..powerProfile->size() {
+		for vehiclePower in powerProfile {
 			perform action dynamics : StraightLineDynamics {
-				in power = powerProfile#(i);
+				in power = vehiclePower;
 				in mass = vehicleMass;
 				in delta_t = deltaT;
 				in x_in = position;


### PR DESCRIPTION
This PR implements some or all of the resolutions of the following issues approved on KerML FTF2 Ballot 5:

- [KERML_-1](http://issues.omg.org/issues/KERML_-1) isEnd of the redefining feature must match isEnd of the redefined feature
- [KERML_-58](http://issues.omg.org/issues/KERML_-58) checkFeatureParameterRedefinition fails for named-argument invocations
- [KERML_-151](http://issues.omg.org/issues/KERML_-151) Corrections to the resolution of KERML_-39

The resolutions of the following related issues had already been previously implemented:

- [KERML_-59](http://issues.omg.org/issues/KERML_-59) OCL for checkFeatureParameterRedefinition is wrong
- [KERML_-146](http://issues.omg.org/issues/KERML_-146) Need to revise derivation of AnnotatingElement::ownedAnnotatingRelationship
- [KERML_-220](http://issues.omg.org/issues/KERML_-220) Corrections to the resolution of KERML_-18
- [SYSML2_-515](http://issues.omg.org/issues/SYSML2_-515) Corrections to operation and constraints from previous resolutions

The implementation also makes the following adjustments:

- [KERML_-58](http://issues.omg.org/issues/KERML_-58) – Updates the KerML Semantic Library model for `ControlPerformances::LoopPerformance` and the SysML Systems Library model for `Actions::LoopAction` and its specializations to ensure that parameters are redefined in the proper order.
- [KERML_-117](http://issues.omg.org/issues/KERML_-117) – Revises the previous implementation (see PR [#611](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/pull/611)) so that implied sequence argument subsetting is added to the result of an index expression if the sequence is typed both as an `Array` and as a `ScalarValue` (which is the case for `ScalarQuantityValues`).