### PR TITLE
ST6RI-857/858/860/861 Semantic transformation bugs

### DIFF
--- a/kerml/src/examples/Simple Tests/Associations.kerml
+++ b/kerml/src/examples/Simple Tests/Associations.kerml
@@ -1,7 +1,10 @@
-package Associations {	
+package Associations {
+    datatype X;
+    class Y;
+    
 	assoc A {
-		end x;
-		end [1..*] feature y;
+		end x_cross [1..1] feature x : X; 
+		end y_cross [1..*] feature y : Y;
 	}
 	
 	assoc B specializes A {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AcceptActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AcceptActionUsageAdapter.java
@@ -45,7 +45,7 @@ public class AcceptActionUsageAdapter extends ActionUsageAdapter {
 	@Override
 	public void addDefaultGeneralType() {
 		// Don't add a default type for a transition trigger action because such
-		// an action will always redefine TransitionAction::accepter anyway.
+		// an action will always redefine TransitionAction::accepter anyway: checkAcceptActionUsageTriggerActionSpecialization
 		if (!isTriggerAction()) {
 			super.addDefaultGeneralType();
 		}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -48,6 +48,12 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkAcceptActionUsageTriggerActionSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -67,6 +73,11 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkAcceptActionUsageSpecialization
+	 * @satisfies checkSendActionUsageSpecialization
+	 * @satisfies checkWhileLoopActionUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
@@ -77,6 +88,22 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 		return super.isSuboccurrence() && !isActionOwnedComposite();
 	}
 	
+	/**
+	 * @satisfies checkActionUsageSubactionSpecialization
+	 * @satisfies checkAcceptActionUsageSubactionSpecialization
+	 * @satisfies checkDecisionNodeSpecialization
+	 * @satisfies checkForkNodeSpecialization
+	 * @satisfies checkForLoopActionUsageSubactionSpecialization
+	 * @satisfies checkIfActionUsageSubactionSpecialization
+	 * @satisfies checkJoinNodeSpecialization
+	 * @satisfies checkMergeNodeSpecialization
+	 * @satisfies checkAssignmentActionUsageSubactionSpecialization
+	 * @satisfies checkSendActionUsageSubactionSpecialization
+	 * @satisfies checkWhileLoopActionUsageSubactionSpecialization
+	 * @satisfies checkActionUsageOwnedActionSpecialization
+	 * @satisfies checkStateUsageOwnedStateSpecialization
+	 * 
+	 */
 	protected String getSubactionType() {
 		return isActionOwnedComposite()? "subaction": 
 			   isPartOwnedComposite()? "ownedAction":
@@ -96,6 +123,7 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	 */
 	@Override
 	public boolean isComputeRedefinitions() {
+		//checkActionUsageStateActionRedefinition
 		String redefinedFeature = getRedefinedFeature(getTarget());
 		return redefinedFeature != null? isComputeRedefinitions:
 				super.isComputeRedefinitions();
@@ -110,6 +138,9 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 			   Collections.singletonList((Feature)getLibraryType(redefinedFeature));
 	}
 	
+	/**
+	 * @satisfies checkTransitionUsageTransitionFeatureSpecialization
+	 */
 	protected static String getRedefinedFeature(Feature target) {
 		FeatureMembership membership = target.getOwningFeatureMembership();
 		String kind = 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AnalysisCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AnalysisCaseUsageAdapter.java
@@ -38,6 +38,8 @@ public class AnalysisCaseUsageAdapter extends CaseUsageAdapter {
 	
 	@Override
 	protected String getSubactionType() {
+		//checkAnalysisCaseUsageSpecialization
+		//checkAnalysisCaseUsageSubAnalysisCaseSpecialization
 		return isSubAnalysisCase()? "subAnalysisCase": super.getSubactionType();	
 	}
 		

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AssertConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AssertConstraintUsageAdapter.java
@@ -36,6 +36,9 @@ public class AssertConstraintUsageAdapter extends ConstraintUsageAdapter {
 		return (AssertConstraintUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkAssertConstraintUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getTarget().isNegated()?

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AssignmentActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AssignmentActionUsageAdapter.java
@@ -34,6 +34,11 @@ public class AssignmentActionUsageAdapter extends ActionUsageAdapter {
 		return (AssignmentActionUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkAssignmentActionUsageReferentRedefinition
+	 * @satisfies checkAssignmentActionUsageAccessedFeatureRedefinition
+	 * @satisfies checkAssignmentActionUsageStartingAtRedefinition
+	 */
 	protected void addTargetRedefinitions() {
 		AssignmentActionUsage target = getTarget();
 		addFeatureWriteTypes(TypeUtil.getOwnedParametersOf(target), target.getReferent());

--- a/org.omg.sysml/src/org/omg/sysml/adapter/AssociationAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AssociationAdapter.java
@@ -33,7 +33,13 @@ public class AssociationAdapter extends ClassifierAdapter {
 	public Association getTarget() {
 		return (Association)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkAssociationSpecialization
+	 * @satisfies checkAssociationBinarySpecialization
+	 * @satisfies checkAssociationStructureSpecialization
+	 * @satisfies checkAssociationStructureBinarySpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getTarget().getOwnedEndFeature().size() != 2 ? 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationDefinitionAdapter.java
@@ -33,6 +33,9 @@ public class CalculationDefinitionAdapter extends ActionDefinitionAdapter {
 		return (CalculationDefinition)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkFunctionResultBindingConnector
+	 */
 	@Override
 	public void doTransform() {
 		super.doTransform();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -38,12 +38,28 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 		return (CalculationUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkCalculationUsageSpecialization
+	 * @satisfies checkCalculationUsageSubcalculationSpecialization
+	 */
 	@Override
 	protected String getSubactionType() {
 		return isSubcalculation()? "subcalculation": super.getSubactionType();	
 	}		
 		
 	public boolean isSubcalculation() {
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * checkCalculationUsageSubcalculationSpecialization
+		 * 
+		 * owningType <> null and
+		 * (owningType.oclIsKindOf(CalculationDefinition) or
+ 		 * owningType.oclIsKindOf(CalculationUsage)) implies
+    	 * specializesFromLibrary('Calculations::Calculation::subcalculations')
+    	 * 
+    	 * isNonEntryExitComposite check is not part of the OCL
+		 */
 		CalculationUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return isNonEntryExitComposite() &&

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CalculationUsageAdapter.java
@@ -49,16 +49,10 @@ public class CalculationUsageAdapter extends ActionUsageAdapter {
 		
 	public boolean isSubcalculation() {
 		/*
-		 * TODO: ST6RI-843
+		 * TODO: Update checkCalculationUsageSubcalculationSpecialization
 		 * 
-		 * checkCalculationUsageSubcalculationSpecialization
-		 * 
-		 * owningType <> null and
-		 * (owningType.oclIsKindOf(CalculationDefinition) or
- 		 * owningType.oclIsKindOf(CalculationUsage)) implies
-    	 * specializesFromLibrary('Calculations::Calculation::subcalculations')
-    	 * 
     	 * isNonEntryExitComposite check is not part of the OCL
+    	 * See SYSML12-298
 		 */
 		CalculationUsage target = getTarget();
 		Type owningType = target.getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2023-2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2023-2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -57,16 +57,11 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	}
 		
 	public boolean isSubcase() {
-		/*TODO: ST6RI-843
-		 * 
-		 * checkCaseUsageSubcaseSpecialization
-		 * 
-		 * isComposite and owningType <> null and 
-    	 * (owningType.oclIsKindOf(CaseDefinition) or
-         * owningType.oclIsKindOf(CaseUsage)) implies
-         * specializesFromLibrary('Cases::Case::subcases')
+		/*
+		 * TODO: Update checkCaseUsageSubcaseSpecialization
 		 * 
 		 * nonEntryExit part of the check is not reflected of the OCL
+    	 * See SYSML21-298
 		 */
 		CaseUsage target = getTarget();
 		Type owningType = target.getOwningType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/CaseUsageAdapter.java
@@ -47,12 +47,27 @@ public class CaseUsageAdapter extends CalculationUsageAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkCaseUsageSpecialization
+	 * @satisfies checkCaseUsageSubcaseSpecialization
+	 */
 	@Override
 	protected String getSubactionType() {
 		return isSubcase()? "subcase": super.getSubactionType();	
 	}
 		
 	public boolean isSubcase() {
+		/*TODO: ST6RI-843
+		 * 
+		 * checkCaseUsageSubcaseSpecialization
+		 * 
+		 * isComposite and owningType <> null and 
+    	 * (owningType.oclIsKindOf(CaseDefinition) or
+         * owningType.oclIsKindOf(CaseUsage)) implies
+         * specializesFromLibrary('Cases::Case::subcases')
+		 * 
+		 * nonEntryExit part of the check is not reflected of the OCL
+		 */
 		CaseUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return isNonEntryExitComposite() &&

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConcernUsageAdapter.java
@@ -35,6 +35,9 @@ public class ConcernUsageAdapter extends RequirementUsageAdapter {
 		return (ConcernUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkRequirementUsageSubrequirementSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -43,10 +46,17 @@ public class ConcernUsageAdapter extends RequirementUsageAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkConcernUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
 	}
+	
+	/**
+	 * @satisfies checkConcernUsageFramedConcernSpecialization
+	 */
 	@Override
 	public void addRequirementConstraintSubsetting() {
 		if (UsageUtil.isFramedConcern(getTarget())) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionDefinitionAdapter.java
@@ -33,10 +33,18 @@ public class ConnectionDefinitionAdapter extends PartDefinitionAdapter {
 	public ConnectionDefinition getTarget() {
 		return (ConnectionDefinition)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkConnectionDefinitionSpecializations
+	 * @satisfies checkInterfaceDefinitionSpecialization
+	 * @satisfies checkAllocationDefinitionSpecialization
+	 * @satisfies checkConnectionDefinitionBinarySpecialization
+	 * @satisfies checkInterfaceDefinitionBinarySpecialization
+	 * @satisfies checkAllocationDefinitionSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
-		return getTarget().getOwnedEndFeature().size() != 2 ? 
+		return getTarget().getOwnedEndFeature().size() != 2 ?
 				getDefaultSupertype("base") :
 				getDefaultSupertype("binary");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
@@ -35,11 +35,19 @@ public class ConnectionUsageAdapter extends PartUsageAdapter {
 	public ConnectionUsage getTarget() {
 		return (ConnectionUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkConnectionUsageSpecialization
+	 * @satisfies checkAllocationUsageSpecialization
+	 * @satisfies checkInterfaceDefinitionSpecialization
+	 * @satisfies checkConnectionUsageBinarySpecialization
+	 * @satisfies checkAllocationUsageSpecialization
+	 * @satisfies checkInterfaceDefinitionBinarySpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		int numEnds = TypeUtil.getOwnedEndFeaturesOf(getTarget()).size();
-		return numEnds != 2? 
+		return numEnds != 2?
 				getDefaultSupertype("base"):
 				getDefaultSupertype("binary");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -34,6 +34,17 @@ public class ConnectionUsageAdapter extends PartUsageAdapter {
 	@Override
 	public ConnectionUsage getTarget() {
 		return (ConnectionUsage)super.getTarget();
+	}
+	
+	/**
+	 * @satisfies checkPartUsageSubpartSpecialization
+	 */
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (isSubitem()) {
+			addDefaultGeneralType("subpart");
+		}
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConnectorAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConnectorAdapter.java
@@ -39,7 +39,13 @@ public class ConnectorAdapter extends FeatureAdapter {
 	public Connector getTarget() {
 		return (Connector)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkConnectorBinaryObjectSpecialization
+	 * @satisfies checkConnectorBinarySpecialization
+	 * @satisfies checkConnectorObjectSpecialization
+	 * @satisfies checkConnectorSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		Connector target = getTarget();
@@ -52,7 +58,10 @@ public class ConnectorAdapter extends FeatureAdapter {
 					getDefaultSupertype("base"):
 					getDefaultSupertype("binary");
 	}
-		
+	
+	/**
+	 * @satisfies checkConnectorTypeFeaturing
+	 */
 	protected void addContextFeaturingType() {
 		addFeaturingTypeIfNecessary(ConnectorUtil.getContextTypeFor(getTarget()));
 	}
@@ -72,6 +81,9 @@ public class ConnectorAdapter extends FeatureAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkConnectorTypeFeaturing
+	 */
 	@Override
 	public void doTransform() {
 		Connector target = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintDefinitionAdapter.java
@@ -33,7 +33,10 @@ public class ConstraintDefinitionAdapter extends OccurrenceDefinitionAdapter {
 	public ConstraintDefinition getTarget() {
 		return (ConstraintDefinition)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkFunctionResultBindingConnector
+	 */
 	@Override
 	public void doTransform() {
 		super.doTransform();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -86,14 +86,7 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 	
 	protected boolean isCheckedConstraint() {
 		/*
-		 * TODO: ST6RI-843
-		 * 
-		 *  checkConstraintUsageCheckedConstraintSpecialization
-		 *  
-		 *  owningType <> null and
-		 *	(owningType.oclIsKindOf(ItemDefinition) or
-		 * owningType.oclIsKindOf(ItemUsage)) implies
-		 * specializesFromLibrary('Items::Item::checkedConstraints')
+		 * TODO: Update checkConstraintUsageCheckedConstraintSpecialization
 		 * 
 		 * OCL doesn't require composite
 		 *  

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -44,6 +44,13 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkConstraintUsageRequirementConstraintSpecialization
+	 * @satisfies checkConstraintUsageCheckedConstraintSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 */
 	@Override
 	public void computeImplicitGeneralTypes() {
 		addRequirementConstraintSubsetting();
@@ -69,12 +76,28 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkConstraintUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
 	}
 	
 	protected boolean isCheckedConstraint() {
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 *  checkConstraintUsageCheckedConstraintSpecialization
+		 *  
+		 *  owningType <> null and
+		 *	(owningType.oclIsKindOf(ItemDefinition) or
+		 * owningType.oclIsKindOf(ItemUsage)) implies
+		 * specializesFromLibrary('Items::Item::checkedConstraints')
+		 * 
+		 * OCL doesn't require composite
+		 *  
+		 */
 		ConstraintUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return target.isComposite() &&

--- a/org.omg.sysml/src/org/omg/sysml/adapter/EventOccurrenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/EventOccurrenceUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -37,30 +37,8 @@ public class EventOccurrenceUsageAdapter extends OccurrenceUsageAdapter {
 		return (EventOccurrenceUsage)super.getTarget();
 	}
 	
-	/*
-	 * TODO: ST6RI-843
-	 * 
-	 * All general semantic constraints on an OccurrenceUsage
-	 * (see 8.4.5.2 ) also apply to an EventOccurrenceUsage.
-	 * 
-	 * addDefaultGeneralType and getDefaultSuperType overrides look redundant
-	 * as they both check for subOccurrence which is also done by OccurrenceUsageAdapter
-	 */
-	
 	/**
-	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
-	 */
-	@Override
-	public void addDefaultGeneralType() {
-		super.addDefaultGeneralType();
-		if (isSuboccurrence()) {
-			addImplicitGeneralType(getSpecializationEClass(), 
-					getLibraryType(getDefaultSupertype("suboccurrence")));
-		}
-	}
-	
-	/**
-	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
+	 * @satisfies checkEventOccurrenceUsageSpecialization
 	 */
 	@Override
 	protected String getDefaultSupertype() {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/EventOccurrenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/EventOccurrenceUsageAdapter.java
@@ -36,16 +36,32 @@ public class EventOccurrenceUsageAdapter extends OccurrenceUsageAdapter {
 	public EventOccurrenceUsage getTarget() {
 		return (EventOccurrenceUsage)super.getTarget();
 	}
-
+	
+	/*
+	 * TODO: ST6RI-843
+	 * 
+	 * All general semantic constraints on an OccurrenceUsage
+	 * (see 8.4.5.2 ) also apply to an EventOccurrenceUsage.
+	 * 
+	 * addDefaultGeneralType and getDefaultSuperType overrides look redundant
+	 * as they both check for subOccurrence which is also done by OccurrenceUsageAdapter
+	 */
+	
+	/**
+	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
 		if (isSuboccurrence()) {
 			addImplicitGeneralType(getSpecializationEClass(), 
-					getLibraryType(getDefaultSupertype("suboccurrence")));;
+					getLibraryType(getDefaultSupertype("suboccurrence")));
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return isSuboccurrence()? 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExhibitStateUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExhibitStateUsageAdapter.java
@@ -33,7 +33,10 @@ public class ExhibitStateUsageAdapter extends StateUsageAdapter {
 	public ExhibitStateUsage getTarget() {
 		return (ExhibitStateUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkExhibitStateUsageSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -60,7 +60,10 @@ public class ExpressionAdapter extends StepAdapter {
 			addDefaultGeneralType("enclosedPerformance");
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkExpressionSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");
@@ -89,7 +92,11 @@ public class ExpressionAdapter extends StepAdapter {
 	}
 	
 	// Transformation
-
+	
+	/**
+	 * @satisfies checkExpressionTypeFeaturing
+	 * @satisfies checkExpressionResultBindingConnector
+	 */
 	@Override
 	public void doTransform() {
 		Expression expression = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -47,6 +47,14 @@ public class ExpressionAdapter extends StepAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 * 
+	 * Note: These are satisfied by getDefaultSupertype in StepAdapter, 
+	 * which is overridden in ExpressionAdapater.
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -96,6 +104,7 @@ public class ExpressionAdapter extends StepAdapter {
 	/**
 	 * @satisfies checkExpressionTypeFeaturing
 	 * @satisfies checkExpressionResultBindingConnector
+	 * @satisfies checkMultiplicityRangeExpressionTypeFeaturing
 	 */
 	@Override
 	public void doTransform() {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -228,12 +228,14 @@ public class FeatureAdapter extends TypeAdapter {
 	 */
 	@Override
 	public void addDefaultGeneralType() {
+		// Note: This must happen before call to super, because default supertype depends on ownedTyping.
+		addOwnedCrossFeatureSpecialization();
+
 		super.addDefaultGeneralType();
 		
 		addBoundValueSubsetting();
 		addParticipantSubsetting();
 		addCrossingSpecialization();
-		addOwnedCrossFeatureSpecialization();
 	}
 	
 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -238,18 +238,6 @@ public class FeatureAdapter extends TypeAdapter {
 	
 
 	protected void addBoundValueSubsetting() {
-		/*
-		 * TODO: ST6RI-843
-		 * 
-		 * direction = null and
-		 * ownedSpecializations->forAll(isImplied) implies
-		 * ownedMembership->
-         * selectByKind(FeatureValue)->
-         * forAll(fv | specializes(fv.value.result))
-		 * 
-		 * 
-		 */
-		
 		Feature target = getTarget();
 		Feature result = getBoundValueResult();
 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -219,6 +219,13 @@ public class FeatureAdapter extends TypeAdapter {
 		return null;
 	}
 	
+	/**
+	 * @satisfies checkFeatureValuationSpecialization
+	 * @satisfies checkFeatureCrossingSpecialization
+	 * @satisfies checkFeatureOwnedCrossFeatureSpecialization
+	 * @satisfies checkFeatureOwnedCrossFeatureRedefinitionSpecialization
+	 * 
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -229,14 +236,31 @@ public class FeatureAdapter extends TypeAdapter {
 		addOwnedCrossFeatureSpecialization();
 	}
 	
+
 	protected void addBoundValueSubsetting() {
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * direction = null and
+		 * ownedSpecializations->forAll(isImplied) implies
+		 * ownedMembership->
+         * selectByKind(FeatureValue)->
+         * forAll(fv | specializes(fv.value.result))
+		 * 
+		 * 
+		 */
+		
 		Feature target = getTarget();
 		Feature result = getBoundValueResult();
+
 		if (result != null && target.getOwnedSpecialization().isEmpty() && target.getDirection() == null) {
 			addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), result);
 		}
 	}
 	
+	/**
+	 * @satisfies checkFeatureEndSpecialization
+	 */
 	protected void addParticipantSubsetting() {
 		if (isAssociationEnd() && 
 				!isImplicitSpecializationDeclaredFor(SysMLPackage.eINSTANCE.getRedefinition())) {
@@ -244,7 +268,9 @@ public class FeatureAdapter extends TypeAdapter {
 		}
 	}
 	
-	// checkFeatureCrossingSpecialization 
+	/**
+	 * @satisfies checkFeatureCrossingSpecialization
+	 */
 	public void addCrossingSpecialization() {
 		Feature target = getTarget();
 		Feature ownedCrossFeature = FeatureUtil.getOwnedCrossFeatureOf(target);
@@ -277,17 +303,19 @@ public class FeatureAdapter extends TypeAdapter {
 			}
 		}
 	}
-	 
+	
+	/**
+	 * @satisfies checkFeatureOwnedCrossFeatureSpecialization
+	 * @satisfies checkFeatureOwnedCrossFeatureRedefinitionSpecialization
+	 */
 	protected void addOwnedCrossFeatureSpecialization() {
 		Feature target = getTarget();
 		Namespace owner = target.getOwningNamespace();
 		if (FeatureUtil.isOwnedCrossFeature(target)) {
-			// checkFeatureOwnedCrossFeatureSpecialization
 			for (Type type: ((Feature)owner).getType()) {
 				addImplicitGeneralType(SysMLPackage.eINSTANCE.getFeatureTyping(), type);
 			}
 			
-			// checkFeatureOwnedCrossFeatureRedefinitionSpecialization
 			for (Feature redefinedFeature: FeatureUtil.getRedefinedFeaturesWithComputedOf((Feature)owner, null)) {
 				if (redefinedFeature.isEnd()) {
 					Feature crossFeature = getCrossFeatureOf(redefinedFeature);
@@ -310,12 +338,21 @@ public class FeatureAdapter extends TypeAdapter {
 		return crossFeature;
 	}
 	
+	/**
+	 * @satisfies checkFeatureObjectSpecialization
+	 * @satisfies checkFeatureSubobjectSpecialization
+	 * @satisfies checkFeatureSuboccurrenceSpecialization
+	 * @satisfies checkFeaturePortionSpecialization
+	 * @satisfies checkFeatureOccurrenceSpecialization
+	 * @satisfies checkFeatureDataValueSpecialization
+	 * @satisfies checkFeatureSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype(
 			hasStructureType()? isSubobject()? "subobject": "object":
-			hasClassType()? 
-					isSuboccurrence()? "suboccurrence": 
+			hasClassType()?
+					isSuboccurrence()? "suboccurrence":
 					isPortion()? "portion":
 					"occurrence":
 			hasDataType()? "dataValue":
@@ -337,7 +374,7 @@ public class FeatureAdapter extends TypeAdapter {
 				(owningType instanceof org.omg.sysml.lang.sysml.Class ||
 				 owningType instanceof Feature && (hasClassType((Feature)owningType)));
 	}
-	
+		
 	public boolean hasClassType() {
 		return hasClassType(getTarget());
 	}
@@ -537,6 +574,8 @@ public class FeatureAdapter extends TypeAdapter {
 	 * owning Type, then it is paired with relevant Features in the same position in Generalizations of the 
 	 * owning Type. The determination of what are relevant Categories and Features can be adjusted by
 	 * overriding getGeneralCategories and getRelevantFeatures.
+	 * 
+	 * @satisfies checkFeatureParameterRedefinition
 	 */
 	protected void addRedefinitions(Element skip) {
 		Feature target = getTarget();
@@ -586,6 +625,9 @@ public class FeatureAdapter extends TypeAdapter {
 			   Collections.emptyList();
 	}
 	
+	/**
+	 * @satisfies checkConstructorExpressionResultFeatureRedefinition
+	 */
 	protected List<? extends Feature> getConstructorRelevantFeatures(Type type) {
 		Type owningType = getTarget().getOwningType();
 		if (type == owningType) {
@@ -636,6 +678,9 @@ public class FeatureAdapter extends TypeAdapter {
 	
 	// Transformation
 	
+	/**
+	 * @satisfies checkFeatureFeatureMembershipTypeFeaturing
+	 */
 	protected Type computeFeaturingType() {
 		Feature feature = getTarget();
 		Type owningType = feature.getOwningType();
@@ -727,9 +772,13 @@ public class FeatureAdapter extends TypeAdapter {
 			}
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkFeatureValueBindingConnector
+	 */
 	protected void computeValueConnector() {
 		Feature target = getTarget();
+		//returns null if valuation isDefault is true
 		Feature result = getBoundValueResult();
 		if (result != null) {
 			List<Type> featuringTypes;
@@ -744,7 +793,9 @@ public class FeatureAdapter extends TypeAdapter {
 		}
 	}
 	
-	// checkFeatureOwnedCrossFeatureTypeFeaturing
+	/**
+	 * @satisfies checkFeatureOwnedCrossFeatureTypeFeaturing
+	 */
 	public void addOwnedCrossFeatureTypeFeaturing() {
 		Feature target = getTarget();
 		if (FeatureUtil.isOwnedCrossFeature(target) && target.getOwnedTypeFeaturing().isEmpty() && isImplicitFeaturingTypesEmpty()) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -237,6 +237,9 @@ public class FeatureAdapter extends TypeAdapter {
 	}
 	
 
+	/**
+	 * @satisfies checkFeatureValuationSpecialization
+	 */
 	protected void addBoundValueSubsetting() {
 		Feature target = getTarget();
 		Feature result = getBoundValueResult();
@@ -562,8 +565,6 @@ public class FeatureAdapter extends TypeAdapter {
 	 * owning Type, then it is paired with relevant Features in the same position in Generalizations of the 
 	 * owning Type. The determination of what are relevant Categories and Features can be adjusted by
 	 * overriding getGeneralCategories and getRelevantFeatures.
-	 * 
-	 * @satisfies checkFeatureParameterRedefinition
 	 */
 	protected void addRedefinitions(Element skip) {
 		Feature target = getTarget();
@@ -603,6 +604,8 @@ public class FeatureAdapter extends TypeAdapter {
 	 * Get the relevant Features that may be redefined from the given Type.
 	 * This includes end features, owned features of constructor results, and
 	 * generally parameters.
+	 * 
+	 * @satisfies checkFeatureEndRedefinition
 	 */
 	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
 		Feature target = getTarget();
@@ -632,6 +635,8 @@ public class FeatureAdapter extends TypeAdapter {
 	 * Parameters redefine (owned) Parameters of general Types, with a result
 	 * Parameter always redefining the result Parameter of a general Function or
 	 * Expression.
+	 * 
+	 * @satisfies checkFeatureResultRedefinition
 	 */
 	public List<? extends Feature> getParameterRelevantFeatures(Type type, Element skip) {
 		if (type != null) {
@@ -647,6 +652,9 @@ public class FeatureAdapter extends TypeAdapter {
 		return Collections.emptyList();
 	}
 	
+	/**
+	 * @satisfies checkFeatureParameterRedefinition
+	 */
 	protected List<Feature> getRelevantParameters(Type type, Element skip) {
 		Type owningType = getTarget().getOwningType();
 		return filterIgnoredParameters(type == owningType? 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
@@ -69,14 +69,20 @@ public class FeatureChainExpressionAdapter extends OperatorExpressionAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkFeatureChainExpressionTargetRedefinition
+	 * @satisfies checkFeatureChainExpressionSourceTargetRedefinition
+	 */
 	protected void addTargetRedefinition() {
 		FeatureChainExpression target = getTarget();
 		Feature sourceParameter = TypeUtil.getOwnedParameterOf(target, 0, Feature.class);
 		if (sourceParameter != null) {
 			Feature sourceTarget = target.sourceTargetFeature();
 			TypeUtil.addImplicitGeneralTypeTo(sourceTarget,
-					SysMLPackage.eINSTANCE.getRedefinition(), 
+					SysMLPackage.eINSTANCE.getRedefinition(),
+					//checkFeatureChainExpressionTargetRedefinition
 					getLibraryType(ImplicitGeneralizationMap.getDefaultSupertypeFor(target.getClass(), "target")));
+			//checkFeatureChainExpressionSourceTargetRedefinition
 			TypeUtil.addImplicitGeneralTypeTo(sourceTarget,
 					SysMLPackage.eINSTANCE.getRedefinition(), target.getTargetFeature());
 			TypeUtil.setIsAddImplicitGeneralTypesFor(sourceTarget, false);

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
@@ -42,6 +42,8 @@ public class FeatureChainExpressionAdapter extends OperatorExpressionAdapter {
 
 	/**
 	 * @satisfies checkFeatureChainExpressionResultSpecialization
+	 * 
+	 * TODO: Revise to explicitly get first "in" parameter, to more closely match OCL.
 	 */
 	@Override
 	protected void addResultTyping() {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureChainExpressionAdapter.java
@@ -40,6 +40,9 @@ public class FeatureChainExpressionAdapter extends OperatorExpressionAdapter {
 		return (FeatureChainExpression)super.getTarget();
 	}
 
+	/**
+	 * @satisfies checkFeatureChainExpressionResultSpecialization
+	 */
 	@Override
 	protected void addResultTyping() {
 		FeatureChainExpression target = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
@@ -64,11 +64,9 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 	 */
 	protected void addReferenceConnector() {
 		/*
-		 * TODO: ST6RI-843
-		 * 
-		 * ownedMember->selectByKind(BindingConnector)->exists(b |
-		 * b.relatedFeatures->includes(targetFeature) and
-         * b.relatedFeatures->includes(result))
+		 * TODO: Update checkFeatureReferenceExpressionBindingConnector?
+         * 
+         * OCL does not include !isInFilterExpression check.
 		 * 
 		 */
 		if (!isInFilterExpression()) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
@@ -59,7 +59,18 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 		return root.getOwningMembership() instanceof ElementFilterMembership;
 	}
 	
+	/**
+	 * @satisfies checkFeatureReferenceExpressionBindingConnector
+	 */
 	protected void addReferenceConnector() {
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * ownedMember->selectByKind(BindingConnector)->exists(b |
+		 * b.relatedFeatures->includes(targetFeature) and
+         * b.relatedFeatures->includes(result))
+		 * 
+		 */
 		if (!isInFilterExpression()) {
 			FeatureReferenceExpression target = getTarget();
 			Feature referent = target.getReferent();
@@ -69,7 +80,10 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 			}
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkFeatureFeatureReferenceResultSpecialization
+	 */
 	protected void addResultSubsetting() {
 		FeatureReferenceExpression expression = getTarget();
 		Feature result = expression.getResult();
@@ -89,6 +103,7 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 	@Override
 	public void doTransform() {
 		super.doTransform();
+		//checkFeatureReferenceExpressionBindingConnector
 		addReferenceConnector();
 		// Add subsetting in order to inherit typing of referent.
 		addResultSubsetting();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowAdapter.java
@@ -35,6 +35,11 @@ public class FlowAdapter extends ConnectorAdapter {
 		return (Flow)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowDefinitionAdapter.java
@@ -32,7 +32,11 @@ public class FlowDefinitionAdapter extends ActionDefinitionAdapter {
 	public FlowDefinition getTarget() {
 		return (FlowDefinition)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkFlowDefinitionBinarySpecialization
+	 * @satisfies checkFlowDefinitionSpecialization
+	 */
 	// From AssociationAdapter
 	@Override
 	protected String getDefaultSupertype() {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowEndAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowEndAdapter.java
@@ -75,6 +75,9 @@ public class FlowEndAdapter extends FeatureAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkFeatureFlowFeatureRedefinition
+	 */
 	public void addItemFlowFeatureRedefinition() {
 		FlowEnd target = getTarget();
 		Element owner = target.getOwner();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FlowUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FlowUsageAdapter.java
@@ -38,6 +38,16 @@ public class FlowUsageAdapter extends ConnectorAsUsageAdapter {
 		return (FlowUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkActionUsageOwnedActionSpecialization
+	 * @satisfies checkActionUsageSubactionSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 * @satisfies checkOccurrenceUsageTimeSliceSpecialization
+	 * @satisfies checkOccurrenceUsageSnapshotSpecialization
+	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -77,7 +87,11 @@ public class FlowUsageAdapter extends ConnectorAsUsageAdapter {
 				target.isComposite() && 
 			   	target.getOwningType() instanceof OccurrenceUsage;
 	}
-
+	
+	/**
+	 * @satisfies checkFlowUsageFlowSpecialization
+	 * @satisfies checkFlowUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return UsageUtil.isMessageConnection(getTarget())?

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ForLoopActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ForLoopActionUsageAdapter.java
@@ -38,6 +38,9 @@ public class ForLoopActionUsageAdapter extends LoopActionUsageAdapter {
 		return (ForLoopActionUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkForLoopActionUsageVarRedefinition
+	 */
 	public void transformLoopVariable() {
 		ForLoopActionUsage target = getTarget();
 		ReferenceUsage loopVariable = target.getLoopVariable();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FunctionAdapter.java
@@ -33,11 +33,14 @@ public class FunctionAdapter extends BehaviorAdapter {
 	public Function getTarget() {
 		return (Function)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkFunctionResultBindingConnector
+	 */
 	@Override
 	public void doTransform() {
 		super.doTransform();
-		createResultConnector(getTarget().getResult());		
+		createResultConnector(getTarget().getResult());
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IfActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IfActionUsageAdapter.java
@@ -33,7 +33,10 @@ public class IfActionUsageAdapter extends ActionUsageAdapter {
 	public IfActionUsage getTarget() {
 		return (IfActionUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkIfActionUsageSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
@@ -37,6 +37,9 @@ public class IncludeUseCaseUsageAdapter extends UseCaseUsageAdapter {
 		return (IncludeUseCaseUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkPerformActionUsageSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
@@ -38,6 +38,13 @@ public class IncludeUseCaseUsageAdapter extends UseCaseUsageAdapter {
 	}
 	
 	/**
+	 * TODO: checkIncludeUseCaseUsageSpecialization
+	 * 
+	 * TODO: Rename checkIncludeUseCaseSpecialization
+	 * See SYSML21-299
+	 */
+	
+	/**
 	 * @satisfies checkPerformActionUsageSpecialization
 	 */
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
@@ -43,7 +43,10 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 	public IndexExpression getTarget() {
 		return (IndexExpression)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkIndexExpressionResultSpecialization
+	 */
 	@Override
 	protected void addResultTyping() {
 		IndexExpression target = getTarget();
@@ -54,6 +57,15 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 			Feature seqResult = seqArgument.getResult();
 			Type arrayType = getLibraryType(ARRAY_TYPE);
 			Type scalarValueType = getLibraryType(SCALAR_VALUE_TYPE);
+			/*
+			 * TODO: ST6RI-843
+			 * checkIndexExpressionResultSpecialization:
+			 * arguments->notEmpty() and 
+			 * not arguments->first().result.specializesFromLibrary('Collections::Array') implies
+    		 * result.specializes(arguments->first().result)
+    		 * 
+    		 * '|| TypeUtil.specializes(target, scalarValueType)' part is not reflected by the OCL 
+			 */
 			if (!TypeUtil.specializes(target, arrayType) || TypeUtil.specializes(target, scalarValueType)) {
 				Feature resultFeature = target.getResult();
 				if (resultFeature != null && seqResult != null) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
@@ -58,13 +58,10 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 			Type arrayType = getLibraryType(ARRAY_TYPE);
 			Type scalarValueType = getLibraryType(SCALAR_VALUE_TYPE);
 			/*
-			 * TODO: ST6RI-843
-			 * checkIndexExpressionResultSpecialization:
-			 * arguments->notEmpty() and 
-			 * not arguments->first().result.specializesFromLibrary('Collections::Array') implies
-    		 * result.specializes(arguments->first().result)
+			 * TODO: Update checkIndexExpressionResultSpecialization
+			 * See KERML11-69.
     		 * 
-    		 * '|| TypeUtil.specializes(target, scalarValueType)' part is not reflected by the OCL 
+    		 * TODO: Generalize to handle all types other than Collection types?
 			 */
 			if (!TypeUtil.specializes(target, arrayType) || TypeUtil.specializes(target, scalarValueType)) {
 				Feature resultFeature = target.getResult();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/IndexExpressionAdapter.java
@@ -62,6 +62,7 @@ public class IndexExpressionAdapter extends OperatorExpressionAdapter {
 			 * See KERML11-69.
     		 * 
     		 * TODO: Generalize to handle all types other than Collection types?
+    		 * TODO: Replace target with seqResult in specialization checks.
 			 */
 			if (!TypeUtil.specializes(target, arrayType) || TypeUtil.specializes(target, scalarValueType)) {
 				Feature resultFeature = target.getResult();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/InvariantAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/InvariantAdapter.java
@@ -34,6 +34,9 @@ public class InvariantAdapter extends BooleanExpressionAdapter {
 		return (Invariant)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkInvariantSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getTarget().isNegated()?

--- a/org.omg.sysml/src/org/omg/sysml/adapter/InvocationExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/InvocationExpressionAdapter.java
@@ -58,8 +58,10 @@ public class InvocationExpressionAdapter extends InstantiationExpressionAdapter 
 	
 	// Transformation
 	
+	/**
+	 * @satisfies checkInvocationExpressionBehaviorBindingConnector
+	 */
 	protected void createSelfResultConnector() {
-		// checkInvocationExpressionBehaviorBindingConnector
 		InvocationExpression target = getTarget();
 		Type instantiatedType = target.getInstantiatedType();
 		if (instantiatedType != null && !isFunctionType(instantiatedType)) {
@@ -70,8 +72,10 @@ public class InvocationExpressionAdapter extends InstantiationExpressionAdapter 
 		}		
 	}
 	
+	/**
+	 * @satisfies checkInvocationExpressionBehaviorResultSpecialization
+	 */
 	protected void addResultTyping() {
-		// checkInvocationExpressionBehaviorResultSpecialization
 		InvocationExpression target = getTarget();
 		Type instantiatedType = target.getInstantiatedType();
 		if (instantiatedType != null && !isFunctionType(instantiatedType)) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ItemUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ItemUsageAdapter.java
@@ -37,9 +37,15 @@ public class ItemUsageAdapter extends OccurrenceUsageAdapter {
 
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkItemUsageSubitemSpecialization
+	 * @satisfies checkItemUsageSpecialization
+	 * @satisfies checkPartUsageSubpartSpecialization
+	 * @satisfies checkPartUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
-		return isSubitem()? 
+		return isSubitem()?
 					getDefaultSupertype("subitem"):
 					getDefaultSupertype("base");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/MetadataFeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/MetadataFeatureAdapter.java
@@ -36,7 +36,10 @@ public class MetadataFeatureAdapter extends FeatureAdapter {
 	public MetadataFeature getTarget() {
 		return (MetadataFeature)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkMetadataFeatureSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");

--- a/org.omg.sysml/src/org/omg/sysml/adapter/MetadataUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/MetadataUsageAdapter.java
@@ -32,7 +32,10 @@ public class MetadataUsageAdapter extends ItemUsageAdapter {
 	public MetadataUsage getTarget() {
 		return (MetadataUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkMetadataUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");

--- a/org.omg.sysml/src/org/omg/sysml/adapter/MultiplicityAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/MultiplicityAdapter.java
@@ -42,7 +42,11 @@ public class MultiplicityAdapter extends FeatureAdapter {
 	public Multiplicity getTarget() {
 		return (Multiplicity)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkOccurrenceDefinitionMultiplicitySpecialization, Note: SysML grammar adds the empty multiplicity
+	 * @satisfies checkMultiplicitySpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		Element owner = getTarget().getOwner();
@@ -58,6 +62,9 @@ public class MultiplicityAdapter extends FeatureAdapter {
 		return Collections.emptyList();
 	}
 	
+	/**
+	 * @satisfies checkMultiplicityTypeFeaturing
+	 */
 	@Override
 	protected void addImplicitFeaturingTypesIfNecessary() {
 		Feature feature = getTarget();
@@ -76,6 +83,7 @@ public class MultiplicityAdapter extends FeatureAdapter {
 	@Override
 	public void doTransform() {
 		super.doTransform();
+		//checkMultiplicityTypeFeaturing
 		addImplicitFeaturingTypesIfNecessary();
 	}
 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceDefinitionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceDefinitionAdapter.java
@@ -34,6 +34,11 @@ public class OccurrenceDefinitionAdapter extends DefinitionAdapter {
 		return (OccurrenceDefinition)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkOccurrenceDefinitionIndividualSpecialization
+	 * @satisfies checkClassSpecialization
+	 * @satisfies checkCalculationDefinitionSpecialization
+	 */
 	protected String getDefaultSupertype() {
 		return getTarget().isIndividual()? getDefaultSupertype("life"):
 			getDefaultSupertype("base");

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OccurrenceUsageAdapter.java
@@ -48,7 +48,12 @@ public class OccurrenceUsageAdapter extends UsageAdapter {
 	}
 	
 	// Implicit Generalization
-
+	
+	/**
+	 * @satisfies checkOccurrenceUsageSnapshotSpecialization
+	 * @satisfies checkOccurrenceUsageSuboccurrenceSpecialization
+	 * @satisfies checkOccurrenceUsageTimeSliceSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();
@@ -71,6 +76,9 @@ public class OccurrenceUsageAdapter extends UsageAdapter {
 			   	target.getOwningType() instanceof OccurrenceUsage;
 	}
 	
+	/**
+	 * @satisfies checkOccurrenceUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype("base");

--- a/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/OperatorExpressionAdapter.java
@@ -36,6 +36,9 @@ public class OperatorExpressionAdapter extends InvocationExpressionAdapter {
 		return (OperatorExpression)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkOperatorExpressionSpecialization
+	 */
 	@Override
 	public void computeImplicitGeneralTypes() {
 		OperatorExpression target = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -62,13 +62,7 @@ public class PartUsageAdapter extends ItemUsageAdapter {
 
 	protected boolean isRequirementStakeholder() {
 		/*
-		 * TODO: ST6RI-843
-		 * 
-		 * checkPartUsageStakeholderSpecialization
-		 * 
-		 * owningFeatureMembership <> null and
-		 * owningFeatureMembership.oclIsKindOf(StakeholderMembership) implies
-		 * specializesFromLibrary('Requirements::RequirementCheck::stakeholders')
+		 * TODO: Update checkPartUsageStakeholderSpecialization?
 		 *
 		 * OCL doesn't require the owningType to be ReqDef or ReqUsage 
 		 */

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
@@ -39,6 +39,11 @@ public class PartUsageAdapter extends ItemUsageAdapter {
 		return (PartUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkPartUsageActorSpecialization
+	 * @satisfies checkPartUsageStakeholderSpecialization
+	 * @satisfies checkPartUsageSubpartSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return isRequirementActor()? getDefaultSupertype("requirementActor"):
@@ -56,6 +61,17 @@ public class PartUsageAdapter extends ItemUsageAdapter {
 	}
 
 	protected boolean isRequirementStakeholder() {
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * checkPartUsageStakeholderSpecialization
+		 * 
+		 * owningFeatureMembership <> null and
+		 * owningFeatureMembership.oclIsKindOf(StakeholderMembership) implies
+		 * specializesFromLibrary('Requirements::RequirementCheck::stakeholders')
+		 *
+		 * OCL doesn't require the owningType to be ReqDef or ReqUsage 
+		 */
 		PartUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return UsageUtil.isStakeholderParameter(target) &&

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PayloadFeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PayloadFeatureAdapter.java
@@ -38,6 +38,9 @@ public class PayloadFeatureAdapter extends FeatureAdapter {
 		return (PayloadFeature)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkPayloadFeatureRedefinition
+	 */
 	@Override
 	public void addRedefinitions(Element skip) {
 		Feature redefinedFeature = (Feature)SysMLLibraryUtil.getLibraryType(getTarget(), getDefaultSupertype("payload"));

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PerformActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PerformActionUsageAdapter.java
@@ -34,6 +34,9 @@ public class PerformActionUsageAdapter extends ActionUsageAdapter {
 		return (PerformActionUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkPerformActionUsageSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		super.addDefaultGeneralType();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/PortUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PortUsageAdapter.java
@@ -38,7 +38,12 @@ public class PortUsageAdapter extends UsageAdapter {
 	}
 	
 	// Implicit Generalization
-
+	
+	/**
+	 * @satisfies checkPortUsageOwnedPortSpecialization
+	 * @satisfies checkPortUsageSubportSpecialization
+	 * @satisfies checkPortUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return isOwnedPort()?

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceUsageAdapter.java
@@ -48,6 +48,9 @@ public class ReferenceUsageAdapter extends UsageAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkTransitionUsagePayloadSpecialization
+	 */
 	@Override
 	public void addDefaultGeneralType() {
 		ReferenceUsage target = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ReferenceUsageAdapter.java
@@ -30,6 +30,7 @@ import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.ReferenceUsage;
 import org.omg.sysml.lang.sysml.SuccessionAsUsage;
 import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
+import org.omg.sysml.util.FeatureUtil;
 import org.omg.sysml.util.TypeUtil;
 import org.omg.sysml.util.UsageUtil;
 
@@ -56,10 +57,12 @@ public class ReferenceUsageAdapter extends UsageAdapter {
 		ReferenceUsage target = getTarget();
 		Type type = target.getOwningType();
 		if (type instanceof TransitionUsage) {
+			// checkTransitionUsagePayloadSpecialization
 			if (target == UsageUtil.getPayloadParameterOf((TransitionUsage)type)) {
 				Feature accepterParameter = UsageUtil.getAccepterPayloadParameterOf((TransitionUsage)type);
 				if (accepterParameter != null) {
-					addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), accepterParameter);
+					addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), 
+							FeatureUtil.chainFeatures((Feature)accepterParameter.getOwningType(), accepterParameter));
 					target.setDeclaredName(accepterParameter.getDeclaredName());
 					return;
 				}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
@@ -35,6 +35,17 @@ public class RenderingUsageAdapter extends PartUsageAdapter {
 		super(element);
 	}
 	
+	/**
+	 * @satisfies checkPartUsageSubpartSpecialization
+	 */
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (isSubitem()) {
+			addDefaultGeneralType("subpart");
+		}
+	}
+	
 	@Override
 	public RenderingUsage getTarget() {
 		return (RenderingUsage)super.getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RenderingUsageAdapter.java
@@ -40,6 +40,9 @@ public class RenderingUsageAdapter extends PartUsageAdapter {
 		return (RenderingUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkRenderingUsageRedefinition
+	 */
 	@Override
 	public void addRedefinitions(Element skip) {
 		super.addRedefinitions(skip);
@@ -47,10 +50,14 @@ public class RenderingUsageAdapter extends PartUsageAdapter {
 			addImplicitGeneralType(SysMLPackage.eINSTANCE.getRedefinition(), getLibraryType(getDefaultSupertype("viewRendering")));
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkRenderingUsageSubrenderingSpecialization
+	 * @satisfies checkRenderingUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
-		return isSubrendering()? 
+		return isSubrendering()?
 					getDefaultSupertype("subrendering"):
 					getDefaultSupertype("base");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -52,6 +52,10 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkRequirementUsageSubrequirementSpecialization
+	 * @satisfies checkRequirementUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return UsageUtil.isSubrequirement(getTarget())? 
@@ -59,6 +63,9 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 				getDefaultSupertype("base");
 	}
 	
+	/**
+	 * @satisfies checkRequirementUsageRequirementVerificationSpecialization
+	 */
 	@Override
 	public void addRequirementConstraintSubsetting() {
 		if (UsageUtil.isVerifiedRequirement(getTarget())) {
@@ -70,9 +77,12 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	
 	// Computed Redefinition
 	
+	/**
+	 * @satisfies checkRequirementUsageObjectiveRedefinition
+	 */
 	@Override
 	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
-		return UsageUtil.isObjective(getTarget())? 
+		return UsageUtil.isObjective(getTarget())?
 				Collections.singletonList(UsageUtil.getObjectiveRequirementOf(type)):
 			    super.getRelevantFeatures(type, skip);
 	}
@@ -84,5 +94,4 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 		UsageUtil.addSubjectParameterTo(getTarget());
 		super.addAdditionalMembers();
 	}
-	
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SatisfyRequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SatisfyRequirementUsageAdapter.java
@@ -47,6 +47,9 @@ public class SatisfyRequirementUsageAdapter extends RequirementUsageAdapter {
 		super.computeImplicitGeneralTypes();
 	}
 	
+	/**
+	 * @satisfies checkSatisfyRequirementUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getTarget().isNegated()?

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SelectExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SelectExpressionAdapter.java
@@ -39,6 +39,9 @@ public class SelectExpressionAdapter extends OperatorExpressionAdapter {
 		return (SelectExpression)super.getTarget();
 	}
 
+	/**
+	 * @satisfies checkSelectExpressionResultSpecialization
+	 */
 	@Override
 	protected void addResultTyping() {
 		SelectExpression target = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StateUsageAdapter.java
@@ -33,7 +33,11 @@ public class StateUsageAdapter extends ActionUsageAdapter {
 	public StateUsage getTarget() {
 		return (StateUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkStateUsageExclusiveStateSpecialization
+	 * @satisfies checkStateUsageSubstateSpecialization
+	 */
 	@Override
 	protected String getSubactionType() {
 		return isExclusiveState()? "exclusiveState":

--- a/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/StepAdapter.java
@@ -35,6 +35,12 @@ public class StepAdapter extends FeatureAdapter {
 		return (Step)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkStepOwnedPerformanceSpecialization
+	 * @satisfies checkStepSubperformanceSpecialization
+	 * @satisfies checkStepEnclosedPerformanceSpecialization
+	 * @satisfies checkStepSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return getDefaultSupertype(

--- a/org.omg.sysml/src/org/omg/sysml/adapter/SuccessionAsUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/SuccessionAsUsageAdapter.java
@@ -46,5 +46,10 @@ public class SuccessionAsUsageAdapter extends SuccessionAdapter {
 			addFeaturingTypes(((TransitionUsage)owningNamespace).getFeaturingType());
 		}
 	}
+	
+	/**
+	 * TODO: checkDecisionNodeOutgoingSuccessionSpecialization
+	 * TODO: checkMergeNodeIncomingSuccessionSpecialization
+	 */
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -50,6 +50,11 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	
 	// Implicit Generalization
 	
+	/**
+	 * @satisfies checkTransitionUsageStateSpecialization
+	 * @satisfies checkTransitionUsageActionSpecialization
+	 * @satisfies checkTransitionUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return isStateTransition()? getDefaultSupertype("stateTransition"):
@@ -57,8 +62,6 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 			   getDefaultSupertype("base");
 	}
 	
-	
-	// checkTransitionUsageActionSpecialization
 	protected boolean isActionTransition() {
 		TransitionUsage target = getTarget();
 		Type owningType = target.getOwningType();
@@ -67,7 +70,6 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 			   !(target.getSource() instanceof StateUsage);
 	}	
 	
-	// checkTransitionUsageStateSpecialization
 	protected boolean isStateTransition() {
 		TransitionUsage target = getTarget();
 		Type owningType = target.getOwningType();
@@ -78,6 +80,9 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	
 	// Transformation
 	
+	/**
+	 * @satisfies checkTransitionUsageSuccessionSourceSpecialization
+	 */
 	protected void computeSource() {
 		TransitionUsage target = getTarget();
 		List<Membership> ownedMemberships = target.getOwnedMembership();
@@ -89,11 +94,14 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkTransitionUsageSuccessionBindingConnector
+	 * @satisfies checkTransitionUsageSourceBindingConnector
+	 */
 	protected Feature computeTransitionLinkConnectors() {
 		TransitionUsage transition = getTarget();
 		Feature transitionLinkFeature = UsageUtil.getTransitionLinkFeatureOf(transition);
 		if (transitionLinkFeature == null) {
-			// checkTransitionUsageSuccessionBindingConnector
 			Succession succession = transition.getSuccession();
 			if (succession != null) {
 				transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
@@ -101,7 +109,6 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 				addBindingConnector(succession, transitionLinkFeature);
 			}
 			
-			// checkTransitionUsageSourceBindingConnector
 			List<Feature> parameters = TypeUtil.getOwnedParametersOf(transition);
 			if (!parameters.isEmpty()) {
 				Feature source = transition.getSource();
@@ -116,8 +123,10 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	@Override
 	public void addAdditionalMembers() {
 		// Note: Needs to come before computeTransitionLinkConnectors.
+		//checkTransitionUsageSuccessionSourceSpecialization
 		computeSource();
 		// Note: Needs to come before clearing and recomputation of inheritance cache.
+		//checkTransitionUsageSuccessionBindingConnector
 		computeTransitionLinkConnectors();		
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TriggerInvocationExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TriggerInvocationExpressionAdapter.java
@@ -44,6 +44,7 @@ public class TriggerInvocationExpressionAdapter extends InvocationExpressionAdap
 	
 	@Override
 	public void computeImplicitGeneralTypes() {
+		//checkTriggerInvocationExpressionSpecialization
 		TriggerInvocationExpression target = getTarget();
 		TriggerKind kind = target.getKind();
 		if (kind != null) {
@@ -53,7 +54,12 @@ public class TriggerInvocationExpressionAdapter extends InvocationExpressionAdap
 		super.computeImplicitGeneralTypes();
 	}
 	
+	
+	/**
+	 * @satisfies checkAcceptActionUsageReceiverBindingConnector
+	 */
 	public void addReceiverBinding() {
+		//checkAcceptActionUsageReceiverBindingConnector
 		TriggerInvocationExpression target = getTarget();
 		Feature receiverParameter = TypeUtil.getOwnedParameterOf(target, 1, Feature.class);
 		if (receiverParameter != null) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -395,6 +395,9 @@ public class TypeAdapter extends NamespaceAdapter {
  		}
 	}
 	
+	/**
+	 * @satisfies checkMetadataFeatureSemanticSpecialization
+	 */
 	public void addDefaultGeneralType() {
 		for (Type baseType: getBaseTypes()) {
 			addImplicitGeneralType(getSpecializationEClass(), baseType);

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -489,7 +489,7 @@ public class TypeAdapter extends NamespaceAdapter {
 			addResultBinding(resultExpression, result);
 		}
 	}
-
+	
 	@Override
 	public void doTransform() {
 		super.doTransform();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -131,7 +131,11 @@ public class UsageAdapter extends FeatureAdapter {
 			addImplicitGeneralType(SysMLPackage.eINSTANCE.getSubsetting(), feature);
 		}
 	}
-
+	
+	/**
+	 * @satisfies checkUsageVariationDefinitionSpecialization
+	 * @satisfies checkUsageVariationUsageSpecialization
+	 */
 	protected void addVariationTyping() {
 		Usage usage = getTarget();
 		if (UsageUtil.isVariant(usage)) {
@@ -150,6 +154,7 @@ public class UsageAdapter extends FeatureAdapter {
 	@Override
 	public void addDefaultGeneralType() {
 		addVariationTyping();
+		
 		super.addDefaultGeneralType();
 	}
 	
@@ -189,6 +194,9 @@ public class UsageAdapter extends FeatureAdapter {
 			   UsageUtil.getSubjectParameterOf(((Usage)owningType).getOwningType());
 	}
 	
+	/**
+	 * @satisfies checkSatisfyRequirementUsageBindingConnector
+	 */
 	@Override
 	protected void computeValueConnector() {
 		Usage usage = getTarget();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UsageAdapter.java
@@ -211,6 +211,9 @@ public class UsageAdapter extends FeatureAdapter {
 		}
 	}
 	
+	/**
+	 * @satisfies checkUsageVariationUsageTypeFeaturing
+	 */
 	@Override
 	public void doTransform() {
 		super.doTransform();

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
@@ -31,6 +31,11 @@ public class UseCaseUsageAdapter extends CaseUsageAdapter {
 		super(element);
 	}
 	
+	/**
+	 * @satisfies checkIncludeUseCaseSpecialization
+	 * @satisfies checkUseCaseUsageSpecialization
+	 * @satisfies checkUseCaseUsageSubUseCaseSpecialization
+	 */
 	@Override
 	protected String getSubactionType() {
 		return isSubUseCase()? "subUseCase": super.getSubactionType();	
@@ -38,6 +43,21 @@ public class UseCaseUsageAdapter extends CaseUsageAdapter {
 		
 	public boolean isSubUseCase() {		
 		Type owningType = getTarget().getOwningType();
+		
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * checkIncludeUseCaseSpecialization
+		 * 
+		 * owningType <> null and
+		 * (owningType.oclIsKindOf(UseCaseDefinition) or
+		 * owningType.oclIsKindOf(UseCaseUsage) implies
+		 * specializesFromLibrary('UseCases::UseCase::includedUseCases')
+		 * 
+		 * the semantic constraint doens't require the IncludeUseCaseUsage to be composite, also
+		 * IncludeUseCaseUsageImpl overrides isComposite to always return false
+		 */
+		
 		return isNonEntryExitComposite() && 
 			   (owningType instanceof UseCaseDefinition || owningType instanceof UseCaseUsage);
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/UseCaseUsageAdapter.java
@@ -45,17 +45,10 @@ public class UseCaseUsageAdapter extends CaseUsageAdapter {
 		Type owningType = getTarget().getOwningType();
 		
 		/*
-		 * TODO: ST6RI-843
+		 * TODO: Update checkUseCaseSubUseCaseSpecialization
 		 * 
-		 * checkIncludeUseCaseSpecialization
-		 * 
-		 * owningType <> null and
-		 * (owningType.oclIsKindOf(UseCaseDefinition) or
-		 * owningType.oclIsKindOf(UseCaseUsage) implies
-		 * specializesFromLibrary('UseCases::UseCase::includedUseCases')
-		 * 
-		 * the semantic constraint doens't require the IncludeUseCaseUsage to be composite, also
-		 * IncludeUseCaseUsageImpl overrides isComposite to always return false
+		 * OCL does not include isNonEntryExitComposite.
+    	 * See SYSML21-298
 		 */
 		
 		return isNonEntryExitComposite() && 

--- a/org.omg.sysml/src/org/omg/sysml/adapter/VerificationCaseUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/VerificationCaseUsageAdapter.java
@@ -36,6 +36,10 @@ public class VerificationCaseUsageAdapter extends CaseUsageAdapter {
 		return (VerificationCaseUsage)super.getTarget();
 	}
 	
+	/**
+	 * @satisfies checkVerificationCaseUsageSubVerification
+	 * @satisfies checkVerificationCaseUsageSubVerification
+	 */
 	@Override
 	protected String getSubactionType() {
 		return isSubVerificationCase()? "subVerificationCase": super.getSubactionType();	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
@@ -35,10 +35,14 @@ public class ViewUsageAdapter extends PartUsageAdapter {
 	public ViewUsage getTarget() {
 		return (ViewUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkViewUsageSubviewSpecialization
+	 * @satisfies checkViewpointUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
-		return isSubview()? 
+		return isSubview()?
 					getDefaultSupertype("subview"):
 					getDefaultSupertype("base");
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ViewUsageAdapter.java
@@ -37,6 +37,17 @@ public class ViewUsageAdapter extends PartUsageAdapter {
 	}
 	
 	/**
+	 * @satisfies checkPartUsageSubpartSpecialization
+	 */
+	@Override
+	public void addDefaultGeneralType() {
+		super.addDefaultGeneralType();
+		if (isSubitem()) {
+			addDefaultGeneralType("subpart");
+		}
+	}
+	
+	/**
 	 * @satisfies checkViewUsageSubviewSpecialization
 	 * @satisfies checkViewpointUsageSpecialization
 	 */

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ViewpointUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ViewpointUsageAdapter.java
@@ -36,7 +36,11 @@ public class ViewpointUsageAdapter extends RequirementUsageAdapter {
 	public ViewpointUsage getTarget() {
 		return (ViewpointUsage)super.getTarget();
 	}
-
+	
+	/**
+	 * @satisfies checkViewpointUsageViewpointSatisfactionSpecialization
+	 * @satisfies checkViewpointUsageSpecialization
+	 */
 	@Override
 	protected String getDefaultSupertype() {
 		return isSatisfiedViewpoint()?

--- a/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/FeatureUtil.java
@@ -61,8 +61,6 @@ import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.TypeFeaturing;
-import org.omg.sysml.lang.sysml.impl.ClassifierImpl;
-import org.omg.sysml.lang.sysml.util.SysMLLibraryUtil;
 
 public class FeatureUtil {
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -124,6 +124,10 @@ public class ImplicitGeneralizationMap {
 		//checkPayloadFeatureRedefinition
 		put(PayloadFeatureImpl.class, "payload", "Transfers::Transfer::payload");
 		
+		/*
+		 * TODO: checkFlowSpecialization
+		 * specializesFromLibrary('Transfers::transfers')
+		 */		
 		//checkFlowWithEndsSpecialization
 		put(FlowImpl.class, "base", "Transfers::flowTransfers");
 		//checkStepEnclosedPerformanceSpecialization
@@ -132,15 +136,6 @@ public class ImplicitGeneralizationMap {
 		put(FlowImpl.class, "subperformance", "Performances::Performance::subperformances");
 		//checkStepOwnedPerformanceSpecialization
 		put(FlowImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
-		
-		/*
-		 * TODO: ST6RI-843
-		 * checkFlowSpecialization
-		 * specializesFromLibrary('Transfers::transfers')
-		 * 
-		 * This case is missing from the implementation
-		 */
-		
 		
 		//checkFeatureFlowFeatureRedefinition
 		put(FlowEndImpl.class, "sourceOutput", "Transfers::Transfer::source::sourceOutput");
@@ -566,17 +561,9 @@ public class ImplicitGeneralizationMap {
 		put(ViewpointUsageImpl.class, "satisfied", "Views::View::viewpointSatisfactions");
 		
 		/*
-		 * TODO: ST6RI-843
+		 * TODO: Update checkViewpointDefinitionSpecialization and checkViewpointUsageSpecialization
 		 * 
-		 * checkViewpointDefinitionSpecialization
-		 * specializesFromLibrary('Views::Viewpoint')
-		 * 
-		 * TODO: ST6RI-843
-		 * 
-		 * checkViewpointUsageSpecialization
-		 * specializesFromLibrary('Views::viewpoints')
-		 * 
-		 * OCL doesn't match with the implementation
+		 * See SYSML21-301
 		 */
 		
 		//checkWhileLoopActionUsageSpecialization

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -44,312 +44,545 @@ public class ImplicitGeneralizationMap {
 		
 		// KerML
 		
+		//checkAssociationSpecialization
 		put(AssociationImpl.class, "base", "Links::Link");
+		//checkAssociationBinarySpecialization
 		put(AssociationImpl.class, "binary", "Links::BinaryLink");
 		
+		//checkAssociationStructureSpecialization
 		put(AssociationStructureImpl.class, "base", "Objects::LinkObject");
+		//checkAssociationStructureBinarySpecialization
 		put(AssociationStructureImpl.class, "binary", "Objects::BinaryLinkObject");
 		
+		//checkBehaviorSpecialization
 		put(BehaviorImpl.class, "base", "Performances::Performance");
 		
+		//checkBindingConnectorSpecialization
 		put(BindingConnectorImpl.class, "binary", "Links::selfLinks");
 		
+		//checkBooleanExpressionSpecialization
 		put(BooleanExpressionImpl.class, "base", "Performances::booleanEvaluations");
 		
+		//checkClassSpecialization
 		put(ClassImpl.class, "base", "Occurrences::Occurrence");
 		
+		//
 		put(ClassifierImpl.class, "base", "Base::Anything");
 		
+		//checkConnectorSpecialization
 		put(ConnectorImpl.class, "base", "Links::links");
+		//checkConnectorBinarySpecialization
 		put(ConnectorImpl.class, "binary", "Links::binaryLinks");
+		//checkConnectorObjectSpecialization
 		put(ConnectorImpl.class, "object", "Objects::linkObjects");
+		//checkConnectorBinaryObjectSpecialization
 		put(ConnectorImpl.class, "binaryObject", "Objects::binaryLinkObjects");
 		
+		//checkConstructorExpressionSpecialization
 		put(ConstructorExpressionImpl.class, "base", "Performances::constructorEvaluations");
-
+		
+		//checkDataTypeSpecialization
 		put(DataTypeImpl.class, "base", "Base::DataValue");
 		
+		//checkDataTypeSpecialization
 		put(ExpressionImpl.class, "base", "Performances::evaluations");
+		//
 		put(ExpressionImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		
+		//checkFeatureSpecialization
 		put(FeatureImpl.class, "base", "Base::things");
+		//checkFeatureDataValueSpecialization
 		put(FeatureImpl.class, "dataValue", "Base::dataValues");
+		//checkFeatureOccurrenceSpecialization
 		put(FeatureImpl.class, "occurrence", "Occurrences::occurrences");
+		//checkFeatureSuboccurrenceSpecialization
 		put(FeatureImpl.class, "suboccurrence", "Occurrences::Occurrence::suboccurrences");
+		//checkFeaturePortionSpecialization
 		put(FeatureImpl.class, "portion", "Occurrences::Occurrence::portions");
+		//checkFeatureObjectSpecialization
 		put(FeatureImpl.class, "object", "Objects::objects");
+		//checkFeatureSubobjectSpecialization
 		put(FeatureImpl.class, "subobject", "Objects::Object::subobjects");
+		//checkFeatureEndSpecialization
 		put(FeatureImpl.class, "participant", "Links::Link::participant");
+		//checkAssignmentActionUsageStartingAtRedefinition
 		put(FeatureImpl.class, "startingAt", "FeatureReferencingPerformances::FeatureAccessPerformance::onOccurrence::startingAt");
+		//checkAssignmentActionUsageAccessedFeatureRedefinition
 		put(FeatureImpl.class, "accessedFeature", "FeatureReferencingPerformances::FeatureAccessPerformance::onOccurrence::startingAt::accessedFeature");
 		
+		//checkAssignmentActionUsageAccessedFeatureRedefinition
 		put(FeatureChainExpressionImpl.class, "target", "ControlFunctions::'.'::source::target");
 		
+		//checkAssignmentActionUsageAccessedFeatureRedefinition
 		put(FunctionImpl.class, "base", "Performances::Evaluation");
 		
+		//checkInvariantSpecialization
 		put(InvariantImpl.class, "base", "Performances::trueEvaluations");
+		//checkInvariantSpecialization
 		put(InvariantImpl.class, "negated", "Performances::falseEvaluations");
 		
+		//checkPayloadFeatureRedefinition
 		put(PayloadFeatureImpl.class, "payload", "Transfers::Transfer::payload");
 		
+		//checkFlowWithEndsSpecialization
 		put(FlowImpl.class, "base", "Transfers::flowTransfers");
+		//checkStepEnclosedPerformanceSpecialization
 		put(FlowImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
+		//checkStepSubperformanceSpecialization
 		put(FlowImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(FlowImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		
+		/*
+		 * TODO: ST6RI-843
+		 * checkFlowSpecialization
+		 * specializesFromLibrary('Transfers::transfers')
+		 * 
+		 * This case is missing from the implementation
+		 */
+		
+		
+		//checkFeatureFlowFeatureRedefinition
 		put(FlowEndImpl.class, "sourceOutput", "Transfers::Transfer::source::sourceOutput");
+		//checkFeatureFlowFeatureRedefinition
 		put(FlowEndImpl.class, "targetInput", "Transfers::Transfer::target::targetInput");
 		
+		//checkLiteralBooleanSpecialization
 		put(LiteralBooleanImpl.class, "base", "Performances::literalBooleanEvaluations");
 		
+		//checkLiteralExpressionSpecialization
 		put(LiteralExpressionImpl.class, "base", "Performances::literalEvaluations");
 		
+		//checkLiteralInfinitySpecialization
 		put(LiteralInfinityImpl.class, "base", "Performances::literalIntegerEvaluations");
 		
+		//checkLiteralIntegerSpecialization
 		put(LiteralIntegerImpl.class, "base", "Performances::literalIntegerEvaluations");
 		
+		//checkLiteralRationalSpecialization
 		put(LiteralRationalImpl.class, "base", "Performances::literalRationalEvaluations");
 		
+		//checkLiteralStringSpecialization
 		put(LiteralStringImpl.class, "base", "Performances::literalStringEvaluations");
 		
+		//checkMetaclassSpecialization
 		put(MetaclassImpl.class, "base", "Metaobjects::Metaobject");
+		//checkMetadataFeatureSpecialization
 		put(MetadataFeatureImpl.class, "base", "Metaobjects::metaobjects");
 		put(MetadataFeatureImpl.class, "annotatedElement", "Metaobjects::Metaobject::annotatedElement");
+		//checkMetadataFeatureSemanticSpecialization
 		put(MetadataFeatureImpl.class, "baseType", "Metaobjects::SemanticMetadata::baseType");
 		
+		//checkMetadataAccessExpressionSpecialization
 		put(MetadataAccessExpressionImpl.class, "base", "Performances::metadataAccessEvaluations");
-
+		
+		//checkMultiplicitySpecialization
 		put(MultiplicityImpl.class, "base", "Base::naturals");
 		put(MultiplicityImpl.class, "feature", "Base::exactlyOne");
+		//checkOccurrenceDefinitionMultiplicitySpecialization
 		put(MultiplicityImpl.class, "classifier", "Base::zeroOrOne");
-
+		
+		
 		put(MultiplicityRangeImpl.class, "feature", "Base::naturals");
 		put(MultiplicityRangeImpl.class, "classifier", "Base::naturals");
 		
+		//checkNullExpressionSpecialization
 		put(NullExpressionImpl.class, "base", "Performances::nullEvaluations");
 		
+		//checkPredicateSpecialization
 		put(PredicateImpl.class, "base", "Performances::BooleanEvaluation");
 		
+		//checkStepSpecialization
 		put(StepImpl.class, "base", "Performances::performances");
+		//checkStepEnclosedPerformanceSpecialization
 		put(StepImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
+		//checkStepSubperformanceSpecialization
 		put(StepImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(StepImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
 		put(StepImpl.class, "incomingTransfer", "Occurrences::Occurrence::incomingTransfers");
 		put(StepImpl.class, "featureWrite", "FeatureReferencingPerformances::FeatureWritePerformance");
 		
+		//checkStructureSpecialization
 		put(StructureImpl.class, "base", "Objects::Object");
 		
+		//checkSuccessionSpecialization
 		put(SuccessionImpl.class, "binary", "Occurrences::happensBeforeLinks");
 		
+		//checkSuccessionSpecialization
 		put(SuccessionFlowImpl.class, "base", "Transfers::flowTransfersBefore");
+		//checkStepEnclosedPerformanceSpecialization
 		put(SuccessionFlowImpl.class, "enclosedperformance", "Performances::Performance::enclosedPerformances");
+		//checkStepSubperformanceSpecialization
 		put(SuccessionFlowImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(SuccessionFlowImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
-
+		
+		//checkTypeSpecialization
 		put(TypeImpl.class, "base", "Base::Anything");
 
 		// SysML
 		
+		//checkAcceptActionUsageSpecialization
 		put(AcceptActionUsageImpl.class, "base", "Actions::acceptActions");
+		//checkAcceptActionUsageSubactionSpecialization
 		put(AcceptActionUsageImpl.class, "subaction", "Actions::Action::acceptSubactions");
 		
-		put(ActionDefinitionImpl.class, "base", "Actions::Action");		
+		//checkActionDefinitionSpecialization
+		put(ActionDefinitionImpl.class, "base", "Actions::Action");
+		//checkActionUsageSpecialization
 		put(ActionUsageImpl.class, "base", "Actions::actions");
+		//checkActionUsageSubactionSpecialization
 		put(ActionUsageImpl.class, "subaction", "Actions::Action::subactions");
+		//checkActionUsageOwnedActionSpecialization
 		put(ActionUsageImpl.class, "ownedAction", "Parts::Part::ownedActions");
+		//checkStepSubperformanceSpecialization
 		put(ActionUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepEnclosedPerformanceSpecialization
 		put(ActionUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(ActionUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
+		//checkActionUsageStateActionRedefinition
 		put(ActionUsageImpl.class, "entry", "States::StateAction::entryAction");
+		//checkActionUsageStateActionRedefinition
 		put(ActionUsageImpl.class, "do", "States::StateAction::doAction");
+		//checkActionUsageStateActionRedefinition
 		put(ActionUsageImpl.class, "exit", "States::StateAction::exitAction");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(ActionUsageImpl.class, "trigger", "Actions::TransitionAction::accepter");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(ActionUsageImpl.class, "guard", "Actions::TransitionAction::guard");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(ActionUsageImpl.class, "effect", "Actions::TransitionAction::effect");
 		
+		//checkAllocationDefinitionSpecialization
 		put(AllocationDefinitionImpl.class, "base", "Allocations::Allocation");
+		//checkAllocationDefinitionSpecialization
 		put(AllocationDefinitionImpl.class, "binary", "Allocations::Allocation");
+		//checkAllocationUsageSpecialization
 		put(AllocationUsageImpl.class, "base", "Allocations::allocations");
+		//checkAllocationUsageSpecialization
 		put(AllocationUsageImpl.class, "binary", "Allocations::allocations");
 		
+		//checkAnalysisCaseDefinitionSpecialization
 		put(AnalysisCaseDefinitionImpl.class, "base", "AnalysisCases::AnalysisCase");
+		//checkAnalysisCaseUsageSpecialization
 		put(AnalysisCaseUsageImpl.class, "base", "AnalysisCases::analysisCases");
+		//checkAnalysisCaseUsageSubAnalysisCaseSpecialization
 		put(AnalysisCaseUsageImpl.class, "subAnalysisCase", "AnalysisCases::AnalysisCase::subAnalysisCases");
 		
+		//checkAssertConstraintUsageSpecialization
 		put(AssertConstraintUsageImpl.class, "base", "Constraints::assertedConstraintChecks");
+		//checkAssertConstraintUsageSpecialization
 		put(AssertConstraintUsageImpl.class, "negated", "Constraints::negatedConstraintChecks");
 		
+		//checkAssignmentActionUsageSpecialization
 		put(AssignmentActionUsageImpl.class, "base", "Actions::assignmentActions");
+		//checkAssignmentActionUsageSubactionSpecialization
 		put(AssignmentActionUsageImpl.class, "subaction", "Actions::Action::assignments");
 		put(AssignmentActionUsageImpl.class, "featureWrite", "Actions::AssignmentAction");
 		
+		//
 		put(AttributeDefinitionImpl.class, "base", "Base::DataValue");
+		//checkAttributeUsageSpecialization
 		put(AttributeUsageImpl.class, "base", "Base::dataValues");
 		
+		//checkBindingConnectorSpecialization
 		put(BindingConnectorAsUsageImpl.class, "base", "Links::selfLinks");
+		//checkBindingConnectorSpecialization
 		put(BindingConnectorAsUsageImpl.class, "binary", "Links::selfLinks");
 		
+		//checkCalculationDefinitionSpecialization
 		put(CalculationDefinitionImpl.class, "base", "Calculations::Calculation");
+		//checkCalculationUsageSpecialization
 		put(CalculationUsageImpl.class, "base", "Calculations::calculations");
+		//checkCalculationUsageSubcalculationSpecialization
 		put(CalculationUsageImpl.class, "subcalculation", "Calculations::Calculation::subcalculations");
 		
+		//checkCaseDefinitionSpecialization
 		put(CaseDefinitionImpl.class, "base", "Cases::Case");
+		//checkCaseUsageSpecialization
 		put(CaseUsageImpl.class, "base", "Cases::cases");
+		//checkCaseUsageSubcaseSpecialization
 		put(CaseUsageImpl.class, "subcase", "Cases::Case::subcases");
 		
+		//checkCaseUsageSubcaseSpecialization
 		put(ConcernDefinitionImpl.class, "base", "Requirements::ConcernCheck");
+		//checkConcernUsageSpecialization
 		put(ConcernUsageImpl.class, "base", "Requirements::concernChecks");
+		//checkConcernUsageFramedConcernSpecialization
 		put(ConcernUsageImpl.class, "concern", "Requirements::RequirementCheck::concerns");
 		
+		//checkConnectionDefinitionBinarySpecialization
 		put(ConnectionDefinitionImpl.class, "base", "Connections::Connection");
+		//checkConnectionDefinitionBinarySpecialization
 		put(ConnectionDefinitionImpl.class, "binary", "Connections::BinaryConnection");
+		//checkConnectionUsageSpecialization
 		put(ConnectionUsageImpl.class, "base", "Connections::connections");
+		//checkConnectionUsageBinarySpecialization
 		put(ConnectionUsageImpl.class, "binary", "Connections::binaryConnections");
 		
+		//checkConstraintDefinitionSpecialization
 		put(ConstraintDefinitionImpl.class, "base", "Constraints::ConstraintCheck");
+		//checkConstraintUsageSpecialization
 		put(ConstraintUsageImpl.class, "base", "Constraints::constraintChecks");
+		//checkConstraintUsageCheckedConstraintSpecialization
 		put(ConstraintUsageImpl.class, "checkedConstraint", "Items::Item::checkedConstraints");
+		//checkStepEnclosedPerformanceSpecialization
 		put(ConstraintUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
+		//checkStepSubperformanceSpecialization
 		put(ConstraintUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(ConstraintUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
+		//checkConstraintUsageRequirementConstraintSpecialization
 		put(ConstraintUsageImpl.class, "assumption", "Requirements::RequirementCheck::assumptions");
+		//checkConstraintUsageRequirementConstraintSpecialization
 		put(ConstraintUsageImpl.class, "requirement", "Requirements::RequirementCheck::constraints");
 		
+		//checkDecisionNodeSpecialization
 		put(DecisionNodeImpl.class, "subaction", "Actions::Action::decisions");
 		
+		//checkEventOccurrenceUsageSpecialization
 		put(EventOccurrenceUsageImpl.class, "suboccurrence", "Occurrences::Occurrence::timeEnclosedOccurrences");
-
+		
+		//checkExhibitStateUsageSpecialization
 		put(ExhibitStateUsageImpl.class, "performedAction", "Parts::Part::exhibitedStates");
 		
-		put(FlowDefinitionImpl.class, "base", "Flows::MessageAction");		
-		put(FlowDefinitionImpl.class, "binary", "Flows::Message");		
+		//checkFlowDefinitionSpecialization
+		put(FlowDefinitionImpl.class, "base", "Flows::MessageAction");
+		//checkFlowDefinitionBinarySpecialization
+		put(FlowDefinitionImpl.class, "binary", "Flows::Message");
+		//checkFlowUsageFlowSpecialization
 		put(FlowUsageImpl.class, "base", "Flows::flows");
+		//checkFlowUsageSpecialization
 		put(FlowUsageImpl.class, "message", "Flows::messages");
+		//checkActionUsageSubactionSpecialization
 		put(FlowUsageImpl.class, "subaction", "Actions::Action::subactions");
+		//checkActionUsageOwnedActionSpecialization
 		put(FlowUsageImpl.class, "ownedAction", "Parts::Part::ownedActions");
+		//checkStepEnclosedPerformanceSpecialization
 		put(FlowUsageImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
+		//checkStepSubperformanceSpecialization
 		put(FlowUsageImpl.class, "subperformance", "Performances::Performance::subperformances");
+		//checkStepOwnedPerformanceSpecialization
 		put(FlowUsageImpl.class, "ownedPerformance", "Objects::Object::ownedPerformances");
+		//checkActionUsageStateActionRedefinition
 		put(FlowUsageImpl.class, "entry", "States::StateAction::entryAction");
+		//checkActionUsageStateActionRedefinition
 		put(FlowUsageImpl.class, "do", "States::StateAction::doAction");
+		//checkActionUsageStateActionRedefinition
 		put(FlowUsageImpl.class, "exit", "States::StateAction::exitAction");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(FlowUsageImpl.class, "trigger", "Actions::TransitionAction::accepter");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(FlowUsageImpl.class, "guard", "Actions::TransitionAction::guard");
+		//checkTransitionUsageTransitionFeatureSpecialization
 		put(FlowUsageImpl.class, "effect", "Actions::TransitionAction::effect");
+		//checkOccurrenceUsageTimeSliceSpecialization
 		put(FlowUsageImpl.class, "timeslice", "Occurrences::Occurrence::timeSlices");
+		//checkOccurrenceUsageSnapshotSpecialization
 		put(FlowUsageImpl.class, "snapshot", "Occurrences::Occurrence::snapshots");
 		
+		//checkForLoopActionUsageSpecialization
 		put(ForLoopActionUsageImpl.class, "base", "Actions::forLoopActions");
+		//checkForLoopActionUsageSubactionSpecialization
 		put(ForLoopActionUsageImpl.class, "subaction", "Actions::Action::forLoops");
+		//checkForLoopActionUsageVarRedefinition
 		put(ForLoopActionUsageImpl.class, "loopVariable", "Actions::ForLoopAction::var");
 		
+		//checkForkNodeSpecialization
 		put(ForkNodeImpl.class, "subaction", "Actions::Action::forks");
 		
+		//checkIfActionUsageSpecialization
 		put(IfActionUsageImpl.class, "base", "Actions::ifThenActions");
+		//checkIfActionUsageSpecialization
 		put(IfActionUsageImpl.class, "ifThenElse", "Actions::ifThenElseActions");
+		//checkIfActionUsageSubactionSpecialization
 		put(IfActionUsageImpl.class, "subaction", "Actions::Action::ifSubactions");
 		
+		//checkIncludeUseCaseSpecialization
 		put(IncludeUseCaseUsageImpl.class, "subUseCase", "UseCases::UseCase::includedUseCases");
+		//checkPerformActionUsageSpecialization
 		put(IncludeUseCaseUsageImpl.class, "performedAction", "Parts::Part::performedActions");
 		
+		//checkInterfaceDefinitionSpecialization
 		put(InterfaceDefinitionImpl.class, "base", "Interfaces::Interface");
+		//checkInterfaceDefinitionBinarySpecialization
 		put(InterfaceDefinitionImpl.class, "binary", "Interfaces::BinaryInterface");
+		//checkInterfaceUsageSpecialization
 		put(InterfaceUsageImpl.class, "base", "Interfaces::interfaces");
+		//checkInterfaceUsageBinarySpecialization
 		put(InterfaceUsageImpl.class, "binary", "Interfaces::binaryInterfaces");
 		
+		//checkItemDefinitionSpecialization
 		put(ItemDefinitionImpl.class, "base", "Items::Item");
+		//checkItemDefinitionSpecialization
 		put(ItemUsageImpl.class, "base", "Items::items");
+		//checkItemUsageSubitemSpecialization
 		put(ItemUsageImpl.class, "subitem", "Items::Item::subitems");
 		
+		//checkJoinNodeSpecialization
 		put(JoinNodeImpl.class, "subaction", "Actions::Action::joins");
 		
+		//checkMetadataDefinitionSpecialization
 		put(MetadataDefinitionImpl.class, "base", "Metadata::MetadataItem");
+		//checkMetadataUsageSpecialization
 		put(MetadataUsageImpl.class, "base", "Metadata::metadataItems");
 		put(MetadataUsageImpl.class, "annotatedElement", "Metaobjects::Metaobject::annotatedElement");
 		put(MetadataUsageImpl.class, "baseType", "Metaobjects::SemanticMetadata::baseType");
 		
+		//checkMergeNodeSpecialization
 		put(MergeNodeImpl.class, "subaction", "Actions::Action::merges");
 		
+		//
 		put(OccurrenceDefinitionImpl.class, "base", "Occurrences::Occurrence");
+		//checkOccurrenceDefinitionIndividualSpecialization
 		put(OccurrenceDefinitionImpl.class, "life", "Occurrences::Life");
+		//checkOccurrenceUsageSpecialization
 		put(OccurrenceUsageImpl.class, "base", "Occurrences::occurrences");
+		//checkOccurrenceUsageTimeSliceSpecialization
 		put(OccurrenceUsageImpl.class, "timeslice", "Occurrences::Occurrence::timeSlices");
+		//checkOccurrenceUsageSnapshotSpecialization
 		put(OccurrenceUsageImpl.class, "snapshot", "Occurrences::Occurrence::snapshots");
-		
+				
+		//checkPartDefinitionSpecialization
 		put(PartDefinitionImpl.class, "base", "Parts::Part");
+		//checkPartUsageSpecialization
 		put(PartUsageImpl.class, "base", "Parts::parts");
+		//checkPartUsageSubpartSpecialization
 		put(PartUsageImpl.class, "subitem", "Items::Item::subparts");
+		//checkPartUsageActorSpecialization
 		put(PartUsageImpl.class, "requirementActor", "Requirements::RequirementCheck::actors");
+		//checkPartUsageStakeholderSpecialization
 		put(PartUsageImpl.class, "requirementStakeholder", "Requirements::RequirementCheck::stakeholders");
+		//checkPartUsageActorSpecialization
 		put(PartUsageImpl.class, "caseActor", "Cases::Case::actors");
 		
+		//checkPerformActionUsageSpecialization
 		put(PerformActionUsageImpl.class, "performedAction", "Parts::Part::performedActions");
 		
+		//checkPortDefinitionSpecialization
 		put(PortDefinitionImpl.class, "base", "Ports::Port");
+		//checkPortUsageSpecialization
 		put(PortUsageImpl.class, "base", "Ports::ports");
+		//checkPortUsageOwnedPortSpecialization
 		put(PortUsageImpl.class, "ownedPort", "Parts::Part::ownedPorts");
+		//checkPortUsageSubportSpecialization
 		put(PortUsageImpl.class, "subport", "Ports::Port::subports");
 		
+		//checkRenderingDefinitionSpecialization
 		put(RenderingDefinitionImpl.class, "base", "Views::Rendering");
+		//checkRenderingUsageSpecialization
 		put(RenderingUsageImpl.class, "base", "Views::renderings");
+		//checkRenderingUsageSubrenderingSpecialization
 		put(RenderingUsageImpl.class, "subrendering", "Views::Rendering::subrenderings");
+		//checkRenderingUsageRedefinition
 		put(RenderingUsageImpl.class, "viewRendering", "Views::View::viewRendering");
 		
+		//checkRequirementDefinitionSpecialization
 		put(RequirementDefinitionImpl.class, "base", "Requirements::RequirementCheck");
+		//checkRequirementUsageSpecialization
 		put(RequirementUsageImpl.class, "base", "Requirements::requirementChecks");
+		//checkRequirementUsageSubrequirementSpecialization
 		put(RequirementUsageImpl.class, "subrequirement", "Requirements::RequirementCheck::subrequirements");
+		//checkRequirementUsageRequirementVerificationSpecialization
 		put(RequirementUsageImpl.class, "verification", "Verifications::VerificationCase::obj::requirementVerifications");
 		
+		//checkSatisfyRequirementUsageSpecialization
 		put(SatisfyRequirementUsageImpl.class, "base", "Requirements::satisfiedRequirementChecks");
+		//checkSatisfyRequirementUsageSpecialization
 		put(SatisfyRequirementUsageImpl.class, "negated", "Requirements::notSatisfiedRequirementChecks");
 		
+		//checkSendActionUsageSpecialization
 		put(SendActionUsageImpl.class, "base", "Actions::sendActions");
+		//checkActionUsageSubactionSpecialization
 		put(SendActionUsageImpl.class, "subaction", "Actions::Action::sendSubactions");
 		
+		//checkStateDefinitionSpecialization
 		put(StateDefinitionImpl.class, "base", "States::StateAction");
+		//checkStateUsageSpecialization
 		put(StateUsageImpl.class, "base", "States::stateActions");
+		//checkStateUsageSubstateSpecialization
 		put(StateUsageImpl.class, "substate", "States::StateAction::substates");
+		//checkStateUsageExclusiveStateSpecialization
 		put(StateUsageImpl.class, "exclusiveState", "States::StateAction::exclusiveStates");
+		//checkStateUsageOwnedStateSpecialization
 		put(StateUsageImpl.class, "ownedAction", "Parts::Part::ownedStates");
 		
+		//checkSuccessionSpecialization
 		put(SuccessionAsUsageImpl.class, "base", "Occurrences::happensBeforeLinks");
+		//checkSuccessionSpecialization
 		put(SuccessionAsUsageImpl.class, "binary", "Occurrences::happensBeforeLinks");
 		
+		//checkSuccessionFlowUsageSpecialization
 		put(SuccessionFlowUsageImpl.class, "base", "Flows::successionFlows");
+		//checkSuccessionFlowUsageSpecialization
 		put(SuccessionFlowUsageImpl.class, "message", "Flows::successionFlows");
-
+		
+		//checkTerminateActionUsageSpecialization
 		put(TerminateActionUsageImpl.class, "base", "Actions::terminateActions");
+		//checkTerminateActionUsageSubactionSpecialization
 		put(TerminateActionUsageImpl.class, "subaction", "Actions::Action::terminateSubactions");
 		
 		put(TerminateActionUsageImpl.class, "subaction", "Actions::Action::terminateWithResultSubactions");
-
+		
+		//checkTransitionUsageSpecialization
 		put(TransitionUsageImpl.class, "base", "Actions::transitionActions");
+		//checkTransitionUsageActionSpecialization
 		put(TransitionUsageImpl.class, "actionTransition", "Actions::Action::decisionTransitions");
+		//checkTransitionUsageStateSpecialization
 		put(TransitionUsageImpl.class, "stateTransition", "States::StateAction::stateTransitions");
 		
 		put(TriggerInvocationExpressionImpl.class, "when", "Triggers::TriggerWhen");
 		put(TriggerInvocationExpressionImpl.class, "at", "Triggers::TriggerAt");
 		put(TriggerInvocationExpressionImpl.class, "after", "Triggers::TriggerAfter");
 		
+		//checkUseCaseDefinitionSpecialization
 		put(UseCaseDefinitionImpl.class, "base", "UseCases::UseCase");
+		//checkUseCaseUsageSpecialization
 		put(UseCaseUsageImpl.class, "base", "UseCases::useCases");
+		//checkUseCaseUsageSubUseCaseSpecialization
 		put(UseCaseUsageImpl.class, "subUseCase", "UseCases::UseCase::subUseCases");
 		
+		//checkVerificationCaseSpecialization
 		put(VerificationCaseDefinitionImpl.class, "base", "VerificationCases::VerificationCase");
+		//checkVerificationCaseUsageSpecialization
 		put(VerificationCaseUsageImpl.class, "base", "VerificationCases::verificationCases");
+		//checkVerificationCaseUsageSubVerificationCaseSpecialization
 		put(VerificationCaseUsageImpl.class, "subVerificationCase", "VerificationCases::VerificationCase::subVerificationCases");
 		
+		//checkViewDefinitionSpecialization
 		put(ViewDefinitionImpl.class, "base", "Views::View");
+		//checkViewUsageSpecialization
 		put(ViewUsageImpl.class, "base", "Views::views");
+		//checkViewUsageSubviewSpecialization
 		put(ViewUsageImpl.class, "subview", "Views::View::subviews");
-
+		
+		//checkViewpointDefinitionSpecialization
 		put(ViewpointDefinitionImpl.class, "base", "Views::ViewpointCheck");
+		//checkViewpointUsageSpecialization
 		put(ViewpointUsageImpl.class, "base", "Views::viewpointChecks");
+		//checkViewpointUsageViewpointSatisfactionSpecialization
 		put(ViewpointUsageImpl.class, "satisfied", "Views::View::viewpointSatisfactions");
 		
-		put(WhileLoopActionUsageImpl.class, "base", "Actions::whileLoopActions");
-		put(WhileLoopActionUsageImpl.class, "subaction", "Actions::Action::whileLoops");
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * checkViewpointDefinitionSpecialization
+		 * specializesFromLibrary('Views::Viewpoint')
+		 * 
+		 * TODO: ST6RI-843
+		 * 
+		 * checkViewpointUsageSpecialization
+		 * specializesFromLibrary('Views::viewpoints')
+		 * 
+		 * OCL doesn't match with the implementation
+		 */
 		
+		//checkWhileLoopActionUsageSpecialization
+		put(WhileLoopActionUsageImpl.class, "base", "Actions::whileLoopActions");
+		//checkWhileLoopActionUsageSubactionSpecialization
+		put(WhileLoopActionUsageImpl.class, "subaction", "Actions::Action::whileLoops");
 	}
 	
 	public String get(Class<?> elementType) {

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -84,9 +84,9 @@ public class ImplicitGeneralizationMap {
 		//checkDataTypeSpecialization
 		put(DataTypeImpl.class, "base", "Base::DataValue");
 		
-		//checkDataTypeSpecialization
+		//checkExpressionSpecialization
 		put(ExpressionImpl.class, "base", "Performances::evaluations");
-		//
+		//checkStepEnclosedPerformanceSpecialization
 		put(ExpressionImpl.class, "enclosedPerformance", "Performances::Performance::enclosedPerformances");
 		
 		//checkFeatureSpecialization
@@ -173,7 +173,8 @@ public class ImplicitGeneralizationMap {
 		
 		//checkMultiplicitySpecialization
 		put(MultiplicityImpl.class, "base", "Base::naturals");
-		// TODO: Update specification for SysML default multiplicities.
+		// TODO: Update SysML specification to formalize default multiplicities.
+		// See SYSML21-185
 		put(MultiplicityImpl.class, "feature", "Base::exactlyOne");
 		//checkOccurrenceDefinitionMultiplicitySpecialization
 		put(MultiplicityImpl.class, "classifier", "Base::zeroOrOne");

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -317,6 +317,8 @@ public class ImplicitGeneralizationMap {
 		put(ConnectionUsageImpl.class, "base", "Connections::connections");
 		//checkConnectionUsageBinarySpecialization
 		put(ConnectionUsageImpl.class, "binary", "Connections::binaryConnections");
+		//checkPartUsageSubpartSpecialization (a ConnectionUsage is a PartUsage)
+		put(ConnectionUsageImpl.class, "subpart", "Items::Item::subparts");
 		
 		//checkConstraintDefinitionSpecialization
 		put(ConstraintDefinitionImpl.class, "base", "Constraints::ConstraintCheck");
@@ -474,6 +476,8 @@ public class ImplicitGeneralizationMap {
 		put(RenderingUsageImpl.class, "subrendering", "Views::Rendering::subrenderings");
 		//checkRenderingUsageRedefinition
 		put(RenderingUsageImpl.class, "viewRendering", "Views::View::viewRendering");
+		//checkPartUsageSubpartSpecialization (a RenderingUsage is a PartUsage)
+		put(RenderingUsageImpl.class, "subpart", "Items::Item::subparts");
 		
 		//checkRequirementDefinitionSpecialization
 		put(RequirementDefinitionImpl.class, "base", "Requirements::RequirementCheck");
@@ -555,6 +559,8 @@ public class ImplicitGeneralizationMap {
 		put(ViewUsageImpl.class, "base", "Views::views");
 		//checkViewUsageSubviewSpecialization
 		put(ViewUsageImpl.class, "subview", "Views::View::subviews");
+		//checkPartUsageSubpartSpecialization (a ViewUsage is a PartUsage)
+		put(ViewUsageImpl.class, "subpart", "Items::Item::subparts");
 		
 		//checkViewpointDefinitionSpecialization
 		put(ViewpointDefinitionImpl.class, "base", "Views::ViewpointCheck");

--- a/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -66,7 +66,7 @@ public class ImplicitGeneralizationMap {
 		//checkClassSpecialization
 		put(ClassImpl.class, "base", "Occurrences::Occurrence");
 		
-		//
+		//checkTypeSpcialization
 		put(ClassifierImpl.class, "base", "Base::Anything");
 		
 		//checkConnectorSpecialization
@@ -173,10 +173,10 @@ public class ImplicitGeneralizationMap {
 		
 		//checkMultiplicitySpecialization
 		put(MultiplicityImpl.class, "base", "Base::naturals");
+		// TODO: Update specification for SysML default multiplicities.
 		put(MultiplicityImpl.class, "feature", "Base::exactlyOne");
 		//checkOccurrenceDefinitionMultiplicitySpecialization
 		put(MultiplicityImpl.class, "classifier", "Base::zeroOrOne");
-		
 		
 		put(MultiplicityRangeImpl.class, "feature", "Base::naturals");
 		put(MultiplicityRangeImpl.class, "classifier", "Base::naturals");
@@ -277,7 +277,7 @@ public class ImplicitGeneralizationMap {
 		put(AssignmentActionUsageImpl.class, "subaction", "Actions::Action::assignments");
 		put(AssignmentActionUsageImpl.class, "featureWrite", "Actions::AssignmentAction");
 		
-		//
+		//checkDataTypeSpecialization (an AttributeDefinition is a DataType)
 		put(AttributeDefinitionImpl.class, "base", "Base::DataValue");
 		//checkAttributeUsageSpecialization
 		put(AttributeUsageImpl.class, "base", "Base::dataValues");
@@ -429,7 +429,7 @@ public class ImplicitGeneralizationMap {
 		//checkMergeNodeSpecialization
 		put(MergeNodeImpl.class, "subaction", "Actions::Action::merges");
 		
-		//
+		//checkClassSpecialization (an OccurrenceDefinition is a Class)
 		put(OccurrenceDefinitionImpl.class, "base", "Occurrences::Occurrence");
 		//checkOccurrenceDefinitionIndividualSpecialization
 		put(OccurrenceDefinitionImpl.class, "life", "Occurrences::Life");
@@ -519,6 +519,7 @@ public class ImplicitGeneralizationMap {
 		//checkTerminateActionUsageSubactionSpecialization
 		put(TerminateActionUsageImpl.class, "subaction", "Actions::Action::terminateSubactions");
 		
+		// TODO: Delete this.
 		put(TerminateActionUsageImpl.class, "subaction", "Actions::Action::terminateWithResultSubactions");
 		
 		//checkTransitionUsageSpecialization
@@ -528,6 +529,7 @@ public class ImplicitGeneralizationMap {
 		//checkTransitionUsageStateSpecialization
 		put(TransitionUsageImpl.class, "stateTransition", "States::StateAction::stateTransitions");
 		
+		//checkInvocationExpressionSpecialization (with appropriate insantiatedType)
 		put(TriggerInvocationExpressionImpl.class, "when", "Triggers::TriggerWhen");
 		put(TriggerInvocationExpressionImpl.class, "at", "Triggers::TriggerAt");
 		put(TriggerInvocationExpressionImpl.class, "after", "Triggers::TriggerAfter");

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -291,7 +291,7 @@ public class TypeUtil {
 		getTypeAdapter(type).addAdditionalMembers();
 		Feature resultParameter = getOwnedResultParameterOf(type);
 		if (resultParameter == null) {
-			for (Type general: getSupertypesOf(type)) {
+			for (Type general: getGeneralTypesOf(type)) {
 				if (general != null && !visited.contains(general)) {
 					resultParameter = getResultParameterOf(general, visited);
 					if (resultParameter != null) {

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -265,16 +265,10 @@ public class UsageUtil {
 	public static boolean isSubrequirement(RequirementUsage requirement) {
 		Type owningType = requirement.getOwningType();
 		/*
-		 * TODO: ST6RI-843
-		 * 
-		 * checkRequirementUsageSubrequirementSpecialization
-		 * 
-		 * isComposite and owningType <> null and
-		 * (owningType.oclIsKindOf(RequirementDefinition) or
-		 * owningType.oclIsKindOf(RequirementUsage)) implies
-		 * specializesFromLibrary('Requirements::RequirementCheck::subrequirements')
+		 * TODO: Update checkRequirementUsageSubrequirementSpecialization
 		 * 
 		 * !isAssumptionConstraint is not in the OCL
+		 * See SYSML21-300
 		 * 
 		 */
 		return !isAssumptionConstraint(requirement) && requirement.isComposite() &&

--- a/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/UsageUtil.java
@@ -264,6 +264,19 @@ public class UsageUtil {
 	
 	public static boolean isSubrequirement(RequirementUsage requirement) {
 		Type owningType = requirement.getOwningType();
+		/*
+		 * TODO: ST6RI-843
+		 * 
+		 * checkRequirementUsageSubrequirementSpecialization
+		 * 
+		 * isComposite and owningType <> null and
+		 * (owningType.oclIsKindOf(RequirementDefinition) or
+		 * owningType.oclIsKindOf(RequirementUsage)) implies
+		 * specializesFromLibrary('Requirements::RequirementCheck::subrequirements')
+		 * 
+		 * !isAssumptionConstraint is not in the OCL
+		 * 
+		 */
 		return !isAssumptionConstraint(requirement) && requirement.isComposite() &&
 			   (owningType instanceof RequirementDefinition || 
 			    owningType instanceof RequirementUsage);

--- a/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RenderingUsageImpl.java
+++ b/org.omg.sysml/syntax-gen/org/omg/sysml/lang/sysml/impl/RenderingUsageImpl.java
@@ -120,7 +120,11 @@ public class RenderingUsageImpl extends PartUsageImpl implements RenderingUsage 
 	
 	// Additional overrides
 	
-	// TODO: Add this override to the SysML abstract syntax.
+	/**
+	 * TODO: Update RenderingUsage with namingFeature redefinition.
+	 * 
+	 * See SYSML21-302
+	 */	
 	@Override
 	public Feature namingFeature() {
 		FeatureMembership membership = getOwningFeatureMembership();

--- a/sysml/src/examples/Simple Tests/AllocationTest.sysml
+++ b/sysml/src/examples/Simple Tests/AllocationTest.sysml
@@ -16,6 +16,7 @@ package AllocationTest {
 		part :>> assembly {
 			part :>> element;
 		}
+        allocate l.component to assembly.element;
 	}
 	
 	allocation def A;


### PR DESCRIPTION
This PR corrects several bugs in the implementation of transformation code satisfying semantic constraints from the KerML and SysML specifications

**ST6RI-857 Cross feature implicit subsetting is incorrect**

This bug resulted in owned cross features subsetting `Base::things` when the implied typing by their owning end feature's type meant they should subset `Base::dataValues`, `Occurrence::occurrences` or `Object::objects`. It was fixed by moving the call to `addOwnedCrossFeatureSpecialization` in `FeatureAdapter.addDefaultGeneralType` to before the call `super.addDefaultGeneralType`. In this way, the implied owned typing for a cross feature is now added before the determination of the default subsetting, which is based on owned typing.

**ST6RI-858 Incorrect implicit specialization of feature chain invocation result**

This bug resulted in the `result` parameter of an invocation expression not properly redefining the `result` parameter of its `instantiatedType` if that type was a feature chain and the feature target of the chain did not have an owned `result` parameter. It was fixed by replacing the call to `getSupertypesOf` with `getGeneralTypesOf` in `FeatureUtil.getResultParameterOf`.

**ST6RI-860 ConnectionUsages, ViewUsages and RenderingUsages should subset subparts**

This bug was that composite `ConnectionUsages`, `ViewUsages` and `RenderingUsages` that were features of `ItemDefinitions` or `ItemUsages` were not implicitly subsetting `Item::subparts`. It was fixed by updating the relevant adapter classes to override `addDefaultGeneralTypes` to handling being a subpart.

**ST6RI-861 TransitionUsage payload parameter subsetting is incorrect**

This bug was that the `payload` parameter of a `TransitionUsage` was implicitly subsetting directly the `payload` parameter of the `triggerAction` of the `TransitionUsage`, rather than subsetting a feature chain of the `triggerAction` and its `payload` parameter. This was corrected in the `ReferenceUsageAdapter.addDefaultGeneralType` method.