### PR TITLE
ST6RI-857 Added owned cross feature type before default subsetting.

### DIFF
--- a/kerml/src/examples/Simple Tests/Associations.kerml
+++ b/kerml/src/examples/Simple Tests/Associations.kerml
@@ -1,7 +1,10 @@
-package Associations {	
+package Associations {
+    datatype X;
+    class Y;
+    
 	assoc A {
-		end x;
-		end [1..*] feature y;
+		end x_cross [1..1] feature x : X; 
+		end y_cross [1..*] feature y : Y;
 	}
 	
 	assoc B specializes A {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -228,12 +228,14 @@ public class FeatureAdapter extends TypeAdapter {
 	 */
 	@Override
 	public void addDefaultGeneralType() {
+		// Note: This must happen before call to super, because default supertype depends on ownedTyping.
+		addOwnedCrossFeatureSpecialization();
+
 		super.addDefaultGeneralType();
 		
 		addBoundValueSubsetting();
 		addParticipantSubsetting();
 		addCrossingSpecialization();
-		addOwnedCrossFeatureSpecialization();
 	}
 	
 


### PR DESCRIPTION
This PR corrects a bug that resulted in owned cross features subsetting `Base::things` when the implied typing by their owning end feature's type meant they should subset `Base::dataValues`, `Occurrence::occurrences` or `Object::objects`. The bug was fixed by moving the call to `addOwnedCrossFeatureSpecialization` in `FeatureAdapter.addDefaultGeneralType` to before the call `super.addDefaultGeneralType`. In this way, the implied owned typing for a cross feature is now added before the determination of the default subsetting, which is based on owned typing.