### PR TITLE
ST6RI-850 Generating XMI with implicit elements can cause an exception

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -209,8 +209,11 @@ public class FeatureAdapter extends TypeAdapter {
 			Expression value = valuation.getValue();
 			if (value != null) {
 				ElementUtil.transform(value);
-				Feature result = FeatureUtil.chainFeatures(value, value.getResult());
-				return result;
+				Feature valueResult = value.getResult();
+				if (valueResult != null) {
+					Feature result = FeatureUtil.chainFeatures(value, value.getResult());
+					return result;
+				}
 			}
 		}
 		return null;

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -94,10 +94,12 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 		Feature transitionLinkFeature = UsageUtil.getTransitionLinkFeatureOf(transition);
 		if (transitionLinkFeature == null) {
 			// checkTransitionUsageSuccessionBindingConnector
-			transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
-			TypeUtil.addOwnedFeatureTo(transition, transitionLinkFeature);			
 			Succession succession = transition.getSuccession();
-			addBindingConnector(succession, transitionLinkFeature);		
+			if (succession != null) {
+				transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
+				TypeUtil.addOwnedFeatureTo(transition, transitionLinkFeature);			
+				addBindingConnector(succession, transitionLinkFeature);
+			}
 			
 			// checkTransitionUsageSourceBindingConnector
 			List<Feature> parameters = TypeUtil.getOwnedParametersOf(transition);

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -478,7 +478,8 @@ public class TypeAdapter extends NamespaceAdapter {
 
 	public BindingConnector addResultBinding(Expression sourceExpression, Feature target) {
 		ElementUtil.transform(sourceExpression);
-		return addBindingConnector(sourceExpression.getResult(), target);
+		Feature sourceResult = sourceExpression.getResult();
+		return sourceResult == null || target == null? null: addBindingConnector(sourceResult, target);
 	}
 	
 	public void createResultConnector(Feature result) {

--- a/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ConnectorUtil.java
@@ -67,6 +67,9 @@ public class ConnectorUtil {
 	public static Feature addConnectorEndTo(Connector connector, Feature relatedFeature) {
 		Feature endFeature = SysMLFactory.eINSTANCE.createFeature();
 		ReferenceSubsetting subsetting = SysMLFactory.eINSTANCE.createReferenceSubsetting();
+		if (relatedFeature.getOwner() == null) {
+			subsetting.getOwnedRelatedElement().add(relatedFeature);
+		}
 		subsetting.setReferencedFeature(relatedFeature);
 		endFeature.getOwnedRelationship().add(subsetting);
 		endFeature.setIsEnd(true);


### PR DESCRIPTION
This PR corrects a bug that can cause an exception when a model is saved to XMI with implicit elements.

In the Beta 3 version of the KerML Specification, the `checkFeatureValueBindingConnector` constraint was updated so that the implied `BindingConnector` for a `FeatureValue` is between the `featureWithValue` and a feature chain consisting of the `value` `Expression` and the `result` of that `Expression` (where previously it had been directly to the `result`). This was implemented in the 2025-02 release (see change to `FeatureAdapter` in PR #638). The target feature chain of the implied `BindingConnector` should have been owned by the `ReferenceSubsetting` relating it to the appropriate `connectorEnd`. Unfortunately, the implementation did not do this, so the owning `Feature` for the feature chain ended up not being contained in the resource being saved to XMI, which can cause the exception.

This PR fixes the bug by adding a check to `ConnectorUtil::addConnectorEnd` of whether the given `relatedElement` has an owner. If not, the `relatedElement` is added as an `ownedRelatedElement` of the `ReferenceSubsetting` of the `connectorEnd` being created.