### PR TITLE
ST6RI-863 Actions in a case will cause a crash of the visualization (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
@@ -45,11 +45,11 @@ import org.omg.sysml.lang.sysml.TransitionUsage;
 
 public abstract class VBehavior extends VDefault {
     protected boolean isDoneAction(Feature f) {
-        return "Actions::Action::done".equals(f.getQualifiedName());
+        return f != null && f.specializesFromLibrary("Actions::Action::done");
     }
 
     protected boolean isStartAction(Feature f) {
-        return "Actions::Action::start".equals(f.getQualifiedName());
+        return f != null && f.specializesFromLibrary("Actions::Action::start");
     }
 
     protected boolean isEntryAction(ActionUsage au) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCase.java
@@ -26,7 +26,7 @@ package org.omg.sysml.plantuml;
 
 import java.util.List;
 
-import org.omg.sysml.lang.sysml.CaseDefinition;
+import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
@@ -39,7 +39,7 @@ import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.plantuml.SysML2PlantUMLStyle.StyleRelSwitch;
 import org.omg.sysml.plantuml.SysML2PlantUMLStyle.StyleSwitch;
 
-public class VCase extends VTree {
+public class VCase extends VMixed {
     private static final SysML2PlantUMLStyle style
     = new SysML2PlantUMLStyle
     ("VCase",
@@ -66,7 +66,7 @@ public class VCase extends VTree {
         return new VCase(this, namespace, membership);
     }
 
-    private String addCase(Type typ) {
+    private String addAction(Type typ) {
         String name = extractTitleName(typ);
         int id = addRecLine(name, typ, true);
         addSpecializations(id, typ);
@@ -104,13 +104,14 @@ public class VCase extends VTree {
     }
 
     @Override
-    public String caseCaseUsage(CaseUsage ucu) {
-        return addCase(ucu);
+    public String caseActionUsage(ActionUsage au) {
+        return addAction(au);
     }
 
     @Override
-    public String caseCaseDefinition(CaseDefinition ucd) {
-        return addCase(ucd);
+    public String caseCaseUsage(CaseUsage cu) {
+        // We MUST override VMixed.caseCaseUsage()
+        return addAction(cu);
     }
 
     VCase(Visitor vt, Namespace namespace, Membership membership) {

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
@@ -27,7 +27,8 @@ package org.omg.sysml.plantuml;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.omg.sysml.lang.sysml.CaseDefinition;
+import org.omg.sysml.lang.sysml.ActionDefinition;
+import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Membership;
@@ -66,25 +67,20 @@ public class VCaseMembers extends VBehavior {
         rec(new VCase(this), e, inside);
     }
     
-    private String addCase(Type typ) {
+    private String addAction(Type typ) {
         recElement(typ, true);
         return "";
     }
 
     @Override
-    public String caseCaseUsage(CaseUsage ucu) {
-        return addCase(ucu);
-    }
-
-    @Override
-    public String caseCaseDefinition(CaseDefinition ucd) {
-        return addCase(ucd);
+    public String caseActionUsage(ActionUsage ucu) {
+        return addAction(ucu);
     }
 
     @Override
     public String caseMembership(Membership m) {
         Element e = m.getMemberElement();
-        if ((e instanceof CaseUsage)
+        if ((e instanceof ActionUsage)  // Action-like elements are recursively rendered.
             || (e instanceof Relationship)) {
             return super.caseMembership(m);
         }

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VCaseMembers.java
@@ -27,9 +27,7 @@ package org.omg.sysml.plantuml;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.omg.sysml.lang.sysml.ActionDefinition;
 import org.omg.sysml.lang.sysml.ActionUsage;
-import org.omg.sysml.lang.sysml.CaseUsage;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.ObjectiveMembership;

--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VMixed.java
@@ -110,7 +110,7 @@ public class VMixed extends VTree {
     }
 
 
-    private VMixed(VTree vt, Namespace namespace, Membership membership) {
+    protected VMixed(Visitor vt, Namespace namespace, Membership membership) {
         super(vt, namespace, membership);
     }
 


### PR DESCRIPTION
Since VCase cannot handle actions properly, the model below causes a crash.
```
case c1 {
        first start;
        then action a;
}
```
This PR fixes this issue and lets the visualizer properly render actions as well as cases.