### PR TITLE
ST6RI-892 State transition visualization cause null pointer exception (PlantUML)

### DIFF
--- a/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
+++ b/org.omg.sysml.plantuml/src/org/omg/sysml/plantuml/VBehavior.java
@@ -259,8 +259,9 @@ public abstract class VBehavior extends VDefault {
         StringBuilder sb = new StringBuilder();
 
         Expression payload = aau.getPayloadArgument();
-        if (payload != null) {
-            sb.append(getText(payload));
+        String payloadText = getText(payload);
+        if (payloadText != null) {
+            sb.append(payloadText);
         } else {
             ReferenceUsage ru = aau.getPayloadParameter();
             appendNameAndType(sb, ru, "payload");
@@ -281,31 +282,31 @@ public abstract class VBehavior extends VDefault {
         
         List<AcceptActionUsage> triggerActions = tu.getTriggerAction();
         if (!triggerActions.isEmpty()) {
-            String triggerString = triggerToText(triggerActions.get(0)).trim();
-            if (!(triggerString.isEmpty())) {
-                ls.append(triggerString);
+            String triggerString = triggerToText(triggerActions.get(0));
+            if (triggerString != null && !(triggerString.isEmpty())) {
+                ls.append(triggerString.trim());
                 ls.append(' ');
             }
         }
         
         List<Expression> guardExpressions = tu.getGuardExpression();
         if (!guardExpressions.isEmpty()) {
-            String guardString = getText(guardExpressions.get(0)).trim();
-            if (!guardString.isEmpty()) {
+            String guardString = getText(guardExpressions.get(0));
+            if (guardString != null && !guardString.isEmpty()) {
                 ls.fold();
                 ls.append('[');
-                ls.append(guardString);
+                ls.append(guardString.trim());
                 ls.append(']');
             }
         }
         
         List<ActionUsage> effectActions = tu.getEffectAction();
         if (!effectActions.isEmpty()) {
-            String effectString = getText(effectActions.get(0)).trim();
-            if (!effectString.isEmpty()) {
+            String effectString = getText(effectActions.get(0));
+            if (effectString != null && !effectString.isEmpty()) {
                 ls.fold();
                 ls.append('/');
-                ls.append(effectString);
+                ls.append(effectString.trim());
             }
         }
 


### PR DESCRIPTION
This PR fixes a bug that can cause a null-pointer exception when visualizing a state transition in a model that has been loaded from a repository.

**Background**

Consider the following simple state model:
```
package StateVizTest {
    item def Cmd {
        attribute turnOn : ScalarValues::Boolean;
    }
    state def States {
        entry; then off;
        state off;                                  
        state on;
        transition off_To_on
            first off
            accept cmd : Cmd
                if cmd.turnOn
            then on;
        transition on_To_off
            first on
            accept Cmd
                do action Test
            then off;
    }
}
```
This would normally be visualized as
<img width="585" height="447" alt="image" src="https://github.com/user-attachments/assets/c74698fe-ee47-4423-b718-84ea2cc4043d" />
However, if the model is published to a repository and then later loaded back into memory rather than being parsed from text, attempting to visualize it results in a null pointer exception.

Normally, the guard expressions and effect actions are rendered using the textual notation from which they were parsed. However, when the model is loaded from a repository, the original textual notation is no longer available. The exception occurs because the code was attampting to call `trim()` on null text strings.

**Code changes**

This PR fixes the bug by updating the code in `VBehavior.convertToDescription` to check if textual notation strings are null before calling `trim()` on them. After this change, the above model, when loaded from a repository, is visualized without an exception as:
<img width="266" height="447" alt="image" src="https://github.com/user-attachments/assets/ed6fc352-7196-454e-969b-2047a1d1fe29" />
This is probably the best that can be done for now, without re-serializing the text from the abstract syntax or storing the original text as an annotation in the repository.

**Note.** The lack of rendering of typing on features in the loaded model is due to the `featuredType` property of `FeatureTyping` relationships not being set properly for the loaded model. This is not a visualization issue.
