### PR TITLE
Bump org.apache.commons:commons-lang3 in /org.omg.sysml.jupyter.kernel

### DIFF
--- a/org.omg.sysml.jupyter.kernel/pom.xml
+++ b/org.omg.sysml.jupyter.kernel/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.14.0 to 3.18.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-lang3 dependency-version: 3.18.0 dependency-type: direct:production ...