### PR TITLE
ST6RI-869 Diamond inheritance problem in TradeStudy model (SYSML21-318)

### DIFF
--- a/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Analysis/TradeStudies.sysml
@@ -65,7 +65,7 @@ standard library package TradeStudies {
 			 */
 		}
 		
-		out attribute best : ScalarValue {
+		attribute best : ScalarValue {
 			doc
 			/*
 			 * Out of the evaluation results of all the given alternatives, the one that is considered 
@@ -85,11 +85,7 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 		 
-		subject :>> selectedAlternative;
-		in ref :>> alternatives;
-		in calc :>> eval;
-	
-		out attribute :>> best = alternatives->minimize {
+		attribute :>> best = alternatives->minimize {
 			doc
 			/*
 			 * For a MinimizeObjective, the best value is the minimum one.
@@ -107,11 +103,7 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 	
-        subject :>> selectedAlternative;
-        in ref :>> alternatives;
-        in calc :>> eval;
-    
-		out attribute :>> best = alternatives->maximize {
+		attribute :>> best = alternatives->maximize {
 			doc
 			/*
 			 * For a MinimizeObjective, the best value is the maximum one.

--- a/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
+++ b/sysml.library/Domain Libraries/Analysis/TradeStudies.sysml
@@ -65,7 +65,7 @@ standard library package TradeStudies {
 			 */
 		}
 		
-		out attribute best : ScalarValue {
+		attribute best : ScalarValue {
 			doc
 			/*
 			 * Out of the evaluation results of all the given alternatives, the one that is considered 
@@ -85,11 +85,7 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 		 
-		subject :>> selectedAlternative;
-		in ref :>> alternatives;
-		in calc :>> eval;
-	
-		out attribute :>> best = alternatives->minimize {
+		attribute :>> best = alternatives->minimize {
 			doc
 			/*
 			 * For a MinimizeObjective, the best value is the minimum one.
@@ -107,11 +103,7 @@ standard library package TradeStudies {
 		 * given alternatives.
 		 */
 	
-        subject :>> selectedAlternative;
-        in ref :>> alternatives;
-        in calc :>> eval;
-    
-		out attribute :>> best = alternatives->maximize {
+		attribute :>> best = alternatives->maximize {
 			doc
 			/*
 			 * For a MinimizeObjective, the best value is the maximum one.


### PR DESCRIPTION
This PR proactively fixes the `TradeStudy` model bug report in the following SysML 2.1 RTF issue:

- [SYSML21-318](https://issues.omg.org/issues/SYSML21-318)  Diamond inheritance problem with TradeStudy

The `TradeStudy` model is intended to be used as in the following example, in which its objective is redefined to be typed by `MinimizeObjective` or `MaximizeObjective`:
```
analysis tradeStudy : TradeStudy {
    objective :>> tradeStudyObjective : MinimizeObjective;
    ...
}
```
But, previously, this cause input parameters from the `TradeStudyObjective` base definition to be invalidly inherited, once from redefinitions in `MinimizeObjective` or `MaximizeObjective` and once from redefinitions in the redefined objective `TradeStudy::tradeStudyObjective`. This was not detected previously, because the Pilot Implementation does not currently cross-check inheritance of redefinitions from different general types. Further, if (as above) a subject is not explicitly modeled for an objective requirement, the Pilot Implementation physically inserts one behind the scenes, which then implicitly redefines the two otherwise inherited subject parameters. However, this is not conformant with the specification, and it is planned to be removed from the Pilot Implementation, in which case the inheritance of two subject parameters _will_ cause a validation error to be reported.

This PR eliminates these problems by updating the declaration for `TradeStudyObjective` so that the nested feature `best` is no longer a parameter (it was previously an `out` parameter). This allows `best` to be redefined in `MinimizeObjective` and `MaximizeObjective` without having to redefine the input parameters before it. The redefined input parameters in `TradeStudy::tradeStudyObjective` can then be inherited without any problem.



