### PR TITLE
ST6RI-900 Actor and stakeholder parameters are not implicitly redefined

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/PartUsageAdapter.java
@@ -82,12 +82,4 @@ public class PartUsageAdapter extends ItemUsageAdapter {
 				 owningType instanceof CaseUsage);
 	}
 
-	@Override
-	public boolean isIgnoredParameter() {
-		PartUsage target = getTarget();
-		return super.isIgnoredParameter() || 
-				UsageUtil.isActorParameter(target) ||
-				UsageUtil.isStakeholderParameter(target);
-	}
-	
 }

--- a/sysml/src/training/35. Use Cases/Use Case Usage Example.sysml
+++ b/sysml/src/training/35. Use Cases/Use Case Usage Example.sysml
@@ -11,8 +11,8 @@ package 'Use Case Usage Example' {
 		
 		then include use case 'enter vehicle' : 'Enter Vehicle' {
 		    subject vehicle;
-			actor :>> driver = 'provide transportation'::driver;
-			actor :>> passengers = 'provide transportation'::passengers;
+			actor driver = 'provide transportation'::driver;
+			actor passengers = 'provide transportation'::passengers;
 		}
 		
 		then use case 'drive vehicle' {
@@ -22,14 +22,14 @@ package 'Use Case Usage Example' {
 			
 			include 'add fuel'[0..*] { 
                 subject vehicle;
-				actor :>> fueler = driver;
+				actor fueler = driver;
 			}
 		}
 		
 		then include use case 'exit vehicle' : 'Exit Vehicle' {
             subject vehicle;
-			actor :>> driver = 'provide transportation'::driver;
-			actor :>> passengers = 'provide transportation'::passengers;
+			actor driver = 'provide transportation'::driver;
+			actor passengers = 'provide transportation'::passengers;
 		}
 		
 		then done;		


### PR DESCRIPTION
This PR fixes a non-conformance in the implementation of implied redefinitions for actor and stakeholder parameters.
 
The KerML semantic constraint `checkFeatureParameterRedefinition` requires that a feature that is a parameter redefine the parameter at the same position in any supertype of its owning type (with exceptions only for result parameters and parameters of positional invocations). However, in the implementation, actor and stakeholder parameters were not being given implicit redefinitions to meet this constraint.

In fact, prevously, the `PartUsageAdapter` specifically overrode the method `isIgnoredParameter` so that actor and stakeholder parameters were not given implicit redefinitions. Since this is not conformant with the specification, this override now has been removed.