### PR TITLE
ST6RI-873 Implied binding connectors not generated

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -346,10 +346,6 @@ public class ElementUtil {
 	}
 	
 	public static void transformAll(Element root, boolean addImplicitElements) {
-		if (addImplicitElements && root instanceof Type) {
-			root.setIsImpliedIncluded(true);
-			TypeUtil.insertImplicitBindingConnectors((Type) root);
-		}
 		transform(root);
 		for (Relationship relationship: root.getOwnedRelationship()) {
 			// transformAll(relationship, addImplicitElements);
@@ -357,11 +353,15 @@ public class ElementUtil {
 				transformAll(element, addImplicitElements);
 			}
 		}
-		if (addImplicitElements && root instanceof Type) {
-			TypeUtil.insertImplicitSpecializations((Type)root);
-		}
-		if (addImplicitElements && root instanceof Feature) {
-			FeatureUtil.insertImplicitTypeFeaturings((Feature)root);
+		if (addImplicitElements) {
+			root.setIsImpliedIncluded(true);
+			if (root instanceof Type) {
+				TypeUtil.insertImplicitBindingConnectors((Type)root);
+				TypeUtil.insertImplicitSpecializations((Type)root);
+				if (root instanceof Feature) {
+					FeatureUtil.insertImplicitTypeFeaturings((Feature)root);
+				}
+			}
 		}
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -353,14 +353,11 @@ public class ElementUtil {
 				transformAll(element, addImplicitElements);
 			}
 		}
-		if (addImplicitElements) {
-			root.setIsImpliedIncluded(true);
-			if (root instanceof Type) {
-				TypeUtil.insertImplicitBindingConnectors((Type)root);
-				TypeUtil.insertImplicitSpecializations((Type)root);
-				if (root instanceof Feature) {
-					FeatureUtil.insertImplicitTypeFeaturings((Feature)root);
-				}
+		if (addImplicitElements && root instanceof Type) {
+			TypeUtil.insertImplicitBindingConnectors((Type)root);
+			TypeUtil.insertImplicitSpecializations((Type)root);
+			if (root instanceof Feature) {
+				FeatureUtil.insertImplicitTypeFeaturings((Feature)root);
 			}
 		}
 	}


### PR DESCRIPTION
This PR corrects the insertion of implied binding connectors during XMI or JSON export of a model.

For historical reasons, the insertion of binding connectors was previously done before the transformation of the corresponding owning element. However, the implied binding connector of a feature value is owned by the feature that owns the feature value, and that binding connector will not be creating unless the owning feature is transformed first.

This PR updates the method `ElementUtil::transformAll` so that an element and all its owned elements are transformed before any implied elements are inserted, including binding connectors and specializations.