### PR TITLE
ST6RI-856 isConstant not serialized in XMI for end Usages

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/DefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/DefinitionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -32,6 +32,15 @@ public class DefinitionAdapter extends ClassifierAdapter {
 	@Override
 	public Definition getTarget() {
 		return (Definition)super.getTarget();
+	}
+	
+	@Override
+	public void postProcess() {
+		super.postProcess();
+		Definition target = getTarget();
+		if (target.isVariation()) {
+			target.setIsAbstract(true);
+		}
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -206,8 +206,14 @@ public class UsageAdapter extends FeatureAdapter {
 	@Override
 	public void doTransform() {
 		super.doTransform();
-		if (UsageUtil.isVariant(getTarget())) {
+		Usage target = getTarget();
+		if (UsageUtil.isVariant(target)) {
 			addImplicitFeaturingTypesIfNecessary();
+		}
+		
+		// Note: This cannot be done in postProcess, because of mayTimeVary computation.
+		if (target.isEnd() && mayTimeVary()) {
+			target.setIsConstant(true);
 		}
 	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -52,6 +52,15 @@ public class UsageAdapter extends FeatureAdapter {
 	}
 	
 	// Post-processing
+	
+	@Override
+	public void postProcess () {
+		super.postProcess();
+		Usage target = getTarget();
+		if (target.isVariation()) {
+			target.setIsAbstract(true);
+		}
+	}
 	
 	@Override
 	protected void setIsVariableIfConstant() {

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DefinitionImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/DefinitionImpl.java
@@ -784,15 +784,6 @@ public class DefinitionImpl extends ClassifierImpl implements Definition {
 		return (EList<VariantMembership>)VARIANT_MEMBERSHIP__ESETTING_DELEGATE.dynamicGet(this, null, 0, true, false);
 	}
 
-	// Additional Overrides
-	
-	@Override
-	public boolean isAbstract() {
-		return isVariation() || super.isAbstract();
-	}
-	
-	//
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
@@ -1047,11 +1047,6 @@ public class UsageImpl extends FeatureImpl implements Usage {
 	// Additional overrides
 	
 	@Override
-	public boolean isAbstract() {
-		return isVariation() || super.isAbstract();
-	}
-
-	@Override
 	public boolean isComposite() {
 		return UsageUtil.isComposite(this, isComposite);
 	}

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/UsageImpl.java
@@ -1051,11 +1051,6 @@ public class UsageImpl extends FeatureImpl implements Usage {
 		return UsageUtil.isComposite(this, isComposite);
 	}
 	
-	@Override
-	public boolean isConstant() {
-		return isConstant || isEnd() && isMayTimeVary();
-	}
-
 	//
 	
 	/**


### PR DESCRIPTION
An end usage is automatically considered to be constant if it may time vary. However, while `isConstant()` returned true for such elements in memory, the value `isConstant = true` was not being serialized to XMI for them. Similarly, the `isAbstract` property was not being serialized for variation definitions and usages, even though `isAbstract()` returns true for them.

The underlying problem is that the automatic setting of `isConstant` and `isAbstract` was bing done by overriding the methods `isConstant()` in `UsageImpl` and `isAbstract` in `DefinitionImpl` and `UsageImpl`. In both case, the corresponding the field actually retained its default value. During XMI serialization, the `eIsSet` operation is used to check if a field is set. Unfortunately, the generated implementation for this for both `isConstant` and `isAbstract` directly checks the field against the default value. These fields are thus treated as having the default value and not serialized.

This PR fixes the problem as follows.
1. The "additional override" for `isConstant()` has been removed from `UsageImpl`. Instead, in `UsageAdapter::transform`, the `isConstant` property is explicitly set to true if the usage is an end and it may time vary. (Note that this cannot be done in `postProcess`, because the computation of `mayTimeVary` requires traversing the specializations of the usage, which cannot be properly done during parse post-processing.
2. The "additional overrides" for `isAbstract()` have been removed from `DefinitionImpl` and `UsageImpl`. Instead `DefinitionAdapter::postProcess` and `UsageAdapter::postProcess` have been updated to explicitly set `isAbstract` to true if `isVariation` is true.