### PR TITLE
ST6RI-847 TypeUtil.isCompatibleWith does not match specification

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -185,7 +185,7 @@ public class TypeUtil {
 		if (specializes(subtype, supertype)) {
 			return true;
 		} else if (subtype instanceof Feature && supertype instanceof Feature &&
-				   (subtype.getOwnedFeature().isEmpty() || supertype.getOwnedFeature().isEmpty())) {
+				   subtype.getOwnedFeature().isEmpty() && supertype.getOwnedFeature().isEmpty()) {
 			Set<Feature> subtypeRedefined = FeatureUtil.getAllRedefinedFeaturesOf((Feature)subtype);
 			Set<Feature> supertypeRedefined = FeatureUtil.getAllRedefinedFeaturesOf((Feature)supertype);
 			if (subtypeRedefined.stream().anyMatch(supertypeRedefined::contains)) {


### PR DESCRIPTION
This PR corrects a non-conformance of the Pilot Implementation with the KerML Specification on the computation of the `Feature::isCompatibleWith` operation.

The `isCompatibleWith` operation allows a feature to be considered "compatible with" another feature, even if the first feature is not a specialization of the second. This is necessary to allow the implied featuring types of variable features to be considered compatible in certain cases. But, according to the specification, two features can only be compatible in this way if they both have no nested features. Previously, the Pilot Implementation allowed compatibility if at least one of the features had no nested features, but didn't require both to have no features. This PR changes the implementation to conform to the specification.

The non-conformance in the implementation was not actually accidental, however. As previously implemented, the following model was considered valid:
```
class A {
    :>> snapshots {
        feature s;
    }
    var feature x :> snapshots::s;
}
```
With the change made in this PR, the implied featuring type of the variable feature `x` is no longer considered compatible with `snapshots`, because `snapshots` has the nested feature `s`, so the subsetting violates the `validateSubsettingFeaturingTypes` constraint. The workaround is to use the feature chain `snapshots.s`, rather than the qualified name `snapshots::s`.

The intent had been to propose revising the specification of `isCompatibleWith` to be similar to the implementation of `isCompatibleWith` that allowed models such as the example above. This did not happen, though, and, since there is generally an easy workaround for the missing capability, it the Pilot Implementation to be conformant to the specification as adopted.