### PR TITLE
ST6RI-874 Features subset each other in Transfers and Flows library models (KERML11-78, SYSML21-324)

### DIFF
--- a/org.omg.kerml.xpect.tests/library/Transfers.kerml
+++ b/org.omg.kerml.xpect.tests/library/Transfers.kerml
@@ -177,7 +177,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, TransferBefore::target;         
     }
     
-    abstract flow transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
+    abstract step transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
         doc
         /*
          * transfers is a specialization of performances and binaryLinks restricted to type 
@@ -188,7 +188,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, binaryLinks::target;
     }
     
-    abstract flow messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
+    abstract step messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
         doc
         /*
          * messageTransfers is a specialization of transfers restricted to type MessageTransfers.

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -957,7 +957,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 		}		
 		
 		// validateConnectorBinarySpecialization
-		val connectorEnds = TypeUtil.getAllEndFeaturesOf(c)
+		val connectorEnds = c.connectorEnd
 		if (connectorEnds.size() > 2) {
 			val binaryLinkType = SysMLLibraryUtil.getLibraryElement(c, "Links::BinaryLink") as Type
 			if (c.conformsTo(binaryLinkType)) {

--- a/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/Transfers.kerml
@@ -177,7 +177,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, TransferBefore::target;         
     }
     
-    abstract flow transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
+    abstract step transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
         doc
         /*
          * transfers is a specialization of performances and binaryLinks restricted to type 
@@ -188,7 +188,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, binaryLinks::target;
     }
     
-    abstract flow messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
+    abstract step messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
         doc
         /*
          * messageTransfers is a specialization of transfers restricted to type MessageTransfers.

--- a/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
@@ -103,7 +103,7 @@ standard library package Flows {
          */
     }
     
-    abstract message flows: Flow[0..*] nonunique :> messages, flowTransfers {
+    abstract flow flows: Flow[0..*] nonunique :> messages, flowTransfers {
         doc
         /*
          * flows is the base feature for FlowUsages that identify their source output
@@ -114,7 +114,7 @@ standard library package Flows {
         end occurrence target: Occurrence :>> Flow::target, messages::target, flowTransfers::target;
     }
     
-    abstract message successionFlows: SuccessionFlow[0..*] nonunique :> flows, flowTransfersBefore {
+    abstract flow successionFlows: SuccessionFlow[0..*] nonunique :> flows, flowTransfersBefore {
         doc
         /*
          * successionFlows is the base feature of all SuccessionFlowUsages.

--- a/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Flows.sysml
@@ -42,9 +42,6 @@ standard library package Flows {
          * a transfer of objects or values between two occurrences. It is 
          * the base type of all FlowUsages.
          */
-    
-        end occurrence source: Occurrence :>> Transfer::source;
-        end occurrence target: Occurrence :>> Transfer::target;
         
         ref payload :>> MessageAction::payload, Transfer::payload;
         
@@ -104,9 +101,6 @@ standard library package Flows {
         /*
          * messages is the base feature of all FlowUsages.
          */
-    
-        end occurrence source: Occurrence :>> Message::source, transfers::source;
-        end occurrence target: Occurrence :>> Message::target, transfers::target;
     }
     
     abstract message flows: Flow[0..*] nonunique :> messages, flowTransfers {

--- a/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/ElementUtil.java
@@ -354,6 +354,7 @@ public class ElementUtil {
 			}
 		}
 		if (addImplicitElements && root instanceof Type) {
+			root.setIsImpliedIncluded(true);
 			TypeUtil.insertImplicitBindingConnectors((Type)root);
 			TypeUtil.insertImplicitSpecializations((Type)root);
 			if (root instanceof Feature) {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/Transfers.kerml
@@ -177,7 +177,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, TransferBefore::target;         
     }
     
-    abstract flow transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
+    abstract step transfers: Transfer[0..*] nonunique subsets performances, binaryLinks {
         doc
         /*
          * transfers is a specialization of performances and binaryLinks restricted to type 
@@ -188,7 +188,7 @@ standard library package Transfers {
         end feature target: Occurrence redefines Transfer::target, binaryLinks::target;
     }
     
-    abstract flow messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
+    abstract step messageTransfers: MessageTransfer[0..*] nonunique subsets transfers {
         doc
         /*
          * messageTransfers is a specialization of transfers restricted to type MessageTransfers.

--- a/sysml.library/Systems Library/Flows.sysml
+++ b/sysml.library/Systems Library/Flows.sysml
@@ -103,7 +103,7 @@ standard library package Flows {
          */
     }
     
-    abstract message flows: Flow[0..*] nonunique :> messages, flowTransfers {
+    abstract flow flows: Flow[0..*] nonunique :> messages, flowTransfers {
         doc
         /*
          * flows is the base feature for FlowUsages that identify their source output
@@ -114,7 +114,7 @@ standard library package Flows {
         end occurrence target: Occurrence :>> Flow::target, messages::target, flowTransfers::target;
     }
     
-    abstract message successionFlows: SuccessionFlow[0..*] nonunique :> flows, flowTransfersBefore {
+    abstract flow successionFlows: SuccessionFlow[0..*] nonunique :> flows, flowTransfersBefore {
         doc
         /*
          * successionFlows is the base feature of all SuccessionFlowUsages.

--- a/sysml.library/Systems Library/Flows.sysml
+++ b/sysml.library/Systems Library/Flows.sysml
@@ -42,9 +42,6 @@ standard library package Flows {
          * a transfer of objects or values between two occurrences. It is 
          * the base type of all FlowUsages.
          */
-    
-        end occurrence source: Occurrence :>> Transfer::source;
-        end occurrence target: Occurrence :>> Transfer::target;
         
         ref payload :>> MessageAction::payload, Transfer::payload;
         
@@ -104,9 +101,6 @@ standard library package Flows {
         /*
          * messages is the base feature of all FlowUsages.
          */
-    
-        end occurrence source: Occurrence :>> Message::source, transfers::source;
-        end occurrence target: Occurrence :>> Message::target, transfers::target;
     }
     
     abstract message flows: Flow[0..*] nonunique :> messages, flowTransfers {

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
@@ -826,7 +826,7 @@ package SimpleVehicleModel{
                         }
                         part redefines speedSensor{
                             port redefines speedSensorPort{
-                                event sendSensedSpeed.source;
+                                event sendSensedSpeed.sourceEvent;
                             }
                         }
                         part redefines vehicleSoftware{
@@ -838,17 +838,17 @@ package SimpleVehicleModel{
                                     }
                                     port redefines speedSensorPort{
                                         event occurrence setSpeedReceived=setSpeedPort.setSpeedReceived;
-                                        then event sendSensedSpeed.target;
+                                        then event sendSensedSpeed.targetEvent;
                                     }
                                     port redefines cruiseControlPort{             
-                                        event sendFuelCmd.source;
+                                        event sendFuelCmd.sourceEvent;
                                     }
                                 }
                             }
                         }
                         part redefines engine{
                             port redefines fuelCmdPort{
-                                event sendFuelCmd.target;
+                                event sendFuelCmd.targetEvent;
                             }
                         }
                         message sendSensedSpeed of SensedSpeed;

--- a/sysml/src/training/13. Flows/Flow Definition Example.sysml
+++ b/sysml/src/training/13. Flows/Flow Definition Example.sysml
@@ -13,7 +13,7 @@ package 'Flow Definition Example' {
 		part tankAssy : FuelTankAssembly;
 		part eng : Engine;
 		
-		flow : FuelFlow
+		flow : FuelFlow of Fuel
 		  from tankAssy.fuelTankPort.fuelSupply
 			to eng.engineFuelPort.fuelSupply;
 			

--- a/sysml/src/training/41. Language Extension/User Keyword Example.sysml
+++ b/sysml/src/training/41. Language Extension/User Keyword Example.sysml
@@ -17,13 +17,13 @@ package 'User Keyword Example' {
 			:>> probability = 0.01;			
 		}
 		
-		#causation first 'battery old' then 'power low';
+		#causation connect 'battery old' to 'power low';
 		
 		#situation 'power low' {
 			constraint { device.battery.power < minPower }			
 		}
 		
-		#causation first 'power low' then 'device shutoff';
+		#causation connect 'power low' to 'device shutoff';
 		
 		#failure 'device shutoff' {
 			:>> severity = LevelEnum::high;

--- a/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
+++ b/sysml/src/validation/14-Language Extensions/14c-Language Extensions.sysml
@@ -110,7 +110,7 @@ package '14c-Language-Extensions' {
 		}
 		
 		metadata def <causation> CausationMetadata :> SemanticMetadata {
-			:>> annotatedElement : SysML::SuccessionAsUsage;
+			:>> annotatedElement : SysML::ConnectionUsage;
 			:>> baseType = causations meta SysML::Usage;
 		}
 		
@@ -166,17 +166,17 @@ package '14c-Language-Extensions' {
 				:>> occurs = 0.005;
 			}
 			
-			#causation first 'battery depleted' then 'battery cannot be charged';
+			#causation connect 'battery depleted' to 'battery cannot be charged';
 			
 			#failure occurrence 'battery cannot be charged' {
 				:>> detected = 0.013;
 			}
 			
-			#causation first 'battery cannot be charged' then 'glucose level undetected';
+			#causation connect 'battery cannot be charged' to 'glucose level undetected';
 			
 			#effect occurrence 'glucose level undetected';
 			
-			#causation first 'glucose level undetected' then 'therapy delay';
+			#causation connect 'glucose level undetected' to 'therapy delay';
 			
 			#effect occurrence 'therapy delay' {
 				:>> severity = "High";

--- a/sysml/src/validation/17-Sequence Modeling/17b-Sequence-Modeling.sysml
+++ b/sysml/src/validation/17-Sequence Modeling/17b-Sequence-Modeling.sysml
@@ -20,23 +20,23 @@ package '17b-Sequence-Modeling' {
 
 	occurrence def PubSubSequence {
 		part producer[1] {
-			event publish_message.source;
+			event publish_message.sourceEvent;
 		}
 		
 		message publish_message of Publish[1];
 		
 		part server[1] {
-			event subscribe_message.target;
-			then event publish_message.target;
-			then event deliver_message.source;
+			event subscribe_message.targetEvent;
+			then event publish_message.targetEvent;
+			then event deliver_message.sourceEvent;
 		}
 		
 		message subscribe_message of Subscribe[1];
 		message deliver_message of Deliver[1];
 		
 		part consumer[1] {
-			event subscribe_message.source;
-			then event deliver_message.target;
+			event subscribe_message.sourceEvent;
+			then event deliver_message.targetEvent;
 		}
 	}
 }


### PR DESCRIPTION
This PR proactively fixes the following issues, even though resolutions for them have not yet been approved by the KerML 1.1 RTF or SysML 2.1 RTF:

- [KERML11-78](https://issues.omg.org/issues/KERML11-78) Transfers::transfers and Transfers::flowTransfers subset each other
- [SYSML21-324](https://issues.omg.org/issues/SYSML21-324) Flows::messages and Flows::flows subset each other

**Model Libraries**

_Kernel Semantic Library_

`Transfers`
- Made the features `transfers` and `messageTransfers` steps instead of flows. As a result, these features no longer have implied subsettings of `flowTransfers`.

_Systems Library_

`Flows`
- Removed the end features from the flow definition `Message` and the flow usage `messages`. As a result, `messages` no longer has an implied subsetting of `flows`.
- Changed the keyword used in the declaration of `flows` and `successionFlows` from **`message`** to **`flow`**, since these flow usages still have owned end features and, therefore, are _not_ message flows.

**Validation**

`KerMLValidator`
- Corrected the implementation of the check of the constraint `validateConnectorBinarySpecialization` to properly handle redefined features when counting connector ends. Otherwise, it was incorrectly reporting a validation error on `messages` as modified above.

**Backward Incompatibilities**

1. The end features `source` and `target` of `Messages` and `messages` are now inherited and are no longer occurrence usages. This means that they cannot be used as the referenced occurrences in an event occurrence usage. However, this is appropriate, because the referenced events for a message should instead be `sourceEvent` and `targetEvent` which are still occurrence usages.
2. The correction to the `validateConnectorBinarySpecialization` check may result both in cases in which a previously valid model becomes invalid or a previously invalid model becomes valid.