### PR TITLE
ST6RI-872 Library models have inherited member name collisions (KERML11-76, SYSML21-322)

### DIFF
--- a/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
+++ b/kerml/src/examples/KerML Spec Annex A Examples/A-3-8-ChangingFeatureValues.kerml
@@ -110,15 +110,21 @@ package ChangingFeatureValuesExecution {
 	#atom
 	behavior MyPaint specializes Paint {
 		feature redefines objectToPaint : MyProduct;
-		step redefines painting : PaintingMyProductFeatureWrite;
-		step redefines painted : PaintedMyProductFeatureWrite;
+		step redefines painting : PaintingMyProductFeatureWrite {
+		    in onOccurrence;
+		}
+		step redefines painted : PaintedMyProductFeatureWrite {
+            in onOccurrence;
+        }
 		succession redefines p_before_p : MyPaintingFW_Before_PaintFW_Link first painting then painted;
 	}
 
 	#atom
 	behavior MyDry specializes Dry {
 		feature redefines objectToDry : MyProduct;
-		step redefines dried : MyProductFeatureWrite;  
+		step redefines dried : MyProductFeatureWrite {
+            in onOccurrence;
+        }
 	}
 	#atom
 	assoc MyPaint_Before_Dry_Link specializes HappensBefore {
@@ -128,7 +134,9 @@ package ChangingFeatureValuesExecution {
 	#atom
 	behavior MyShip specializes Ship {
 		feature redefines objectToShip : MyProduct;
-		step redefines shipped : MyProductFeatureWrite;  
+		step redefines shipped : MyProductFeatureWrite {
+            in onOccurrence;
+        }
 	}
 	#atom
 	assoc MyDry_Before_Ship_Link specializes HappensBefore {
@@ -144,7 +152,9 @@ package ChangingFeatureValuesExecution {
 		feature obPiS chains objectToFinish.beforePaint.isShipped = false;
 
 
-		step redefines paint : MyPaint;
+		step redefines paint : MyPaint {
+		    feature redefines paint::objectToPaint, MyPaint::objectToPaint;
+		}
 		feature subsets objectToFinish.beforePaint.immediateSuccessors,
 				objectToFinish.whilePainting.startShot.timeCoincidentOccurrences
 			chains paint.painting.endShot;
@@ -161,7 +171,9 @@ package ChangingFeatureValuesExecution {
 		feature oaPiS chains objectToFinish.afterPaint.isShipped = false;
 
 
-		step redefines dry : MyDry;
+		step redefines dry : MyDry {
+            feature redefines dry::objectToDry, MyDry::objectToDry;
+        }
 		succession redefines p_before_d : MyPaint_Before_Dry_Link [1] first paint then dry;
 		feature subsets objectToFinish.afterPaint.immediateSuccessors,
 				objectToFinish.afterDry.startShot.timeCoincidentOccurrences
@@ -171,7 +183,9 @@ package ChangingFeatureValuesExecution {
 		feature oaDiS chains objectToFinish.afterDry.isShipped = false;
 
 
-		step redefines ship : MyShip;
+		step redefines ship : MyShip {
+            feature redefines ship::objectToShip, MyShip::objectToShip;
+        }
 		succession redefines d_before_s : MyDry_Before_Ship_Link [1] first dry then ship;
 		feature subsets objectToFinish.afterDry.immediateSuccessors,
 				objectToFinish.afterShip.startShot.timeCoincidentOccurrences

--- a/kerml/src/examples/Variable Feature Examples/Enhancements/ExtendedOccurrences.kerml
+++ b/kerml/src/examples/Variable Feature Examples/Enhancements/ExtendedOccurrences.kerml
@@ -47,4 +47,8 @@ package ExtendedOccurrences {
         	connector : Occurrences::HappensDuring from [1] that to [1] self;
         }
     }
+    struct ExtendedObject :> ExtendedOccurrence {
+        feature self : ExtendedObject :>> Objects::Object::self, ExtendedOccurrence::self;
+    }
+
 }

--- a/kerml/src/examples/Variable Feature Examples/Enhancements/TimeVaryingFeaturesEnhanced.kerml
+++ b/kerml/src/examples/Variable Feature Examples/Enhancements/TimeVaryingFeaturesEnhanced.kerml
@@ -1,6 +1,6 @@
 package TimeVaryingFeaturesEnhanced {
     private import ExtendedOccurrences::*;
-
+    
     class CC1 :> ExtendedOccurrence {
         var feature x;
         //member feature x featured by CC1_snapshots {
@@ -116,7 +116,7 @@ package TimeVaryingFeaturesEnhanced {
         //}
     }
     
-    struct Car1 :> ExtendedOccurrence {  // May or may not be a life
+    struct Car1 :> ExtendedObject {  // May or may not be a life
 	    var feature driver : Person [0..1];
 	    //member feature driver : Person [0..1] featured by Car_snapshots {
 	    //    member feature Car_snapshots :>> ExtendedOccurrences::ExtendedOccurrence::snapshots featured by Car1;

--- a/org.omg.kerml.xpect.tests/library/FeatureReferencingPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/FeatureReferencingPerformances.kerml
@@ -133,8 +133,8 @@ standard library package FeatureReferencingPerformances {
 		 */
 		
 		in feature onOccurrence : Evaluation redefines onOccurrence {
-	    	protected monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
-				out result : Anything[*] redefines result, monitoredFeature; 
+	    	protected expr monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
+				return result : Anything[*] redefines result, monitoredFeature; 
 			} 
 		} 
 	}
@@ -147,7 +147,9 @@ standard library package FeatureReferencingPerformances {
 		 */	
 		
 	  	in bool redefines onOccurrence {
-	    	protected bool redefines monitoredOccurrence[1];
+	    	protected bool redefines monitoredOccurrence[1] {
+	    	    return result : Boolean [1];
+	    	}
 		}
 		out redefines afterValues : Boolean [1]; 
 		out redefines beforeValues : Boolean [1];	 
@@ -167,10 +169,16 @@ standard library package FeatureReferencingPerformances {
   		feature isToTrue : Boolean [1] default true;
   		out afterValues: Boolean[1] redefines values  = isToTrue;
   		private feature monitor1 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+    		    end feature earlierOccurrence;
+    		    end feature laterOccurrence;
+    		}
   		}
   		private feature monitor2 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+                end feature earlierOccurrence;
+                end feature laterOccurrence;
+            }
   		}
 
   		private connector : HappensJustBefore from [1] monitor1 to [0..1] monitor2;

--- a/org.omg.kerml.xpect.tests/library/Objects.kerml
+++ b/org.omg.kerml.xpect.tests/library/Objects.kerml
@@ -165,27 +165,46 @@ standard library package Objects {
 		 * inner space dimension of structured space object is the highest of their cells.
 		 */
 
-		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
-		  { feature cellOrientation : Integer [0..1];
+        abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices { 
+            feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
-		  }
+		}
+		
+		comment about StructuredSurface, StructuredCurve, StructuredPoint
+		/*
+		 * The structures StructuredSurface, StructuredCurve and StructuredPoint provide common, necessary redefinitions of
+		 * innerSpaceDimension. They also provide single types for the StructuredSpaceObject features faces, edges and
+		 * vertices, which avoids problems when these features are related by connectors with ends that have owned
+		 * cross features.
+		 */
+		struct StructuredSurface specializes StructuredSpaceObject, Surface {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Surface::innerSpaceDimension;		    
+		}
+        struct StructuredCurve specializes StructuredSpaceObject, Curve {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Curve::innerSpaceDimension;         
+        }
+        struct StructuredPoint specializes StructuredSpaceObject, Point {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Point::innerSpaceDimension;         
+        }
 
-		portion feature faces : Surface[0..*] ordered subsets structuredSpaceObjectCells {
-			feature redefines edges subsets StructuredSpaceObject::edges;
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature faces : StructuredSurface[0..*] ordered subsets structuredSpaceObjectCells {
+		    feature redefines that : StructuredSpaceObject;
+			feature redefines edges subsets that.edges;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary; 
 			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
 		}
 
-		portion feature edges : Curve[0..*] ordered subsets structuredSpaceObjectCells {
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature edges : StructuredCurve[0..*] ordered subsets structuredSpaceObjectCells {
+            feature redefines that : StructuredSpaceObject;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary;
 			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
 		}
 
-		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells;
+		portion feature vertices : StructuredPoint[0..*] ordered subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
 			if notEmpty(faces) ? 2 else if notEmpty(edges) ? 1 else 0;

--- a/org.omg.kerml.xpect.tests/library/Observation.kerml
+++ b/org.omg.kerml.xpect.tests/library/Observation.kerml
@@ -92,6 +92,7 @@ standard library package Observation {
 	    	end feature source {
 	    		feature redefines sourceOutput = changeSignal;
 	    	}
+	    	end feature target;
 	    }
 	}
 	

--- a/org.omg.kerml.xpect.tests/library/Occurrences.kerml
+++ b/org.omg.kerml.xpect.tests/library/Occurrences.kerml
@@ -537,16 +537,16 @@ standard library package Occurrences {
 			 * the inner ones.
 			 */
 
-			feature redefines isClosed = true;
+			inv { isClosed == true }
 
 			feature spaceBounder: Occurrence [1] subsets self;
 
-			outer: Occurrence [0..1] subsets spaceSlices {
+			feature outer: Occurrence [0..1] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}
 
-			inner: Occurrence [0..*] subsets spaceSlices {
+			feature inner: Occurrence [0..*] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}

--- a/org.omg.kerml.xpect.tests/library/Transfers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Transfers.kerml
@@ -167,7 +167,7 @@ standard library package Transfers {
         private succession self then target;
     }
     
-    interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
+    interaction FlowTransferBefore specializes TransferBefore, FlowTransfer intersects FlowTransfer, TransferBefore {
         doc
         /*
          * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 

--- a/org.omg.kerml.xpect.tests/library/VectorFunctions.kerml
+++ b/org.omg.kerml.xpect.tests/library/VectorFunctions.kerml
@@ -179,7 +179,9 @@ standard library package VectorFunctions {
 	}
 	function CartesianThreeVectorOf specializes CartesianVectorOf { 
 		in components: Real[3] ordered nonunique;
-		return : CartesianThreeVectorValue[1];
+		return : CartesianThreeVectorValue[1] {
+		    feature :>> CartesianVectorOf::result::dimension, CartesianThreeVectorValue::dimension;
+		}
 	}
 	
 	feature cartesianZeroVector: CartesianVectorValue[3] =

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase3_Rdef.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/testsuite/ShadowingTests_ImportAndInnerClassesNamesAreTheSameBadCase3_Rdef.kerml.xt
@@ -25,7 +25,7 @@ package test{
 		public import OuterPackage::*;
 	}
 	feature inner1 subsets inner {
-		//XPECT warnings --> "Duplicate of inherited member name B from OuterPackage" at "B"
+		//XPECT warnings --> "Duplicate of inherited member name 'B' from OuterPackage" at "B"
 		feature B redefines A {
 			//XPECT linkedName at a1 --> OuterPackage.A.a1
 			//* XPECT scope at a1 ---

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MembershipTests_Distinguishability.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MembershipTests_Distinguishability.kerml.xt
@@ -33,11 +33,12 @@ package test{
 		classifier F {}
 	}
 	classifier D :> C {
-		// XPECT warnings --> "Duplicate of inherited member name D from C" at "D"
+		// XPECT warnings --> "Duplicate of inherited member name 'D' from C" at "D"
 		classifier D {}
 	}
-	classifier E :> D {
-		// XPECT warnings --> "Duplicate of inherited member name F from C" at "F"
+	classifier E :> C;
+	classifier F :> E {
+		// XPECT warnings --> "Duplicate of inherited member name 'F' from C" at "F"
 		classifier F {}
 	}	
 

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_Diamond1_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_Diamond1_invalid.kerml.xt
@@ -33,7 +33,7 @@ package RedefinitionDiamond {
 	
 	feature B :> A1, A2 {
 		p2 :>> p1; // 2
-// XPECT warnings ---> "Duplicate of inherited member name p from A2" at "p"
+// XPECT warnings ---> "Duplicate of inherited member name 'p' from A2" at "p"
 		feature p;
 	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_Diamond_Invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Redefinition_Diamond_Invalid.kerml.xt
@@ -33,7 +33,7 @@ package RedefinitionDiamond {
 	
 	feature B :> A1, A2 {
 //		p2 :>> p1; // 2
-// XPECT warnings ---> "Duplicate of inherited member name p from A2" at "p"
+// XPECT warnings ---> "Duplicate of inherited member name 'p' from A2" at "p"
 		feature p;
 	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/Specialization_invalid.kerml.xt
@@ -36,6 +36,7 @@ package Specialization_invalid {
 	   "Cannot specialize class or association" at "A1"
 	   ---
 	*/
+	// XPECT warnings ---> "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "datatype D2 specializes D1, C1, A1;"
 	datatype D2 specializes D1, C1, A1;
 	
 	class C1;
@@ -44,15 +45,18 @@ package Specialization_invalid {
 	   "Cannot specialize data type or association" at "A1"
 	   ---
 	*/
+	// XPECT warnings ---> "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "class C2 specializes C1, D1, A1;"
 	class C2 specializes C1, D1, A1;
 	
 	abstract assoc A1;
-	abstract assoc struct A2 specializes C2, A1;
-	abstract interaction A3 specializes C2, A1;
+	abstract assoc struct A2 specializes A, A1;
+	abstract interaction A3 specializes A, A1;
 	
 	// XPECT errors--->"Cannot specialize behavior" at "B1"
+	// XPECT warnings ---> "Duplicate of inherited member name 'self' from Object, Performance" at "struct S specializes B1;"
 	struct S specializes B1;
 
 	// XPECT errors--->"Cannot specialize structure" at "S"
+	// XPECT warnings ---> "Duplicate of inherited member name 'self' from Object, Performance" at "behavior B1 specializes S;"
 	behavior B1 specializes S;
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -419,9 +419,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 				for (mem: ownedMemberships) {
 					checkDistinguishibility(namesp, mem, inheritedMembershipMap, INVALID_NAMESPACE_DISTINGUISHABILITY_MSG_2)
 				}
-				for (mem: inheritedMemberships) {
-					checkDistinguishibility(namesp, inheritedMembershipMap, INVALID_NAMESPACE_DISTINGUISHABILITY_MSG_2)
-				}
+				checkDistinguishibility(namesp, inheritedMembershipMap, INVALID_NAMESPACE_DISTINGUISHABILITY_MSG_2)
 			}
 		}		
 	}
@@ -488,19 +486,9 @@ class KerMLValidator extends AbstractKerMLValidator {
 	}
 	
 	def identifyDuplicates(String msg, Namespace memNs, String name, Iterable<Membership> dups) {
-		var nsNames = ""
-		for (dup: dups) {
-			val ns = dup.membershipOwningNamespace
-			if (ns !== memNs) {
-				val nsName = ns.name
-				if (nsName !== null) {
-					if (!nsNames.empty) {
-						nsNames += ", "
-					}
-					nsNames += nsName
-				}
-			}
-		}
+		val nsNames = dups.map[membershipOwningNamespace].filter[ns | ns !== memNs].
+						map[getName].map[n | if (n === null) "" else n].sort.
+						map[n | ElementUtil.escapeName(n)].join(", ");
 		if (nsNames.empty) msg
 		else msg + " '" + ElementUtil.escapeString(name) + "' from " + nsNames;
 	}

--- a/org.omg.sysml.xpect.tests/library.domain/Geometry/ShapeItems.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Geometry/ShapeItems.sysml
@@ -56,12 +56,12 @@ standard library package ShapeItems {
 		attribute :>> outerSpaceDimension = 1;
 	}
 
-	abstract item def Path :> StructuredSpaceObject, Curve {
+	abstract item def Path :> StructuredSpaceObject::StructuredCurve {
 		doc
 		/*
 		 * Path is the most general structured Curve.
 		 */
-	
+        
 		item :>> faces [0];
 		item :>> edges [1..*] {
 			item :>> vertices [0..2];
@@ -227,7 +227,7 @@ standard library package ShapeItems {
 		item :>> e4 { attribute :>> length = e2.length; }
 	}
 
-	abstract item def Shell :> StructuredSpaceObject, Surface {
+	abstract item def Shell :> StructuredSpaceObject::StructuredSurface {
 		doc
 		/*
 		 * Shell is the most general structured Surface.
@@ -251,7 +251,10 @@ standard library package ShapeItems {
 		item :>> faces : PlanarSurface [1] {
 			item :>> edges [1];
 		}
-		item :>> edges : Ellipse [1] = shape;
+		item :>> edges : Ellipse [1] = shape {
+            attribute :>> edges::innerSpaceDimension, Ellipse::innerSpaceDimension;
+            ref item :>> edges::vertices, Ellipse::vertices;
+		}
 		item :>> vertices [0];
 	}
 
@@ -265,7 +268,10 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> shape : Circle;
+		item :>> shape : Circle {
+            attribute :>> Disc::shape::semiMajorAxis, Circle::semiMajorAxis;
+            attribute :>> Disc::shape::semiMinorAxis, Circle::semiMinorAxis;
+        }
 		item :>> edges : Circle;
 	}
 
@@ -371,6 +377,7 @@ standard library package ShapeItems {
 		item :>> revolvedCurve: Rectangle [1] {
 			attribute :>> length = rectangleLength;
 			attribute :>> width  = rectangleWidth;
+			attribute :>> revolvedCurve::isClosed, Rectangle::isClosed;
 		}
 	}
 
@@ -390,8 +397,20 @@ standard library package ShapeItems {
 		attribute :>> yoffset [1];
 
 		item :>> faces [2..3];
-		item base : Disc [1] :> faces;
-		item af : Disc [0..1] :> faces;
+		item base : Disc [1] :> faces {        
+            attribute :>> Disc::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Disc::edges, ConeOrCylinder::faces::edges {
+                attribute :>> Disc::edges::innerSpaceDimension, ConeOrCylinder::faces::edges::innerSpaceDimension;
+            }
+            ref :>> Disc::vertices, ConeOrCylinder::faces::vertices;		    
+		}
+		item af : Disc [0..1] :> faces {        
+            attribute :>> Disc::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Disc::edges, ConeOrCylinder::faces::edges {
+                attribute :>> Disc::edges::innerSpaceDimension, ConeOrCylinder::faces::edges::innerSpaceDimension;
+            }
+            ref :>> Disc::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		item cf : Surface [1] :> faces;
 
 		item :>> edges [2..4] = faces.edges;
@@ -452,7 +471,9 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> base : CircularDisc;
+		item :>> base : CircularDisc {
+		    ref :>> base::edges, CircularDisc::edges;
+		}
 	}
 
 	item def RightCircularCone :> CircularCone {
@@ -499,8 +520,12 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> base : CircularDisc;
-		item :>> af : CircularDisc;
+		item :>> base : CircularDisc {
+            ref :>> base::edges, CircularDisc::edges;
+        }
+		item :>> af : CircularDisc {
+            ref :>> af::edges, CircularDisc::edges;
+        }
 	}
 
 	item def RightCircularCylinder :> CircularCylinder {
@@ -521,7 +546,11 @@ standard library package ShapeItems {
 
 		attribute :>> isClosed = true;
 
-		item :>> faces : Polygon [2..*];
+		item :>> faces : Polygon [2..*] {        
+            attribute :>> Polygon::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Polygon::edges, ConeOrCylinder::faces::edges;
+            ref :>> Polygon::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		
 		item :>> edges = faces.edges;
 		
@@ -537,12 +566,24 @@ standard library package ShapeItems {
 		 */
 
 		item :>> faces [5..6];
-		item tf	 : Quadrilateral [1] :> faces;
-		item bf	 : Quadrilateral [1] :> faces;
+		item tf	 : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item bf	 : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		item ff	 : Polygon [1] :> faces { item :>> Polygon::edges, faces::edges [3..4]; }
 		item rf	 : Polygon [1] :> faces { item :>> Polygon::edges, faces::edges [3..4]; }
-		item slf : Quadrilateral [1] :> faces;
-		item srf : Quadrilateral [0..1] :> faces;
+		item slf : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item srf : Quadrilateral [0..1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges;
 		assert constraint { size(edges) == 18 or size(edges) == 24 }
@@ -645,8 +686,14 @@ standard library package ShapeItems {
 	
 
 		item :>> faces [5];
-		item :>> ff : Triangle;
-		item :>> rf : Triangle;
+		item :>> ff : Triangle {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item :>> rf : Triangle {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges [18];
 
@@ -703,8 +750,14 @@ standard library package ShapeItems {
 		 */	
 
 		item :>> faces [6];
-		item :>> ff : Quadrilateral;
-		item :>> rf : Quadrilateral;
+		item :>> ff : Quadrilateral {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item :>> rf : Quadrilateral {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges [24];
 
@@ -781,7 +834,10 @@ standard library package ShapeItems {
 
 		item :>> faces;
 		item base [1] :> faces;
-		item wall : Triangle :> faces;
+		item wall : Triangle :> faces {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		attribute wallNumber : Positive = size(wall);
 
 		assert constraint { size(faces) == wallNumber + 1 }
@@ -817,6 +873,8 @@ standard library package ShapeItems {
 		attribute :>> baseWidth [1];
 
 		item :>> base : Triangle {
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
 			attribute :>> length = Tetrahedron::baseLength;
 			attribute :>> width  = Tetrahedron::baseWidth;
 		}
@@ -832,6 +890,8 @@ standard library package ShapeItems {
 		attribute :>> baseWidth [1];
 
 		item :>> base : Rectangle {
+            ref :>> Rectangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Rectangle::vertices, ConeOrCylinder::faces::vertices;            
 			attribute :>> length = RectangularPyramid::baseLength;
 			attribute :>> width = RectangularPyramid::baseWidth;
 		}

--- a/org.omg.sysml.xpect.tests/library.domain/Geometry/SpatialItems.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Geometry/SpatialItems.sysml
@@ -32,7 +32,7 @@ standard library package SpatialItems {
 			 * A local Clock to be used as the corresponding time reference within this SpatialItem. 
 			 * By default this is the singleton universalClock.
 			 */
-			}
+		}
 		
 		attribute coordinateFrame : ThreeDCoordinateFrame[1] default universalCartesianSpatial3dCoordinateFrame {
             doc
@@ -59,7 +59,15 @@ standard library package SpatialItems {
 			isZeroVector(CurrentPositionOf(originPoint, that))
 		}
 
-		item componentItems : SpatialItem[1..*] :> subitems {
+        item subSpatialItems : SpatialItem[1..*] :> subitems {
+            ref item :>> SpatialItem::localClock, subitems::localClock;
+        }
+        
+        part subSpatialParts : SpatialItem[1..*] :> subSpatialItems, subparts {
+            ref item :>> SpatialItem::localClock, subSpatialItems::localClock, subparts::localClock;
+        }
+
+		item componentItems : SpatialItem[1..*] :> subSpatialItems {
 			doc
 			/*
 			 * A SpatialItem with componentItems is entirely made up of those items (the SpatialItem occurs only
@@ -67,7 +75,7 @@ standard library package SpatialItems {
 			 * coordinate frame as the SpatialItem they make up.  A SpatialItem without componentItems occurs
 			 * on its own, separately from its subitems.
 			 */		
-			item :>> SpatialItem::localClock, subitems::localClock default (that as SpatialItem).localClock;
+			ref item :>> SpatialItem::localClock, subSpatialItems::localClock default (that as SpatialItem).localClock;
 			attribute :>> coordinateFrame {
 				attribute :>> mRefs default (that.that as SpatialItem).coordinateFrame.mRefs;
 				attribute :>> transformation[1] default nullTransformation {
@@ -84,6 +92,10 @@ standard library package SpatialItems {
 			 */
 		
 			item :>> elements : SpatialItem [1..*] = componentItems;
+		}
+		
+		part componentParts : SpatialItem[1..*] :> componentItems, subSpatialParts {
+		    ref item :>> SpatialItem::localClock, componentItems::localClock, subSpatialParts::localClock, subparts::localClock;
 		}
 	}
 

--- a/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/SI.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/SI.sysml
@@ -29,6 +29,9 @@ standard library package SI {
             :>> definition = "temperature in kelvin of pure water at the triple point";
         }
         attribute :>> definitionalQuantityValues = temperatureOfWaterAtTriplePointInK;
+        attribute :>> ThermodynamicTemperatureUnit::quantityDimension, TemperatureDifferenceUnit::quantityDimension {
+            :>> ThermodynamicTemperatureUnit::quantityDimension::quantityPowerFactors, TemperatureDifferenceUnit::quantityDimension::quantityPowerFactors;
+        }
     }
     attribute <mol> mole : AmountOfSubstanceUnit;
     attribute <cd> candela : LuminousIntensityUnit;
@@ -55,7 +58,11 @@ standard library package SI {
     attribute <E> erlang : TrafficIntensityUnit = one;
     attribute <F> farad : CapacitanceUnit = C/V;
     attribute <Gy> gray : AbsorbedDoseUnit = J/kg;
-    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A;
+    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A {
+        attribute :>> PermeanceUnit::quantityDimension, InductanceUnit::quantityDimension {
+            :>> PermeanceUnit::quantityDimension::quantityPowerFactors, InductanceUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute <Hart> hartley : InformationContentUnit = one;
     attribute <Hz> hertz : FrequencyUnit = s^-1;
     attribute <J> joule : EnergyUnit = N*m;
@@ -246,7 +253,11 @@ standard library package SI {
     attribute <'mol/kg'> 'mole per kilogram' : MolalityUnit = mol/kg;
     attribute <'mol/L'> 'mole per l' : AmountOfSubstanceConcentrationUnit = mol/L;
     attribute <'mol/m³'> 'mole per cubic metre' : EquilibriumConstantOnConcentrationBasisUnit = mol/m^3;
-    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m;
+    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m {
+        attribute :>> MomentOfForceUnit::quantityDimension, TorqueUnit::quantityDimension {
+            :>> MomentOfForceUnit::quantityDimension::quantityPowerFactors, TorqueUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute <'N⋅m⋅s'> 'newton metre second' : AngularImpulseUnit = N*m*s;
     attribute <'N⋅m⋅s⁻¹'> 'newton metre second to the power minus 1' : PowerUnit = N*m*s^-1;
     attribute <'N⋅m⁻¹'> 'newton metre to the power minus 1' : SurfaceTensionUnit = N*m^-1;

--- a/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/USCustomaryUnits.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Quantities and Units/USCustomaryUnits.sysml
@@ -79,7 +79,12 @@ standard library package <USCU> USCustomaryUnits {
     //attribute <'°F⋅h⋅ft²/(Btu_th⋅in)'> 'degree Fahrenheit hour square foot per British thermal unit (th) inch' : ThermalResistivityUnit = '°F'*h*ft^2/(Btu_th*'in');
     attribute <'°F⋅s/Btu_IT'> 'degree Fahrenheit second per British thermal unit (IT)' : ThermalResistanceUnit = '°F'*s/Btu_IT;
     attribute <'°F⋅s/Btu_th'> 'degree Fahrenheit second per British thermal unit (th)' : ThermalResistanceUnit = '°F'*s/Btu_th;
-    attribute <'°R'> 'degree Rankine' : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; } }
+    attribute <'°R'> 'degree Rankine' : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit { 
+        :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; }
+        :>> ThermodynamicTemperatureUnit::quantityDimension, TemperatureDifferenceUnit::quantityDimension {
+            :>> ThermodynamicTemperatureUnit::quantityDimension::quantityPowerFactors, TemperatureDifferenceUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute 'fathom (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.828804E+00; :>> isExact = false; } }
     attribute <floz> 'fluid ounce (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; :>> isExact = false; } }
     attribute <ft> 'foot' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048E-01; } }

--- a/org.omg.sysml.xpect.tests/library.domain/Requirement Derivation/DerivationConnections.sysml
+++ b/org.omg.sysml.xpect.tests/library.domain/Requirement Derivation/DerivationConnections.sysml
@@ -26,10 +26,12 @@ standard library package DerivationConnections {
 		 * The single end for the originalRequirement should subset originalRequirement, while
 		 * the rest of the ends should subset derivedRequirements.
 		 */
-		 
-		ref requirement :>> participant {
-			doc /* All the participants in a Derivation must be requirements. */
-		}
+		
+		// Note: This redefinition causes a distinguishibility problem for binary connections, becuse
+		// participant is already redefined for them to limit the multiplicity to 2.
+		// ref requirement :>> participant {
+		//	doc /* All the participants in a Derivation must be requirements. */
+		// }
 		
 		ref requirement originalRequirement[1] :>> originalRequirements :> participant {
 			doc /* The single original requirement. */

--- a/org.omg.sysml.xpect.tests/library.kernel/FeatureReferencingPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/FeatureReferencingPerformances.kerml
@@ -133,8 +133,8 @@ standard library package FeatureReferencingPerformances {
 		 */
 		
 		in feature onOccurrence : Evaluation redefines onOccurrence {
-	    	protected monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
-				out result : Anything[*] redefines result, monitoredFeature; 
+	    	protected expr monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
+				return result : Anything[*] redefines result, monitoredFeature; 
 			} 
 		} 
 	}
@@ -147,7 +147,9 @@ standard library package FeatureReferencingPerformances {
 		 */	
 		
 	  	in bool redefines onOccurrence {
-	    	protected bool redefines monitoredOccurrence[1];
+	    	protected bool redefines monitoredOccurrence[1] {
+	    	    return result : Boolean [1];
+	    	}
 		}
 		out redefines afterValues : Boolean [1]; 
 		out redefines beforeValues : Boolean [1];	 
@@ -167,10 +169,16 @@ standard library package FeatureReferencingPerformances {
   		feature isToTrue : Boolean [1] default true;
   		out afterValues: Boolean[1] redefines values  = isToTrue;
   		private feature monitor1 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+    		    end feature earlierOccurrence;
+    		    end feature laterOccurrence;
+    		}
   		}
   		private feature monitor2 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+                end feature earlierOccurrence;
+                end feature laterOccurrence;
+            }
   		}
 
   		private connector : HappensJustBefore from [1] monitor1 to [0..1] monitor2;

--- a/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Objects.kerml
@@ -165,27 +165,46 @@ standard library package Objects {
 		 * inner space dimension of structured space object is the highest of their cells.
 		 */
 
-		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
-		  { feature cellOrientation : Integer [0..1];
+        abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices { 
+            feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
-		  }
+		}
+		
+		comment about StructuredSurface, StructuredCurve, StructuredPoint
+		/*
+		 * The structures StructuredSurface, StructuredCurve and StructuredPoint provide common, necessary redefinitions of
+		 * innerSpaceDimension. They also provide single types for the StructuredSpaceObject features faces, edges and
+		 * vertices, which avoids problems when these features are related by connectors with ends that have owned
+		 * cross features.
+		 */
+		struct StructuredSurface specializes StructuredSpaceObject, Surface {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Surface::innerSpaceDimension;		    
+		}
+        struct StructuredCurve specializes StructuredSpaceObject, Curve {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Curve::innerSpaceDimension;         
+        }
+        struct StructuredPoint specializes StructuredSpaceObject, Point {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Point::innerSpaceDimension;         
+        }
 
-		portion feature faces : Surface[0..*] ordered subsets structuredSpaceObjectCells {
-			feature redefines edges subsets StructuredSpaceObject::edges;
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature faces : StructuredSurface[0..*] ordered subsets structuredSpaceObjectCells {
+		    feature redefines that : StructuredSpaceObject;
+			feature redefines edges subsets that.edges;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary; 
 			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
 		}
 
-		portion feature edges : Curve[0..*] ordered subsets structuredSpaceObjectCells {
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature edges : StructuredCurve[0..*] ordered subsets structuredSpaceObjectCells {
+            feature redefines that : StructuredSpaceObject;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary;
 			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
 		}
 
-		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells;
+		portion feature vertices : StructuredPoint[0..*] ordered subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
 			if notEmpty(faces) ? 2 else if notEmpty(edges) ? 1 else 0;

--- a/org.omg.sysml.xpect.tests/library.kernel/Observation.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Observation.kerml
@@ -92,6 +92,7 @@ standard library package Observation {
 	    	end feature source {
 	    		feature redefines sourceOutput = changeSignal;
 	    	}
+	    	end feature target;
 	    }
 	}
 	

--- a/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Occurrences.kerml
@@ -537,16 +537,16 @@ standard library package Occurrences {
 			 * the inner ones.
 			 */
 
-			feature redefines isClosed = true;
+			inv { isClosed == true }
 
 			feature spaceBounder: Occurrence [1] subsets self;
 
-			outer: Occurrence [0..1] subsets spaceSlices {
+			feature outer: Occurrence [0..1] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}
 
-			inner: Occurrence [0..*] subsets spaceSlices {
+			feature inner: Occurrence [0..*] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}

--- a/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
@@ -167,7 +167,7 @@ standard library package Transfers {
         private succession self then target;
     }
     
-    interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
+    interaction FlowTransferBefore specializes TransferBefore, FlowTransfer intersects FlowTransfer, TransferBefore {
         doc
         /*
          * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 

--- a/org.omg.sysml.xpect.tests/library.kernel/VectorFunctions.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/VectorFunctions.kerml
@@ -179,7 +179,9 @@ standard library package VectorFunctions {
 	}
 	function CartesianThreeVectorOf specializes CartesianVectorOf { 
 		in components: Real[3] ordered nonunique;
-		return : CartesianThreeVectorValue[1];
+		return : CartesianThreeVectorValue[1] {
+		    feature :>> CartesianVectorOf::result::dimension, CartesianThreeVectorValue::dimension;
+		}
 	}
 	
 	feature cartesianZeroVector: CartesianVectorValue[3] =

--- a/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
@@ -190,7 +190,9 @@ standard library package Actions {
 		 */
 	
 		in :>> payload [0..*];
-	    ref sentMessage :>> sentTransfer: MessageTransfer, MessageAction;
+	    ref sentMessage :>> sentTransfer: MessageTransfer, MessageAction {
+	        in :>> MessageTransfer::payload, MessageAction::payload;
+	    }
 	}
 	
 	abstract action sendActions: SendAction[0..*] nonunique :> actions, sendPerformances {
@@ -207,7 +209,9 @@ standard library package Actions {
 		 * of a designated receiver Occurrence, providing its payload as output.
 		 */
 		inout :>> payload;
-		ref acceptedMessage :>> acceptedTransfer: MessageTransfer, MessageAction;
+		ref acceptedMessage :>> acceptedTransfer: MessageTransfer, MessageAction {
+            in :>> MessageTransfer::payload, MessageAction::payload;
+        }
 	}
 	
 	action def AcceptAction :> AcceptMessageAction {
@@ -330,7 +334,9 @@ standard library package Actions {
 		 */
 	
 		in transitionLinkSource : Action :>> TransitionPerformance::transitionLinkSource;
-		ref acceptedMessage : MessageTransfer, MessageAction :>> trigger;
+		ref acceptedMessage : MessageTransfer, MessageAction :>> trigger {
+            in :>> MessageTransfer::payload, MessageAction::payload;
+        }
 		
 		ref receiver :>> triggerTarget;
 

--- a/org.omg.sysml.xpect.tests/library.systems/Connections.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Connections.sysml
@@ -32,7 +32,7 @@ standard library package Connections {
          */
     }
      
-    abstract connection def BinaryConnection :> Connection, BinaryLinkObject {
+    abstract connection def BinaryConnection :> BinaryLinkObject, Connection {
         doc
         /*
          * BinaryConnection is the most general class of binary links between two things 

--- a/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
@@ -81,7 +81,7 @@ standard library package Flows {
          * It is the base type for FlowUsages that identify their source output and
          * target input.
          */
-        
+         
         end occurrence source: Occurrence :>> Message::source, FlowTransfer::source;
         end occurrence target: Occurrence :>> Message::target, FlowTransfer::target;
     }
@@ -92,6 +92,8 @@ standard library package Flows {
          * SuccessionFlow is a subclass of flowss that appen after their source and 
          * before their target. It is the base type for all SuccessionFlowUsages.
          */
+         
+        ref self : SuccessionFlow :>> Flow::self, FlowTransferBefore::self;
     
         end occurrence source: Occurrence :>> Flow::source, FlowTransferBefore::source;
         end occurrence target: Occurrence :>> Flow::target, FlowTransferBefore::target;

--- a/org.omg.sysml.xpect.tests/library.systems/Items.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Items.sysml
@@ -41,20 +41,22 @@ standard library package Items {
 		}
 		
 		item envelopingShapes : Item[0..*] {
-		doc
+            doc
 			/*
 			 * Each enveloping shape is the shape of an Item that spacially overlaps this Item for its
 			 * entire lifetime.
-			 */		
+			 */
+			 
+			ref item envelopedItem :>> that;	
 
-			 /* Enables two dimensional items to be enveloped by two or three dimensional shapes. */
-			attribute :>> innerSpaceDimension = 
-				if (that as Item).innerSpaceDimension == 3  | (that as Item).outerSpaceDimension == 3? 2 
-				else (that as Item).outerSpaceDimension - 1 {
-				doc
-			 	/* 
-			 	 * Enables two dimensional items to be enveloped by two or three dimensional shapes.
-			 	 */				
+			assert constraint { 
+                doc
+                /* 
+                 * Enables two dimensional items to be enveloped by two or three dimensional shapes.
+                 */             
+			    innerSpaceDimension == 
+    				(if envelopedItem.innerSpaceDimension == 3  | envelopedItem.outerSpaceDimension == 3? 2 
+    				else envelopedItem.outerSpaceDimension - 1)
 			}
 			assert constraint { (that as Item).innerSpaceDimension < 3 implies notEmpty(outerSpaceDimension) }
 
@@ -63,7 +65,7 @@ standard library package Items {
 			assert constraint {
 				doc
 				/* 
-				 * This constraint prevents an envelopingShape frombeing a portion.
+				 * This constraint prevents an envelopingShape from being a portion.
 				 */
 				 
 				envelopingItem.shape.spaceTimeCoincidentOccurrences->includes(that) and
@@ -72,21 +74,21 @@ standard library package Items {
 		}
 		
 		item boundingShapes : StructuredSpaceObject [0..*] :> envelopingShapes {
-		doc
+            doc
 			/*
 			 * envelopingShapes that are structured space objects with every face or every edge
 			 * intersecting this Item.
 			 */		
+            
+			ref item boundingShape: Item :>> self;
 
-			item boundingShape: Item :>> self;
-
-			item :>> faces {
-				item face :>> self;
+			private item :>> faces {
+				ref item face :>> self;
 				item inter [1];
 				assert constraint { contains(inter.intersectionsOf, union(face, boundingShape)) }
 			}
-			item :>> edges {
-				item edge :>> self;
+			private item :>> edges {
+				ref item edge :>> self;
 				item inter [1];
 				assert constraint { isEmpty(faces) implies
 							contains(inter.intersectionsOf, union(edge, boundingShape)) }
@@ -112,6 +114,8 @@ standard library package Items {
 			/*
 			 * The Items that are composite subitems of this Item.
 			 */
+			 
+			private ref redefines Item::incomingTransferSort, subobjects::incomingTransferSort;
 		}
 		
 		abstract part subparts: Part[0..*] :> subitems, parts {

--- a/org.omg.sysml.xpect.tests/library.systems/Metadata.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Metadata.sysml
@@ -16,6 +16,8 @@ doc
 		 * MetadataItem is the most general class of Items that represent Metaobjects. 
 		 * MetadataItem is the base type of all MetadataDefinitions.
 		 */
+		 
+		 ref self : MetadataItem redefines Metaobject::self, Item::self;
 	}
 	
 	abstract item metadataItems : MetadataItem[0..*] :> metaobjects, items {

--- a/org.omg.sysml.xpect.tests/library.systems/Parts.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Parts.sysml
@@ -48,7 +48,7 @@ doc
 			 * Actions that are owned by this Part.
 			 */
 		
-		 	ref part :>> this : Part = that as Part {
+		 	ref part this : Part :>> Action::this, ownedPerformances::this = that as Part {
 				doc
 				/*
 				 * The "this" reference of an ownedAction is always its owning Part.

--- a/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Ports.sysml
@@ -39,6 +39,9 @@ standard library package Ports {
             /* 
              * The target of each of the outgoingTransfersFromSelf of a Port must be an interfacingPort.
              */
+             
+             end ref source;
+             end ref target;
         }
     }
     

--- a/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/SysML.sysml
@@ -11,48 +11,48 @@ standard library package SysML {
 		public import KerML::Kernel::*;
 		
 		metadata def AcceptActionUsage specializes ActionUsage {
-			derived ref item receiverArgument : Expression[0..1];
-			derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference, parameter;
-			derived ref item payloadArgument : Expression[0..1];
+			derived ref item receiverArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference, parameter subsets Metadata::metadataItems;
+			derived ref item payloadArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActionDefinition specializes Behavior, OccurrenceDefinition {
-			derived ref item 'action' : ActionUsage[0..*] ordered subsets step, usage;
+			derived ref item 'action' : ActionUsage[0..*] ordered subsets step, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActionUsage specializes Step, OccurrenceUsage {
-			derived ref item actionDefinition : Behavior[0..*] ordered redefines behavior, occurrenceDefinition;
+			derived ref item actionDefinition : Behavior[0..*] ordered redefines behavior, occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActorMembership specializes ParameterMembership {
-			derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter;
+			derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AllocationDefinition specializes ConnectionDefinition {
-			derived ref item 'allocation' : AllocationUsage[0..*] ordered subsets usage;
+			derived ref item 'allocation' : AllocationUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AllocationUsage specializes ConnectionUsage {
-			derived ref item allocationDefinition : AllocationDefinition[0..*] ordered redefines connectionDefinition;
+			derived ref item allocationDefinition : AllocationDefinition[0..*] ordered redefines connectionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AnalysisCaseDefinition specializes CaseDefinition {
-			derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature;
+			derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AnalysisCaseUsage specializes CaseUsage {
-			derived ref item analysisCaseDefinition : AnalysisCaseDefinition[0..1] redefines caseDefinition;
-			derived ref item resultExpression : Expression[0..1] subsets ownedFeature;
+			derived ref item analysisCaseDefinition : AnalysisCaseDefinition[0..1] redefines caseDefinition subsets Metadata::metadataItems;
+			derived ref item resultExpression : Expression[0..1] subsets ownedFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AssertConstraintUsage specializes ConstraintUsage, Invariant {
-			derived ref item assertedConstraint : ConstraintUsage[1..1];
+			derived ref item assertedConstraint : ConstraintUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AssignmentActionUsage specializes ActionUsage {
-			derived ref item targetArgument : Expression[0..1];
-			derived ref item valueExpression : Expression[0..1];
-			derived ref item referent : Feature[1..1] subsets member;
+			derived ref item targetArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item valueExpression : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item referent : Feature[1..1] subsets member subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AttributeDefinition specializes DataType, Definition;		
@@ -60,56 +60,56 @@ standard library package SysML {
 		metadata def AttributeUsage specializes Usage {
 			derived attribute isReference : Boolean[1..1] redefines isReference;
 			
-			derived ref item attributeDefinition : DataType[0..*] ordered redefines definition;
+			derived ref item attributeDefinition : DataType[0..*] ordered redefines definition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def BindingConnectorAsUsage specializes BindingConnector, ConnectorAsUsage;		
 		
 		metadata def CalculationDefinition specializes Function, ActionDefinition {
-			derived ref item calculation : CalculationUsage[0..*] ordered subsets 'action', expression;
+			derived ref item calculation : CalculationUsage[0..*] ordered subsets 'action', expression subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CalculationUsage specializes Expression, ActionUsage {
-			derived ref item calculationDefinition : Function[0..1] ordered redefines function, actionDefinition;
+			derived ref item calculationDefinition : Function[0..1] ordered redefines function, actionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CaseDefinition specializes CalculationDefinition {
-			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CaseUsage specializes CalculationUsage {
-			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage;
-			derived ref item caseDefinition : CaseDefinition[0..1] redefines calculationDefinition;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item caseDefinition : CaseDefinition[0..1] redefines calculationDefinition subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConcernDefinition specializes RequirementDefinition;		
 		
 		metadata def ConcernUsage specializes RequirementUsage {
-			derived ref item concernDefinition : ConcernDefinition[0..1] redefines requirementDefinition;
+			derived ref item concernDefinition : ConcernDefinition[0..1] redefines requirementDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConjugatedPortDefinition specializes PortDefinition {
-			derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace;
-			derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator;
+			derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace subsets Metadata::metadataItems;
+			derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConjugatedPortTyping specializes FeatureTyping {
-			ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type;
-			derived ref item portDefinition : PortDefinition[1..1];
+			ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type subsets Metadata::metadataItems;
+			derived ref item portDefinition : PortDefinition[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConnectionDefinition specializes AssociationStructure, PartDefinition {
 			attribute isSufficient : Boolean[1..1] redefines isSufficient;
 			
-			derived ref item connectionEnd : Usage[0..*] ordered redefines associationEnd;
+			derived ref item connectionEnd : Usage[0..*] ordered redefines associationEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConnectionUsage specializes ConnectorAsUsage, PartUsage {
-			derived ref item connectionDefinition : AssociationStructure[0..*] ordered subsets itemDefinition redefines association;
+			derived ref item connectionDefinition : AssociationStructure[0..*] ordered subsets itemDefinition redefines association subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def ConnectorAsUsage specializes Usage, Connector;		
@@ -117,7 +117,7 @@ standard library package SysML {
 		metadata def ConstraintDefinition specializes OccurrenceDefinition, Predicate;		
 		
 		metadata def ConstraintUsage specializes BooleanExpression, OccurrenceUsage {
-			derived ref item constraintDefinition : Predicate[0..1] redefines predicate;
+			derived ref item constraintDefinition : Predicate[0..1] redefines predicate subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def ControlNode specializes ActionUsage;		
@@ -127,57 +127,57 @@ standard library package SysML {
 		metadata def Definition specializes Classifier {
 			attribute isVariation : Boolean[1..1];
 			
-			derived ref item 'variant' : Usage[0..*] subsets ownedMember;
-			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
-			derived ref item usage : Usage[0..*] ordered subsets feature;
-			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage;
-			derived ref item ownedUsage : Usage[0..*] ordered subsets ownedFeature, usage;
-			derived ref item ownedReference : ReferenceUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedAttribute : AttributeUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedEnumeration : EnumerationUsage[0..*] ordered subsets ownedAttribute;
-			derived ref item ownedOccurrence : OccurrenceUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedItem : ItemUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedPart : PartUsage[0..*] ordered subsets ownedItem;
-			derived ref item ownedPort : PortUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedConnection : ConnectorAsUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedFlow : FlowUsage[0..*] subsets ownedConnection;
-			derived ref item ownedInterface : InterfaceUsage[0..*] ordered subsets ownedConnection;
-			derived ref item ownedAllocation : AllocationUsage[0..*] ordered subsets ownedConnection;
-			derived ref item ownedAction : ActionUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedState : StateUsage[0..*] ordered subsets ownedAction;
-			derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage;
-			derived ref item ownedCalculation : CalculationUsage[0..*] ordered subsets ownedAction;
-			derived ref item ownedConstraint : ConstraintUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedRequirement : RequirementUsage[0..*] ordered subsets ownedConstraint;
-			derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement;
-			derived ref item ownedCase : CaseUsage[0..*] ordered subsets ownedCalculation;
-			derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedUseCase : UseCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedView : ViewUsage[0..*] ordered subsets ownedPart;
-			derived ref item ownedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement;
-			derived ref item ownedRendering : RenderingUsage[0..*] ordered subsets ownedPart;
-			derived ref item ownedMetadata : MetadataUsage[0..*] ordered subsets ownedItem;
+			derived ref item 'variant' : Usage[0..*] subsets ownedMember subsets Metadata::metadataItems;
+			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership subsets Metadata::metadataItems;
+			derived ref item usage : Usage[0..*] ordered subsets feature subsets Metadata::metadataItems;
+			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage subsets Metadata::metadataItems;
+			derived ref item ownedUsage : Usage[0..*] ordered subsets ownedFeature, usage subsets Metadata::metadataItems;
+			derived ref item ownedReference : ReferenceUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedAttribute : AttributeUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedEnumeration : EnumerationUsage[0..*] ordered subsets ownedAttribute subsets Metadata::metadataItems;
+			derived ref item ownedOccurrence : OccurrenceUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedItem : ItemUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedPart : PartUsage[0..*] ordered subsets ownedItem subsets Metadata::metadataItems;
+			derived ref item ownedPort : PortUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedConnection : ConnectorAsUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedFlow : FlowUsage[0..*] subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedInterface : InterfaceUsage[0..*] ordered subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedAllocation : AllocationUsage[0..*] ordered subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedAction : ActionUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedState : StateUsage[0..*] ordered subsets ownedAction subsets Metadata::metadataItems;
+			derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedCalculation : CalculationUsage[0..*] ordered subsets ownedAction subsets Metadata::metadataItems;
+			derived ref item ownedConstraint : ConstraintUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedRequirement : RequirementUsage[0..*] ordered subsets ownedConstraint subsets Metadata::metadataItems;
+			derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item ownedCase : CaseUsage[0..*] ordered subsets ownedCalculation subsets Metadata::metadataItems;
+			derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedUseCase : UseCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedView : ViewUsage[0..*] ordered subsets ownedPart subsets Metadata::metadataItems;
+			derived ref item ownedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item ownedRendering : RenderingUsage[0..*] ordered subsets ownedPart subsets Metadata::metadataItems;
+			derived ref item ownedMetadata : MetadataUsage[0..*] ordered subsets ownedItem subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EnumerationDefinition specializes AttributeDefinition {
 			attribute isVariation : Boolean[1..1] redefines isVariation;
 			
-			derived ref item enumeratedValue : EnumerationUsage[0..*] ordered redefines 'variant';
+			derived ref item enumeratedValue : EnumerationUsage[0..*] ordered redefines 'variant' subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EnumerationUsage specializes AttributeUsage {
-			derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition;
+			derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EventOccurrenceUsage specializes OccurrenceUsage {
 			derived attribute isReference : Boolean[1..1] redefines isReference;
 			
-			derived ref item eventOccurrence : OccurrenceUsage[1..1];
+			derived ref item eventOccurrence : OccurrenceUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ExhibitStateUsage specializes StateUsage, PerformActionUsage {
-			derived ref item exhibitedState : StateUsage[1..1] redefines performedAction;
+			derived ref item exhibitedState : StateUsage[1..1] redefines performedAction subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def Expose specializes Import {
@@ -186,16 +186,16 @@ standard library package SysML {
 		}		
 		
 		metadata def FlowDefinition specializes Interaction, ActionDefinition {
-			derived ref item flowEnd : Usage[0..*] redefines associationEnd;
+			derived ref item flowEnd : Usage[0..*] redefines associationEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def FlowUsage specializes ConnectorAsUsage, Flow, ActionUsage {
-			derived ref item flowDefinition : Interaction[0..*] ordered redefines actionDefinition, interaction;
+			derived ref item flowDefinition : Interaction[0..*] ordered redefines actionDefinition, interaction subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ForLoopActionUsage specializes LoopActionUsage {
-			derived ref item seqArgument : Expression[1..1];
-			derived ref item loopVariable : ReferenceUsage[1..1];
+			derived ref item seqArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item loopVariable : ReferenceUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ForkNode specializes ControlNode;		
@@ -203,38 +203,38 @@ standard library package SysML {
 		metadata def FramedConcernMembership specializes RequirementConstraintMembership {
 			attribute kind : RequirementConstraintKind[1..1] redefines kind;
 			
-			derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint;
-			derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint;
+			derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint subsets Metadata::metadataItems;
+			derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def IfActionUsage specializes ActionUsage {
-			derived ref item elseAction : ActionUsage[0..1];
-			derived ref item thenAction : ActionUsage[1..1];
-			derived ref item ifArgument : Expression[1..1];
+			derived ref item elseAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item thenAction : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item ifArgument : Expression[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def IncludeUseCaseUsage specializes UseCaseUsage, PerformActionUsage {
-			derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction;
+			derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction subsets Metadata::metadataItems;
 		}		
 		
 		metadata def InterfaceDefinition specializes ConnectionDefinition {
-			derived ref item interfaceEnd : PortUsage[0..*] ordered redefines connectionEnd;
+			derived ref item interfaceEnd : PortUsage[0..*] ordered redefines connectionEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def InterfaceUsage specializes ConnectionUsage {
-			derived ref item interfaceDefinition : InterfaceDefinition[0..*] redefines connectionDefinition;
+			derived ref item interfaceDefinition : InterfaceDefinition[0..*] redefines connectionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ItemDefinition specializes Structure, OccurrenceDefinition;		
 		
 		metadata def ItemUsage specializes OccurrenceUsage {
-			derived ref item itemDefinition : Structure[0..*] ordered subsets occurrenceDefinition;
+			derived ref item itemDefinition : Structure[0..*] ordered subsets occurrenceDefinition subsets Metadata::metadataItems subsets Metadata::metadataItems;
 		}		
 		
 		metadata def JoinNode specializes ControlNode;		
 		
 		abstract metadata def LoopActionUsage specializes ActionUsage {
-			derived ref item bodyAction : ActionUsage[1..1];
+			derived ref item bodyAction : ActionUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def MembershipExpose specializes MembershipImport, Expose;		
@@ -244,13 +244,13 @@ standard library package SysML {
 		metadata def MetadataDefinition specializes ItemDefinition, Metaclass;		
 		
 		metadata def MetadataUsage specializes ItemUsage, MetadataFeature {
-			derived ref item metadataDefinition : Metaclass[0..1] redefines itemDefinition, metaclass;
+			derived ref item metadataDefinition : Metaclass[0..1] redefines itemDefinition, metaclass subsets Metadata::metadataItems;
 		}		
 		
 		metadata def NamespaceExpose specializes Expose, NamespaceImport;		
 		
 		metadata def ObjectiveMembership specializes FeatureMembership {
-			derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature;
+			derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def OccurrenceDefinition specializes Definition, Class {
@@ -261,31 +261,31 @@ standard library package SysML {
 			attribute isIndividual : Boolean[1..1];
 			attribute portionKind : PortionKind[0..1];
 			
-			derived ref item occurrenceDefinition : Class[0..*] ordered redefines definition;
-			derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition;
+			derived ref item occurrenceDefinition : Class[0..*] ordered redefines definition subsets Metadata::metadataItems;
+			derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PartDefinition specializes ItemDefinition;		
 		
 		metadata def PartUsage specializes ItemUsage {
-			derived ref item partDefinition : PartDefinition[0..*] ordered subsets itemDefinition;
+			derived ref item partDefinition : PartDefinition[0..*] ordered subsets itemDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PerformActionUsage specializes ActionUsage, EventOccurrenceUsage {
-			derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence;
+			derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortConjugation specializes Conjugation {
-			ref item originalPortDefinition : PortDefinition[1..1] redefines originalType;
-			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType;
+			ref item originalPortDefinition : PortDefinition[1..1] redefines originalType subsets Metadata::metadataItems;
+			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortDefinition specializes OccurrenceDefinition, Structure {
-			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember;
+			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortUsage specializes OccurrenceUsage {
-			derived ref item portDefinition : PortDefinition[0..*] ordered redefines occurrenceDefinition;
+			derived ref item portDefinition : PortDefinition[0..*] ordered redefines occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		enum def PortionKind {
@@ -298,11 +298,11 @@ standard library package SysML {
 		}		
 		
 		metadata def RenderingDefinition specializes PartDefinition {
-			derived ref item 'rendering' : RenderingUsage[0..*] ordered subsets usage;
+			derived ref item 'rendering' : RenderingUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RenderingUsage specializes PartUsage {
-			derived ref item renderingDefinition : RenderingDefinition[0..1] redefines partDefinition;
+			derived ref item renderingDefinition : RenderingDefinition[0..1] redefines partDefinition subsets Metadata::metadataItems;
 		}		
 		
 		enum def RequirementConstraintKind {
@@ -313,64 +313,64 @@ standard library package SysML {
 		metadata def RequirementConstraintMembership specializes FeatureMembership {
 			attribute kind : RequirementConstraintKind[1..1];
 			
-			derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature;
-			derived ref item referencedConstraint : ConstraintUsage[1..1];
+			derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
+			derived ref item referencedConstraint : ConstraintUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementDefinition specializes ConstraintDefinition {
 			attribute reqId : String[0..1] redefines declaredShortName;
 			derived attribute text : String[0..*];
 			
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementUsage specializes ConstraintUsage {
 			attribute reqId : String[0..1] redefines declaredShortName;
 			derived attribute text : String[0..*];
 			
-			derived ref item requirementDefinition : RequirementDefinition[0..1] redefines constraintDefinition;
-			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item requirementDefinition : RequirementDefinition[0..1] redefines constraintDefinition subsets Metadata::metadataItems;
+			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementVerificationMembership specializes RequirementConstraintMembership {
 			attribute kind : RequirementConstraintKind[1..1] redefines kind;
 			
-			derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint;
-			derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint;
+			derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint subsets Metadata::metadataItems;
+			derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SatisfyRequirementUsage specializes RequirementUsage, AssertConstraintUsage {
-			derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint;
-			derived ref item satisfyingFeature : Feature[1..1];
+			derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint subsets Metadata::metadataItems;
+			derived ref item satisfyingFeature : Feature[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SendActionUsage specializes ActionUsage {
-			derived ref item receiverArgument : Expression[0..1];
-			derived ref item payloadArgument : Expression[1..1];
-			derived ref item senderArgument : Expression[0..1];
+			derived ref item receiverArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item payloadArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item senderArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StakeholderMembership specializes ParameterMembership {
-			derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter;
+			derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StateDefinition specializes ActionDefinition {
 			attribute isParallel : Boolean[1..1];
 			
-			derived ref item 'state' : StateUsage[0..*] ordered subsets 'action';
-			derived ref item entryAction : ActionUsage[0..1];
-			derived ref item doAction : ActionUsage[0..1];
-			derived ref item exitAction : ActionUsage[0..1];
+			derived ref item 'state' : StateUsage[0..*] ordered subsets 'action' subsets Metadata::metadataItems;
+			derived ref item entryAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item doAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item exitAction : ActionUsage[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		enum def StateSubactionKind {
@@ -382,20 +382,20 @@ standard library package SysML {
 		metadata def StateSubactionMembership specializes FeatureMembership {
 			attribute kind : StateSubactionKind[1..1];
 			
-			derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature;
+			derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StateUsage specializes ActionUsage {
 			attribute isParallel : Boolean[1..1];
 			
-			derived ref item stateDefinition : Behavior[0..*] ordered redefines actionDefinition;
-			derived ref item entryAction : ActionUsage[0..1];
-			derived ref item doAction : ActionUsage[0..1];
-			derived ref item exitAction : ActionUsage[0..1];
+			derived ref item stateDefinition : Behavior[0..*] ordered redefines actionDefinition subsets Metadata::metadataItems;
+			derived ref item entryAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item doAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item exitAction : ActionUsage[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SubjectMembership specializes ParameterMembership {
-			derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter;
+			derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SuccessionAsUsage specializes ConnectorAsUsage, Succession;		
@@ -403,7 +403,7 @@ standard library package SysML {
 		metadata def SuccessionFlowUsage specializes SuccessionFlow, FlowUsage;		
 		
 		metadata def TerminateActionUsage specializes ActionUsage {
-			derived ref item terminatedOccurrenceArgument : Expression[0..1];
+			derived ref item terminatedOccurrenceArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		enum def TransitionFeatureKind {
@@ -415,16 +415,16 @@ standard library package SysML {
 		metadata def TransitionFeatureMembership specializes FeatureMembership {
 			attribute kind : TransitionFeatureKind[1..1];
 			
-			derived item transitionFeature : Step[1..1] redefines ownedMemberFeature;
+			derived item transitionFeature : Step[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def TransitionUsage specializes ActionUsage {
-			derived ref item source : ActionUsage[1..1];
-			derived ref item target : ActionUsage[1..1];
-			derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature;
-			derived ref item guardExpression : Expression[0..*] subsets ownedFeature;
-			derived ref item effectAction : ActionUsage[0..*] subsets feature;
-			derived ref item 'succession' : Succession[1..1] subsets ownedMember;
+			derived ref item source : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item target : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item guardExpression : Expression[0..*] subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item effectAction : ActionUsage[0..*] subsets feature subsets Metadata::metadataItems;
+			derived ref item 'succession' : Succession[1..1] subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def TriggerInvocationExpression specializes InvocationExpression {
@@ -442,96 +442,96 @@ standard library package SysML {
 			derived attribute mayTimeVary : Boolean[1..1] redefines isVariable;
 			derived attribute isReference : Boolean[1..1];
 			
-			derived ref item 'variant' : Usage[0..*] subsets ownedMember;
-			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
-			derived ref item owningDefinition : Definition[0..1] subsets owningType;
-			derived ref item owningUsage : Usage[0..1] subsets owningType;
-			derived ref item definition : Classifier[0..*] ordered redefines type;
-			derived ref item usage : Usage[0..*] ordered subsets feature;
-			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage;
-			derived ref item nestedUsage : Usage[0..*] ordered subsets ownedFeature, usage;
-			derived ref item nestedReference : ReferenceUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedAttribute : AttributeUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedEnumeration : EnumerationUsage[0..*] ordered subsets nestedAttribute;
-			derived ref item nestedOccurrence : OccurrenceUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedItem : ItemUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedPart : PartUsage[0..*] ordered subsets nestedItem;
-			derived ref item nestedPort : PortUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedConnection : ConnectorAsUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedFlow : FlowUsage[0..*] subsets nestedConnection;
-			derived ref item nestedInterface : InterfaceUsage[0..*] ordered subsets nestedConnection;
-			derived ref item nestedAllocation : AllocationUsage[0..*] ordered subsets nestedConnection;
-			derived ref item nestedAction : ActionUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedState : StateUsage[0..*] ordered subsets nestedAction;
-			derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage;
-			derived ref item nestedCalculation : CalculationUsage[0..*] ordered subsets nestedAction;
-			derived ref item nestedConstraint : ConstraintUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedRequirement : RequirementUsage[0..*] ordered subsets nestedConstraint;
-			derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement;
-			derived ref item nestedCase : CaseUsage[0..*] ordered subsets nestedCalculation;
-			derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedUseCase : UseCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedView : ViewUsage[0..*] ordered subsets nestedPart;
-			derived ref item nestedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement;
-			derived ref item nestedRendering : RenderingUsage[0..*] ordered subsets nestedPart;
-			derived ref item nestedMetadata : MetadataUsage[0..*] ordered subsets nestedItem;
+			derived ref item 'variant' : Usage[0..*] subsets ownedMember subsets Metadata::metadataItems;
+			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership subsets Metadata::metadataItems;
+			derived ref item owningDefinition : Definition[0..1] subsets owningType subsets Metadata::metadataItems;
+			derived ref item owningUsage : Usage[0..1] subsets owningType subsets Metadata::metadataItems;
+			derived ref item definition : Classifier[0..*] ordered redefines type subsets Metadata::metadataItems;
+			derived ref item usage : Usage[0..*] ordered subsets feature subsets Metadata::metadataItems;
+			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage subsets Metadata::metadataItems;
+			derived ref item nestedUsage : Usage[0..*] ordered subsets ownedFeature, usage subsets Metadata::metadataItems;
+			derived ref item nestedReference : ReferenceUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedAttribute : AttributeUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedEnumeration : EnumerationUsage[0..*] ordered subsets nestedAttribute subsets Metadata::metadataItems;
+			derived ref item nestedOccurrence : OccurrenceUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedItem : ItemUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedPart : PartUsage[0..*] ordered subsets nestedItem subsets Metadata::metadataItems;
+			derived ref item nestedPort : PortUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedConnection : ConnectorAsUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedFlow : FlowUsage[0..*] subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedInterface : InterfaceUsage[0..*] ordered subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedAllocation : AllocationUsage[0..*] ordered subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedAction : ActionUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedState : StateUsage[0..*] ordered subsets nestedAction subsets Metadata::metadataItems;
+			derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedCalculation : CalculationUsage[0..*] ordered subsets nestedAction subsets Metadata::metadataItems;
+			derived ref item nestedConstraint : ConstraintUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedRequirement : RequirementUsage[0..*] ordered subsets nestedConstraint subsets Metadata::metadataItems;
+			derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item nestedCase : CaseUsage[0..*] ordered subsets nestedCalculation subsets Metadata::metadataItems;
+			derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedUseCase : UseCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedView : ViewUsage[0..*] ordered subsets nestedPart subsets Metadata::metadataItems;
+			derived ref item nestedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item nestedRendering : RenderingUsage[0..*] ordered subsets nestedPart subsets Metadata::metadataItems;
+			derived ref item nestedMetadata : MetadataUsage[0..*] ordered subsets nestedItem subsets Metadata::metadataItems;
 		}		
 		
 		metadata def UseCaseDefinition specializes CaseDefinition {
-			derived ref item includedUseCase : UseCaseUsage[0..*] ordered;
+			derived ref item includedUseCase : UseCaseUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def UseCaseUsage specializes CaseUsage {
-			derived ref item useCaseDefinition : UseCaseDefinition[0..1] redefines caseDefinition;
-			derived ref item includedUseCase : UseCaseUsage[0..*] ordered;
+			derived ref item useCaseDefinition : UseCaseDefinition[0..1] redefines caseDefinition subsets Metadata::metadataItems;
+			derived ref item includedUseCase : UseCaseUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VariantMembership specializes OwningMembership {
-			derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement;
+			derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VerificationCaseDefinition specializes CaseDefinition {
-			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered;
+			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VerificationCaseUsage specializes CaseUsage {
-			derived ref item verificationCaseDefinition : VerificationCaseDefinition[0..1] subsets caseDefinition;
-			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered;
+			derived ref item verificationCaseDefinition : VerificationCaseDefinition[0..1] subsets caseDefinition subsets Metadata::metadataItems;
+			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewDefinition specializes PartDefinition {
-			derived ref item 'view' : ViewUsage[0..*] ordered subsets usage;
-			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement;
-			derived ref item viewRendering : RenderingUsage[0..1];
-			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember;
+			derived ref item 'view' : ViewUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item viewRendering : RenderingUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewRenderingMembership specializes FeatureMembership {
-			derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature;
-			derived ref item referencedRendering : RenderingUsage[1..1];
+			derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
+			derived ref item referencedRendering : RenderingUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewUsage specializes PartUsage {
-			derived ref item viewDefinition : ViewDefinition[0..1] redefines partDefinition;
-			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement;
-			derived ref item exposedElement : Element[0..*] ordered subsets member;
-			derived ref item viewRendering : RenderingUsage[0..1];
-			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember;
+			derived ref item viewDefinition : ViewDefinition[0..1] redefines partDefinition subsets Metadata::metadataItems;
+			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item exposedElement : Element[0..*] ordered subsets member subsets Metadata::metadataItems;
+			derived ref item viewRendering : RenderingUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewpointDefinition specializes RequirementDefinition {
-			derived ref item viewpointStakeholder : PartUsage[0..*] ordered;
+			derived ref item viewpointStakeholder : PartUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewpointUsage specializes RequirementUsage {
-			derived ref item viewpointDefinition : ViewpointDefinition[0..1] redefines requirementDefinition;
-			derived ref item viewpointStakeholder : PartUsage[0..*] ordered;
+			derived ref item viewpointDefinition : ViewpointDefinition[0..1] redefines requirementDefinition subsets Metadata::metadataItems;
+			derived ref item viewpointStakeholder : PartUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def WhileLoopActionUsage specializes LoopActionUsage {
-			derived ref item whileArgument : Expression[1..1];
-			derived ref item untilArgument : Expression[0..1];
+			derived ref item whileArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item untilArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 	}

--- a/org.omg.sysml.xpect.tests/library.systems/Views.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Views.sysml
@@ -14,21 +14,21 @@ standard library package Views {
 		ref view :>> self : View;
 		
 		abstract ref view subviews : View[0..*] :> views {
-		doc
-		/*
-		 * Other Views that are used in the rendering of this View.
-		 */
+    		doc
+    		/*
+    		 * Other Views that are used in the rendering of this View.
+    		 */
 		}
 		
 		abstract ref rendering viewRendering : Rendering[0..1] {
-		doc
+            doc
 			/*
 			 * The rendering of this View.
 			 */
 		}
 		
 		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] :> viewpointChecks, checkedConstraints {
-		doc
+            doc
 			/*
 			 * Checks that the View satisfies all required ViewpointUsages.
 			 */
@@ -39,12 +39,13 @@ standard library package Views {
 			/*
 			 * An assertion that all viewpointSatisfactions are true.
 			 */
-		
+			 
 			require viewpointSatisfactions {
 				doc
 				/*
 				 * The required ViewpointChecks.
 				 */
+                ref :>> ownedPerformances::this, subperformances::this default that.that;
 			}
 		}
 	}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/PartTest.sysml.xt
@@ -34,20 +34,34 @@ package PartTest {
 	public part def A {
 		part <'1'> b: B;
 		protected port c: C;
-		attribute x;
-		derived ref attribute y :> x;
+		constant attribute x;
+		derived constant ref attribute y :> x;
+		ref z;
 	}
+	
+	item def S;
 	
 	abstract part def <xx> B {
 		public abstract part a: A;
-		port x: ~C;
+		public abstract part b subsets a;
+		public abstract part c subsets a;
+		port x: ~C {
+		    port p;
+		    ref port q;
+		}
 		package P { }
 	}
 	
 	private port def C {
-		private in ref y: A, B;
+		private in ref y: A, B {
+		    part B_b redefines B::b;
+		    part B_c redefines B::c;
+		    port B_x redefines B::x;
+		}
 		alias z1 for y;
 		alias z2 for y;
+		port c1 : C;
+		ref port c2 : C;
 	}
 	
     part p1 :> p2;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ActionUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ActionUsage_invalid.sysml.xt
@@ -37,8 +37,18 @@ package pkg {
 	action def AnActivity;
 	action def B {
 		// XPECT errors --> "An action must be typed by action definitions." at "action a: ABlock;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Part" at "action a: ABlock;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "action a: ABlock;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "action a: ABlock;"
+		--- */
 		action a: ABlock;
 		// XPECT errors --> "An action must be typed by action definitions." at "action b: ABlock, AnActivity;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Part" at "action b: ABlock, AnActivity;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "action b: ABlock, AnActivity;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "action b: ABlock, AnActivity;"
+		--- */
 		action b: ABlock, AnActivity;
 	}
 	
@@ -48,5 +58,13 @@ package pkg {
 	perform b;
 	
 	// XPECT errors --> "An action must be typed by action definitions." at "perform b.a;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Part" at "perform b.a;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "perform b.a;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "perform b.a;"
+		   "Duplicate of inherited member name 'self' from Action, Part" at "b.a"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "b.a"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "b.a"
+		--- */
 	perform b.a;
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/AttributeUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/AttributeUsage_invalid.sysml.xt
@@ -47,13 +47,15 @@ package 'ValueProperty Example' {
 		--- */
 		attribute a : A;
 		// XPECT errors --> "An attribute must be typed by attribute definitions." at "attribute b : A::a;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "attribute b : A::a;"
 		attribute b : A::a;
 		//* XPECT errors ---
 			"An attribute must be typed by attribute definitions." at "attribute s : P;"
 			"Features must have at least one type" at "attribute s : P;"
 		--- */
 		attribute s : P;
-		//XPECT errors --> "An attribute must be typed by attribute definitions." at "attribute un : A::p;"
+		// XPECT errors --> "An attribute must be typed by attribute definitions." at "attribute un : A::p;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Port" at "attribute un : A::p;"
 		attribute un: A::p;
 		//* XPECT errors ---
 			"An attribute must be typed by attribute definitions." at "attribute n: AB;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CalculationUsage_Invalid1.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CalculationUsage_Invalid1.sysml.xt
@@ -45,11 +45,21 @@ package pkg {
 	 	/* XPECT errors --- 
 	 	   "A calculation must be typed by one calculation definition." at "calc f2 : A;"
 		--- */ 
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Calculation, Part" at "calc f2 : A;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "calc f2 : A;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "calc f2 : A;"
+		--- */
     	calc f2: A;
     	/* XPECT errors --- 
     	   "A calculation must be typed by one calculation definition." at "calc f3 : f2;"
     		"Features must have at least one type" at "calc f3 : f2;"
 		--- */ 
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Calculation, Part" at "calc f3 : f2;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "calc f3 : f2;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "calc f3 : f2;"
+		--- */
     	calc f3: f2;
     	/* XPECT errors --- 
     	   "A calculation must be typed by one calculation definition." at "calc f4 : A::f1;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/CaseUsage_Invalid.sysml.xt
@@ -59,6 +59,11 @@ package pkg {
 		// XPECT errors ---> "A case must be typed by one case definition." at "case c1: C1, C2;"
 	 	case c1: C1, C2;
 	 	// XPECT errors ---> "A case must be typed by one case definition." at "case c2: A;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Case, Part" at "case c2: A;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "case c2: A;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "case c2: A;"
+		--- */
     	case c2: A;
     	
  	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac1: C1;"
@@ -66,6 +71,11 @@ package pkg {
  	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac2: AC1, AC2;"
     	analysis ac2: AC1, AC2;
  	 	// XPECT errors ---> "An analysis case must be typed by one analysis case definition." at "analysis ac3: B;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from AnalysisCase, Part" at "analysis ac3: B;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "analysis ac3: B;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "analysis ac3: B;"
+		--- */
     	analysis ac3: B;
     	
  	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc1: C1;"
@@ -73,6 +83,11 @@ package pkg {
  	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc2: UC1, UC2;"
     	use case uc2: UC1, UC2;
  	 	// XPECT errors ---> "A use case must be typed by one use case definition." at "use case uc3: B;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Part, UseCase" at "use case uc3: B;"
+		   "Duplicate of inherited member name 'start' from Part, UseCase" at "use case uc3: B;"
+		   "Duplicate of inherited member name 'done' from Part, UseCase" at "use case uc3: B;"
+		--- */
     	use case uc3: B;
    	}
    	

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ConstraintUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ConstraintUsage_Invalid.sysml.xt
@@ -35,8 +35,10 @@ package pkg {
 	constraint def AConstraint1;
 	part def ABlock {
 		// XPECT errors ---> "A constraint must be typed by one constraint definition." at "assert constraint two_types : AConstraint, ABlock;"
+		// XPECT warnings ---> "Duplicate of inherited member name 'self' from ConstraintCheck, Part" at "assert constraint two_types : AConstraint, ABlock;"
 		assert constraint two_types : AConstraint, ABlock;
 		// XPECT errors ---> "A constraint must be typed by one constraint definition." at "assert constraint aConstraint0 : ABlock;"
+		// XPECT warnings ---> "Duplicate of inherited member name 'self' from ConstraintCheck, Part" at "assert constraint aConstraint0: ABlock;"
 		assert constraint aConstraint0: ABlock;
 		//XPECT errors ---> "A constraint must be typed by one constraint definition." at "assert constraint aConstraint1 : AConstraint, AConstraint1;"
 		assert constraint aConstraint1 : AConstraint, AConstraint1;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/FlowConnectionUsage_Invalid.sysml.xt
@@ -64,8 +64,18 @@ package P {
 		message : F, G from b to c;
 		
 		// XPECT errors --> "A flow connection must be typed by flow connection definitions." at "message :A from b to c;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Part" at "message :A from b to c;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "message :A from b to c;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "message :A from b to c;"
+		--- */
 		message :A from b to c;
 		// XPECT errors --> "A flow connection must be typed by flow connection definitions." at "message :apart from b to c;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Part" at "message :apart from b to c;"
+		   "Duplicate of inherited member name 'start' from Action, Part" at "message :apart from b to c;"
+		   "Duplicate of inherited member name 'done' from Action, Part" at "message :apart from b to c;"
+		--- */
 		message :apart from b to c;
 	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/InterfaceUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/InterfaceUsage_Invalid.sysml.xt
@@ -78,6 +78,7 @@ package 'Interface Example' {
 		interface opposite1 : fi connect eng.engineFuelPort to tankAssy.fuelTankPort; 
 		interface bad {
 			//XPECT errors --> "An interface end must be a port." at "end part ::> tankAssy.fuel;"
+			// XPECT warnings ---> "Duplicate of inherited member name 'self' from Part, Port" at "end part ::> tankAssy.fuel;"
 			end part ::> tankAssy.fuel;
 			end port ::> eng.engineFuelPort;
 		}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ItemUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/ItemUsage_invalid.sysml.xt
@@ -38,14 +38,23 @@ package pkg {
 	public import ScalarValues::*;
 	item def A {
 		// XPECT errors --> "An item must be typed by item definitions." at "item i1: Real;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Item" at "item i1: Real;"
 		item i1: Real;
 		// XPECT errors --> "An item must be typed by item definitions." at "item i2: att;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Item" at "item i2: att;"
 		item i2: att;
 		// XPECT errors --> "An item must be typed by item definitions." at "item i3: act;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Action, Item" at "item i3: act;"
+		   "Duplicate of inherited member name 'start' from Action, Item" at "item i3: act;"
+		   "Duplicate of inherited member name 'done' from Action, Item" at "item i3: act;"
+		--- */
 		item i3: act;
 		// XPECT errors --> "An item must be typed by item definitions." at "item i4: AttDef;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Item" at "item i4: AttDef;"
 		item i4: AttDef;
 		// XPECT errors ---> "An item must be typed by item definitions." at "item i5: PartDef::aPort;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from Item, Port" at "item i5: PartDef::aPort;"
 		item i5: PartDef::aPort;
 		/* XPECT errors ---
 		 "An item must be typed by item definitions." at "item i6: PartDef::aPart;"
@@ -53,6 +62,7 @@ package pkg {
 		--- */
 		item i6: PartDef::aPart;
 		// XPECT errors --> "An item must be typed by item definitions." at "item i7: PartDef, AttDef;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "item i7: PartDef, AttDef;"
 		item i7: PartDef, AttDef;
 	}
 	attribute def AttDef;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Membership_distingushability_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/Membership_distingushability_invalid.sysml.xt
@@ -39,7 +39,7 @@ package pkg {
 	}
 	part def B {}
 	part a : A {
-		//XPECT warnings --> "Duplicate of inherited member name b from A" at "b"
+		//XPECT warnings --> "Duplicate of inherited member name 'b' from A" at "b"
 		part b: B;
 		part redefines c;
 	}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/OccurrenceUsage_invalid.sysml.xt
@@ -38,10 +38,13 @@ package pkg {
 	public import ScalarValues::*;
 	occurrence def A {
 		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence areal: Real;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "occurrence areal: Real;"
 		occurrence areal: Real;
 		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence avalue :> aValue;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "occurrence avalue :> aValue;"
 		occurrence avalue:> aValue;
 		// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "occurrence twoTypes: PartDef, Real;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "occurrence twoTypes: PartDef, Real;"
 		occurrence twoTypes: PartDef, Real;
 	}
 	attribute aValue: Real;
@@ -53,5 +56,9 @@ package pkg {
 	event a;
 
 	// XPECT errors --> "An occurrence must be typed by occurrence definitions." at "event a.areal;"
+	//* XPECT warnings ---
+	   "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "event a.areal;"
+	   "Duplicate of inherited member name 'self' from DataValue, Occurrence" at "a.areal"
+	--- */
 	event a.areal;	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PartUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PartUsage_invalid.sysml.xt
@@ -38,21 +38,31 @@ package pkg {
 	public import ScalarValues::*;
 	part def A {
 		// XPECT errors --> "A part must be typed by item definitions." at "part p1: Real;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "part p1: Real;"
 		part p1: Real;
 		// XPECT errors --> "A part must be typed by item definitions." at "part p2: att;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "part p2: att;"
 		part p2: att;
 		// XPECT errors --> "A part must be typed by item definitions." at "part p3: act;"
+		//* XPECT warnings ---
+		 "Duplicate of inherited member name 'self' from Action, Part" at "part p3: act;"
+		 "Duplicate of inherited member name 'start' from Action, Part" at "part p3: act;"
+		 "Duplicate of inherited member name 'done' from Action, Part" at "part p3: act;"
+		--- */
 		part p3: act;
 		// XPECT errors --> "A part must be typed by item definitions." at "part p4: AttDef;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "part p4: AttDef;"
 		part p4: AttDef;
 		// XPECT errors --> "A part must be typed by item definitions." at "part p5: PartDef::aPort;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from Part, Port" at "part p5: PartDef::aPort;"
 		part p5: PartDef::aPort;
-		/* XPECT errors ---
+		//* XPECT errors ---
 		 "A part must be typed by item definitions." at "part p6: PartDef::aPart;"
 		 "Features must have at least one type" at "part p6: PartDef::aPart;"
 		--- */
 		part p6: PartDef::aPart;
 		// XPECT errors --> "A part must be typed by item definitions." at "part p7: PartDef, AttDef;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Part" at "part p7: PartDef, AttDef;"
 		part p7: PartDef, AttDef;
 	}
 	attribute def AttDef;

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PortUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/PortUsage_Invalid.sysml.xt
@@ -38,8 +38,10 @@ package 'Port Example' {
 	port def pd2;
 	part def FA {
 		// XPECT errors --> "A port must be typed by port definitions." at "port p1 : B;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from Part, Port" at "port p1 : B;"
 		port p1 : B;
 		// XPECT errors --> "A port must be typed by port definitions." at "port p2 : Vt;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, Port" at "port p2 : Vt;"
 		port p2 : Vt;
 
 		port two_port_def_types: pd1, pd2 {
@@ -51,6 +53,7 @@ package 'Port Example' {
 	}
 	part f: FA {
 		// XPECT errors --> "A port must be typed by port definitions." at "port pp redefines p1;"
+		// XPECT warnings --> "Duplicate of inherited member name 'self' from Part, Port" at "port pp redefines p1;"
 		port pp redefines p1;
 	}
 	port def OutPort {

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RedefinitionDiamond1_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RedefinitionDiamond1_invalid.sysml.xt
@@ -37,7 +37,7 @@ package RedefinitionDiamond {
 	
 	part B :> A1, A2 {
 		p2 :>> p1; // 2
-// XPECT warnings ---> "Duplicate of inherited member name p from A2" at "p"
+// XPECT warnings ---> "Duplicate of inherited member name 'p' from A2" at "p"
 		part p;
 	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RedefinitionDiamond_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RedefinitionDiamond_Invalid.sysml.xt
@@ -37,7 +37,7 @@ package RedefinitionDiamond {
 	
 	part B :> A1, A2 {
 //		p2 :>> p1; // 2
-// XPECT warnings ---> "Duplicate of inherited member name p from A2" at "p"
+// XPECT warnings ---> "Duplicate of inherited member name 'p' from A2" at "p"
 		part p;
 	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/RequirementUsage_Invalid.sysml.xt
@@ -72,10 +72,12 @@ package 'Requirement Definitions' {
 	//*XPECT errors ---
 		"A requirement must be typed by one requirement definition." at "requirement r13 : A;"
 	---*/
+	// XPECT warnings --> "Duplicate of inherited member name 'self' from Part, RequirementCheck" at "requirement r13 : A;"
 	requirement r13 : A;
 	//*XPECT errors ---
 		"A requirement must be typed by one requirement definition." at "requirement r14 : A::a;"
 	---*/
+	// XPECT warnings --> "Duplicate of inherited member name 'self' from Part, RequirementCheck" at "requirement r14 : A::a;"
 	requirement r14 : A::a;
 	//*XPECT errors ---
 		"A requirement must be typed by one requirement definition." at "requirement r15 : c;"

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/StateUsage_invalid.sysml.xt
@@ -43,11 +43,17 @@ package StateUsage_invalid {
 	part def A;
 	attribute def VT;
 	action ac;
-	//XPECT errors --> "A state must be typed by state definitions." at "state s1 : A;"	
+	// XPECT errors --> "A state must be typed by state definitions." at "state s1 : A;"
+	//* XPECT warnings ---
+	   "Duplicate of inherited member name 'self' from Part, StateAction" at "state s1 : A;"
+	   "Duplicate of inherited member name 'start' from Part, StateAction" at "state s1 : A;"
+	   "Duplicate of inherited member name 'done' from Part, StateAction" at "state s1 : A;"
+	--- */
 	state s1 : A;
-	//XPECT errors --> "A state must be typed by state definitions." at "state s2 : VT;"
+	// XPECT errors --> "A state must be typed by state definitions." at "state s2 : VT;"
+	// XPECT warnings --> "Duplicate of inherited member name 'self' from DataValue, StateAction" at "state s2 : VT;"
 	state s2 : VT;
-	//XPECT errors --> "A state must be typed by state definitions." at "state s3 : ac;"
+	// XPECT errors --> "A state must be typed by state definitions." at "state s3 : ac;"
 	state s3 : ac;
 	
 	state s4 {
@@ -64,6 +70,11 @@ package StateUsage_invalid {
   		exit action c2;
   		
 		//XPECT errors --> "A state must be typed by state definitions." at "state sa : A;"
+		//* XPECT warnings ---
+		   "Duplicate of inherited member name 'self' from Part, StateAction" at "state sa : A;"
+		   "Duplicate of inherited member name 'start' from Part, StateAction" at "state sa : A;"
+		   "Duplicate of inherited member name 'done' from Part, StateAction" at "state sa : A;"
+		--- */
 		state sa : A;
 	}
 	
@@ -73,6 +84,14 @@ package StateUsage_invalid {
 	exhibit s;
 	
 	//XPECT errors --> "A state must be typed by state definitions." at "exhibit s.sa;"
+	//* XPECT warnings ---
+	   "Duplicate of inherited member name 'self' from Part, StateAction" at "exhibit s.sa;"
+	   "Duplicate of inherited member name 'start' from Part, StateAction" at "exhibit s.sa;"
+	   "Duplicate of inherited member name 'done' from Part, StateAction" at "exhibit s.sa;"
+	   "Duplicate of inherited member name 'self' from Part, StateAction" at "s.sa"
+	   "Duplicate of inherited member name 'start' from Part, StateAction" at "s.sa"
+	   "Duplicate of inherited member name 'done' from Part, StateAction" at "s.sa"
+	--- */
 	exhibit s.sa;
 	
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/InterfaceUsage.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/valid/InterfaceUsage.sysml.xt
@@ -12,6 +12,8 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 		File {from ="/library.systems/Ports.sysml"}
 		File {from ="/library.systems/Connections.sysml"}
 		File {from ="/library.systems/Interfaces.sysml"}
+		File {from ="/library.systems/Actions.sysml"}
+		File {from ="/library.systems/Flows.sysml"}
 	}
 	Workspace {
 		JavaProject {
@@ -27,6 +29,8 @@ XPECT_SETUP org.omg.sysml.xpect.tests.validation.valid.SysMLTests
 				File {from ="/library.systems/Ports.sysml"}
 				File {from ="/library.systems/Connections.sysml"}
 				File {from ="/library.systems/Interfaces.sysml"}
+				File {from ="/library.systems/Actions.sysml"}
+				File {from ="/library.systems/Flows.sysml"}
 			}
 		}
 	}
@@ -45,8 +49,8 @@ package 'Interface Example' {
 	
 	port def FuelInPort {
 		attribute temperature : Temp;
-		out ref fuelSupply : Fuel;
-		in ref fuelReturn : Fuel;
+		in ref fuelSupply : Fuel;
+		out ref fuelReturn : Fuel;
 	}
 	
 	part def FuelTankAssembly {
@@ -62,6 +66,8 @@ package 'Interface Example' {
 	interface def FuelInterface {
 		end supplierPort : FuelOutPort;
 		end consumerPort : FuelInPort;
+		flow supplierPort.fuelSupply to consumerPort.fuelSupply;
+		flow consumerPort.fuelReturn to supplierPort.fuelReturn;
 	}
 	
 	part vehicle : Vehicle {	
@@ -72,12 +78,8 @@ package 'Interface Example' {
 		part eng : Engine {
 			port redefines engineFuelPort;
 		}
-		interface original: FuelInterface connect 
+		interface FuelInterface connect 
 			supplierPort ::> tankAssy.fuelTankPort to 
 			consumerPort ::> eng.engineFuelPort;
-		
-		interface opposite : FuelInterface connect 
-			consumerPort ::> eng.engineFuelPort to
-			supplierPort ::> tankAssy.fuelTankPort; 
 	} 
 }

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -56,12 +56,12 @@ standard library package ShapeItems {
 		attribute :>> outerSpaceDimension = 1;
 	}
 
-	abstract item def Path :> StructuredSpaceObject, Curve {
+	abstract item def Path :> StructuredSpaceObject::StructuredCurve {
 		doc
 		/*
 		 * Path is the most general structured Curve.
 		 */
-	
+        
 		item :>> faces [0];
 		item :>> edges [1..*] {
 			item :>> vertices [0..2];
@@ -227,7 +227,7 @@ standard library package ShapeItems {
 		item :>> e4 { attribute :>> length = e2.length; }
 	}
 
-	abstract item def Shell :> StructuredSpaceObject, Surface {
+	abstract item def Shell :> StructuredSpaceObject::StructuredSurface {
 		doc
 		/*
 		 * Shell is the most general structured Surface.
@@ -251,7 +251,10 @@ standard library package ShapeItems {
 		item :>> faces : PlanarSurface [1] {
 			item :>> edges [1];
 		}
-		item :>> edges : Ellipse [1] = shape;
+		item :>> edges : Ellipse [1] = shape {
+            attribute :>> edges::innerSpaceDimension, Ellipse::innerSpaceDimension;
+            ref item :>> edges::vertices, Ellipse::vertices;
+		}
 		item :>> vertices [0];
 	}
 
@@ -265,7 +268,10 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> shape : Circle;
+		item :>> shape : Circle {
+            attribute :>> Disc::shape::semiMajorAxis, Circle::semiMajorAxis;
+            attribute :>> Disc::shape::semiMinorAxis, Circle::semiMinorAxis;
+        }
 		item :>> edges : Circle;
 	}
 
@@ -371,6 +377,7 @@ standard library package ShapeItems {
 		item :>> revolvedCurve: Rectangle [1] {
 			attribute :>> length = rectangleLength;
 			attribute :>> width  = rectangleWidth;
+			attribute :>> revolvedCurve::isClosed, Rectangle::isClosed;
 		}
 	}
 
@@ -390,8 +397,20 @@ standard library package ShapeItems {
 		attribute :>> yoffset [1];
 
 		item :>> faces [2..3];
-		item base : Disc [1] :> faces;
-		item af : Disc [0..1] :> faces;
+		item base : Disc [1] :> faces {        
+            attribute :>> Disc::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Disc::edges, ConeOrCylinder::faces::edges {
+                attribute :>> Disc::edges::innerSpaceDimension, ConeOrCylinder::faces::edges::innerSpaceDimension;
+            }
+            ref :>> Disc::vertices, ConeOrCylinder::faces::vertices;		    
+		}
+		item af : Disc [0..1] :> faces {        
+            attribute :>> Disc::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Disc::edges, ConeOrCylinder::faces::edges {
+                attribute :>> Disc::edges::innerSpaceDimension, ConeOrCylinder::faces::edges::innerSpaceDimension;
+            }
+            ref :>> Disc::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		item cf : Surface [1] :> faces;
 
 		item :>> edges [2..4] = faces.edges;
@@ -452,7 +471,9 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> base : CircularDisc;
+		item :>> base : CircularDisc {
+		    ref :>> base::edges, CircularDisc::edges;
+		}
 	}
 
 	item def RightCircularCone :> CircularCone {
@@ -499,8 +520,12 @@ standard library package ShapeItems {
 		attribute :>> semiMajorAxis [1] = radius;
 		attribute :>> semiMinorAxis [1] = radius;
 
-		item :>> base : CircularDisc;
-		item :>> af : CircularDisc;
+		item :>> base : CircularDisc {
+            ref :>> base::edges, CircularDisc::edges;
+        }
+		item :>> af : CircularDisc {
+            ref :>> af::edges, CircularDisc::edges;
+        }
 	}
 
 	item def RightCircularCylinder :> CircularCylinder {
@@ -521,7 +546,11 @@ standard library package ShapeItems {
 
 		attribute :>> isClosed = true;
 
-		item :>> faces : Polygon [2..*];
+		item :>> faces : Polygon [2..*] {        
+            attribute :>> Polygon::innerSpaceDimension, faces::innerSpaceDimension;
+            ref :>> Polygon::edges, ConeOrCylinder::faces::edges;
+            ref :>> Polygon::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		
 		item :>> edges = faces.edges;
 		
@@ -537,12 +566,24 @@ standard library package ShapeItems {
 		 */
 
 		item :>> faces [5..6];
-		item tf	 : Quadrilateral [1] :> faces;
-		item bf	 : Quadrilateral [1] :> faces;
+		item tf	 : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item bf	 : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		item ff	 : Polygon [1] :> faces { item :>> Polygon::edges, faces::edges [3..4]; }
 		item rf	 : Polygon [1] :> faces { item :>> Polygon::edges, faces::edges [3..4]; }
-		item slf : Quadrilateral [1] :> faces;
-		item srf : Quadrilateral [0..1] :> faces;
+		item slf : Quadrilateral [1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item srf : Quadrilateral [0..1] :> faces {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges;
 		assert constraint { size(edges) == 18 or size(edges) == 24 }
@@ -645,8 +686,14 @@ standard library package ShapeItems {
 	
 
 		item :>> faces [5];
-		item :>> ff : Triangle;
-		item :>> rf : Triangle;
+		item :>> ff : Triangle {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item :>> rf : Triangle {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges [18];
 
@@ -703,8 +750,14 @@ standard library package ShapeItems {
 		 */	
 
 		item :>> faces [6];
-		item :>> ff : Quadrilateral;
-		item :>> rf : Quadrilateral;
+		item :>> ff : Quadrilateral {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
+		item :>> rf : Quadrilateral {        
+            ref :>> Quadrilateral::edges, ConeOrCylinder::faces::edges;
+            ref :>> Quadrilateral::vertices, ConeOrCylinder::faces::vertices;            
+        }
 
 		item :>> edges [24];
 
@@ -781,7 +834,10 @@ standard library package ShapeItems {
 
 		item :>> faces;
 		item base [1] :> faces;
-		item wall : Triangle :> faces;
+		item wall : Triangle :> faces {        
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
+        }
 		attribute wallNumber : Positive = size(wall);
 
 		assert constraint { size(faces) == wallNumber + 1 }
@@ -817,6 +873,8 @@ standard library package ShapeItems {
 		attribute :>> baseWidth [1];
 
 		item :>> base : Triangle {
+            ref :>> Triangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Triangle::vertices, ConeOrCylinder::faces::vertices;            
 			attribute :>> length = Tetrahedron::baseLength;
 			attribute :>> width  = Tetrahedron::baseWidth;
 		}
@@ -832,6 +890,8 @@ standard library package ShapeItems {
 		attribute :>> baseWidth [1];
 
 		item :>> base : Rectangle {
+            ref :>> Rectangle::edges, ConeOrCylinder::faces::edges;
+            ref :>> Rectangle::vertices, ConeOrCylinder::faces::vertices;            
 			attribute :>> length = RectangularPyramid::baseLength;
 			attribute :>> width = RectangularPyramid::baseWidth;
 		}

--- a/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/SpatialItems.sysml
@@ -32,7 +32,7 @@ standard library package SpatialItems {
 			 * A local Clock to be used as the corresponding time reference within this SpatialItem. 
 			 * By default this is the singleton universalClock.
 			 */
-			}
+		}
 		
 		attribute coordinateFrame : ThreeDCoordinateFrame[1] default universalCartesianSpatial3dCoordinateFrame {
             doc
@@ -59,7 +59,15 @@ standard library package SpatialItems {
 			isZeroVector(CurrentPositionOf(originPoint, that))
 		}
 
-		item componentItems : SpatialItem[1..*] :> subitems {
+        item subSpatialItems : SpatialItem[1..*] :> subitems {
+            ref item :>> SpatialItem::localClock, subitems::localClock;
+        }
+        
+        part subSpatialParts : SpatialItem[1..*] :> subSpatialItems, subparts {
+            ref item :>> SpatialItem::localClock, subSpatialItems::localClock, subparts::localClock;
+        }
+
+		item componentItems : SpatialItem[1..*] :> subSpatialItems {
 			doc
 			/*
 			 * A SpatialItem with componentItems is entirely made up of those items (the SpatialItem occurs only
@@ -67,7 +75,7 @@ standard library package SpatialItems {
 			 * coordinate frame as the SpatialItem they make up.  A SpatialItem without componentItems occurs
 			 * on its own, separately from its subitems.
 			 */		
-			item :>> SpatialItem::localClock, subitems::localClock default (that as SpatialItem).localClock;
+			ref item :>> SpatialItem::localClock, subSpatialItems::localClock default (that as SpatialItem).localClock;
 			attribute :>> coordinateFrame {
 				attribute :>> mRefs default (that.that as SpatialItem).coordinateFrame.mRefs;
 				attribute :>> transformation[1] default nullTransformation {
@@ -84,6 +92,10 @@ standard library package SpatialItems {
 			 */
 		
 			item :>> elements : SpatialItem [1..*] = componentItems;
+		}
+		
+		part componentParts : SpatialItem[1..*] :> componentItems, subSpatialParts {
+		    ref item :>> SpatialItem::localClock, componentItems::localClock, subSpatialParts::localClock, subparts::localClock;
 		}
 	}
 

--- a/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SI.sysml
@@ -29,6 +29,9 @@ standard library package SI {
             :>> definition = "temperature in kelvin of pure water at the triple point";
         }
         attribute :>> definitionalQuantityValues = temperatureOfWaterAtTriplePointInK;
+        attribute :>> ThermodynamicTemperatureUnit::quantityDimension, TemperatureDifferenceUnit::quantityDimension {
+            :>> ThermodynamicTemperatureUnit::quantityDimension::quantityPowerFactors, TemperatureDifferenceUnit::quantityDimension::quantityPowerFactors;
+        }
     }
     attribute <mol> mole : AmountOfSubstanceUnit;
     attribute <cd> candela : LuminousIntensityUnit;
@@ -55,7 +58,11 @@ standard library package SI {
     attribute <E> erlang : TrafficIntensityUnit = one;
     attribute <F> farad : CapacitanceUnit = C/V;
     attribute <Gy> gray : AbsorbedDoseUnit = J/kg;
-    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A;
+    attribute <H> henry : PermeanceUnit, InductanceUnit = Wb/A {
+        attribute :>> PermeanceUnit::quantityDimension, InductanceUnit::quantityDimension {
+            :>> PermeanceUnit::quantityDimension::quantityPowerFactors, InductanceUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute <Hart> hartley : InformationContentUnit = one;
     attribute <Hz> hertz : FrequencyUnit = s^-1;
     attribute <J> joule : EnergyUnit = N*m;
@@ -246,7 +253,11 @@ standard library package SI {
     attribute <'mol/kg'> 'mole per kilogram' : MolalityUnit = mol/kg;
     attribute <'mol/L'> 'mole per l' : AmountOfSubstanceConcentrationUnit = mol/L;
     attribute <'mol/m³'> 'mole per cubic metre' : EquilibriumConstantOnConcentrationBasisUnit = mol/m^3;
-    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m;
+    attribute <'N⋅m'> 'newton metre' : MomentOfForceUnit, TorqueUnit = N*m {
+        attribute :>> MomentOfForceUnit::quantityDimension, TorqueUnit::quantityDimension {
+            :>> MomentOfForceUnit::quantityDimension::quantityPowerFactors, TorqueUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute <'N⋅m⋅s'> 'newton metre second' : AngularImpulseUnit = N*m*s;
     attribute <'N⋅m⋅s⁻¹'> 'newton metre second to the power minus 1' : PowerUnit = N*m*s^-1;
     attribute <'N⋅m⁻¹'> 'newton metre to the power minus 1' : SurfaceTensionUnit = N*m^-1;

--- a/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/USCustomaryUnits.sysml
@@ -79,7 +79,12 @@ standard library package <USCU> USCustomaryUnits {
     //attribute <'°F⋅h⋅ft²/(Btu_th⋅in)'> 'degree Fahrenheit hour square foot per British thermal unit (th) inch' : ThermalResistivityUnit = '°F'*h*ft^2/(Btu_th*'in');
     attribute <'°F⋅s/Btu_IT'> 'degree Fahrenheit second per British thermal unit (IT)' : ThermalResistanceUnit = '°F'*s/Btu_IT;
     attribute <'°F⋅s/Btu_th'> 'degree Fahrenheit second per British thermal unit (th)' : ThermalResistanceUnit = '°F'*s/Btu_th;
-    attribute <'°R'> 'degree Rankine' : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; } }
+    attribute <'°R'> 'degree Rankine' : ThermodynamicTemperatureUnit, TemperatureDifferenceUnit { 
+        :>> unitConversion: ConversionByConvention { :>> referenceUnit = K; :>> conversionFactor = 5/9; :>> isExact = true; }
+        :>> ThermodynamicTemperatureUnit::quantityDimension, TemperatureDifferenceUnit::quantityDimension {
+            :>> ThermodynamicTemperatureUnit::quantityDimension::quantityPowerFactors, TemperatureDifferenceUnit::quantityDimension::quantityPowerFactors;
+        }
+    }
     attribute 'fathom (based on US survey foot)' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 1.828804E+00; :>> isExact = false; } }
     attribute <floz> 'fluid ounce (US)' : VolumeUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m^3; :>> conversionFactor = 2.957353E-05; :>> isExact = false; } }
     attribute <ft> 'foot' : LengthUnit { :>> unitConversion: ConversionByConvention { :>> referenceUnit = m; :>> conversionFactor = 3.048E-01; } }

--- a/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
+++ b/sysml.library/Domain Libraries/Requirement Derivation/DerivationConnections.sysml
@@ -26,10 +26,12 @@ standard library package DerivationConnections {
 		 * The single end for the originalRequirement should subset originalRequirement, while
 		 * the rest of the ends should subset derivedRequirements.
 		 */
-		 
-		ref requirement :>> participant {
-			doc /* All the participants in a Derivation must be requirements. */
-		}
+		
+		// Note: This redefinition causes a distinguishibility problem for binary connections, becuse
+		// participant is already redefined for them to limit the multiplicity to 2.
+		// ref requirement :>> participant {
+		//	doc /* All the participants in a Derivation must be requirements. */
+		// }
 		
 		ref requirement originalRequirement[1] :>> originalRequirements :> participant {
 			doc /* The single original requirement. */

--- a/sysml.library/Kernel Libraries/Kernel Function Library/VectorFunctions.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/VectorFunctions.kerml
@@ -179,7 +179,9 @@ standard library package VectorFunctions {
 	}
 	function CartesianThreeVectorOf specializes CartesianVectorOf { 
 		in components: Real[3] ordered nonunique;
-		return : CartesianThreeVectorValue[1];
+		return : CartesianThreeVectorValue[1] {
+		    feature :>> CartesianVectorOf::result::dimension, CartesianThreeVectorValue::dimension;
+		}
 	}
 	
 	feature cartesianZeroVector: CartesianVectorValue[3] =

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/FeatureReferencingPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/FeatureReferencingPerformances.kerml
@@ -133,8 +133,8 @@ standard library package FeatureReferencingPerformances {
 		 */
 		
 		in feature onOccurrence : Evaluation redefines onOccurrence {
-	    	protected monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
-				out result : Anything[*] redefines result, monitoredFeature; 
+	    	protected expr monitoredOccurrence : Evaluation [1] redefines monitoredOccurrence {
+				return result : Anything[*] redefines result, monitoredFeature; 
 			} 
 		} 
 	}
@@ -147,7 +147,9 @@ standard library package FeatureReferencingPerformances {
 		 */	
 		
 	  	in bool redefines onOccurrence {
-	    	protected bool redefines monitoredOccurrence[1];
+	    	protected bool redefines monitoredOccurrence[1] {
+	    	    return result : Boolean [1];
+	    	}
 		}
 		out redefines afterValues : Boolean [1]; 
 		out redefines beforeValues : Boolean [1];	 
@@ -167,10 +169,16 @@ standard library package FeatureReferencingPerformances {
   		feature isToTrue : Boolean [1] default true;
   		out afterValues: Boolean[1] redefines values  = isToTrue;
   		private feature monitor1 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+    		    end feature earlierOccurrence;
+    		    end feature laterOccurrence;
+    		}
   		}
   		private feature monitor2 : BooleanEvaluationResultMonitorPerformance [1] {
-    		feature redefines endWhen : HappensJustBefore;
+    		feature redefines endWhen : HappensJustBefore {
+                end feature earlierOccurrence;
+                end feature laterOccurrence;
+            }
   		}
 
   		private connector : HappensJustBefore from [1] monitor1 to [0..1] monitor2;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
@@ -165,31 +165,46 @@ standard library package Objects {
 		 * inner space dimension of structured space object is the highest of their cells.
 		 */
 
-        abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
-		  { feature cellOrientation : Integer [0..1];
+        abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices { 
+            feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
-		  }
+		}
+		
+		comment about StructuredSurface, StructuredCurve, StructuredPoint
+		/*
+		 * The structures StructuredSurface, StructuredCurve and StructuredPoint provide common, necessary redefinitions of
+		 * innerSpaceDimension. They also provide single types for the StructuredSpaceObject features faces, edges and
+		 * vertices, which avoids problems when these features are related by connectors with ends that have owned
+		 * cross features.
+		 */
+		struct StructuredSurface specializes StructuredSpaceObject, Surface {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Surface::innerSpaceDimension;		    
+		}
+        struct StructuredCurve specializes StructuredSpaceObject, Curve {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Curve::innerSpaceDimension;         
+        }
+        struct StructuredPoint specializes StructuredSpaceObject, Point {
+            feature redefines StructuredSpaceObject::innerSpaceDimension, Point::innerSpaceDimension;         
+        }
 
-		portion feature faces : Surface[0..*] ordered subsets structuredSpaceObjectCells {
-		    feature redefines Surface::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;
-			feature redefines edges subsets StructuredSpaceObject::edges;
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature faces : StructuredSurface[0..*] ordered subsets structuredSpaceObjectCells {
+		    feature redefines that : StructuredSpaceObject;
+			feature redefines edges subsets that.edges;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary; 
 			inv { isEmpty(spaceBoundary) == isEmpty(union(edges, vertices)) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, union(edges, vertices)) }
 		}
 
-		portion feature edges : Curve[0..*] ordered subsets structuredSpaceObjectCells {
-            feature redefines Curve::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;
-			feature redefines vertices subsets StructuredSpaceObject::vertices;
+		portion feature edges : StructuredCurve[0..*] ordered subsets structuredSpaceObjectCells {
+            feature redefines that : StructuredSpaceObject;
+			feature redefines vertices subsets that.vertices;
 			derived feature redefines spaceBoundary;
 			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
 		}
 
-		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells{
-            feature redefines Point::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;		    
-		}
+		portion feature vertices : StructuredPoint[0..*] ordered subsets structuredSpaceObjectCells;
 		
 		derived feature redefines innerSpaceDimension = 
 			if notEmpty(faces) ? 2 else if notEmpty(edges) ? 1 else 0;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Objects.kerml
@@ -165,12 +165,13 @@ standard library package Objects {
 		 * inner space dimension of structured space object is the highest of their cells.
 		 */
 
-		abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
+        abstract portion feature structuredSpaceObjectCells : StructuredSpaceObject[1..*] subsets Occurrence::spaceSlices
 		  { feature cellOrientation : Integer [0..1];
 		    inv { notEmpty(cellOrientation) implies (cellOrientation >= -1 & cellOrientation <= 1) }
 		  }
 
 		portion feature faces : Surface[0..*] ordered subsets structuredSpaceObjectCells {
+		    feature redefines Surface::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;
 			feature redefines edges subsets StructuredSpaceObject::edges;
 			feature redefines vertices subsets StructuredSpaceObject::vertices;
 			derived feature redefines spaceBoundary; 
@@ -179,13 +180,16 @@ standard library package Objects {
 		}
 
 		portion feature edges : Curve[0..*] ordered subsets structuredSpaceObjectCells {
+            feature redefines Curve::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;
 			feature redefines vertices subsets StructuredSpaceObject::vertices;
 			derived feature redefines spaceBoundary;
 			inv { isEmpty(spaceBoundary) == isEmpty(vertices) }
 			inv { notEmpty(spaceBoundary) implies contains(spaceBoundary.unionsOf, vertices) }
 		}
 
-		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells;
+		portion feature vertices : Point[0..*] ordered subsets structuredSpaceObjectCells{
+            feature redefines Point::innerSpaceDimension, structuredSpaceObjectCells::innerSpaceDimension;		    
+		}
 		
 		derived feature redefines innerSpaceDimension = 
 			if notEmpty(faces) ? 2 else if notEmpty(edges) ? 1 else 0;

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Observation.kerml
@@ -92,6 +92,7 @@ standard library package Observation {
 	    	end feature source {
 	    		feature redefines sourceOutput = changeSignal;
 	    	}
+	    	end feature target;
 	    }
 	}
 	

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Occurrences.kerml
@@ -537,16 +537,16 @@ standard library package Occurrences {
 			 * the inner ones.
 			 */
 
-			feature redefines isClosed = true;
+			inv { isClosed == true }
 
 			feature spaceBounder: Occurrence [1] subsets self;
 
-			outer: Occurrence [0..1] subsets spaceSlices {
+			feature outer: Occurrence [0..1] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}
 
-			inner: Occurrence [0..*] subsets spaceSlices {
+			feature inner: Occurrence [0..*] subsets spaceSlices {
 				feature redefines isClosed = true;
 				feature redefines innerSpaceDimension = spaceBounder.innerSpaceDimension;
 			}

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -167,7 +167,7 @@ standard library package Transfers {
         private succession self then target;
     }
     
-    interaction FlowTransferBefore specializes FlowTransfer, TransferBefore intersects FlowTransfer, TransferBefore {
+    interaction FlowTransferBefore specializes TransferBefore, FlowTransfer intersects FlowTransfer, TransferBefore {
         doc
         /*
          * FlowTransferBefore is a FlowTransfer that is also a TransferBefore. 

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -190,7 +190,9 @@ standard library package Actions {
 		 */
 	
 		in :>> payload [0..*];
-	    ref sentMessage :>> sentTransfer: MessageTransfer, MessageAction;
+	    ref sentMessage :>> sentTransfer: MessageTransfer, MessageAction {
+	        in :>> MessageTransfer::payload, MessageAction::payload;
+	    }
 	}
 	
 	abstract action sendActions: SendAction[0..*] nonunique :> actions, sendPerformances {
@@ -207,7 +209,9 @@ standard library package Actions {
 		 * of a designated receiver Occurrence, providing its payload as output.
 		 */
 		inout :>> payload;
-		ref acceptedMessage :>> acceptedTransfer: MessageTransfer, MessageAction;
+		ref acceptedMessage :>> acceptedTransfer: MessageTransfer, MessageAction {
+            in :>> MessageTransfer::payload, MessageAction::payload;
+        }
 	}
 	
 	action def AcceptAction :> AcceptMessageAction {
@@ -330,7 +334,9 @@ standard library package Actions {
 		 */
 	
 		in transitionLinkSource : Action :>> TransitionPerformance::transitionLinkSource;
-		ref acceptedMessage : MessageTransfer, MessageAction :>> trigger;
+		ref acceptedMessage : MessageTransfer, MessageAction :>> trigger {
+            in :>> MessageTransfer::payload, MessageAction::payload;
+        }
 		
 		ref receiver :>> triggerTarget;
 

--- a/sysml.library/Systems Library/Connections.sysml
+++ b/sysml.library/Systems Library/Connections.sysml
@@ -32,7 +32,7 @@ standard library package Connections {
          */
     }
      
-    abstract connection def BinaryConnection :> Connection, BinaryLinkObject {
+    abstract connection def BinaryConnection :> BinaryLinkObject, Connection {
         doc
         /*
          * BinaryConnection is the most general class of binary links between two things 

--- a/sysml.library/Systems Library/Flows.sysml
+++ b/sysml.library/Systems Library/Flows.sysml
@@ -81,7 +81,7 @@ standard library package Flows {
          * It is the base type for FlowUsages that identify their source output and
          * target input.
          */
-        
+         
         end occurrence source: Occurrence :>> Message::source, FlowTransfer::source;
         end occurrence target: Occurrence :>> Message::target, FlowTransfer::target;
     }
@@ -92,6 +92,8 @@ standard library package Flows {
          * SuccessionFlow is a subclass of flowss that appen after their source and 
          * before their target. It is the base type for all SuccessionFlowUsages.
          */
+         
+        ref self : SuccessionFlow :>> Flow::self, FlowTransferBefore::self;
     
         end occurrence source: Occurrence :>> Flow::source, FlowTransferBefore::source;
         end occurrence target: Occurrence :>> Flow::target, FlowTransferBefore::target;

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -72,12 +72,14 @@ standard library package Items {
 		}
 		
 		item boundingShapes : StructuredSpaceObject [0..*] :> envelopingShapes {
-		doc
+            doc
 			/*
 			 * envelopingShapes that are structured space objects with every face or every edge
 			 * intersecting this Item.
 			 */		
-
+            
+            attribute :>> StructuredSpaceObject::innerSpaceDimension, envelopingShapes::innerSpaceDimension;
+            
 			item boundingShape: Item :>> self;
 
 			item :>> faces {

--- a/sysml.library/Systems Library/Items.sysml
+++ b/sysml.library/Systems Library/Items.sysml
@@ -41,20 +41,22 @@ standard library package Items {
 		}
 		
 		item envelopingShapes : Item[0..*] {
-		doc
+            doc
 			/*
 			 * Each enveloping shape is the shape of an Item that spacially overlaps this Item for its
 			 * entire lifetime.
-			 */		
+			 */
+			 
+			ref item envelopedItem :>> that;	
 
-			 /* Enables two dimensional items to be enveloped by two or three dimensional shapes. */
-			attribute :>> innerSpaceDimension = 
-				if (that as Item).innerSpaceDimension == 3  | (that as Item).outerSpaceDimension == 3? 2 
-				else (that as Item).outerSpaceDimension - 1 {
-				doc
-			 	/* 
-			 	 * Enables two dimensional items to be enveloped by two or three dimensional shapes.
-			 	 */				
+			assert constraint { 
+                doc
+                /* 
+                 * Enables two dimensional items to be enveloped by two or three dimensional shapes.
+                 */             
+			    innerSpaceDimension == 
+    				(if envelopedItem.innerSpaceDimension == 3  | envelopedItem.outerSpaceDimension == 3? 2 
+    				else envelopedItem.outerSpaceDimension - 1)
 			}
 			assert constraint { (that as Item).innerSpaceDimension < 3 implies notEmpty(outerSpaceDimension) }
 
@@ -63,7 +65,7 @@ standard library package Items {
 			assert constraint {
 				doc
 				/* 
-				 * This constraint prevents an envelopingShape frombeing a portion.
+				 * This constraint prevents an envelopingShape from being a portion.
 				 */
 				 
 				envelopingItem.shape.spaceTimeCoincidentOccurrences->includes(that) and
@@ -78,17 +80,15 @@ standard library package Items {
 			 * intersecting this Item.
 			 */		
             
-            attribute :>> StructuredSpaceObject::innerSpaceDimension, envelopingShapes::innerSpaceDimension;
-            
-			item boundingShape: Item :>> self;
+			ref item boundingShape: Item :>> self;
 
-			item :>> faces {
-				item face :>> self;
+			private item :>> faces {
+				ref item face :>> self;
 				item inter [1];
 				assert constraint { contains(inter.intersectionsOf, union(face, boundingShape)) }
 			}
-			item :>> edges {
-				item edge :>> self;
+			private item :>> edges {
+				ref item edge :>> self;
 				item inter [1];
 				assert constraint { isEmpty(faces) implies
 							contains(inter.intersectionsOf, union(edge, boundingShape)) }
@@ -114,6 +114,8 @@ standard library package Items {
 			/*
 			 * The Items that are composite subitems of this Item.
 			 */
+			 
+			private ref redefines Item::incomingTransferSort, subobjects::incomingTransferSort;
 		}
 		
 		abstract part subparts: Part[0..*] :> subitems, parts {

--- a/sysml.library/Systems Library/Metadata.sysml
+++ b/sysml.library/Systems Library/Metadata.sysml
@@ -16,6 +16,8 @@ doc
 		 * MetadataItem is the most general class of Items that represent Metaobjects. 
 		 * MetadataItem is the base type of all MetadataDefinitions.
 		 */
+		 
+		 ref self : MetadataItem redefines Metaobject::self, Item::self;
 	}
 	
 	abstract item metadataItems : MetadataItem[0..*] :> metaobjects, items {

--- a/sysml.library/Systems Library/Parts.sysml
+++ b/sysml.library/Systems Library/Parts.sysml
@@ -48,7 +48,7 @@ doc
 			 * Actions that are owned by this Part.
 			 */
 		
-		 	ref part :>> this : Part = that as Part {
+		 	ref part this : Part :>> Action::this, ownedPerformances::this = that as Part {
 				doc
 				/*
 				 * The "this" reference of an ownedAction is always its owning Part.

--- a/sysml.library/Systems Library/Ports.sysml
+++ b/sysml.library/Systems Library/Ports.sysml
@@ -39,6 +39,9 @@ standard library package Ports {
             /* 
              * The target of each of the outgoingTransfersFromSelf of a Port must be an interfacingPort.
              */
+             
+             end ref source;
+             end ref target;
         }
     }
     

--- a/sysml.library/Systems Library/SysML.sysml
+++ b/sysml.library/Systems Library/SysML.sysml
@@ -11,48 +11,48 @@ standard library package SysML {
 		public import KerML::Kernel::*;
 		
 		metadata def AcceptActionUsage specializes ActionUsage {
-			derived ref item receiverArgument : Expression[0..1];
-			derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference, parameter;
-			derived ref item payloadArgument : Expression[0..1];
+			derived ref item receiverArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item payloadParameter : ReferenceUsage[1..1] subsets nestedReference, parameter subsets Metadata::metadataItems;
+			derived ref item payloadArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActionDefinition specializes Behavior, OccurrenceDefinition {
-			derived ref item 'action' : ActionUsage[0..*] ordered subsets step, usage;
+			derived ref item 'action' : ActionUsage[0..*] ordered subsets step, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActionUsage specializes Step, OccurrenceUsage {
-			derived ref item actionDefinition : Behavior[0..*] ordered redefines behavior, occurrenceDefinition;
+			derived ref item actionDefinition : Behavior[0..*] ordered redefines behavior, occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ActorMembership specializes ParameterMembership {
-			derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter;
+			derived item ownedActorParameter : PartUsage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AllocationDefinition specializes ConnectionDefinition {
-			derived ref item 'allocation' : AllocationUsage[0..*] ordered subsets usage;
+			derived ref item 'allocation' : AllocationUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AllocationUsage specializes ConnectionUsage {
-			derived ref item allocationDefinition : AllocationDefinition[0..*] ordered redefines connectionDefinition;
+			derived ref item allocationDefinition : AllocationDefinition[0..*] ordered redefines connectionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AnalysisCaseDefinition specializes CaseDefinition {
-			derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature;
+			derived ref item resultExpression : Expression[0..1] subsets expression, ownedFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AnalysisCaseUsage specializes CaseUsage {
-			derived ref item analysisCaseDefinition : AnalysisCaseDefinition[0..1] redefines caseDefinition;
-			derived ref item resultExpression : Expression[0..1] subsets ownedFeature;
+			derived ref item analysisCaseDefinition : AnalysisCaseDefinition[0..1] redefines caseDefinition subsets Metadata::metadataItems;
+			derived ref item resultExpression : Expression[0..1] subsets ownedFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AssertConstraintUsage specializes ConstraintUsage, Invariant {
-			derived ref item assertedConstraint : ConstraintUsage[1..1];
+			derived ref item assertedConstraint : ConstraintUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AssignmentActionUsage specializes ActionUsage {
-			derived ref item targetArgument : Expression[0..1];
-			derived ref item valueExpression : Expression[0..1];
-			derived ref item referent : Feature[1..1] subsets member;
+			derived ref item targetArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item valueExpression : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item referent : Feature[1..1] subsets member subsets Metadata::metadataItems;
 		}		
 		
 		metadata def AttributeDefinition specializes DataType, Definition;		
@@ -60,56 +60,56 @@ standard library package SysML {
 		metadata def AttributeUsage specializes Usage {
 			derived attribute isReference : Boolean[1..1] redefines isReference;
 			
-			derived ref item attributeDefinition : DataType[0..*] ordered redefines definition;
+			derived ref item attributeDefinition : DataType[0..*] ordered redefines definition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def BindingConnectorAsUsage specializes BindingConnector, ConnectorAsUsage;		
 		
 		metadata def CalculationDefinition specializes Function, ActionDefinition {
-			derived ref item calculation : CalculationUsage[0..*] ordered subsets 'action', expression;
+			derived ref item calculation : CalculationUsage[0..*] ordered subsets 'action', expression subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CalculationUsage specializes Expression, ActionUsage {
-			derived ref item calculationDefinition : Function[0..1] ordered redefines function, actionDefinition;
+			derived ref item calculationDefinition : Function[0..1] ordered redefines function, actionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CaseDefinition specializes CalculationDefinition {
-			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def CaseUsage specializes CalculationUsage {
-			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage;
-			derived ref item caseDefinition : CaseDefinition[0..1] redefines calculationDefinition;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item objectiveRequirement : RequirementUsage[0..1] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item caseDefinition : CaseDefinition[0..1] redefines calculationDefinition subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConcernDefinition specializes RequirementDefinition;		
 		
 		metadata def ConcernUsage specializes RequirementUsage {
-			derived ref item concernDefinition : ConcernDefinition[0..1] redefines requirementDefinition;
+			derived ref item concernDefinition : ConcernDefinition[0..1] redefines requirementDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConjugatedPortDefinition specializes PortDefinition {
-			derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace;
-			derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator;
+			derived ref item originalPortDefinition : PortDefinition[1..1] redefines owningNamespace subsets Metadata::metadataItems;
+			derived ref item ownedPortConjugator : PortConjugation[1..1] redefines ownedConjugator subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConjugatedPortTyping specializes FeatureTyping {
-			ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type;
-			derived ref item portDefinition : PortDefinition[1..1];
+			ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines type subsets Metadata::metadataItems;
+			derived ref item portDefinition : PortDefinition[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConnectionDefinition specializes AssociationStructure, PartDefinition {
 			attribute isSufficient : Boolean[1..1] redefines isSufficient;
 			
-			derived ref item connectionEnd : Usage[0..*] ordered redefines associationEnd;
+			derived ref item connectionEnd : Usage[0..*] ordered redefines associationEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ConnectionUsage specializes ConnectorAsUsage, PartUsage {
-			derived ref item connectionDefinition : AssociationStructure[0..*] ordered subsets itemDefinition redefines association;
+			derived ref item connectionDefinition : AssociationStructure[0..*] ordered subsets itemDefinition redefines association subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def ConnectorAsUsage specializes Usage, Connector;		
@@ -117,7 +117,7 @@ standard library package SysML {
 		metadata def ConstraintDefinition specializes OccurrenceDefinition, Predicate;		
 		
 		metadata def ConstraintUsage specializes BooleanExpression, OccurrenceUsage {
-			derived ref item constraintDefinition : Predicate[0..1] redefines predicate;
+			derived ref item constraintDefinition : Predicate[0..1] redefines predicate subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def ControlNode specializes ActionUsage;		
@@ -127,57 +127,57 @@ standard library package SysML {
 		metadata def Definition specializes Classifier {
 			attribute isVariation : Boolean[1..1];
 			
-			derived ref item 'variant' : Usage[0..*] subsets ownedMember;
-			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
-			derived ref item usage : Usage[0..*] ordered subsets feature;
-			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage;
-			derived ref item ownedUsage : Usage[0..*] ordered subsets ownedFeature, usage;
-			derived ref item ownedReference : ReferenceUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedAttribute : AttributeUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedEnumeration : EnumerationUsage[0..*] ordered subsets ownedAttribute;
-			derived ref item ownedOccurrence : OccurrenceUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedItem : ItemUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedPart : PartUsage[0..*] ordered subsets ownedItem;
-			derived ref item ownedPort : PortUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedConnection : ConnectorAsUsage[0..*] ordered subsets ownedUsage;
-			derived ref item ownedFlow : FlowUsage[0..*] subsets ownedConnection;
-			derived ref item ownedInterface : InterfaceUsage[0..*] ordered subsets ownedConnection;
-			derived ref item ownedAllocation : AllocationUsage[0..*] ordered subsets ownedConnection;
-			derived ref item ownedAction : ActionUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedState : StateUsage[0..*] ordered subsets ownedAction;
-			derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage;
-			derived ref item ownedCalculation : CalculationUsage[0..*] ordered subsets ownedAction;
-			derived ref item ownedConstraint : ConstraintUsage[0..*] ordered subsets ownedOccurrence;
-			derived ref item ownedRequirement : RequirementUsage[0..*] ordered subsets ownedConstraint;
-			derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement;
-			derived ref item ownedCase : CaseUsage[0..*] ordered subsets ownedCalculation;
-			derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedUseCase : UseCaseUsage[0..*] ordered subsets ownedCase;
-			derived ref item ownedView : ViewUsage[0..*] ordered subsets ownedPart;
-			derived ref item ownedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement;
-			derived ref item ownedRendering : RenderingUsage[0..*] ordered subsets ownedPart;
-			derived ref item ownedMetadata : MetadataUsage[0..*] ordered subsets ownedItem;
+			derived ref item 'variant' : Usage[0..*] subsets ownedMember subsets Metadata::metadataItems;
+			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership subsets Metadata::metadataItems;
+			derived ref item usage : Usage[0..*] ordered subsets feature subsets Metadata::metadataItems;
+			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage subsets Metadata::metadataItems;
+			derived ref item ownedUsage : Usage[0..*] ordered subsets ownedFeature, usage subsets Metadata::metadataItems;
+			derived ref item ownedReference : ReferenceUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedAttribute : AttributeUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedEnumeration : EnumerationUsage[0..*] ordered subsets ownedAttribute subsets Metadata::metadataItems;
+			derived ref item ownedOccurrence : OccurrenceUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedItem : ItemUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedPart : PartUsage[0..*] ordered subsets ownedItem subsets Metadata::metadataItems;
+			derived ref item ownedPort : PortUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedConnection : ConnectorAsUsage[0..*] ordered subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedFlow : FlowUsage[0..*] subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedInterface : InterfaceUsage[0..*] ordered subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedAllocation : AllocationUsage[0..*] ordered subsets ownedConnection subsets Metadata::metadataItems;
+			derived ref item ownedAction : ActionUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedState : StateUsage[0..*] ordered subsets ownedAction subsets Metadata::metadataItems;
+			derived ref item ownedTransition : TransitionUsage[0..*] subsets ownedUsage subsets Metadata::metadataItems;
+			derived ref item ownedCalculation : CalculationUsage[0..*] ordered subsets ownedAction subsets Metadata::metadataItems;
+			derived ref item ownedConstraint : ConstraintUsage[0..*] ordered subsets ownedOccurrence subsets Metadata::metadataItems;
+			derived ref item ownedRequirement : RequirementUsage[0..*] ordered subsets ownedConstraint subsets Metadata::metadataItems;
+			derived ref item ownedConcern : ConcernUsage[0..*] subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item ownedCase : CaseUsage[0..*] ordered subsets ownedCalculation subsets Metadata::metadataItems;
+			derived ref item ownedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedVerificationCase : VerificationCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedUseCase : UseCaseUsage[0..*] ordered subsets ownedCase subsets Metadata::metadataItems;
+			derived ref item ownedView : ViewUsage[0..*] ordered subsets ownedPart subsets Metadata::metadataItems;
+			derived ref item ownedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item ownedRendering : RenderingUsage[0..*] ordered subsets ownedPart subsets Metadata::metadataItems;
+			derived ref item ownedMetadata : MetadataUsage[0..*] ordered subsets ownedItem subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EnumerationDefinition specializes AttributeDefinition {
 			attribute isVariation : Boolean[1..1] redefines isVariation;
 			
-			derived ref item enumeratedValue : EnumerationUsage[0..*] ordered redefines 'variant';
+			derived ref item enumeratedValue : EnumerationUsage[0..*] ordered redefines 'variant' subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EnumerationUsage specializes AttributeUsage {
-			derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition;
+			derived ref item enumerationDefinition : EnumerationDefinition[1..1] redefines attributeDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def EventOccurrenceUsage specializes OccurrenceUsage {
 			derived attribute isReference : Boolean[1..1] redefines isReference;
 			
-			derived ref item eventOccurrence : OccurrenceUsage[1..1];
+			derived ref item eventOccurrence : OccurrenceUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ExhibitStateUsage specializes StateUsage, PerformActionUsage {
-			derived ref item exhibitedState : StateUsage[1..1] redefines performedAction;
+			derived ref item exhibitedState : StateUsage[1..1] redefines performedAction subsets Metadata::metadataItems;
 		}		
 		
 		abstract metadata def Expose specializes Import {
@@ -186,16 +186,16 @@ standard library package SysML {
 		}		
 		
 		metadata def FlowDefinition specializes Interaction, ActionDefinition {
-			derived ref item flowEnd : Usage[0..*] redefines associationEnd;
+			derived ref item flowEnd : Usage[0..*] redefines associationEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def FlowUsage specializes ConnectorAsUsage, Flow, ActionUsage {
-			derived ref item flowDefinition : Interaction[0..*] ordered redefines actionDefinition, interaction;
+			derived ref item flowDefinition : Interaction[0..*] ordered redefines actionDefinition, interaction subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ForLoopActionUsage specializes LoopActionUsage {
-			derived ref item seqArgument : Expression[1..1];
-			derived ref item loopVariable : ReferenceUsage[1..1];
+			derived ref item seqArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item loopVariable : ReferenceUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ForkNode specializes ControlNode;		
@@ -203,38 +203,38 @@ standard library package SysML {
 		metadata def FramedConcernMembership specializes RequirementConstraintMembership {
 			attribute kind : RequirementConstraintKind[1..1] redefines kind;
 			
-			derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint;
-			derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint;
+			derived item ownedConcern : ConcernUsage[1..1] redefines ownedConstraint subsets Metadata::metadataItems;
+			derived ref item referencedConcern : ConcernUsage[1..1] redefines referencedConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def IfActionUsage specializes ActionUsage {
-			derived ref item elseAction : ActionUsage[0..1];
-			derived ref item thenAction : ActionUsage[1..1];
-			derived ref item ifArgument : Expression[1..1];
+			derived ref item elseAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item thenAction : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item ifArgument : Expression[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def IncludeUseCaseUsage specializes UseCaseUsage, PerformActionUsage {
-			derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction;
+			derived ref item useCaseIncluded : UseCaseUsage[1..1] redefines performedAction subsets Metadata::metadataItems;
 		}		
 		
 		metadata def InterfaceDefinition specializes ConnectionDefinition {
-			derived ref item interfaceEnd : PortUsage[0..*] ordered redefines connectionEnd;
+			derived ref item interfaceEnd : PortUsage[0..*] ordered redefines connectionEnd subsets Metadata::metadataItems;
 		}		
 		
 		metadata def InterfaceUsage specializes ConnectionUsage {
-			derived ref item interfaceDefinition : InterfaceDefinition[0..*] redefines connectionDefinition;
+			derived ref item interfaceDefinition : InterfaceDefinition[0..*] redefines connectionDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ItemDefinition specializes Structure, OccurrenceDefinition;		
 		
 		metadata def ItemUsage specializes OccurrenceUsage {
-			derived ref item itemDefinition : Structure[0..*] ordered subsets occurrenceDefinition;
+			derived ref item itemDefinition : Structure[0..*] ordered subsets occurrenceDefinition subsets Metadata::metadataItems subsets Metadata::metadataItems;
 		}		
 		
 		metadata def JoinNode specializes ControlNode;		
 		
 		abstract metadata def LoopActionUsage specializes ActionUsage {
-			derived ref item bodyAction : ActionUsage[1..1];
+			derived ref item bodyAction : ActionUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def MembershipExpose specializes MembershipImport, Expose;		
@@ -244,13 +244,13 @@ standard library package SysML {
 		metadata def MetadataDefinition specializes ItemDefinition, Metaclass;		
 		
 		metadata def MetadataUsage specializes ItemUsage, MetadataFeature {
-			derived ref item metadataDefinition : Metaclass[0..1] redefines itemDefinition, metaclass;
+			derived ref item metadataDefinition : Metaclass[0..1] redefines itemDefinition, metaclass subsets Metadata::metadataItems;
 		}		
 		
 		metadata def NamespaceExpose specializes Expose, NamespaceImport;		
 		
 		metadata def ObjectiveMembership specializes FeatureMembership {
-			derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature;
+			derived item ownedObjectiveRequirement : RequirementUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def OccurrenceDefinition specializes Definition, Class {
@@ -261,31 +261,31 @@ standard library package SysML {
 			attribute isIndividual : Boolean[1..1];
 			attribute portionKind : PortionKind[0..1];
 			
-			derived ref item occurrenceDefinition : Class[0..*] ordered redefines definition;
-			derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition;
+			derived ref item occurrenceDefinition : Class[0..*] ordered redefines definition subsets Metadata::metadataItems;
+			derived ref item individualDefinition : OccurrenceDefinition[0..1] subsets occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PartDefinition specializes ItemDefinition;		
 		
 		metadata def PartUsage specializes ItemUsage {
-			derived ref item partDefinition : PartDefinition[0..*] ordered subsets itemDefinition;
+			derived ref item partDefinition : PartDefinition[0..*] ordered subsets itemDefinition subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PerformActionUsage specializes ActionUsage, EventOccurrenceUsage {
-			derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence;
+			derived ref item performedAction : ActionUsage[1..1] redefines eventOccurrence subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortConjugation specializes Conjugation {
-			ref item originalPortDefinition : PortDefinition[1..1] redefines originalType;
-			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType;
+			ref item originalPortDefinition : PortDefinition[1..1] redefines originalType subsets Metadata::metadataItems;
+			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[1..1] redefines owningType subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortDefinition specializes OccurrenceDefinition, Structure {
-			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember;
+			derived ref item conjugatedPortDefinition : ConjugatedPortDefinition[0..1] subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def PortUsage specializes OccurrenceUsage {
-			derived ref item portDefinition : PortDefinition[0..*] ordered redefines occurrenceDefinition;
+			derived ref item portDefinition : PortDefinition[0..*] ordered redefines occurrenceDefinition subsets Metadata::metadataItems;
 		}		
 		
 		enum def PortionKind {
@@ -298,11 +298,11 @@ standard library package SysML {
 		}		
 		
 		metadata def RenderingDefinition specializes PartDefinition {
-			derived ref item 'rendering' : RenderingUsage[0..*] ordered subsets usage;
+			derived ref item 'rendering' : RenderingUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RenderingUsage specializes PartUsage {
-			derived ref item renderingDefinition : RenderingDefinition[0..1] redefines partDefinition;
+			derived ref item renderingDefinition : RenderingDefinition[0..1] redefines partDefinition subsets Metadata::metadataItems;
 		}		
 		
 		enum def RequirementConstraintKind {
@@ -313,64 +313,64 @@ standard library package SysML {
 		metadata def RequirementConstraintMembership specializes FeatureMembership {
 			attribute kind : RequirementConstraintKind[1..1];
 			
-			derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature;
-			derived ref item referencedConstraint : ConstraintUsage[1..1];
+			derived item ownedConstraint : ConstraintUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
+			derived ref item referencedConstraint : ConstraintUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementDefinition specializes ConstraintDefinition {
 			attribute reqId : String[0..1] redefines declaredShortName;
 			derived attribute text : String[0..*];
 			
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementUsage specializes ConstraintUsage {
 			attribute reqId : String[0..1] redefines declaredShortName;
 			derived attribute text : String[0..*];
 			
-			derived ref item requirementDefinition : RequirementDefinition[0..1] redefines constraintDefinition;
-			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature;
-			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage;
-			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint;
-			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage;
-			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage;
+			derived ref item requirementDefinition : RequirementDefinition[0..1] redefines constraintDefinition subsets Metadata::metadataItems;
+			derived ref item requiredConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item assumedConstraint : ConstraintUsage[0..*] ordered subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item subjectParameter : Usage[1..1] subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item framedConcern : ConcernUsage[0..*] ordered subsets requiredConstraint subsets Metadata::metadataItems;
+			derived ref item actorParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
+			derived ref item stakeholderParameter : PartUsage[0..*] ordered subsets parameter, usage subsets Metadata::metadataItems;
 		}		
 		
 		metadata def RequirementVerificationMembership specializes RequirementConstraintMembership {
 			attribute kind : RequirementConstraintKind[1..1] redefines kind;
 			
-			derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint;
-			derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint;
+			derived item ownedRequirement : RequirementUsage[1..1] redefines ownedConstraint subsets Metadata::metadataItems;
+			derived ref item verifiedRequirement : RequirementUsage[1..1] redefines referencedConstraint subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SatisfyRequirementUsage specializes RequirementUsage, AssertConstraintUsage {
-			derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint;
-			derived ref item satisfyingFeature : Feature[1..1];
+			derived ref item satisfiedRequirement : RequirementUsage[1..1] redefines assertedConstraint subsets Metadata::metadataItems;
+			derived ref item satisfyingFeature : Feature[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SendActionUsage specializes ActionUsage {
-			derived ref item receiverArgument : Expression[0..1];
-			derived ref item payloadArgument : Expression[1..1];
-			derived ref item senderArgument : Expression[0..1];
+			derived ref item receiverArgument : Expression[0..1] subsets Metadata::metadataItems;
+			derived ref item payloadArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item senderArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StakeholderMembership specializes ParameterMembership {
-			derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter;
+			derived item ownedStakeholderParameter : PartUsage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StateDefinition specializes ActionDefinition {
 			attribute isParallel : Boolean[1..1];
 			
-			derived ref item 'state' : StateUsage[0..*] ordered subsets 'action';
-			derived ref item entryAction : ActionUsage[0..1];
-			derived ref item doAction : ActionUsage[0..1];
-			derived ref item exitAction : ActionUsage[0..1];
+			derived ref item 'state' : StateUsage[0..*] ordered subsets 'action' subsets Metadata::metadataItems;
+			derived ref item entryAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item doAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item exitAction : ActionUsage[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		enum def StateSubactionKind {
@@ -382,20 +382,20 @@ standard library package SysML {
 		metadata def StateSubactionMembership specializes FeatureMembership {
 			attribute kind : StateSubactionKind[1..1];
 			
-			derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature;
+			derived item 'action' : ActionUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def StateUsage specializes ActionUsage {
 			attribute isParallel : Boolean[1..1];
 			
-			derived ref item stateDefinition : Behavior[0..*] ordered redefines actionDefinition;
-			derived ref item entryAction : ActionUsage[0..1];
-			derived ref item doAction : ActionUsage[0..1];
-			derived ref item exitAction : ActionUsage[0..1];
+			derived ref item stateDefinition : Behavior[0..*] ordered redefines actionDefinition subsets Metadata::metadataItems;
+			derived ref item entryAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item doAction : ActionUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item exitAction : ActionUsage[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SubjectMembership specializes ParameterMembership {
-			derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter;
+			derived item ownedSubjectParameter : Usage[1..1] redefines ownedMemberParameter subsets Metadata::metadataItems;
 		}		
 		
 		metadata def SuccessionAsUsage specializes ConnectorAsUsage, Succession;		
@@ -403,7 +403,7 @@ standard library package SysML {
 		metadata def SuccessionFlowUsage specializes SuccessionFlow, FlowUsage;		
 		
 		metadata def TerminateActionUsage specializes ActionUsage {
-			derived ref item terminatedOccurrenceArgument : Expression[0..1];
+			derived ref item terminatedOccurrenceArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 		enum def TransitionFeatureKind {
@@ -415,16 +415,16 @@ standard library package SysML {
 		metadata def TransitionFeatureMembership specializes FeatureMembership {
 			attribute kind : TransitionFeatureKind[1..1];
 			
-			derived item transitionFeature : Step[1..1] redefines ownedMemberFeature;
+			derived item transitionFeature : Step[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
 		}		
 		
 		metadata def TransitionUsage specializes ActionUsage {
-			derived ref item source : ActionUsage[1..1];
-			derived ref item target : ActionUsage[1..1];
-			derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature;
-			derived ref item guardExpression : Expression[0..*] subsets ownedFeature;
-			derived ref item effectAction : ActionUsage[0..*] subsets feature;
-			derived ref item 'succession' : Succession[1..1] subsets ownedMember;
+			derived ref item source : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item target : ActionUsage[1..1] subsets Metadata::metadataItems;
+			derived ref item triggerAction : AcceptActionUsage[0..*] subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item guardExpression : Expression[0..*] subsets ownedFeature subsets Metadata::metadataItems;
+			derived ref item effectAction : ActionUsage[0..*] subsets feature subsets Metadata::metadataItems;
+			derived ref item 'succession' : Succession[1..1] subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def TriggerInvocationExpression specializes InvocationExpression {
@@ -442,96 +442,96 @@ standard library package SysML {
 			derived attribute mayTimeVary : Boolean[1..1] redefines isVariable;
 			derived attribute isReference : Boolean[1..1];
 			
-			derived ref item 'variant' : Usage[0..*] subsets ownedMember;
-			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership;
-			derived ref item owningDefinition : Definition[0..1] subsets owningType;
-			derived ref item owningUsage : Usage[0..1] subsets owningType;
-			derived ref item definition : Classifier[0..*] ordered redefines type;
-			derived ref item usage : Usage[0..*] ordered subsets feature;
-			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage;
-			derived ref item nestedUsage : Usage[0..*] ordered subsets ownedFeature, usage;
-			derived ref item nestedReference : ReferenceUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedAttribute : AttributeUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedEnumeration : EnumerationUsage[0..*] ordered subsets nestedAttribute;
-			derived ref item nestedOccurrence : OccurrenceUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedItem : ItemUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedPart : PartUsage[0..*] ordered subsets nestedItem;
-			derived ref item nestedPort : PortUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedConnection : ConnectorAsUsage[0..*] ordered subsets nestedUsage;
-			derived ref item nestedFlow : FlowUsage[0..*] subsets nestedConnection;
-			derived ref item nestedInterface : InterfaceUsage[0..*] ordered subsets nestedConnection;
-			derived ref item nestedAllocation : AllocationUsage[0..*] ordered subsets nestedConnection;
-			derived ref item nestedAction : ActionUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedState : StateUsage[0..*] ordered subsets nestedAction;
-			derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage;
-			derived ref item nestedCalculation : CalculationUsage[0..*] ordered subsets nestedAction;
-			derived ref item nestedConstraint : ConstraintUsage[0..*] ordered subsets nestedOccurrence;
-			derived ref item nestedRequirement : RequirementUsage[0..*] ordered subsets nestedConstraint;
-			derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement;
-			derived ref item nestedCase : CaseUsage[0..*] ordered subsets nestedCalculation;
-			derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedUseCase : UseCaseUsage[0..*] ordered subsets nestedCase;
-			derived ref item nestedView : ViewUsage[0..*] ordered subsets nestedPart;
-			derived ref item nestedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement;
-			derived ref item nestedRendering : RenderingUsage[0..*] ordered subsets nestedPart;
-			derived ref item nestedMetadata : MetadataUsage[0..*] ordered subsets nestedItem;
+			derived ref item 'variant' : Usage[0..*] subsets ownedMember subsets Metadata::metadataItems;
+			derived item variantMembership : VariantMembership[0..*] subsets ownedMembership subsets Metadata::metadataItems;
+			derived ref item owningDefinition : Definition[0..1] subsets owningType subsets Metadata::metadataItems;
+			derived ref item owningUsage : Usage[0..1] subsets owningType subsets Metadata::metadataItems;
+			derived ref item definition : Classifier[0..*] ordered redefines type subsets Metadata::metadataItems;
+			derived ref item usage : Usage[0..*] ordered subsets feature subsets Metadata::metadataItems;
+			derived ref item directedUsage : Usage[0..*] ordered subsets directedFeature, usage subsets Metadata::metadataItems;
+			derived ref item nestedUsage : Usage[0..*] ordered subsets ownedFeature, usage subsets Metadata::metadataItems;
+			derived ref item nestedReference : ReferenceUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedAttribute : AttributeUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedEnumeration : EnumerationUsage[0..*] ordered subsets nestedAttribute subsets Metadata::metadataItems;
+			derived ref item nestedOccurrence : OccurrenceUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedItem : ItemUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedPart : PartUsage[0..*] ordered subsets nestedItem subsets Metadata::metadataItems;
+			derived ref item nestedPort : PortUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedConnection : ConnectorAsUsage[0..*] ordered subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedFlow : FlowUsage[0..*] subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedInterface : InterfaceUsage[0..*] ordered subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedAllocation : AllocationUsage[0..*] ordered subsets nestedConnection subsets Metadata::metadataItems;
+			derived ref item nestedAction : ActionUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedState : StateUsage[0..*] ordered subsets nestedAction subsets Metadata::metadataItems;
+			derived ref item nestedTransition : TransitionUsage[0..*] subsets nestedUsage subsets Metadata::metadataItems;
+			derived ref item nestedCalculation : CalculationUsage[0..*] ordered subsets nestedAction subsets Metadata::metadataItems;
+			derived ref item nestedConstraint : ConstraintUsage[0..*] ordered subsets nestedOccurrence subsets Metadata::metadataItems;
+			derived ref item nestedRequirement : RequirementUsage[0..*] ordered subsets nestedConstraint subsets Metadata::metadataItems;
+			derived ref item nestedConcern : ConcernUsage[0..*] subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item nestedCase : CaseUsage[0..*] ordered subsets nestedCalculation subsets Metadata::metadataItems;
+			derived ref item nestedAnalysisCase : AnalysisCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedVerificationCase : VerificationCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedUseCase : UseCaseUsage[0..*] ordered subsets nestedCase subsets Metadata::metadataItems;
+			derived ref item nestedView : ViewUsage[0..*] ordered subsets nestedPart subsets Metadata::metadataItems;
+			derived ref item nestedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item nestedRendering : RenderingUsage[0..*] ordered subsets nestedPart subsets Metadata::metadataItems;
+			derived ref item nestedMetadata : MetadataUsage[0..*] ordered subsets nestedItem subsets Metadata::metadataItems;
 		}		
 		
 		metadata def UseCaseDefinition specializes CaseDefinition {
-			derived ref item includedUseCase : UseCaseUsage[0..*] ordered;
+			derived ref item includedUseCase : UseCaseUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def UseCaseUsage specializes CaseUsage {
-			derived ref item useCaseDefinition : UseCaseDefinition[0..1] redefines caseDefinition;
-			derived ref item includedUseCase : UseCaseUsage[0..*] ordered;
+			derived ref item useCaseDefinition : UseCaseDefinition[0..1] redefines caseDefinition subsets Metadata::metadataItems;
+			derived ref item includedUseCase : UseCaseUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VariantMembership specializes OwningMembership {
-			derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement;
+			derived item ownedVariantUsage : Usage[1..1] redefines ownedMemberElement subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VerificationCaseDefinition specializes CaseDefinition {
-			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered;
+			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def VerificationCaseUsage specializes CaseUsage {
-			derived ref item verificationCaseDefinition : VerificationCaseDefinition[0..1] subsets caseDefinition;
-			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered;
+			derived ref item verificationCaseDefinition : VerificationCaseDefinition[0..1] subsets caseDefinition subsets Metadata::metadataItems;
+			derived ref item verifiedRequirement : RequirementUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewDefinition specializes PartDefinition {
-			derived ref item 'view' : ViewUsage[0..*] ordered subsets usage;
-			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement;
-			derived ref item viewRendering : RenderingUsage[0..1];
-			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember;
+			derived ref item 'view' : ViewUsage[0..*] ordered subsets usage subsets Metadata::metadataItems;
+			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets ownedRequirement subsets Metadata::metadataItems;
+			derived ref item viewRendering : RenderingUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewRenderingMembership specializes FeatureMembership {
-			derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature;
-			derived ref item referencedRendering : RenderingUsage[1..1];
+			derived item ownedRendering : RenderingUsage[1..1] redefines ownedMemberFeature subsets Metadata::metadataItems;
+			derived ref item referencedRendering : RenderingUsage[1..1] subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewUsage specializes PartUsage {
-			derived ref item viewDefinition : ViewDefinition[0..1] redefines partDefinition;
-			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement;
-			derived ref item exposedElement : Element[0..*] ordered subsets member;
-			derived ref item viewRendering : RenderingUsage[0..1];
-			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember;
+			derived ref item viewDefinition : ViewDefinition[0..1] redefines partDefinition subsets Metadata::metadataItems;
+			derived ref item satisfiedViewpoint : ViewpointUsage[0..*] ordered subsets nestedRequirement subsets Metadata::metadataItems;
+			derived ref item exposedElement : Element[0..*] ordered subsets member subsets Metadata::metadataItems;
+			derived ref item viewRendering : RenderingUsage[0..1] subsets Metadata::metadataItems;
+			derived ref item viewCondition : Expression[0..*] ordered subsets ownedMember subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewpointDefinition specializes RequirementDefinition {
-			derived ref item viewpointStakeholder : PartUsage[0..*] ordered;
+			derived ref item viewpointStakeholder : PartUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def ViewpointUsage specializes RequirementUsage {
-			derived ref item viewpointDefinition : ViewpointDefinition[0..1] redefines requirementDefinition;
-			derived ref item viewpointStakeholder : PartUsage[0..*] ordered;
+			derived ref item viewpointDefinition : ViewpointDefinition[0..1] redefines requirementDefinition subsets Metadata::metadataItems;
+			derived ref item viewpointStakeholder : PartUsage[0..*] ordered subsets Metadata::metadataItems;
 		}		
 		
 		metadata def WhileLoopActionUsage specializes LoopActionUsage {
-			derived ref item whileArgument : Expression[1..1];
-			derived ref item untilArgument : Expression[0..1];
+			derived ref item whileArgument : Expression[1..1] subsets Metadata::metadataItems;
+			derived ref item untilArgument : Expression[0..1] subsets Metadata::metadataItems;
 		}		
 		
 	}

--- a/sysml.library/Systems Library/Views.sysml
+++ b/sysml.library/Systems Library/Views.sysml
@@ -14,21 +14,21 @@ standard library package Views {
 		ref view :>> self : View;
 		
 		abstract ref view subviews : View[0..*] :> views {
-		doc
-		/*
-		 * Other Views that are used in the rendering of this View.
-		 */
+    		doc
+    		/*
+    		 * Other Views that are used in the rendering of this View.
+    		 */
 		}
 		
 		abstract ref rendering viewRendering : Rendering[0..1] {
-		doc
+            doc
 			/*
 			 * The rendering of this View.
 			 */
 		}
 		
 		viewpoint viewpointSatisfactions : ViewpointCheck[0..*] :> viewpointChecks, checkedConstraints {
-		doc
+            doc
 			/*
 			 * Checks that the View satisfies all required ViewpointUsages.
 			 */
@@ -39,12 +39,13 @@ standard library package Views {
 			/*
 			 * An assertion that all viewpointSatisfactions are true.
 			 */
-		
+			 
 			require viewpointSatisfactions {
 				doc
 				/*
 				 * The required ViewpointChecks.
 				 */
+                ref :>> ownedPerformances::this, subperformances::this default that.that;
 			}
 		}
 	}

--- a/sysml/src/examples/Flashlight Example/Flashlight Example.sysml
+++ b/sysml/src/examples/Flashlight Example/Flashlight Example.sysml
@@ -20,8 +20,7 @@ package 'Flashlight Example' {
 		}
 		
 		interface userToFlashlight connect user.onOffCmdPort to flashlight.onOffCmdPort {
-			ref flow references illuminateRegion.onOffCmdFlow
-				from source.onOffCmd to target.onOffCmd; 
+			perform illuminateRegion.onOffCmdFlow; 
 		}
 		
 		part flashlight {

--- a/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
+++ b/sysml/src/examples/Geometry Examples/CarWithShapeAndCSG.sysml
@@ -21,7 +21,7 @@ package CarWithShapeAndCSG {
             :>> mRefs = (mm, mm, mm);
         }
 
-		part powerSource : Engine [1] :> componentItems {
+		part powerSource : Engine [1] :> componentParts {
 			:>> ecf { 
 				:>> mRefs = datum.mRefs;
 				:>> transformation : TranslationRotationSequence {
@@ -44,7 +44,7 @@ package CarWithShapeAndCSG {
 		
 		attribute <ecf> engineCoordinateFrame :>> coordinateFrame;		
 
-		part rawEngineBlock : SpatialItem [1] {
+		part rawEngineBlock :> subSpatialParts [1] {
 			item :>> shape : Box [1] {
 	    		:>> length = 300 [mm];
 	    		:>> width = 190 [mm];
@@ -53,7 +53,7 @@ package CarWithShapeAndCSG {
 		}
 		
 		private attribute rearCylinderSpacing = 90 [mm];
-		private item cylinder1 : SpatialItem [1] {
+		private item cylinder1  :> subSpatialParts [1] {
 			item :>> shape : Cylinder [1] {
 	    		:>> radius = 55 [mm];
 	    		:>> height = 350 [mm];
@@ -67,7 +67,7 @@ package CarWithShapeAndCSG {
 		}
 		
 		private attribute cylinderSpacing = 2*cylinder1.shape.radius + 20 [mm];
-		private item cylinder2 : SpatialItem [1] {
+		private item cylinder2  :> subSpatialParts [1] {
 			item :>> shape : Cylinder [1] {
 	    		:>> radius = cylinder1.shape.radius;
 	    		:>> height = cylinder1.shape.height;

--- a/sysml/src/examples/Geometry Examples/SimpleQuadcopter.sysml
+++ b/sysml/src/examples/Geometry Examples/SimpleQuadcopter.sysml
@@ -23,7 +23,7 @@ package SimpleQuadcopter {
         // attribute :>> coordinateFrame { :>> mRefs = (mm, mm, mm); }
         
         /* rawStrut is a construction shape: a rectangular beam */
-        part rawStrut : SpatialItem {
+        part rawStrut :> subSpatialParts {
             item :>> shape : Box {
                 :>> length = 160 [mm];
                 :>> width = 15 [mm];
@@ -37,7 +37,7 @@ package SimpleQuadcopter {
         }
 
         /* motorCutout is a construction shape: a cylinder of the same shape as the  */
-        part motorCutout : SpatialItem {
+        part motorCutout :> subSpatialParts {
             item :>> shape = motorShape.shape;
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
@@ -56,7 +56,7 @@ package SimpleQuadcopter {
         // By default will get same coordinateFrame.mRefs as owning CompoundSpatialItem, i.e.:
         // attribute :>> coordinateFrame { :>> mRefs = (mm, mm, mm); }
 
-        part propeller : SpatialItem {
+        part propeller :> subSpatialParts {
             item :>> shape : Cylinder {
                 doc /* propeller stay-out volume, without propeller shaft */
                 :>> radius = 80 [mm];
@@ -69,7 +69,7 @@ package SimpleQuadcopter {
             }
         }
 
-        part motor : SpatialItem {
+        part motor :> subSpatialParts {
             item :>> shape = motorShape.shape;
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
@@ -85,7 +85,7 @@ package SimpleQuadcopter {
         // By default will get same coordinateFrame.mRefs as owning CompoundSpatialItem, i.e.:
         // attribute :>> coordinateFrame { :>> mRefs = (mm, mm, mm); }
 
-        part cameraHousing : SpatialItem {
+        part cameraHousing :> subSpatialParts {
             item :>> shape : Cylinder {
                 :>> radius = 15 [mm];
                 :>> height = 24 [mm];
@@ -95,7 +95,7 @@ package SimpleQuadcopter {
         /* The field of view is modeled as an item, since it is not a part of the quadcopter but rather a stay-out volume 
          * that can for example be used to formulate a constraint.
          */
-        item fieldOfView : SpatialItem {
+        item fieldOfView :> subSpatialParts {
             doc /* Conical field of view with half-top angle 20 degree */
             item :>> shape : Cone {
                 :>> radius = height * tan(20 * pi/180) [mm];
@@ -121,10 +121,10 @@ package SimpleQuadcopter {
             :>> mRefs = (mm, mm, mm);
         }
 
-        part mainBody : SpatialItem {
+        part mainBody :> subSpatialParts {
 
             /* rawBody is a construction shape: the enveloping rectangular box */
-            part rawBody : SpatialItem {
+            part rawBody :> subSpatialParts {
                 item :>> shape : Box {
                     :>> length = 160 [mm];
                     :>> width = 15 [mm];
@@ -138,7 +138,7 @@ package SimpleQuadcopter {
             }
             
             /* cuttingBox is a construction shape: the enveloping rectangular box */
-            part cuttingCornersBox : SpatialItem {
+            part cuttingCornersBox :> subSpatialParts {
                 item :>> shape : Box {
                     :>> length = 105 [mm];
                     :>> width = 105 [mm];
@@ -167,7 +167,7 @@ package SimpleQuadcopter {
         private attribute zStrut : LengthValue = 25[mm];
         private attribute zPMAssy : LengthValue = 12[mm];
 
-        part strut1 : Strut {
+        part strut1 : Strut :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (xStrut.num, yStrut.num, zStrut.num)[source]), 
@@ -175,7 +175,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part strut2 : Strut {
+        part strut2 : Strut :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (-xStrut.num, yStrut.num, zStrut.num)[source]), 
@@ -183,7 +183,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part strut3 : Strut {
+        part strut3 : Strut :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (-xStrut.num, -yStrut.num, zStrut.num)[source]), 
@@ -191,7 +191,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part strut4 : Strut {
+        part strut4 : Strut :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (xStrut.num, -yStrut.num, zStrut.num)[source]), 
@@ -200,7 +200,7 @@ package SimpleQuadcopter {
             }        
         }
 
-        part propellerMotorAssy1 : PropellerMotorAssy {
+        part propellerMotorAssy1 : PropellerMotorAssy :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (xStrut.num, yStrut.num, zPMAssy.num)[source]), 
@@ -208,7 +208,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part propellerMotorAssy2 : PropellerMotorAssy {
+        part propellerMotorAssy2 : PropellerMotorAssy :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (-xStrut.num, yStrut.num, zPMAssy.num)[source]), 
@@ -216,7 +216,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part propellerMotorAssy3 : PropellerMotorAssy {
+        part propellerMotorAssy3 : PropellerMotorAssy :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (-xStrut.num, -yStrut.num, zPMAssy.num)[source]), 
@@ -224,7 +224,7 @@ package SimpleQuadcopter {
                 }
             }        
         }
-        part propellerMotorAssy4 : PropellerMotorAssy {
+        part propellerMotorAssy4 : PropellerMotorAssy :> subSpatialParts {
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (xStrut.num, -yStrut.num, zPMAssy.num)[source]), 
@@ -234,7 +234,7 @@ package SimpleQuadcopter {
         }
 
         /* The camera is placed protruding from the +X face of the main body, rotated about the +Y axis over 50° downwards */
-        part camera : Camera {
+        part camera : Camera :> subSpatialParts{
             attribute :>> coordinateFrame {
                 :>> transformation : TranslationRotationSequence {
                     :>> elements = (new Translation( (59, 0, 2)[source]), 

--- a/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
+++ b/sysml/src/examples/Geometry Examples/VehicleGeometryAndCoordinateFrames.sysml
@@ -34,7 +34,6 @@ package VehicleGeometryAndCoordinateFrames {
 		 * The wheel has 5 lugbolts that are evenly distributed along a circle centered at the wheel's center.
 		 */
 	
-    	ref item :>> self : Wheel;
         item :>> shape : Cylinder {
             :>> radius = 22/2*25.4 + 110 [mm]; 
             :>> height = 220 [mm];
@@ -42,7 +41,7 @@ package VehicleGeometryAndCoordinateFrames {
         attribute <wcf> wheelCoordinateFrame : CoordinateFrame;
         
         attribute numberOfBolts : Natural = 5;	
-		part lugBolts : LugBolt[1..numberOfBolts];
+		part lugBolts : LugBolt[1..numberOfBolts] :> subSpatialParts;
 		
 		/* 
 		 * As an example of a more involved placement of composite parts, constrain the positions of the coordinate frame origins 
@@ -81,7 +80,7 @@ package VehicleGeometryAndCoordinateFrames {
             :>> mRefs = (mm, mm, mm);
         }
 
-        part chassis : Chassis[1] :> componentItems {
+        part chassis : Chassis[1] :> componentParts {
 			attribute :>> coordinateFrame {
 				attribute :>> transformation : TranslationRotationSequence {
 	 	          	attribute :>> source = datum;
@@ -95,7 +94,7 @@ package VehicleGeometryAndCoordinateFrames {
         private attribute rearWheelXShift : Real = -1820;
         private attribute wheelYShift : Real = 720;
 
-        part leftFrontWheel : Wheel[1] :> componentItems {
+        part leftFrontWheel : Wheel[1] :> componentParts {
             attribute :>> coordinateFrame {
                 attribute :>> transformation : TranslationRotationSequence {
 	            	attribute :>> source = datum;
@@ -103,7 +102,7 @@ package VehicleGeometryAndCoordinateFrames {
                 }
             }
         }
-        part rightFrontWheel : Wheel[1] :> componentItems {
+        part rightFrontWheel : Wheel[1] :> componentParts {
             attribute :>> coordinateFrame {
                 attribute :>> transformation : TranslationRotationSequence {
                 	attribute :>> source = datum;
@@ -111,7 +110,7 @@ package VehicleGeometryAndCoordinateFrames {
                 }
             }
         }
-        part leftRearWheel : Wheel[1] :> componentItems {
+        part leftRearWheel : Wheel[1] :> componentParts {
             attribute :>> coordinateFrame {
                 attribute :>> transformation : TranslationRotationSequence {
                 	attribute :>> source = datum;
@@ -119,7 +118,7 @@ package VehicleGeometryAndCoordinateFrames {
                 }
             }
         }
-        part rightRearWheel : Wheel[1] :> componentItems {
+        part rightRearWheel : Wheel[1] :> componentParts {
             attribute :>> coordinateFrame {
                 attribute :>> transformation : TranslationRotationSequence {
 					attribute :>> source = datum;

--- a/sysml/src/examples/Simple Tests/PartTest.sysml
+++ b/sysml/src/examples/Simple Tests/PartTest.sysml
@@ -35,7 +35,11 @@ package PartTest {
 	}
 	
 	private port def C {
-		private in ref y: A, B;
+		private in ref y: A, B {
+		    part B_b redefines B::b;
+		    part B_c redefines B::c;
+		    port B_x redefines B::x;
+		}
 		alias z1 for y;
 		alias z2 for y;
 		port c1 : C;

--- a/sysml/src/examples/State Space Representation Examples/CartSample.sysml
+++ b/sysml/src/examples/State Space Representation Examples/CartSample.sysml
@@ -59,6 +59,6 @@ package CartSample {
             }
         }
 
-        flow pusher.pusherBehavior.output.force to cart.cartBehavior.input.force;
+        flow pusher.pusherBehavior.output to cart.cartBehavior.input;
     }
 }

--- a/sysml/src/examples/State Space Representation Examples/EVSample.sysml
+++ b/sysml/src/examples/State Space Representation Examples/EVSample.sysml
@@ -179,8 +179,7 @@ package EVSample {
             }
         }
 
-        flow battery.batteryBehavior.output.voltage to motor.motorBehavior.input.voltage;
-        flow motor.motorBehavior.output.current to battery.batteryBehavior.input.current;
+        flow battery.batteryBehavior.output to motor.motorBehavior.input;
 
         part motor: Motor {
             :>> motR = 4['Ω'];
@@ -193,8 +192,7 @@ package EVSample {
             }
         }
 
-        flow motor.motorBehavior.output.torque to tire.tireBehavior.input.torque;
-        flow vehicleBehavior.output.accel to tire.tireBehavior.input.accel;
+        flow motor.motorBehavior.output to tire.tireBehavior.input;
 
         part tire: Tire {
             :>> moment default 300['kg⋅m²'];
@@ -205,8 +203,8 @@ package EVSample {
             }
         }
 
-        flow tire.tireBehavior.output.outTorque to motor.motorBehavior.input.friction;
-        flow tire.tireBehavior.output.force to vehicleBehavior.input.force;
+        flow tire.tireBehavior.output to motor.motorBehavior.input;
+        flow tire.tireBehavior.output to vehicleBehavior.input;
     }
 
     part vehicle_compact :> vehicle {

--- a/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
+++ b/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
@@ -49,10 +49,11 @@ package '11b-Safety and Security Feaure Views' {
 		private import PartsTree::vehicle;
 		
 		view vehicleSafetyFeatureView : SafetyFeatureView {
-			expose vehicle::**;
+			expose vehicle;
 		}
 		
 		view vehicleMandatorySafetyFeatureView :> vehicleSafetyFeatureView {
+		    expose vehicle::*::**;
 			filter Safety::isMandatory;
 		}
 		


### PR DESCRIPTION
This PR resolves diamond inheritance problems that cause name collisions between inherited members of types in several library models. It proactively resolve the following KerML and SysML issues, even though the RTFs have not voted on resolutions yet.

- [KERML11-76](https://issues.omg.org/issues/KERML11-76) Library models have inherited member name collisions
- [SYSML21-322](https://issues.omg.org/issues/SYSML21-322) Library models have inherited member name collisions

**Validation**

- `KerMLValidator`
    - `checkNamespace` – Previously, the implementation of `checkNamespaceMembershipDistinguishibility` did not include checking memberships inherited from different supertypes. It was necessary to implement this checking in order to detect the sort of distinguishibility problems in the library models from KERML11-76 and SYSML21-322 and then to show that they were corrected. 

**Library Models**

_Kernel Semantic Library_
- `FeatureReferencingPerformances`
- `Objects`
- `Observation`
- `Occurrences`
- `Transfers`

_Kernel Function Library_

- `VectorFunctions`

_Systems Library_

- `Actions`
- `Connections`
- `Flows`
- `Items`
- `Metadata`
- `Parts`
- `Ports`
- `SysML`
- `Views`

_Geometry Domain Library_

- `ShapeItems`
- `SpatialItems`

_Quantities and Units Domain Library_

- `SI`
- `USCustomaryUnits`

_Requirement Derivation Domain Library_

- `DerivationConnections`

**Backward Incompatibilities**

1. Existing models may now get distinguishibility warnings that were not previously generated.