### PR TITLE
ST6RI-829 Standard model library element IDs (KERML_-36, SYSML2_-107)

### DIFF
--- a/org.omg.sysml.interactive.tests/.launch/Derived Property and Operation Test.launch
+++ b/org.omg.sysml.interactive.tests/.launch/Derived Property and Operation Test.launch
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <stringAttribute key="bad_container_name" value="/org.omg.sysml.interactive.tests/.lau"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyTest.java"/>
+        <listEntry value="/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="1"/>
@@ -12,10 +13,11 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.interactive.tests.DerivedPropertyTest"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.omg.sysml.interactive.tests.DerivedPropertyAndOperationTest"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.omg.sysml.interactive.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -DlibraryPath=${workspace_loc:/SysML-v2-Pilot-Implementation/sysml.library}"/>

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
@@ -37,11 +37,12 @@ import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.ItemUsage;
 import org.omg.sysml.lang.sysml.Namespace;
+import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.TriggerInvocationExpression;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.lang.sysml.ViewUsage;
 
-public class DerivedPropertyTest extends SysMLInteractiveTest {
+public class DerivedPropertyAndOperationTest extends SysMLInteractiveTest {
 
 	@Test
 	public void testOwnedUsage() throws Exception {
@@ -85,6 +86,68 @@ public class DerivedPropertyTest extends SysMLInteractiveTest {
 		ViewUsage view = (ViewUsage)((Namespace)elements.get(0)).getOwnedMember().get(1);
 		List<Element> exposed = view.getExposedElement();
 		assertEquals(1, exposed.size());
+	}
+	
+	public final String pathTest =
+			  "// Path of package: TopLevel\n"
+			+ "// Path of owning membership: TopLevel/owningMembership\n"
+			+ "package TopLevel {\n"
+			+ "\n"
+			+ "    // Path of classifier: TopLevel::A\n"
+			+ "    // Path of owning membership: TopLevel::A/owningMembership\n"
+			+ "    part def A;\n"
+			+ "\n"
+			+ "    // Path of classifier: TopLevel::B\n"
+			+ "    // Path of owning membership: TopLevel::B/owningMembership\n"
+			+ "    // Path of owned subclassification: TopLevel::B/1\n"
+			+ "    part def B specializes A {\n"
+			+ "        // Path of owning membership: TopLevel::B/2\n"
+			+ "        // Path of feature:  TopLevel::B/2/1\n"
+			+ "        ref;\n"
+			+ "    }\n"
+			+ "\n"
+			+ "    // Path of owning membership: TopLevel/3\n"
+			+ "    // Path of classifier: TopLevel/3/1\n"
+			+ "    part def {\n"
+			+ "        // Path of owning membership: TopLevel/3/1/1\n"
+			+ "        // Path of feature: TopLevel/3/1/1/1\n"
+			+ "        ref f;\n"
+			+ "    }\n"
+			+ "}";
+	
+	@Test
+	public void testPathOperation() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		List<Element> elements = process(instance, pathTest);
+		
+		Namespace TopLevel = (Namespace)elements.get(0);
+		assertEquals("TopLevel", TopLevel.path());
+		assertEquals("TopLevel/owningMembership", TopLevel.getOwningMembership().path());
+		
+		Namespace A = (Namespace)TopLevel.getOwnedMember().get(0);
+		assertEquals("TopLevel::A", A.path());
+		assertEquals("TopLevel::A/owningMembership", A.getOwningMembership().path());
+		
+		Namespace B = (Namespace)TopLevel.getOwnedMember().get(1);
+		assertEquals("TopLevel::B", B.path());
+		assertEquals("TopLevel::B/owningMembership", B.getOwningMembership().path());
+		
+		Relationship B_1 = B.getOwnedRelationship().get(0);
+		assertEquals("TopLevel::B/1", B_1.path());
+		
+		Relationship B_2 = B.getOwnedRelationship().get(1);
+		assertEquals("TopLevel::B/2", B_2.path());
+		assertEquals("TopLevel::B/2/1", B_2.getOwnedRelatedElement().get(0).path());
+		
+		Relationship TopLevel_3 = TopLevel.getOwnedRelationship().get(2);
+		assertEquals("TopLevel/3", TopLevel_3.path());
+		
+		Element TopLevel_3_1 = TopLevel_3.getOwnedRelatedElement().get(0);
+		assertEquals("TopLevel/3/1", TopLevel_3_1.path());
+		
+		Relationship TopLevel_3_1_1 = TopLevel_3_1.getOwnedRelationship().get(0);
+		assertEquals("TopLevel/3/1/1", TopLevel_3_1_1.path());
+		assertEquals("TopLevel/3/1/1/1", TopLevel_3_1_1.getOwnedRelatedElement().get(0).path());
 	}
 
 }

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
@@ -23,12 +23,14 @@ package org.omg.sysml.interactive.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
 import org.junit.Test;
 import org.omg.sysml.interactive.SysMLInteractive;
+import org.omg.sysml.interactive.SysMLInteractiveResult;
 import org.omg.sysml.lang.sysml.AcceptActionUsage;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.AttributeUsage;
@@ -86,6 +88,26 @@ public class DerivedPropertyAndOperationTest extends SysMLInteractiveTest {
 		ViewUsage view = (ViewUsage)((Namespace)elements.get(0)).getOwnedMember().get(1);
 		List<Element> exposed = view.getExposedElement();
 		assertEquals(1, exposed.size());
+	}
+	
+	public final String qualifiedNameTest =
+			"package Test {\n"
+			+ "    package P {\n"
+			+ "        item x;\n"
+			+ "        item x;\n"
+			+ "    }"
+			+ "}";
+	
+	@Test
+	public void testQualifiedName() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		SysMLInteractiveResult result = instance.process(qualifiedNameTest);
+		Element root = result.getRootElement();
+		List<Element> elements = ((Namespace)root).getOwnedMember();
+		Namespace P = (Namespace)((Namespace)elements.get(0)).getOwnedMember().get(0);
+		List<Element> P_ownedMembers = P.getOwnedMember();
+		assertEquals("Test::P::x", P_ownedMembers.get(0).getQualifiedName());
+		assertNull(P_ownedMembers.get(1).getQualifiedName());
 	}
 	
 	public final String pathTest =

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Element_path_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Element_path_InvocationDelegate.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2025 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.delegate.invocation;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.util.BasicInvocationDelegate;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Relationship;
+
+public class Element_path_InvocationDelegate extends BasicInvocationDelegate {
+
+	public Element_path_InvocationDelegate(EOperation operation) {
+		super(operation);
+	}
+	
+	@Override
+	public String dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
+		Element self = (Element) target;
+		String qualifiedName = self.getQualifiedName();
+		Relationship owningRelationship = self.getOwningRelationship();
+		return qualifiedName != null? qualifiedName:
+			   owningRelationship != null? 
+					   owningRelationship.path() + "/" + 
+					   (owningRelationship.getOwnedRelatedElement().indexOf(self) + 1):
+			   "";
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/OwningMembership_path_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/OwningMembership_path_InvocationDelegate.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2025 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.delegate.invocation;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.OwningMembership;
+
+public class OwningMembership_path_InvocationDelegate extends Relationship_path_InvocationDelegate {
+
+	public OwningMembership_path_InvocationDelegate(EOperation operation) {
+		super(operation);
+	}
+	
+	@Override
+	public String dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
+		OwningMembership self = (OwningMembership) target;
+		Element ownedElement = self.getOwnedMemberElement();
+		if (ownedElement != null) {
+			String qualifiedName = ownedElement.getQualifiedName();
+			if (qualifiedName != null) {
+				return qualifiedName + "/owningMembership";
+			}
+		}
+		return super.dynamicInvoke(target, arguments);
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Relationship_path_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/Relationship_path_InvocationDelegate.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2025 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *  
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.delegate.invocation;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.Relationship;
+
+public class Relationship_path_InvocationDelegate extends Element_path_InvocationDelegate {
+
+	public Relationship_path_InvocationDelegate(EOperation operation) {
+		super(operation);
+	}
+	
+	@Override
+	public String dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
+		Relationship self = (Relationship) target;
+		Relationship owningRelationship = self.getOwningRelationship();
+		Element owningRelatedElement = self.getOwningRelatedElement();
+		return owningRelationship == null && owningRelatedElement != null?
+					owningRelatedElement.path() + "/" + 
+					(owningRelatedElement.getOwnedRelationship().indexOf(self) + 1):
+			   super.dynamicInvoke(target, arguments);
+	}
+
+}

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Element_qualifiedName_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Element_qualifiedName_SettingDelegate.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2022-2023, 2025 Model Driven Solutions, Inc.
  * Copyright (c) 2022 Siemens AG
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -35,16 +35,21 @@ public class Element_qualifiedName_SettingDelegate extends BasicDerivedPropertyS
 
 	@Override
 	protected Object basicGet(InternalEObject owner) {
-		Namespace owningNamespace = ((Element) owner).getOwningNamespace();
+		Element self = (Element)owner;
+		Namespace owningNamespace = self.getOwningNamespace();
 		if (owningNamespace == null) {
 			return null;
 		} else {
-			String name = ((Element) owner).escapedName();
-			if (name == null || owningNamespace.getOwner() == null) {
-				return name;
+			String name = self.getName();
+			if (name == null || owningNamespace.getOwnedMember().stream().
+					filter(m->name.equals(m.getName())).
+					findFirst().orElse(null) != self) {
+				return null;
+			} else if (owningNamespace.getOwner() == null) {
+				return self.escapedName();
 			} else {
 				String qualification = owningNamespace.getQualifiedName();
-				return qualification == null? null: qualification + "::" + name;
+				return qualification == null? null: qualification + "::" + self.escapedName();
 			}
 		}
 	}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ElementImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/ElementImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2020-2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2020-2023, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -310,7 +310,9 @@ public abstract class ElementImpl extends MinimalEObjectImpl.Container implement
 	
 	/**
 	 * <!-- begin-user-doc -->
-	 * If there is not elementId, set it to a random UUID.
+	 * If there is no elementId, and the Element is not a standard library Element, 
+	 * set the elementId to a random UUID. If the Element is a standard library Element,
+	 * create a name-based UUID using the Element's path.
 	 * <!-- end-user-doc -->
 	 * @generated NOT
 	 */
@@ -319,12 +321,12 @@ public abstract class ElementImpl extends MinimalEObjectImpl.Container implement
 		if (elementId == null) {
 			UUID uuid = UUID.randomUUID();
 			if (ElementUtil.isStandardLibraryElement(this)) {
-				String qualifiedName = getQualifiedName();
-				if (qualifiedName != null) {
+				String path = path();
+				if (path != null) {
 					Namespace libraryNamespace = libraryNamespace();
 					if (this != libraryNamespace) {
 						UUID namespaceUUID = UUID.fromString(libraryNamespace.getElementId());
-						uuid = ElementUtil.constructNameUUID(namespaceUUID, qualifiedName);
+						uuid = ElementUtil.constructNameUUID(namespaceUUID, path);
 					}
 				}
 			}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/LibraryPackageImpl.java
@@ -102,6 +102,13 @@ public class LibraryPackageImpl extends PackageImpl implements LibraryPackage {
 	// UUID for "NameSpace_URL", per ITU-T Rec. X.667 (10/2012), Annex D.9
 	public final UUID UUID_NAMESPACE_URL = UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
 	
+	/**
+	 * <!-- begin-user-doc -->
+	 * If this is a standard library Package, then set the elementId to a named-based UUID
+	 * using a URL constructed from the KerML or SysML base URI and the Package's name.
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
 	@Override
 	public String getElementId() {
 		if (elementId == null && isStandard()) {

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/NamespaceImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/NamespaceImpl.java
@@ -24,6 +24,8 @@ package org.omg.sysml.lang.sysml.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
+import java.util.UUID;
+
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
@@ -42,6 +44,7 @@ import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.VisibilityKind;
+import org.omg.sysml.util.ElementUtil;
 
 /**
  * <!-- begin-user-doc -->
@@ -520,6 +523,31 @@ public class NamespaceImpl extends ElementImpl implements Namespace {
 		catch (InvocationTargetException ite) {
 			throw new WrappedException(ite);
 		}
+	}
+	
+	/**
+	 * <!-- begin-user-doc -->
+	 * If the Namespace is the root Namespace of a standard library package, then give it a stable elementId.
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	@Override
+	public String getElementId() {
+		if (elementId == null && getOwningRelationship() == null) {
+			EList<Element> ownedMembers = getOwnedMember();
+			if (!ownedMembers.isEmpty()) {
+				Element firstOwnedMember = ownedMembers.get(0);
+				if (ElementUtil.isStandardLibraryElement(firstOwnedMember) && 
+						firstOwnedMember.libraryNamespace() == firstOwnedMember) {
+					String qualifiedName = firstOwnedMember.getQualifiedName();
+					if (qualifiedName != null) {
+						UUID namespaceUUID = UUID.fromString(firstOwnedMember.getElementId());
+						elementId = ElementUtil.constructNameUUID(namespaceUUID, qualifiedName + "/owner").toString();
+					}
+				}
+			}
+		}
+		return super.getElementId();
 	}
 
 	/**

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OwningMembershipImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/OwningMembershipImpl.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package org.omg.sysml.lang.sysml.impl;
 
+import java.util.UUID;
+
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 
@@ -33,6 +35,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.util.ElementUtil;
 
 /**
  * <!-- begin-user-doc -->
@@ -365,6 +368,31 @@ public class OwningMembershipImpl extends MembershipImpl implements OwningMember
 	 */
 	public boolean isSetMemberName() {
   		return false;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * If the OwningMembership is not itself a standard library Element, but its ownedMemberElement 
+	 * is a standard library Package, then give the OwningMembership a stable elementId anyway.
+	 * (This will give a stable elementID to the owningMembership of a top-level standard library Package.)
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	@Override
+	public String getElementId() {
+		if (elementId == null) {
+			Element ownedMemberElement = getOwnedMemberElement();
+			if (!ElementUtil.isStandardLibraryElement(this) &&
+					ElementUtil.isStandardLibraryElement(ownedMemberElement) && 
+					ownedMemberElement.libraryNamespace() == ownedMemberElement) {
+				String path = path();
+				if (path != null) {
+					UUID namespaceUUID = UUID.fromString(ownedMemberElement.getElementId());
+					elementId = ElementUtil.constructNameUUID(namespaceUUID, path).toString();
+				}
+			}
+		}
+		return super.getElementId();
 	}
 
 	/**


### PR DESCRIPTION
This PR implements resolutions to the following issues, as approved in KerML FTF2 Ballot 5 and SysML v2 FTF 2 Ballot 8:

- [KERML_-36](http://issues.omg.org/issues/KERML_-36) KerML Libraries' elements shall have an elementId defined
- [SYSML2_-107](http://issues.omg.org/issues/SYSML2_-107) SysML Libraries' elements shall have an elementId defined

**Paths**

The resolution to KERML_-36 introduces the concept of a "path" for an element that is unique within the composition structure under a specific root namespace. The element path is constructed as follows:

1. If the element has a non-null qualified name, that is used as the path. This means that the UUIDs generated for elements with non-null qualified names will remain unchanged from previous versions of the normative library models.
2. If the element has a null qualified name and a non-null owning relationship, then its path is constructed from the path of its owning relationship by appending the character "`/`", followed by its position in the list of owned related elements of it owning relationship.
3. If the element is a relationship with a non-null owning related element (except for an owning membership as below), then its path is instead constructed from the path of its owning related element by appending the character "`/`", followed by its position in the list of owned relationships of it owning related element.
4. If the element is an owning membership whose owned member element has a non-null qualified name, then its path is constructed from the qualified name of its owned member element by appending the string "`/owningMembership`". Since owning memberships are one-to-one with their owned member elements, this allows owning memberships of named elements in library models to remain stable even if there is a reordering of member elements within the owning namespace.

The following shows some examples of element paths:
```
// Path of package: TopLevel
// Path of owning membership: TopLevel/owningMembership
package TopLevel {

    // Path of classifier: TopLevel::A
    // Path of owning membership: TopLevel::A/owningMembership
    classifier A;

    // Path of classifier: TopLevel::B
    // Path of owning membership: TopLevel::B/owningMembership
    // Path of owned subclassification: TopLevel::B/1
    classifier B specializes A;
        // Path of owning membership: TopLevel::B/2
        // Path of feature:  TopLevel::B/2/1
        feature;
    }

    // Path of owning membership: TopLevel/3
    // Path of classifier: TopLevel/3/1
    classifier {
        // Path of owning membership: TopLevel/3/1/1
        // Path of feature: TopLevel/3/1/1/1
        feature f;
    }
}
```

**Unique UUIDs**

The resolutions to both KERML_-36 and SYSML2_-107 change the algorithm for generating UUIDs, for KerML and SysML, respectively, to use element paths instead of qualified names. This allows a distinct UUID to be generated for every element in a standard library model, not just the ones with non-null qualified name. For elements with non-null qualified names, though, the path is just the qualified name, so the generated UUID is the same as previously. 

The resolution to KERML_-36 also revises the derivation for `qualifiedName` so that, if there are multiple owned members in a namespace with the same name, all but the first of these have a null `qualifiedName`. While the `validateNamespaceDistinguishability` constraint makes it invalid for a namespace to have duplicate names, the revised derivation for `qualifiedName` ensures that no two elements have the same qualified name, even for models that violate the constraint. This eliminates the possibility of different elements with the same qualified name getting the same generated UUID. 

Technically, elements are only "standard library elements" if they are a top-level standard library package or an element in the composition structure of such a package. However, for each library model file, this leaves out two elements that are outside the top-level library package: the root namespace and the owning membership from the root namespace to the top-level library package. The implementation in this PR gives stable UUIDs to these elements, too, by generating name-based UUIDs for them using the libary package UUID as the namespace UUID and a name constructed from the library package name appended with one of the following:

- "`/owner`" for the root namespace
- "`/owningMembership`" for the owning membership

In this way, every element in a library model file has a stable UUID every time the textual notation in the file is parsed without change.