### PR TITLE
ST6RI-849 Configure GitHub Actions for CI builds

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Release Build
+
+on:
+  workflow_dispatch:
+  release:
+      types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Remove -snapshot from version
+      run: ./mvnw -B versions:set -DremoveSnapshot=true
+    - name: Publish to Github Packages
+      run: ./mvnw -B deploy -DskipTests=true
+      env:
+        GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password


### PR DESCRIPTION
Configuration has been added on `master` to use GiHub Actions to initiate CI builds on a push to the repository.

This PR adds a release-build workflow, triggered by publishing a release record in the repository or by executing the workflow manually.

This build is different from normal builds in the following ways:

 - It skips test execution (it is expected a normal build already ran successfully for this commit before the release is finalized)
 - It skips verification of the generated library index (again, it is expected a normal build was already run)
 - A Maven version task is executed to remove the -SNAPSHOT version.

Important to note: if the process is executed a second time without changing the base versions, the publish process will fail, as release builds cannot be overwritten in GitHub Packages.