### PR TITLE
ST6RI-871 Source of a conditional succession not set properly

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -86,11 +86,15 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	protected void computeSource() {
 		TransitionUsage target = getTarget();
 		List<Membership> ownedMemberships = target.getOwnedMembership();
-		if (ownedMemberships.isEmpty() || ownedMemberships.get(0) instanceof ParameterMembership) {
+		if (ownedMemberships.isEmpty() || 
+				ownedMemberships.get(0) instanceof ParameterMembership) {
 			Feature source = UsageUtil.getPreviousFeature(target);
 			Membership membership = SysMLFactory.eINSTANCE.createMembership();
 			membership.setMemberElement(source);
 			target.getOwnedRelationship().add(0, membership);
+		} else if (ownedMemberships.get(0).getMemberElement() == null) {
+			Feature source = UsageUtil.getPreviousFeature(target);
+			ownedMemberships.get(0).setMemberElement(source);
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes a bug that caused spurious validation error markings on conditional successions in the Xtext SysML editor in Eclipse.

For example, in the following model, the source of the conditional succession `s` is implicitly the preceding action `a`:
```
action def A {
  action a;
  if true than b;
  action b;
}
```
Previously, this would initially parse correctly in the Xtext editor without validation errors. But, if it was part of a larger model, then, when a change was made elsewhere in the model, after incremental re-parsing, the source on the conditional succession was not set correctly, resulting in the validation error “Must have at least two related elements”.

A so-called "conditional succession" is actually parsed as a `TransitionUsage`, and an implied source such as above is computed in the `TransitionUsage::computeSource` method. This PR updates the `computeSource` method to handle the case when transformations are re-run on a conditional succession in the abstract syntax tree, when it has not actually been re-parsed.