### PR TITLE
ST6RI-840 Constructor expression evaluation (KERML_-224)

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -300,6 +300,21 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 	}
 	
 	@Test
+	public void testConstructorEvaluation() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		process(instance,
+				"part def P { attribute a; attribute b; } " +
+				"part p1 = new P(1, 2); " +
+				"part p2 = new P(b = p1.b, a = p1.a);");
+		assertEquals(true, evaluateBooleanValue(instance, null, "p1 istype P"));
+		assertEquals(1, evaluateIntegerValue(instance, null, "p1.a"));
+		assertEquals(2, evaluateIntegerValue(instance, null, "p1.b"));
+		assertEquals(true, evaluateBooleanValue(instance, null, "p2 istype P"));
+		assertEquals(1, evaluateIntegerValue(instance, null, "p2.a"));
+		assertEquals(2, evaluateIntegerValue(instance, null, "p2.b"));
+	}
+	
+	@Test
 	public void testFeatureReferenceEvaluation() throws Exception {
 		SysMLInteractive instance = getSysMLInteractiveInstance();
 		process(instance, 

--- a/org.omg.sysml/src/org/omg/sysml/delegate/invocation/FeatureReferenceExpression_modelLevelEvaluable_InvocationDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/invocation/FeatureReferenceExpression_modelLevelEvaluable_InvocationDelegate.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -55,19 +55,22 @@ public class FeatureReferenceExpression_modelLevelEvaluable_InvocationDelegate e
 			return false;
 		} else {
 			visited.add(referent);
+			boolean result;
 			if (referent instanceof Expression && ((Expression) referent).modelLevelEvaluable(visited)) {
-				return true;
+				result = true;
 			} else {
 				Type owningType = referent.getOwningType();
 				if (owningType instanceof Metaclass || owningType instanceof MetadataFeature) {
-					return true;
+					result =  true;
 				} else if (!referent.getFeaturingType().isEmpty()) {
-					return false;
+					result =  false;
 				} else {
 					Expression valueExpression = FeatureUtil.getValueExpressionFor(referent);
-					return valueExpression == null || valueExpression.modelLevelEvaluable(visited);
+					result = valueExpression == null || valueExpression.modelLevelEvaluable(visited);
 				}
 			}
+			visited.remove(referent);
+			return result;
 		}
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
+++ b/org.omg.sysml/src/org/omg/sysml/expressions/ModelLevelExpressionEvaluator.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -30,6 +30,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.omg.sysml.expressions.functions.LibraryFunction;
 import org.omg.sysml.expressions.util.EvaluationUtil;
 import org.omg.sysml.lang.sysml.AnnotatingElement;
+import org.omg.sysml.lang.sysml.ConstructorExpression;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
@@ -74,6 +75,8 @@ public class ModelLevelExpressionEvaluator {
 			return evaluateMetadataAccess((MetadataAccessExpression)expression, target);
 		} else if (expression instanceof InvocationExpression) {
 			return evaluateInvocation((InvocationExpression)expression, target);
+		} else if (expression instanceof ConstructorExpression) {
+			return evaluateConstructor((ConstructorExpression)expression, target);
 		} else {
 			return new BasicEList<>();
 		}		
@@ -107,6 +110,11 @@ public class ModelLevelExpressionEvaluator {
 	public EList<Element> evaluateInvocation(InvocationExpression expression, Element target) {
 		LibraryFunction function = libraryFunctionFactory.getLibraryFunction(expression.getFunction());
 		return function == null? EvaluationUtil.singletonList(expression): function.invoke(expression, target, this);
+	}
+	
+	public EList<Element> evaluateConstructor(ConstructorExpression expression, Element target) {
+		Feature resultParameter = TypeUtil.getResultParameterOf(expression);
+		return resultParameter == null? null: EvaluationUtil.singletonList(resultParameter);
 	}
 	
 	public EList<Element> evaluateFeature(Feature feature, Type type) {


### PR DESCRIPTION
The resolution of the following issue, approved in KerML FTF2 Ballot 7 allowed constructor expression to be model-level evaluable.

- [KERML_-224 ](https://issues.omg.org/issues/KERML_-224)Corrections to Ballot 5 resolutions

The update to the `ConstructorExpression::modelLevelEvaluable operation` from this resolution was already implemented. This PR updates `ModelLevelExpressionEvaluator` to actually evaluate constructor expressions.

A constructor expression is parsed as an expression whose `instantiatedType` is instantiated by its `result` parameter, with `argument` expressions bound to appropriate features of the `instantiatedType`. For example, given the (KerML) declaration
```
struct S {
   feature a;
   feature b;
}
```
then the constructor expression `S(1,2)` is semantically equivalent to the `result` of
```
expr :> Performances::constructorEvaluations {
    return feature :>> result : S {
        feature :>> a = 1;
        feature :>> b = 2;
    }
}
```
Therefore, the model-level evaluation of a constructor expression simply returns its `result`. So, given the following:
```
feature s = new S(1,2);
feature s_a = s.a;
feature s_b = s.b;
```
the feature `s` evaluates to the `result` parameter of the constructor expression, so that `s_a` evaluates to the literal integer `1` and `s_b` evaluates to the literal integer `2`.

The following is an equivalent SysML model that evaluates in the same way:
```
part def P {
    attribute a;
    attribute b;
}
part p = new P(1,2);
attribute p_a = p.a;
attribute p_b = p.b;
```
