### PR TITLE
ST6RI-842: Support shorthand notations (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -548,7 +548,7 @@ public class SysML2PlantUMLStyle {
 		@Override
 		public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
             if (Visitor.getSpecialReference(sru) != null) {
-                return " requirement>> ";
+                return " satisfy>> ";
             } else {
                 return " satisfy requirement>> ";
             }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -37,6 +37,7 @@ import org.omg.sysml.lang.sysml.ActorMembership;
 import org.omg.sysml.lang.sysml.AllocationUsage;
 import org.omg.sysml.lang.sysml.AnalysisCaseDefinition;
 import org.omg.sysml.lang.sysml.AnalysisCaseUsage;
+import org.omg.sysml.lang.sysml.AssertConstraintUsage;
 import org.omg.sysml.lang.sysml.Behavior;
 import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.Class;
@@ -507,6 +508,11 @@ public class SysML2PlantUMLStyle {
             return " --> ";
 		}
 
+		@Override
+		public String caseAssertConstraintUsage(AssertConstraintUsage acu) {
+            return " --> ";
+		}
+
         @Override
 		public String casePerformActionUsage(PerformActionUsage pau) {
             return " --> ";
@@ -534,6 +540,36 @@ public class SysML2PlantUMLStyle {
 		public String caseClass(Class object) {
             if (SysMLPackage.Literals.CLASS.equals(object.eClass())) return " ";
             return null;
+		}
+
+		@Override
+		public String caseAcceptActionUsage(AcceptActionUsage aau) {
+            return " accept action>> ";
+		}
+
+		@Override
+		public String caseSendActionUsage(SendActionUsage sau) {
+            return " send action>> ";
+		}
+
+		@Override
+		public String caseAnalysisCaseUsage(AnalysisCaseUsage acu) {
+            return " analysis>> ";
+		}
+
+		@Override
+		public String caseAnalysisCaseDefinition(AnalysisCaseDefinition acd) {
+            return " analysis def>> ";
+		}
+
+		@Override
+		public String caseVerificationCaseUsage(VerificationCaseUsage acu) {
+            return " verification>> ";
+		}
+
+		@Override
+		public String caseVerificationCaseDefinition(VerificationCaseDefinition acd) {
+            return " verification def>> ";
 		}
 
 		@Override
@@ -573,34 +609,13 @@ public class SysML2PlantUMLStyle {
 		}
 
 		@Override
-		public String caseAcceptActionUsage(AcceptActionUsage aau) {
-            return " accept action>> ";
-		}
-
-		@Override
-		public String caseSendActionUsage(SendActionUsage sau) {
-            return " send action>> ";
-		}
-
-		@Override
-		public String caseAnalysisCaseUsage(AnalysisCaseUsage acu) {
-            return " analysis>> ";
-		}
-
-		@Override
-		public String caseAnalysisCaseDefinition(AnalysisCaseDefinition acd) {
-            return " analysis def>> ";
-		}
-
-		@Override
-		public String caseVerificationCaseUsage(VerificationCaseUsage acu) {
-            return " verification>> ";
-		}
-
-		@Override
-		public String caseVerificationCaseDefinition(VerificationCaseDefinition acd) {
-            return " verification def>> ";
-		}
+		public String caseAssertConstraintUsage(AssertConstraintUsage acu) {
+            if (Visitor.getSpecialReference(acu) != null) {
+                return " assert>> ";
+            } else {
+                return " assert constraint>> ";
+            }
+        }
 
 		@Override
 		public String caseEventOccurrenceUsage(EventOccurrenceUsage eou) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -52,11 +52,11 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.FeatureValue;
+import org.omg.sysml.lang.sysml.Flow;
 import org.omg.sysml.lang.sysml.FlowUsage;
 import org.omg.sysml.lang.sysml.Import;
 import org.omg.sysml.lang.sysml.IncludeUseCaseUsage;
 import org.omg.sysml.lang.sysml.ItemDefinition;
-import org.omg.sysml.lang.sysml.Flow;
 import org.omg.sysml.lang.sysml.ItemUsage;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.MetadataFeature;
@@ -506,6 +506,27 @@ public class SysML2PlantUMLStyle {
 		public String caseImport(Import imp) {
             return " ..> ";
 		}
+
+        @Override
+		public String casePerformActionUsage(PerformActionUsage pau) {
+            return " --> ";
+		}
+
+        @Override
+		public String caseExhibitStateUsage(ExhibitStateUsage esu) {
+            return " --> ";
+		}
+
+        @Override
+		public String caseEventOccurrenceUsage(EventOccurrenceUsage eou) {
+            return " --> ";
+		}
+
+        @Override
+		public String caseIncludeUseCaseUsage(IncludeUseCaseUsage iuc) {
+            return " --> ";
+		}
+
     }
 
     public static class StyleStereotypeDefaultSwitch extends StyleStereotypeSwitch {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -552,7 +552,11 @@ public class SysML2PlantUMLStyle {
 
         @Override
         public String caseIncludeUseCaseUsage(IncludeUseCaseUsage iucu) {
-            return " include use case>> ";
+            if (VStructure.hasRefSubsettingWithoutDeclaredName(iucu)) {
+                return " include>> ";
+            } else {
+                return " include use case>> ";
+            }
 		}
 
 		@Override
@@ -596,7 +600,11 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseEventOccurrenceUsage(EventOccurrenceUsage eou) {
-            return " event occurrence>> ";
+            if (VStructure.hasRefSubsettingWithoutDeclaredName(eou)) {
+                return " event>> ";
+            } else {
+                return " event occurrence>> ";
+            }
 		}
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -463,16 +463,6 @@ public class SysML2PlantUMLStyle {
 		}
 
 		@Override
-		public String caseRequirementConstraintMembership(RequirementConstraintMembership requirementConstraintMembership) {
-            return " ..> ";
-		}
-
-		@Override
-		public String caseSatisfyRequirementUsage(SatisfyRequirementUsage satisfyRequirementUsage) {
-            return " ..> ";
-		}
-
-		@Override
 		public String caseBindingConnector(BindingConnector object) {
             return " -[thickness=5]- ";
 		}
@@ -505,6 +495,16 @@ public class SysML2PlantUMLStyle {
 		@Override
 		public String caseImport(Import imp) {
             return " ..> ";
+		}
+
+		@Override
+		public String caseRequirementConstraintMembership(RequirementConstraintMembership requirementConstraintMembership) {
+            return " --> ";
+		}
+
+		@Override
+		public String caseSatisfyRequirementUsage(SatisfyRequirementUsage satisfyRequirementUsage) {
+            return " --> ";
 		}
 
         @Override
@@ -547,7 +547,11 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
-			return " requirement>> ";
+            if (Visitor.getSpecialReference(sru) != null) {
+                return " requirement>> ";
+            } else {
+                return " satisfy requirement>> ";
+            }
 		}
 
         @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLStyle.java
@@ -538,7 +538,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseExhibitStateUsage(ExhibitStateUsage esu) {
-            if (VStructure.hasRefSubsettingWithoutDeclaredName(esu)) {
+            if (Visitor.getSpecialReference(esu) != null) {
                 return " exhibit>> ";
             } else {
                 return " exhibit state>> ";
@@ -547,12 +547,12 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
-            return "<<requirement>> ";
+			return " requirement>> ";
 		}
 
         @Override
         public String caseIncludeUseCaseUsage(IncludeUseCaseUsage iucu) {
-            if (VStructure.hasRefSubsettingWithoutDeclaredName(iucu)) {
+            if (Visitor.getSpecialReference(iucu) != null) {
                 return " include>> ";
             } else {
                 return " include use case>> ";
@@ -561,7 +561,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String casePerformActionUsage(PerformActionUsage pau) {
-            if (VStructure.hasRefSubsettingWithoutDeclaredName(pau)) {
+            if (Visitor.getSpecialReference(pau) != null) {
                 return " perform>> ";
             } else {
                 return " perform action>> ";
@@ -600,7 +600,7 @@ public class SysML2PlantUMLStyle {
 
 		@Override
 		public String caseEventOccurrenceUsage(EventOccurrenceUsage eou) {
-            if (VStructure.hasRefSubsettingWithoutDeclaredName(eou)) {
+            if (Visitor.getSpecialReference(eou) != null) {
                 return " event>> ";
             } else {
                 return " event occurrence>> ";

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -474,6 +474,17 @@ public class SysML2PlantUMLText {
         sb.append('\n');
     }
 
+    private List<Element> topElements;
+
+    /* package */ boolean toBeRendered(EObject eObj) {
+        while (eObj != null) {
+            if (!(eObj instanceof Element)) return false;
+            if (topElements.contains((Element) eObj)) return true;
+            eObj = eObj.eContainer();
+        }
+        return false;
+    }
+
     public String sysML2PUML(List<? extends EObject> eObjs) {
         initStyle();
         this.vpath = new VPath();
@@ -487,9 +498,11 @@ public class SysML2PlantUMLText {
         init();
 
         numVisits = 0;
+        this.topElements = new ArrayList<>(eObjs.size());
         for (EObject eObj : eObjs) {
             if (eObj instanceof Element) {
                 Element e = (Element) eObj;
+                topElements.add(e);
                 vpath.visit(e);
             }
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/SysML2PlantUMLText.java
@@ -27,8 +27,10 @@ package org.omg.sysml.plantuml;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -595,12 +597,29 @@ public class SysML2PlantUMLText {
         idMap = idMap.pop(keep);
     }
 
+    private Set<Element> assigned = new HashSet<Element>();
+
     Integer newId(Element e) {
-        return idMap.newId(e);
+        if (assigned.contains(e)) {
+            assigned.remove(e);
+            return idMap.getId(e);
+        } else {
+            return idMap.newId(e);
+        }
     }
 
     Integer getId(Element e) {
         return idMap.getId(e);
+    }
+
+    private Integer assignId(Element e) {
+        assigned.add(e);
+        return idMap.getId(e);
+    }
+
+    boolean isReferred(Element e) {
+        int pid = assignId(e);
+        return null != vpath.getPaths(pid);
     }
 
     private boolean inherited;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -59,6 +59,7 @@ import org.omg.sysml.lang.sysml.PortUsage;
 import org.omg.sysml.lang.sysml.ReferenceUsage;
 import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.ReturnParameterMembership;
+import org.omg.sysml.lang.sysml.SatisfyRequirementUsage;
 import org.omg.sysml.lang.sysml.StakeholderMembership;
 import org.omg.sysml.lang.sysml.StateDefinition;
 import org.omg.sysml.lang.sysml.StateUsage;
@@ -252,6 +253,11 @@ public class VCompartment extends VStructure {
     public String caseReferenceUsage(ReferenceUsage ru) {
         // ReferenceUsage should be processed by the parent VTree.
     	return null;
+    }
+
+    @Override
+    public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
+        return recCurrent(sru, true);
     }
 
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCompartment.java
@@ -67,7 +67,6 @@ import org.omg.sysml.lang.sysml.Succession;
 import org.omg.sysml.lang.sysml.SuccessionFlow;
 import org.omg.sysml.lang.sysml.TransitionUsage;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.lang.sysml.VariantMembership;
 import org.omg.sysml.util.ConnectorUtil;
 import org.omg.sysml.util.TypeUtil;
@@ -312,7 +311,7 @@ public class VCompartment extends VStructure {
 
     @Override
     public String caseObjectiveMembership(ObjectiveMembership om) {
-        //rec(om, om, true);
+        if (isEmptyObjective(om)) return "";
         recOrAddOwningMembership(om);
         return "";
     }
@@ -327,12 +326,6 @@ public class VCompartment extends VStructure {
     public String caseStakeholderMembership(StakeholderMembership sm) {
         recOrAddOwningMembership(sm);
         return "";
-    }
-
-    private boolean isEmptySubject(SubjectMembership sm) {
-        Usage u = sm.getOwnedSubjectParameter();
-        if (!"subj".equals(u.getName())) return false;
-        return u.getOwnedRelationship().isEmpty();
     }
 
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -38,6 +38,8 @@ import org.omg.sysml.lang.sysml.ConnectionUsage;
 import org.omg.sysml.lang.sysml.Connector;
 import org.omg.sysml.lang.sysml.Dependency;
 import org.omg.sysml.lang.sysml.Element;
+import org.omg.sysml.lang.sysml.EventOccurrenceUsage;
+import org.omg.sysml.lang.sysml.ExhibitStateUsage;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureChainExpression;
@@ -45,14 +47,17 @@ import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression;
 import org.omg.sysml.lang.sysml.FeatureTyping;
 import org.omg.sysml.lang.sysml.FeatureValue;
+import org.omg.sysml.lang.sysml.Flow;
 import org.omg.sysml.lang.sysml.FlowUsage;
 import org.omg.sysml.lang.sysml.Import;
-import org.omg.sysml.lang.sysml.Flow;
+import org.omg.sysml.lang.sysml.IncludeUseCaseUsage;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.MetadataFeature;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OwningMembership;
+import org.omg.sysml.lang.sysml.PerformActionUsage;
 import org.omg.sysml.lang.sysml.Redefinition;
+import org.omg.sysml.lang.sysml.ReferenceSubsetting;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Subsetting;
@@ -293,6 +298,51 @@ public class VDefault extends VTraverser {
             }
         }
         return ret;
+    }
+
+    // Shorthand notation
+    private boolean addShorthandRelation(Usage u, String title) {
+        if (u.getDeclaredName() != null) return false;
+        if (u.getDeclaredShortName() != null) return false;
+        ReferenceSubsetting rs = u.getOwnedReferenceSubsetting();
+        if (rs == null) return false;
+
+        List<Membership> mss = u.getOwnedMembership();
+        if (!mss.isEmpty()) return false;
+
+        if (isReferred(u)) return false;
+
+        Element owner = u.getOwner();
+        if (!(owner instanceof Type)) return false;
+        if (!checkId(owner)) return false;
+
+        addPRelation(owner, rs.getReferencedFeature(), u, title);
+
+        return true;
+    }
+
+    @Override
+    public String casePerformActionUsage(PerformActionUsage pau) {
+        if (addShorthandRelation(pau, "<<perform>>")) return "";
+        return null;
+    }
+
+    @Override
+    public String caseExhibitStateUsage(ExhibitStateUsage esu) {
+        if (addShorthandRelation(esu, "<<exhibit>>")) return "";
+        return null;
+    }
+
+    @Override
+    public String caseEventOccurrenceUsage(EventOccurrenceUsage eou) {
+        if (addShorthandRelation(eou, "<<event>>")) return "";
+        return null;
+    }
+
+    @Override
+    public String caseIncludeUseCaseUsage(IncludeUseCaseUsage iuc) {
+        if (addShorthandRelation(iuc, "<<include>>")) return "";
+        return null;
     }
 
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -338,7 +338,7 @@ public class VDefault extends VTraverser {
     }
 
     // Shorthand notation
-    private boolean addShorthandRelation(Usage u, String title) {
+    protected boolean addShorthandRelation(Usage u, String title) {
         if (u.getDeclaredName() != null) return false;
         if (u.getDeclaredShortName() != null) return false;
         ReferenceSubsetting rs = u.getOwnedReferenceSubsetting();

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -61,6 +61,8 @@ import org.omg.sysml.lang.sysml.PerformActionUsage;
 import org.omg.sysml.lang.sysml.Redefinition;
 import org.omg.sysml.lang.sysml.ReferenceSubsetting;
 import org.omg.sysml.lang.sysml.Relationship;
+import org.omg.sysml.lang.sysml.RequirementUsage;
+import org.omg.sysml.lang.sysml.SatisfyRequirementUsage;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.SubjectMembership;
 import org.omg.sysml.lang.sysml.Subsetting;
@@ -339,7 +341,7 @@ public class VDefault extends VTraverser {
     }
 
     // Shorthand notation
-    protected boolean addShorthandRelation(Usage u, String title) {
+    private boolean addShorthandRelation(Usage u, String title) {
         if (u.getDeclaredName() != null) return false;
         if (u.getDeclaredShortName() != null) return false;
         ReferenceSubsetting rs = u.getOwnedReferenceSubsetting();
@@ -395,6 +397,19 @@ public class VDefault extends VTraverser {
     @Override
     public String caseAssertConstraintUsage(AssertConstraintUsage acu) {
         if (addShorthandRelation(acu, "<<assert>>")) return "";
+        return null;
+    }
+
+    @Override
+    public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
+        RequirementUsage ru = sru.getSatisfiedRequirement();
+        Feature target = sru.getSatisfyingFeature();
+        if ((ru != null) && (target != null)) {
+            addPRelation(target, ru, sru, "<<satisfy>>");
+            if (getSpecialReference(sru) != null) return "";
+        } else {
+            if (addShorthandRelation(sru, "<<satisfy>>")) return "";
+        }
         return null;
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -304,13 +304,15 @@ public class VDefault extends VTraverser {
 
     protected static boolean isEmptySubject(SubjectMembership sm) {
         Usage u = sm.getOwnedSubjectParameter();
-        if (!"subj".equals(u.getName())) return false;
+        String name = u.getName();
+        if (name != null && !"subj".equals(u.getName())) return false;
         return u.getOwnedRelationship().isEmpty();
     }
 
     protected static boolean isEmptyObjective(ObjectiveMembership om) {
         Usage u = om.getOwnedObjectiveRequirement();
-        if (!"obj".equals(u.getName())) return false;
+        String name = u.getName();
+        if (name != null && !"obj".equals(u.getName())) return false;
         return isEmpty(u);
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -344,9 +344,15 @@ public class VDefault extends VTraverser {
         ReferenceSubsetting rs = u.getOwnedReferenceSubsetting();
         if (rs == null) return false;
         Feature ref = rs.getReferencedFeature();
+
+        /* If the target is not rendered, we do not use a shorthand notation and render a distinct node.
+         * If the target is a feature chain, we only check the first chaining feature because the visualizer
+         * will render all of the features of the feature chain.
+         * However it assumes the current visualizer behavior and we should provide a better 'toBeRendered()' service
+         * by extending VPath */
         Feature tgt = FeatureUtil.getFirstChainingFeatureOf(ref);
         if (tgt == null) tgt = ref;
-        if (!toBeRendered(tgt)) return false; // If the target is not rendered, we render a distinct node.
+        if (!toBeRendered(tgt)) return false;
 
         if (!isEmpty(u)) return false;
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.omg.sysml.lang.sysml.AnnotatingElement;
 import org.omg.sysml.lang.sysml.Annotation;
+import org.omg.sysml.lang.sysml.AssertConstraintUsage;
 import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.BindingConnectorAsUsage;
@@ -388,6 +389,12 @@ public class VDefault extends VTraverser {
     @Override
     public String caseIncludeUseCaseUsage(IncludeUseCaseUsage iuc) {
         if (addShorthandRelation(iuc, "<<include>>")) return "";
+        return null;
+    }
+
+    @Override
+    public String caseAssertConstraintUsage(AssertConstraintUsage acu) {
+        if (addShorthandRelation(acu, "<<assert>>")) return "";
         return null;
     }
 

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VDefault.java
@@ -338,6 +338,8 @@ public class VDefault extends VTraverser {
         if (u.getDeclaredShortName() != null) return false;
         ReferenceSubsetting rs = u.getOwnedReferenceSubsetting();
         if (rs == null) return false;
+        Feature tgt = rs.getReferencedFeature();
+        if (!checkId(tgt)) return false; // If the target does not exist, we render a distinct node.
 
         if (!isEmpty(u)) return false;
 
@@ -347,7 +349,7 @@ public class VDefault extends VTraverser {
         if (!(owner instanceof Type)) return false;
         if (!checkId(owner)) return false;
 
-        addPRelation(owner, rs.getReferencedFeature(), u, title);
+        addPRelation(owner, tgt, u, title);
 
         return true;
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
@@ -57,7 +57,7 @@ public class VMixed extends VTree {
 
     private String process(Visitor v, Element e) {
         v.visit(e);
-        addRel(e, e, null);
+        addRel(e, null);
         v.flush();
         return "";
     }
@@ -69,19 +69,13 @@ public class VMixed extends VTree {
     @Override
     public String caseActionDefinition(ActionDefinition ad) {
         VAction va = new VAction(this);
-        va.caseActionDefinition(ad);
-        addRel(ad, null);
-        va.flush();
-        return "";
+        return process(va, ad);
     }
 
     @Override
     public String caseActionUsage(ActionUsage au) {
         VAction va = new VAction(this);
-        va.caseActionUsage(au);
-        addRel(au, null);
-        va.flush();
-        return "";
+        return process(va, au);
     }
 
     /***************************************************

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -39,9 +39,7 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureValue;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Redefinition;
-import org.omg.sysml.lang.sysml.RequirementUsage;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
-import org.omg.sysml.lang.sysml.SatisfyRequirementUsage;
 import org.omg.sysml.lang.sysml.StakeholderMembership;
 import org.omg.sysml.lang.sysml.Type;
 
@@ -309,19 +307,6 @@ public abstract class VStructure extends VDefault {
         return "";
     }
 
-    @Override
-    public String caseSatisfyRequirementUsage(SatisfyRequirementUsage sru) {
-        RequirementUsage ru = sru.getSatisfiedRequirement();
-        Feature target = sru.getSatisfyingFeature();
-        if ((ru != null) && (target != null)) {
-            addPRelation(target, ru, sru, "<<satisfy>>");
-            if (getSpecialReference(sru) != null) return "";
-        } else {
-            if (addShorthandRelation(sru, "<<satisfy>>")) return "";
-        }
-        return null;
-    }
-    
     @Override
     public String caseConjugatedPortDefinition(ConjugatedPortDefinition cpd) {
         // Do not show conjugated ports.

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -229,13 +229,6 @@ public abstract class VStructure extends VDefault {
         }
     }
 
-    public static boolean hasRefSubsettingWithoutDeclaredName(Feature f) {
-        if (f.getOwnedReferenceSubsetting() == null) return false;
-        if (f.getDeclaredName() != null) return false;
-        if (f.getDeclaredShortName() != null) return false;
-        return true;
-    }
-
     protected String extractTitleName(Element e) {
         String name = getNameAnyway(e);
         StringBuilder sb = new StringBuilder();
@@ -254,7 +247,7 @@ public abstract class VStructure extends VDefault {
             }
             sb.append(' ');
             added = appendSubsettings(sb, f) || added;
-            if (!hasRefSubsettingWithoutDeclaredName(f)) {
+            if (Visitor.getSpecialReference(f) == null) {
                 sb.append(' ');
                 added = appendReferenceSubsetting(sb, f) || added;
             }
@@ -323,7 +316,7 @@ public abstract class VStructure extends VDefault {
         if ((ru != null) && (target != null)) {
             addPRelation(target, ru, sru, "<<satisfy>>");
         }
-        if (hasRefSubsettingWithoutDeclaredName(sru)) return "";
+        if (getSpecialReference(sru) != null) return "";
         return null;
     }
     

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -315,8 +315,10 @@ public abstract class VStructure extends VDefault {
         Feature target = sru.getSatisfyingFeature();
         if ((ru != null) && (target != null)) {
             addPRelation(target, ru, sru, "<<satisfy>>");
+            if (getSpecialReference(sru) != null) return "";
+        } else {
+            if (addShorthandRelation(sru, "<<satisfy>>")) return "";
         }
-        if (getSpecialReference(sru) != null) return "";
         return null;
     }
     

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VStructure.java
@@ -323,7 +323,8 @@ public abstract class VStructure extends VDefault {
         if ((ru != null) && (target != null)) {
             addPRelation(target, ru, sru, "<<satisfy>>");
         }
-        return "";
+        if (hasRefSubsettingWithoutDeclaredName(sru)) return "";
+        return null;
     }
     
     @Override

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VTree.java
@@ -131,6 +131,7 @@ public class VTree extends VStructure {
 
     @Override
     public String caseObjectiveMembership(ObjectiveMembership om) {
+        if (isEmptyObjective(om)) return "";
         RequirementUsage ru = om.getOwnedObjectiveRequirement();
         addRel(ru, om, "<<objective>>");
         addReq("comp usage ", ru);

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
+import org.omg.sysml.lang.sysml.AssertConstraintUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.EventOccurrenceUsage;
 import org.omg.sysml.lang.sysml.ExhibitStateUsage;
@@ -348,6 +349,7 @@ public abstract class Visitor extends SysMLSwitch<String> {
               || e instanceof ExhibitStateUsage
               || e instanceof EventOccurrenceUsage
               || e instanceof IncludeUseCaseUsage
+              || e instanceof AssertConstraintUsage
               || e instanceof SatisfyRequirementUsage)) return null;
         Feature f = (Feature) e;
         if (f.getDeclaredName() != null) return null;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -199,6 +199,10 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return s2p.checkId(e);
     }
 
+    protected boolean isReferred(Element e) {
+        return s2p.isReferred(e);
+    }
+
     protected void pushIdMap() {
         s2p.pushIdMap();
     }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/Visitor.java
@@ -627,6 +627,10 @@ public abstract class Visitor extends SysMLSwitch<String> {
         return checkId(e);
     }
 
+    protected boolean toBeRendered(Element e) {
+        return s2p.toBeRendered(e);
+    }
+
     private void renderImportedPackage(org.omg.sysml.lang.sysml.Package pkg, Collection<Element> nonPkgs) {
         String name = pkg.getQualifiedName();
         if (name == null) return;


### PR DESCRIPTION
This PR renders shorthand notations for `PerformActionUsage`, `ExhibitStateUsage`, `EventOccurrenceUsage`, and `IncludeUsecase`.  In the example below, we can use just an arrow with `<<perform>>` label from p1 to a0 to render `PerformActionUsage` without rendering a distinct node for it.
```
part p1 {
   perform a0;
}
action a0;
```

However, we cannot use this notation if `PerformActionUsage` is referred to by others or if it has its own members, because we cannot properly render this information without a distinct node.  We render a _cumbersome_ notation with a distinct node in such cases.