### PR TITLE
ST6RI 877 Parameter and end features are computed incorrectly / ST6RI-878 Problems with parameters in TransitionPerformances and Actions models (KERML11-79, SYSML21-327)

### DIFF
--- a/org.omg.kerml.xpect.tests/library/TransitionPerformances.kerml
+++ b/org.omg.kerml.xpect.tests/library/TransitionPerformances.kerml
@@ -41,9 +41,9 @@ standard library package TransitionPerformances {
 
 		feature accNum: Natural [1] = if isEmpty(trigger) ? 0 else 1;
 		step accept: AcceptPerformance[accNum] subsets timeEnclosedOccurrences, acceptPerformances {
-			in feature redefines receiver = triggerTarget;
 			feature redefines acceptedTransfer = trigger;
 		}
+        binding accept.receiver = triggerTarget;
 
 		private succession [*] guard then [accNum] accept;
 	}

--- a/org.omg.sysml.xpect.tests/library.kernel/TransitionPerformances.kerml
+++ b/org.omg.sysml.xpect.tests/library.kernel/TransitionPerformances.kerml
@@ -41,9 +41,9 @@ standard library package TransitionPerformances {
 
 		feature accNum: Natural [1] = if isEmpty(trigger) ? 0 else 1;
 		step accept: AcceptPerformance[accNum] subsets timeEnclosedOccurrences, acceptPerformances {
-			in feature redefines receiver = triggerTarget;
 			feature redefines acceptedTransfer = trigger;
 		}
+        binding accept.receiver = triggerTarget;
 
 		private succession [*] guard then [accNum] accept;
 	}

--- a/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
+++ b/org.omg.sysml.xpect.tests/library.systems/Actions.sysml
@@ -144,6 +144,8 @@ standard library package Actions {
 			/*
 			 * The subactions of this Action that are AssignmentActions.
 			 */
+			 
+			 in target;
 		}
 		
 		abstract action ifSubactions : IfThenAction[0..*] :> subactions, ifThenActions {

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -25,6 +25,7 @@
  *****************************************************************************/
 package org.omg.sysml.xtext.validation
 
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.xtext.validation.Check
@@ -88,8 +89,6 @@ import org.omg.sysml.lang.sysml.UseCaseUsage
 import org.omg.sysml.lang.sysml.UseCaseDefinition
 import org.omg.sysml.lang.sysml.MetadataUsage
 import org.omg.sysml.lang.sysml.Metaclass
-import org.omg.sysml.util.FeatureUtil
-import org.omg.sysml.util.UsageUtil
 import org.omg.sysml.lang.sysml.Interaction
 import org.omg.sysml.lang.sysml.SendActionUsage
 import org.omg.sysml.lang.sysml.FeatureReferenceExpression
@@ -122,7 +121,6 @@ import org.omg.sysml.lang.sysml.ViewRenderingMembership
 import org.omg.sysml.lang.sysml.AttributeDefinition
 import org.omg.sysml.lang.sysml.Namespace
 import org.omg.sysml.lang.sysml.ActionDefinition
-import org.eclipse.emf.ecore.EObject
 import org.omg.sysml.lang.sysml.TransitionFeatureKind
 import org.omg.sysml.lang.sysml.ActorMembership
 import org.omg.sysml.lang.sysml.RequirementConstraintKind
@@ -131,10 +129,11 @@ import org.omg.sysml.lang.sysml.ReferenceUsage
 import org.omg.sysml.lang.sysml.IfActionUsage
 import org.omg.sysml.lang.sysml.WhileLoopActionUsage
 import org.omg.sysml.lang.sysml.TriggerKind
-import org.omg.sysml.util.TypeUtil
 import org.omg.sysml.lang.sysml.FlowDefinition
 import org.omg.sysml.lang.sysml.FlowUsage
 import org.omg.sysml.lang.sysml.Relationship
+import org.omg.sysml.util.FeatureUtil
+import org.omg.sysml.util.UsageUtil
 
 /**
  * This class contains custom validation rules. 
@@ -667,7 +666,7 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkFlowDefinition(FlowDefinition cdef) {
 		// validateConnectionDefinitionConnectionEnds
-		val ends = TypeUtil.getAllEndFeaturesOf(cdef)
+		val ends = cdef.endFeature
 		if (ends.size > 2) {
 			val ownedEnds = cdef.ownedEndFeature
 			if (ownedEnds.size <= 2) {

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ActionUsageAdapter.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.omg.sysml.lang.sysml.ActionUsage;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.PartDefinition;
@@ -130,10 +129,10 @@ public class ActionUsageAdapter extends OccurrenceUsageAdapter {
 	}
 	
 	@Override
-	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
+	protected List<? extends Feature> getRelevantFeatures(Type type) {
 		ActionUsage target = getTarget();
 		String redefinedFeature = getRedefinedFeature(target);
-		return redefinedFeature == null? super.getRelevantFeatures(type, skip):
+		return redefinedFeature == null? super.getRelevantFeatures(type):
 			   type == target.getOwningType()? Collections.singletonList(target):
 			   Collections.singletonList((Feature)getLibraryType(redefinedFeature));
 	}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/ExpressionAdapter.java
@@ -80,14 +80,14 @@ public class ExpressionAdapter extends StepAdapter {
 	// Computed Redefinition
 
 	@Override
-	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
+	protected List<? extends Feature> getRelevantFeatures(Type type) {
 		Expression target = getTarget();
 		Type owningType = target.getOwningType();
 		return ExpressionUtil.isTransitionGuard(target)?
 					type == owningType? Collections.singletonList(target):
 					Collections.singletonList((Feature)getLibraryType(EXPRESSION_GUARD_FEATURE)):
 			   owningType instanceof FeatureValue? Collections.emptyList():
-			   super.getRelevantFeatures(type, skip);
+			   super.getRelevantFeatures(type);
 	}
 	
 	@Override

--- a/org.omg.sysml/src/org/omg/sysml/adapter/MultiplicityAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/MultiplicityAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2024, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -58,7 +58,7 @@ public class MultiplicityAdapter extends FeatureAdapter {
 	}
 	
 	@Override
-	protected List<Multiplicity> getRelevantFeatures(Type type, Element skip) {
+	protected List<Multiplicity> getRelevantFeatures(Type type) {
 		return Collections.emptyList();
 	}
 	

--- a/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/RequirementUsageAdapter.java
@@ -24,7 +24,6 @@ package org.omg.sysml.adapter;
 import java.util.Collections;
 import java.util.List;
 
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.RequirementDefinition;
 import org.omg.sysml.lang.sysml.RequirementUsage;
@@ -81,14 +80,14 @@ public class RequirementUsageAdapter extends ConstraintUsageAdapter {
 	 * @satisfies checkRequirementUsageObjectiveRedefinition
 	 */
 	@Override
-	protected List<? extends Feature> getRelevantFeatures(Type type, Element skip) {
+	protected List<? extends Feature> getRelevantFeatures(Type type) {
 		RequirementUsage target = getTarget();
 		return UsageUtil.isObjective(getTarget())?
 				Collections.singletonList(
 						type == target.getOwningType()? 
 						UsageUtil.getOwnedObjectiveRequirementOf(type):
 						UsageUtil.getObjectiveRequirementOf(type)):
-			    super.getRelevantFeatures(type, skip);
+			    super.getRelevantFeatures(type);
 	}
 	
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Behavior_parameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Behavior_parameter_SettingDelegate.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,25 +22,12 @@
 
 package org.omg.sysml.delegate.setting;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.Behavior;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.util.NonNotifyingEObjectEList;
-import org.omg.sysml.util.TypeUtil;
 
-public class Behavior_parameter_SettingDelegate extends BasicDerivedListSettingDelegate {
+public class Behavior_parameter_SettingDelegate extends Type_directedFeature_SettingDelegate {
 
 	public Behavior_parameter_SettingDelegate(EStructuralFeature eStructuralFeature) {
 		super(eStructuralFeature);
-	}
-
-	@Override
-	protected EList<?> basicGet(InternalEObject owner) {
-		EList<Feature> parameters = new NonNotifyingEObjectEList<>(Feature.class, owner, eStructuralFeature.getFeatureID());
-		parameters.addAll(TypeUtil.getAllParametersOf((Behavior)owner));
-		return parameters;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Step_parameter_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Step_parameter_SettingDelegate.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2025 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,25 +22,12 @@
 
 package org.omg.sysml.delegate.setting;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.Feature;
-import org.omg.sysml.lang.sysml.Step;
-import org.omg.sysml.util.NonNotifyingEObjectEList;
-import org.omg.sysml.util.TypeUtil;
 
-public class Step_parameter_SettingDelegate extends BasicDerivedListSettingDelegate {
+public class Step_parameter_SettingDelegate extends Type_directedFeature_SettingDelegate {
 
 	public Step_parameter_SettingDelegate(EStructuralFeature eStructuralFeature) {
 		super(eStructuralFeature);
-	}
-
-	@Override
-	protected EList<?> basicGet(InternalEObject owner) {
-		EList<Feature> parameters = new NonNotifyingEObjectEList<>(Feature.class, owner, eStructuralFeature.getFeatureID());
-		parameters.addAll(TypeUtil.getAllParametersOf((Step)owner));
-		return parameters;
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -208,63 +208,15 @@ public class TypeUtil {
 	}
 	
 	public static List<Feature> getAllEndFeaturesOf(Type type) {
-		return getAllEndFeaturesOf(type, new HashSet<>());
-	}
-	
-	private static List<Feature> getAllEndFeaturesOf(Type type, Set<Type> visited) {
-		visited.add(type);
-		List<Feature> ends = getOwnedEndFeaturesOf(type);
-		int n = ends.size();
-		for (Type general: getGeneralTypesOf(type)) {
-			if (general != null && !visited.contains(general)) {
-				List<Feature> inheritedEnds = getAllEndFeaturesOf(general, visited);
-				if (inheritedEnds.size() > n) {
-					ends.addAll(inheritedEnds.subList(n, inheritedEnds.size()));
-				}
-			}
-		}
-		return ends;
+		return type == null? Collections.emptyList(): type.getEndFeature();
 	}
 	
 	public static List<Feature> getOwnedEndFeaturesOf(Type type) {
-		return type == null? Collections.emptyList():
-			   	type.getOwnedFeature().stream().
-			   		filter(Feature::isEnd).
-			   		collect(Collectors.toList());
+		return type == null? Collections.emptyList(): type.getOwnedEndFeature();
 	}
 	
 	public static List<Feature> getAllParametersOf(Type type) {
-		return getAllParametersOf(type, null);
-	}
-	
-	public static List<Feature> getAllParametersOf(Type type, Element skip) {
-		return getAllParametersOf(type, new HashSet<>(), skip);
-	}
-	
-	private static List<Feature> getAllParametersOf(Type type, Set<Type> visited, Element skip) {
-		visited.add(type);
-		List<Feature> parameters = getOwnedParametersOf(type);
-		parameters.removeIf(FeatureUtil::isResultParameter);
-		int n = parameters.size();
-		Feature resultParameter = getOwnedResultParameterOf(type);
-		for (Type general: TypeUtil.getGeneralTypesOf(type, false, skip)) {
-			if (general != null && !visited.contains(general)) {
-				List<Feature> inheritedParameters = getAllParametersOf(general, visited, skip);
-				if (resultParameter == null) {
-					resultParameter = inheritedParameters.stream().
-							filter(FeatureUtil::isResultParameter).
-							findFirst().orElse(null);
-				}
-				inheritedParameters.removeIf(FeatureUtil::isResultParameter);
-				if (inheritedParameters.size() > n) {
-					parameters.addAll(inheritedParameters.subList(n, inheritedParameters.size()));
-				}
-			}
-		}
-		if (resultParameter != null) {
-			parameters.add(resultParameter);
-		}
-		return parameters;
+		return type.getDirectedFeature();
 	}
 	
 	public static List<Feature> getOwnedParametersOf(Type type) {

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/TransitionPerformances.kerml
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/TransitionPerformances.kerml
@@ -41,9 +41,9 @@ standard library package TransitionPerformances {
 
 		feature accNum: Natural [1] = if isEmpty(trigger) ? 0 else 1;
 		step accept: AcceptPerformance[accNum] subsets timeEnclosedOccurrences, acceptPerformances {
-			in feature redefines receiver = triggerTarget;
 			feature redefines acceptedTransfer = trigger;
 		}
+        binding accept.receiver = triggerTarget;
 
 		private succession [*] guard then [accNum] accept;
 	}

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -144,6 +144,8 @@ standard library package Actions {
 			/*
 			 * The subactions of this Action that are AssignmentActions.
 			 */
+			 
+			 in target;
 		}
 		
 		abstract action ifSubactions : IfThenAction[0..*] :> subactions, ifThenActions {


### PR DESCRIPTION
This PR fixes the computations of the parameters and end features of a type, which are used in determining the implied redefinitions of those features. The PR also proactively fixes a couple issues with library models that were discovered once the code fix was made:

- [KERML11-79](https://issues.omg.org/issues/KERML11-79) TransitionPerformance::accept is incorrect
- [SYSML21-327](https://issues.omg.org/issues/SYSML21-327) AssignmentAction parameters get reordered

**Code**

`Behavior_parameter_SettingDelegate`
`Step_parameter_SettingDelegate`
- Changed to extend `Type_directedFeature_SettingDelegate` and inherit `directedFeature` computation.

`TypeUtil`
- Changed `getAllEndFeaturesOf(type)` to call `type.getEndFeature()`.
- Changed `getAllOwnedEndFeaturesOf(type)` to call `type.getOwnedEndFeature()`.
- Changed `getAllParametersOf(Type)` to call `type.getDirectedFeature()`. Also removed the `skip` parameter.

**Note.** Testing with the `SysMLInteractiveProfiler` indicate that these changes actually slightly improve performance.

`FeatureAdapter`
- Updated `getRelevantFeatures(type)` so that, if the `target` is an end feature, then, if the `type` is the owner of the `target`, it returns `type.getOwnedEndFeature()`, otherwise it returns `type.getEndFeature()`. Also removed the `skip` parameter.

`ActionUsageAdapter`
`ExpressionAdapter`
`MultiplicityAdapter`
`RequirementUsageAdapter`
- Made ancillary changes due to removal of `skip` parameter of `getRelevantFeatures`.

`SysMLValidator`
- In `checkFlowDefinition`, changed the call `TypeUtil.getAllEndFeaturesOf(cdef)` to `cdef.endFeature`.

**Model Libraries**

_Kernel Semantic Library_

`TransitionPerformances`
- In `TransitionPerformance.accept`, removed the nested redefinition of `reciever`.
- In `TransitionPerformance`, added a binding connector between `accept.receiver` and `triggerTarget`.

_Systems Library_

`Actions`
- In `Action::assignments`, added a nested owned parameter `target`, which then implicitly redefines `AssignmentAction::target` and `assignmentActions::target`. As a result, `target` is the first parameter of `assignments`, followed by the inherited parameter `replacementValues`.