### PR TITLE
ST6RI-841 The isCompatibleWith operation needs a return type

### DIFF
--- a/org.omg.sysml/model/KerML_only.uml
+++ b/org.omg.sysml/model/KerML_only.uml
@@ -2753,6 +2753,9 @@ redefines(mem.memberElement.oclAsType(Feature))</body>
         </specification>
       </ownedRule>
       <ownedParameter xmi:id="34116e2a-c79c-4277-b409-2f25e53abe18" name="otherType" visibility="public" type="a32ae34b-57c2-4f49-832c-00f8741d55e7"/>
+      <ownedParameter xmi:id="_Jz9DwCvDEfCJzut8qz2Csg" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedParameter>
     </ownedOperation>
     <ownedOperation xmi:id="43a26f3f-ea82-488e-a0bc-904e16ed9c5e" name="typingFeatures" visibility="public" bodyCondition="3baa429e-0255-4f08-8c83-2a14bd084a1b">
       <ownedComment xmi:id="44a7b1ba-c0ab-40ce-a72a-4ce4bd05c0b9" annotatedElement="43a26f3f-ea82-488e-a0bc-904e16ed9c5e">
@@ -4211,6 +4214,9 @@ specializes(mem.memberElement.oclAsType(Type))</body>
         </specification>
       </ownedRule>
       <ownedParameter xmi:id="1871002f-9e6b-44dd-8e87-759c14da3cd2" name="otherType" visibility="public" type="a32ae34b-57c2-4f49-832c-00f8741d55e7"/>
+      <ownedParameter xmi:id="_7H10oCvCEfCJzut8qz2Csg" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedParameter>
     </ownedOperation>
     <ownedOperation xmi:id="75edcbb6-a75e-4709-911e-0cd1094a28f5" name="multiplicities" visibility="public" bodyCondition="9d09cc58-6842-4d74-a593-63afd30d4287">
       <ownedComment xmi:id="d60ff703-e548-406c-a961-d320510a590c" annotatedElement="75edcbb6-a75e-4709-911e-0cd1094a28f5">

--- a/org.omg.sysml/model/SysML.ecore
+++ b/org.omg.sysml/model/SysML.ecore
@@ -116,7 +116,7 @@
       <eAnnotations source="http://www.omg.org/spec/SysML"/>
       <eParameters name="libraryTypeName" ordered="false" lowerBound="1" eType="ecore:EDataType types.ecore#//String"/>
     </eOperations>
-    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1">
+    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1" eType="ecore:EDataType types.ecore#//Boolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="&lt;p>By default, this &lt;code>Type&lt;/code> is compatible with an &lt;code>otherType&lt;/code> if it directly or indirectly specializes the &lt;code>otherType&lt;/code>.&lt;/p>&#xA;specializes(otherType)"/>
       </eAnnotations>

--- a/org.omg.sysml/model/SysML.uml
+++ b/org.omg.sysml/model/SysML.uml
@@ -4420,6 +4420,9 @@ specializes(mem.memberElement.oclAsType(Type))</body>
         </specification>
       </ownedRule>
       <ownedParameter xmi:id="1871002f-9e6b-44dd-8e87-759c14da3cd2" name="otherType" visibility="public" type="a32ae34b-57c2-4f49-832c-00f8741d55e7"/>
+      <ownedParameter xmi:id="_cqYMoCvCEfCJzut8qz2Csg" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedParameter>
     </ownedOperation>
     <ownedOperation xmi:id="75edcbb6-a75e-4709-911e-0cd1094a28f5" name="multiplicities" visibility="public" bodyCondition="9d09cc58-6842-4d74-a593-63afd30d4287">
       <ownedComment xmi:id="d60ff703-e548-406c-a961-d320510a590c" annotatedElement="75edcbb6-a75e-4709-911e-0cd1094a28f5">
@@ -5863,6 +5866,9 @@ redefines(mem.memberElement.oclAsType(Feature))</body>
         </specification>
       </ownedRule>
       <ownedParameter xmi:id="34116e2a-c79c-4277-b409-2f25e53abe18" name="otherType" visibility="public" type="a32ae34b-57c2-4f49-832c-00f8741d55e7"/>
+      <ownedParameter xmi:id="_qYAaQCvCEfCJzut8qz2Csg" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+      </ownedParameter>
     </ownedOperation>
     <ownedOperation xmi:id="43a26f3f-ea82-488e-a0bc-904e16ed9c5e" name="typingFeatures" visibility="public" bodyCondition="3baa429e-0255-4f08-8c83-2a14bd084a1b">
       <ownedComment xmi:id="44a7b1ba-c0ab-40ce-a72a-4ce4bd05c0b9" annotatedElement="43a26f3f-ea82-488e-a0bc-904e16ed9c5e">

--- a/org.omg.sysml/model/kerml.ecore
+++ b/org.omg.sysml/model/kerml.ecore
@@ -908,7 +908,7 @@
       </eAnnotations>
       <eParameters name="libraryTypeName" ordered="false" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.uml2.types/model/Types.ecore#//String"/>
     </eOperations>
-    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1">
+    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.uml2.types/model/Types.ecore#//Boolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="&lt;p>By default, this &lt;code>Type&lt;/code> is compatible with an &lt;code>otherType&lt;/code> if it directly or indirectly specializes the &lt;code>otherType&lt;/code>.&lt;/p>"/>
       </eAnnotations>

--- a/org.omg.sysml/model/sysml_clean.ecore
+++ b/org.omg.sysml/model/sysml_clean.ecore
@@ -100,7 +100,7 @@
       </eAnnotations>
       <eParameters name="libraryTypeName" ordered="false" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.uml2.types/model/Types.ecore#//String"/>
     </eOperations>
-    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1">
+    <eOperations name="isCompatibleWith" ordered="false" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.uml2.types/model/Types.ecore#//Boolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="&lt;p>By default, this &lt;code>Type&lt;/code> is compatible with an &lt;code>otherType&lt;/code> if it directly or indirectly specializes the &lt;code>otherType&lt;/code>.&lt;/p>&#xA;specializes(otherType)"/>
       </eAnnotations>

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/Type.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/Type.java
@@ -265,11 +265,11 @@ public interface Type extends Namespace {
 	 * <p>By default, this <code>Type</code> is compatible with an <code>otherType</code> if it directly or indirectly specializes the <code>otherType</code>.</p>
 	 * specializes(otherType)
 	 * <!-- end-model-doc -->
-	 * @model otherTypeRequired="true" otherTypeOrdered="false"
+	 * @model dataType="org.omg.sysml.lang.types.Boolean" required="true" ordered="false" otherTypeRequired="true" otherTypeOrdered="false"
 	 *        annotation="http://www.omg.org/spec/SysML"
 	 * @generated
 	 */
-	void isCompatibleWith(Type otherType);
+	boolean isCompatibleWith(Type otherType);
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SysMLPackageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/SysMLPackageImpl.java
@@ -9233,7 +9233,7 @@ public class SysMLPackageImpl extends EPackageImpl implements SysMLPackage {
 		op = initEOperation(getType__SpecializesFromLibrary__String(), theTypesPackage.getBoolean(), "specializesFromLibrary", 1, 1, IS_UNIQUE, !IS_ORDERED);
 		addEParameter(op, theTypesPackage.getString(), "libraryTypeName", 1, 1, IS_UNIQUE, !IS_ORDERED);
 
-		op = initEOperation(getType__IsCompatibleWith__Type(), null, "isCompatibleWith", 1, 1, IS_UNIQUE, !IS_ORDERED);
+		op = initEOperation(getType__IsCompatibleWith__Type(), theTypesPackage.getBoolean(), "isCompatibleWith", 1, 1, IS_UNIQUE, !IS_ORDERED);
 		addEParameter(op, this.getType(), "otherType", 1, 1, IS_UNIQUE, !IS_ORDERED);
 
 		initEOperation(getType__Multiplicities(), this.getMultiplicity(), "multiplicities", 0, -1, IS_UNIQUE, IS_ORDERED);

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/TypeImpl.java
@@ -1084,9 +1084,9 @@ public class TypeImpl extends NamespaceImpl implements Type {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void isCompatibleWith(Type otherType) {
+	public boolean isCompatibleWith(Type otherType) {
 		try {
-			IS_COMPATIBLE_WITH_TYPE__EINVOCATION_DELEGATE.dynamicInvoke(this, new BasicEList.UnmodifiableEList<Object>(1, new Object[]{otherType}));
+			return (Boolean)IS_COMPATIBLE_WITH_TYPE__EINVOCATION_DELEGATE.dynamicInvoke(this, new BasicEList.UnmodifiableEList<Object>(1, new Object[]{otherType}));
 		}
 		catch (InvocationTargetException ite) {
 			throw new WrappedException(ite);
@@ -1495,8 +1495,7 @@ public class TypeImpl extends NamespaceImpl implements Type {
 			case SysMLPackage.TYPE___SPECIALIZES_FROM_LIBRARY__STRING:
 				return specializesFromLibrary((String)arguments.get(0));
 			case SysMLPackage.TYPE___IS_COMPATIBLE_WITH__TYPE:
-				isCompatibleWith((Type)arguments.get(0));
-				return null;
+				return isCompatibleWith((Type)arguments.get(0));
 			case SysMLPackage.TYPE___MULTIPLICITIES:
 				return multiplicities();
 		}


### PR DESCRIPTION
This PR implements a proactive update to resolve the following issue, which is to be considered by the future KerML 1.1 RTF.

- [KERML_-230](https://issues.omg.org/issues/KERML_-230)  isCompatibleWith operation needs a return type

The PR updates the operations `Type::isCompatibleWith` and `Feature::isCompatibleWith` to add the missing return type of `Boolean`. The following files in the `org.omg.sysml/model` directory have been updated for this:
- `SysML.uml`
- `KerML_only.uml`

Note that the following files have _not_ been updated:
- `SysML_xmi.uml`
- `SysML_only_xmi.uml`

The following Ecore files have been regenerated, along with the relevant Java files in the `syntax-gen` directory.
- `SysML.ecore`
- `sysml_clean.ecore`
- `kerml.ecore`