### PR TITLE
ST6RI-837: Do not render <<variation>> for EnumerationDefinition

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -43,6 +43,7 @@ import org.omg.sysml.lang.sysml.CaseDefinition;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Definition;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.EnumerationDefinition;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureTyping;
@@ -270,7 +271,8 @@ public class SysML2PlantUMLText {
             if (!u.isVariation()) return;
         } else if (typ instanceof Definition) {
             Definition d = (Definition) typ;
-            if (!d.isVariation()) return;
+            if (d instanceof EnumerationDefinition // Do not render <<variation>> for EnumerationDefinition
+            	|| !d.isVariation()) return;
         } else {
             return;
         }


### PR DESCRIPTION
By the side effect of the fix by https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/pull/560, `<<variation>>` is rendered for `EnumerationDefinition` because its `isVariation` is true.  However it should not be rendered.  This PR fixes this issue.