### PR TITLE
ST6RI-848 Bug in FeatureUtil.canAccess

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -404,8 +404,7 @@ public class FeatureUtil {
 	private static boolean canAccess(Feature subsettingFeature, Feature subsettedFeature, Set<Feature> visited) {
 		visited.add(subsettingFeature);
 		List<Type> featuringTypes = subsettingFeature.getFeaturingType();
-		return featuringTypes.isEmpty() && subsettedFeature == 
-				SysMLLibraryUtil.getLibraryType(subsettingFeature, ImplicitGeneralizationMap.getDefaultSupertypeFor(ClassifierImpl.class)) ||
+		return featuringTypes.isEmpty() && subsettedFeature.isFeaturedWithin(null) ||
 				featuringTypes.stream().anyMatch(featuringType-> 
 						subsettedFeature.isFeaturedWithin(featuringType) ||				
 						featuringType instanceof Feature &&


### PR DESCRIPTION
This PR fixes a bug in the implementation of `FeatureUtil.canAccess` for checking accessibility when the subsetting feature has no featuring types.