### PR TITLE
ST6RI-728 Name resolution of multiply inherited redefined features is not correct

### DIFF
--- a/kerml/src/examples/Simple Tests/Redefinition.kerml
+++ b/kerml/src/examples/Simple Tests/Redefinition.kerml
@@ -1,15 +1,23 @@
 package Redefinition {
-	class Occurrence;
-	class Transfer {
-		feature transferSource;
-		feature item;
-		assoc SourceOutputLink specializes Objects::BinaryLinkObject {
-			end [1] feature source: Occurrence;
-			end [1..*] feature target: Occurrence;
-		}
-		connector sourceOutputLink: SourceOutputLink[1..*] from transferSource to item {
-			feature startShot: Occurrence redefines SourceOutputLink::startShot;
-			feature endShot: Occurrence redefines SourceOutputLink::endShot;
-		}
+	
+	classifier A {
+	    feature f;
+	}
+	
+	classifier B specializes A {
+	    feature redefines f {
+	        feature g;
+	    }
+	}
+	
+	classifier C specializes A, B {
+	    feature subsets f {
+	        feature redefines g;
+	    }
+	}
+
+	class X {
+		feature redefines startShot;
+		feature redefines endShot;
 	}
 }

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Redefinition.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_Redefinition.kerml.xt
@@ -1,0 +1,44 @@
+//* XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+        ResourceSet {
+                ThisFile {}
+                File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+				File {from ="/library/Occurrences.kerml"}
+        }
+        Workspace {
+                JavaProject {
+                        SrcFolder {
+                                ThisFile {}
+                                File {from ="/library/Base.kerml"}
+								File {from ="/library/Links.kerml"}
+								File {from ="/library/Occurrences.kerml"}
+                        }
+                }
+        }
+END_SETUP
+*/
+
+// XPECT noErrors ---> ""
+package Redefinition {
+	
+	classifier A {
+	    feature f;
+	}
+	
+	classifier B specializes A {
+	    feature redefines f {
+	        feature g;
+	    }
+	}
+	
+	classifier C specializes A, B {
+	    feature subsets f {
+	        feature redefines g;
+	    }
+	}
+
+	class X {
+		feature redefines startShot;
+		feature redefines endShot;
+	}
+}

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScope.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/scoping/KerMLScope.xtend
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2018 IncQuery Labs Ltd.
- * Copyright (c) 2018-2022,2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2018-2022, 2024, 2025 Model Driven Solutions, Inc.
  * Copyright (c) 2018-2020 California Institute of Technology/Jet Propulsion Laboratory
  *    
  * This program is free software: you can redistribute it and/or modify
@@ -123,9 +123,9 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 	protected QualifiedName targetqn;
 	
 	/**
-	 * A map of Elements to the QualifiedNames found for them in the scope.
+	 * A map of QualifiedNames to the Elements resolved for them in the scope.
 	 */
-	protected Map<Element, Set<QualifiedName>> elements
+	protected Map<QualifiedName, Set<Element>> elements
 	
 	/**
 	 * The QualifiedNames that have already been seen during a resolution search.
@@ -200,8 +200,8 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 		this.elements = newHashMap
 		this.visitedqns = newHashSet
 		resolve()
-		elements.keySet.flatMap[key |
-			elements.get(key).map[qn | EObjectDescription.create(qn, key)]
+		elements.keySet.flatMap[qn |
+			elements.get(qn).map[elm | EObjectDescription.create(qn, elm)]
 		]
 	}
 	
@@ -231,18 +231,22 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 	}
 	
 	protected def boolean addName(QualifiedName qn, Membership mem, Element elm) {
-		var el = elm
-		if (referenceType !== SysMLPackage.eINSTANCE.membership && !referenceType.isInstance(el)) {
+		if (referenceType !== SysMLPackage.eINSTANCE.membership && !referenceType.isInstance(elm)) {
 			return false
 		} else {
-			if (findFirst && referenceType === SysMLPackage.eINSTANCE.membership) {
-				el = mem
-			}
-			val qns = elements.get(el)
-			if (qns === null) {
-				elements.put(el, newHashSet(qn))
+			val el = if (findFirst && referenceType === SysMLPackage.eINSTANCE.membership) mem else elm
+			val elms = elements.get(qn)
+			if (elms === null) {
+				elements.put(qn, newHashSet(el))
+			} else if (findFirst && el instanceof Feature) {
+				// If findFirst = true then the only time multiple elements will be added for the same qualified
+				// name is during the traversal of general types. In this case, the chosen element should be one
+				// that is not redefined by any other element for the qualified name.
+				if (elms.exists[old | FeatureUtil.getAllRedefinedFeaturesOf(el as Feature).contains(old)]) {
+					elements.put(qn, newHashSet(el))
+				}
 			} else {
-				qns.add(qn)
+				elms.add(el)
 			}
 			return true
 		}
@@ -326,13 +330,8 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 	protected def addQualifiedName(QualifiedName elementqn, Membership mem, Element memberElement) {
 		visitedqns.add(elementqn)
 		if (targetqn === null || targetqn == elementqn) {
-			if (addName(elementqn, mem, memberElement)) {
-				if (targetqn != elementqn && memberElement instanceof Namespace) {
-					isShadowing = true
-				}
-				if (findFirst && targetqn == elementqn) {
-					return true
-				}
+			if (addName(elementqn, mem, memberElement) && findFirst && targetqn !== null) {
+				return true;
 			}
 		}
 		false
@@ -358,6 +357,7 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 	}
 	
 	protected def boolean gen(Namespace ns, QualifiedName qn, Set<Namespace> visited, Set<Element> redefined, boolean isInheriting, boolean includeImplicit) {
+		var isFound = false
 		if (ns instanceof Type) {
 			val conjugator = ns.ownedConjugator
 			if (conjugator !== null && !scopeProvider.visited.contains(conjugator)) {
@@ -373,15 +373,19 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 				newRedefined.addAll(redefined)
 				newRedefined.addAll(TypeUtil.getFeaturesRedefinedBy(ns, skip))
 			}
+			
+			// Note: All specializations are traversed, even if a resolution is found, in order to check for possible redefinitions inherited
+			// from subsequent specializations. If findFirst = true, the selection of a single element is handled in addName.
+			
 			for (e: ns.ownedSpecialization) {
 				if (!scopeProvider.visited.contains(e)) {
-					// NOTE: Exclude the generalization e to avoid possible circular name resolution
+					// NOTE: Exclude the specialization e to avoid possible circular name resolution
 					// when resolving a proxy for e.general.
 					scopeProvider.addVisited(e)
 					val found = e.general.resolveIfUnvisited(qn, false, visited, newRedefined, isInheriting, false, includeImplicit, false)
 					scopeProvider.removeVisited(e)
 					if (found) {
-						return true
+						isFound = true
 					}
 				}
 			}
@@ -392,7 +396,7 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 				for (type : implicitTypes) {
 					val found = type.resolveIfUnvisited(qn, false, visited, newRedefined, isInheriting, false, true, false)
 					if (found) {
-						return true
+						isFound = true
 					}
 				}
 			}
@@ -400,11 +404,11 @@ class KerMLScope extends AbstractScope implements ISysMLScope {
 				val chainingFeature = FeatureUtil.getLastChainingFeatureOf(ns)
 				if (chainingFeature !== null && 
 					chainingFeature.resolveIfUnvisited(qn, false, visited, newRedefined, isInheriting, false, true, false)) {
-					return true;
+					isFound = true;
 				}
 			}
 		}
-		return false
+		return isFound
 	}
 	
 	protected def boolean imp(Namespace ns, QualifiedName qn, Set<Namespace> visited, boolean isInsideScope, boolean includeImplicitGen, boolean includeAll) {

--- a/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
+++ b/sysml.library/Domain Libraries/Geometry/ShapeItems.sysml
@@ -252,8 +252,8 @@ standard library package ShapeItems {
 			item :>> edges [1];
 		}
 		item :>> edges : Ellipse [1] = shape {
-            attribute :>> edges::innerSpaceDimension, Ellipse::innerSpaceDimension;
-            ref item :>> edges::vertices, Ellipse::vertices;
+            attribute :>> Shell::edges::innerSpaceDimension, Ellipse::innerSpaceDimension;
+            ref item :>> Shell::edges::vertices, Ellipse::vertices;
 		}
 		item :>> vertices [0];
 	}


### PR DESCRIPTION
This PR resolves an anomaly in the resolution of the name of a redefined feature due to certain forms of diamond specialization. This anomaly was because the name resolution algorithm (in `org.omg.kerml.xtext.scoping.KerMLScope`) traverses the specialization hierarchy without using  the derived property computation of inherited memberships, but it was not updated when the inherited membership computation was revised to handle multiply inherited redefinitions per the specification.

**Problem**

Consider the following KerML model:
```
classifier A {
    feature f;
}

classifier B specializes A {
    feature redefines f {
	      feature g;
    }
}

classifier C specializes A, B {
    feature subsets f {
	      feature redefines g; // ERROR: Couldn't resolve reference to Feature 'g'.
    }
}
```
Previously, this model generated the indicated error, because the name resolution algorithm traversed specializations in order, stopping if it found a resolution for the name. Thus, since `C` specializes `A` before `B`, the feature `f` inherited by `C` was `A::f,` which does not include the nested feature `g`. But, if the order of the specialized types was changed from `A, B` to `B, A`, then the error would go away, because `B::f` was now inherited instead. 

**Fix**

In order to remove the dependency on the order of specializations, the name resolution algorithm was updated to traverse _all_ specializations of a type, not stopping if a resolution is found. Instead, each time a potentially resolving element is found, it is compared to the previously found resolution (if any), and if the new element is a feature that directly or indirectly redefines the old element, then the new element replaces the old one as the found resolution. Note that this means that, if there are multiple features found none of which redefine another (i.e., conflicting inherited features), the resolution algorithm still returns the first one.

Due to previous optimizations in the computation of redefined features, the update in this PR seems to have no cause no degradation in performance.