### PR TITLE
ST6RI-866 Substates inherit two "this" features

### DIFF
--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -601,8 +601,8 @@ standard library package Occurrences {
 			 * Occurrences that have inner spaces that completely include this occurrence.
 			 */
 
-			feature surroundedSpace: Occurrence[1] subsets that;
-			end [1] feature surroundingSpace: Occurrence subsets self;
+			feature surroundedSpace: Occurrence [1] subsets that;
+			feature surroundingSpace: Occurrence [1] subsets self;
 
 			connector :InsideOf
 				from [0..1] smallerOccurrence references surroundedSpace

--- a/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
@@ -95,7 +95,7 @@ standard library package TradeStudies {
 			 * For a MinimizeObjective, the best value is the minimum one.
 			 */
 		
-			in x; fn(x)
+			in x; eval(x)
 		};
 	}
 	
@@ -117,7 +117,7 @@ standard library package TradeStudies {
 			 * For a MinimizeObjective, the best value is the maximum one.
 			 */
 		
-			in x; fn(x)
+			in x; eval(x)
 		};
 	}
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
@@ -601,8 +601,8 @@ standard library package Occurrences {
 			 * Occurrences that have inner spaces that completely include this occurrence.
 			 */
 
-			feature surroundedSpace: Occurrence[1] subsets that;
-			end [1] feature surroundingSpace: Occurrence subsets self;
+			feature surroundedSpace: Occurrence [1] subsets that;
+			feature surroundingSpace: Occurrence [1] subsets self;
 
 			connector :InsideOf
 				from [0..1] smallerOccurrence references surroundedSpace

--- a/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
@@ -60,7 +60,7 @@ standard library package Actions {
 			 * The subperformances of this Action that are Actions. 
 			 */
 		
-			ref occurrence :>> this = (that as Action).this {
+			ref occurrence :>> Action::this, actions::this, subperformances::this = (that as Action).this {
 				doc
 				/*
 				 * The "this" reference of a subaction is always the same as that of
@@ -330,7 +330,7 @@ standard library package Actions {
 		 */
 	
 		in transitionLinkSource : Action :>> TransitionPerformance::transitionLinkSource;
-		ref acceptedMessage : MessageAction :>> trigger;
+		ref acceptedMessage : MessageTransfer, MessageAction :>> trigger;
 		
 		ref receiver :>> triggerTarget;
 

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -60,7 +60,7 @@ standard library package Actions {
 			 * The subperformances of this Action that are Actions. 
 			 */
 		
-			ref occurrence :>> this = (that as Action).this {
+			ref occurrence :>> Action::this, actions::this, subperformances::this = (that as Action).this {
 				doc
 				/*
 				 * The "this" reference of a subaction is always the same as that of


### PR DESCRIPTION
This PR proactively implements a resolution to the following issue, even though it has not yet been voting on by the SysML 2.1 RTF.

- [SYSML21-311](https://issues.omg.org/issues/SYSML21-311) Substates may potentially inherit "this" twice

This problem actually manifested itself in the Pilot Implementation such that substates _always_ inherited two `this` features. The problem was resolved by updating the declaration of the redefinition of `this` in `Actions::Action::subactions` to explicitly redefine the inheritable feature from each of the types specialized by `subactions`:
```
action subactions: Action[0..*] :> actions, subperformances {
    ref occurrence :>> Action::this, actions::this, subperformances::this = (that as Action).this {
    ...
}
```