### PR TITLE
ST6RI-921 Invalid feature references are allowed in filter expressions

### DIFF
--- a/kerml/src/examples/Simple Tests/Filtering.kerml
+++ b/kerml/src/examples/Simple Tests/Filtering.kerml
@@ -23,15 +23,17 @@ package Filtering {
 
 	package UpperLevelApprovals {
 	    private import DesignModel::**;
-	    filter Annotations::ApprovalAnnotation::approved and 
-	           Annotations::ApprovalAnnotation::level > 1;
+	    filter (as Annotations::ApprovalAnnotation).approved and 
+	           (as Annotations::ApprovalAnnotation).level > 1;
 	    
 	    struct Test :> System;
 	}
 	
 	package UpperLevelApprovals1 {
 	    private import Annotations::**;
-	    private import DesignModel::**[@Structure][approved and level > 1];
+	    private import DesignModel::**[@Structure]
+		    [(as Annotations::ApprovalAnnotation).approved and 
+	         (as Annotations::ApprovalAnnotation).level > 1];
 	    
 	    struct Test :> System;	    
 	}

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/imports/local/Import_Filtered.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/imports/local/Import_Filtered.kerml.xt
@@ -237,7 +237,7 @@ package Import_Filtered {
 	}
 	
 	package 'Mandatory Features_true_1' {
-		public import vehicle1_c1::**[Safety::isMandatory];
+		public import vehicle1_c1::**[(as Safety).isMandatory];
 		classifier b :> seatBelt; 
 		
 		// XPECT errors --> "Couldn't resolve reference to Classifier 'alarm'." at "alarm"
@@ -259,7 +259,7 @@ package Import_Filtered {
 	}
 	
 	package 'Mandatory Features_true_2' {
-		public import vehicle1_c1::**[Safety::isMandatory == true]; 
+		public import vehicle1_c1::**[(as Safety).isMandatory == true]; 
 		classifier b :> seatBelt; 
 
 		// XPECT errors --> "Couldn't resolve reference to Classifier 'alarm'." at "alarm"
@@ -281,7 +281,7 @@ package Import_Filtered {
 	}
 	
 	package 'Mandatory Features_false' {
-		public import vehicle1_c1::**[Safety::isMandatory == false]; 
+		public import vehicle1_c1::**[(as Safety).isMandatory == false]; 
 		classifier j :> antilockBrakes; 
 		
 		// XPECT errors --> "Couldn't resolve reference to Classifier 'alarm'." at "alarm"

--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MetadataTests_MetadataFeature_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/MetadataTests_MetadataFeature_invalid.kerml.xt
@@ -50,12 +50,12 @@ package MetadataFeatureTest {
 	
 	function f { in x; return : ScalarValues::Boolean; }
 	
-	// XPECT errors --> "Must be model-level evaluable" at "filter f(A::y);"
-	filter f(A::y);
-	// XPECT errors --> "Must be model-level evaluable" at "filter ~A::z;"
-	filter ~A::z;
-	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->ControlFunctions::collect {in x; x};"
-	filter A::y->ControlFunctions::collect {in x; x};
+	// XPECT errors --> "Must be model-level evaluable" at "filter f((as A).y);"
+	filter f((as A).y);
+	// XPECT errors --> "Must be model-level evaluable" at "filter ~(as A).z;"
+	filter ~(as A).z;
+	// XPECT errors --> "Must be model-level evaluable" at "filter (as A).y->ControlFunctions::collect {in x; x};"
+	filter (as A).y->ControlFunctions::collect {in x; x};
 	// XPECT errors --> "Must have a Boolean result" at "filter new A(null, 1, "", false);"
 	filter new A(null, 1, "", false);
 	
@@ -66,8 +66,8 @@ package MetadataFeatureTest {
 			// XPECT errors --> "Must be model-level evaluable" at "= ~3"
 			x = ~3;
 			y = "e";
-			// XPECT errors --> "Must be model-level evaluable" at "= f(A::y)"
-			z = f(A::y);
+			// XPECT errors --> "Must be model-level evaluable" at "= f((as A).y)"
+			z = f((as A).y);
 			u {
 				v = 1;
 				// XPECT errors --> "Must redefine an owning-type feature" at "bad;"

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/ModelLevelEvaluationTest.java
@@ -371,7 +371,7 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		
 		assertEquals(1, evaluateIntegerValue(instance, 
 				checkAnnotatingFeature(instance, "Annotation", "x"), 
-				"Annotation::a"));		
+				"(as Annotation).a"));		
 	}
 	
 	@Test
@@ -385,7 +385,7 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		assertEquals(instance.resolve("E::e"), 
 				evaluateSingleValue(instance, 
 						checkAnnotatingFeature(instance, "Annotation", "x"), 
-						"Annotation::a"));		
+						"(as Annotation).a"));		
 	}
 	
 	@Test
@@ -408,8 +408,8 @@ public class ModelLevelEvaluationTest extends SysMLInteractiveTest {
 		        "attribute x {@Annotation{a = E::e; b = 2;}}");
 		
 		MetadataFeature feature = checkAnnotatingFeature(instance, "Annotation", "x");
-		assertTrue(evaluateBooleanValue(instance, feature, "Annotation::a istype E"));		
-		assertTrue(evaluateBooleanValue(instance, feature, "Annotation::b istype ScalarValues::Integer"));		
+		assertTrue(evaluateBooleanValue(instance, feature, "(as Annotation).a istype E"));		
+		assertTrue(evaluateBooleanValue(instance, feature, "(as Annotation).b istype ScalarValues::Integer"));		
 	}
 	
 	@Test

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ElementFilter.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/simpletests/ElementFilter.sysml.xt
@@ -85,6 +85,6 @@ package ElementFilterTest {
 	}
 	
 	package 'Mandatory Features' {
-		public import vehicle1_c1::**[@Safety and PartInfo::isMandatory];
+		public import vehicle1_c1::**[@Safety and (as PartInfo).isMandatory];
 	}
 }

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/MetadataUsage_Invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/MetadataUsage_Invalid.sysml.xt
@@ -62,12 +62,12 @@ package Test {
 	
 	calc def f { in x : ScalarValues::Boolean; }
 	
-	// XPECT errors --> "Must be model-level evaluable" at "filter f(A::z);"
-	filter f(A::z);
-	// XPECT errors --> "Must be model-level evaluable" at "filter ~A::z;"
-	filter ~A::z;
-	// XPECT errors --> "Must be model-level evaluable" at "filter A::y->ControlFunctions::collect {in ref x; x};"
-	filter A::y->ControlFunctions::collect {in ref x; x};
+	// XPECT errors --> "Must be model-level evaluable" at "filter f((as A).z);"
+	filter f((as A).z);
+	// XPECT errors --> "Must be model-level evaluable" at "filter ~(as A).z;"
+	filter ~(as A).z;
+	// XPECT errors --> "Must be model-level evaluable" at "filter (as A).y->ControlFunctions::collect {in ref x; x};"
+	filter (as A).y->ControlFunctions::collect {in ref x; x};
 	// XPECT errors --> "Must have a Boolean result" at "filter new A(null, 1, "", false);"
 	filter new A(null, 1, "", false);
 	
@@ -82,8 +82,8 @@ package Test {
 			// XPECT errors --> "Must be model-level evaluable" at "= ~3"
 			x = ~3;
 			y = E::e;
-			// XPECT errors --> "Must be model-level evaluable" at "= f(A::z)"
-			z = f(A::z);
+			// XPECT errors --> "Must be model-level evaluable" at "= f((as A).z)"
+			z = f((as A).z);
 			u {
 				v = 1;
 				// XPECT errors --> "Must redefine an owning-type feature" at "bad;"

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureReferenceExpressionAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -63,19 +63,11 @@ public class FeatureReferenceExpressionAdapter extends ExpressionAdapter {
 	 * @satisfies checkFeatureReferenceExpressionBindingConnector
 	 */
 	protected void addReferenceConnector() {
-		/*
-		 * TODO: Update checkFeatureReferenceExpressionBindingConnector?
-         * 
-         * OCL does not include !isInFilterExpression check.
-		 * 
-		 */
-		if (!isInFilterExpression()) {
-			FeatureReferenceExpression target = getTarget();
-			Feature referent = target.getReferent();
-			Feature result = target.getResult();
-			if (referent != null && result != null) {
-				addBindingConnector(referent, result);
-			}
+		FeatureReferenceExpression target = getTarget();
+		Feature referent = target.getReferent();
+		Feature result = target.getResult();
+		if (referent != null && result != null) {
+			addBindingConnector(referent, result);
 		}
 	}
 	

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
@@ -1536,7 +1536,7 @@ package SimpleVehicleModel{
         package MandatorySafetyGroup {
             /* Parts that contribute to safety AND are mandatory. */
             public import vehicle_b::**;
-            filter @Safety and Safety::isMandatory;
+            filter (as Safety).isMandatory;
         }
     }
     package Views_Viewpoints{

--- a/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
+++ b/sysml/src/examples/Vehicle Example/SysML v2 Spec Annex A SimpleVehicleModel.sysml
@@ -1536,7 +1536,7 @@ package SimpleVehicleModel{
         package MandatorySafetyGroup {
             /* Parts that contribute to safety AND are mandatory. */
             public import vehicle_b::**;
-            filter (as Safety).isMandatory;
+            filter @Safety and (as Safety).isMandatory;
         }
     }
     package Views_Viewpoints{

--- a/sysml/src/training/40. Filtering/Filtering Example-1.sysml
+++ b/sysml/src/training/40. Filtering/Filtering Example-1.sysml
@@ -32,6 +32,6 @@ package 'Filtering Example-1' {
 	package 'Mandatory Safety Features' {
 		/* Parts that contribute to safety AND are mandatory. */
 		public import vehicle::**;
-		filter @Safety and Safety::isMandatory;
+		filter @Safety and (as Safety).isMandatory;
 	}
 }

--- a/sysml/src/training/40. Filtering/Filtering Example-2.sysml
+++ b/sysml/src/training/40. Filtering/Filtering Example-2.sysml
@@ -30,6 +30,6 @@ package 'Filtering Example-2' {
 	
 	package 'Mandatory Safety Features' {
 		/* Parts that contribute to safety AND are mandatory. */
-		public import vehicle::**[@Safety and Safety::isMandatory];
+		public import vehicle::**[@Safety and (as Safety).isMandatory];
 	}
 }

--- a/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
+++ b/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
@@ -54,11 +54,11 @@ package '11b-Safety and Security Feaure Views' {
 		
 		view vehicleMandatorySafetyFeatureView :> vehicleSafetyFeatureView {
 		    expose vehicle::*::**;
-			filter (as Safety).isMandatory;
+			filter @Safety and (as Safety).isMandatory;
 		}
 		
 		view vehicleMandatorySafetyFeatureViewStandalone {
-			expose vehicle::**[(as Safety).isMandatory];
+			expose vehicle::**[@Safety and (as Safety).isMandatory];
 			render asElementTable;
 		}	
 	}

--- a/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
+++ b/sysml/src/validation/11-View and Viewpoint/11b-Safety and Security Feature Views.sysml
@@ -54,11 +54,11 @@ package '11b-Safety and Security Feaure Views' {
 		
 		view vehicleMandatorySafetyFeatureView :> vehicleSafetyFeatureView {
 		    expose vehicle::*::**;
-			filter Safety::isMandatory;
+			filter (as Safety).isMandatory;
 		}
 		
 		view vehicleMandatorySafetyFeatureViewStandalone {
-			expose vehicle::**[@Safety and Safety::isMandatory];
+			expose vehicle::**[(as Safety).isMandatory];
 			render asElementTable;
 		}	
 	}

--- a/sysml/src/validation/13-Model Containment/13b-Safety and Security Features Element Group-1.sysml
+++ b/sysml/src/validation/13-Model Containment/13b-Safety and Security Features Element Group-1.sysml
@@ -51,6 +51,6 @@ package '13b-Safety and Security Features Element Group-1' {
 	package 'Mandatory Safety Features' {
 		/* Parts that contribute to safety AND are mandatory. */
 		public import vehicle::**;
-		filter @Safety and Safety::isMandatory;
+		filter @Safety and (as Safety).isMandatory;
 	}
 }

--- a/sysml/src/validation/13-Model Containment/13b-Safety and Security Features Element Group-2.sysml
+++ b/sysml/src/validation/13-Model Containment/13b-Safety and Security Features Element Group-2.sysml
@@ -47,6 +47,6 @@ package '13b-Safety and Security Features Element Group-2' {
 	
 	package 'Mandatory Saftey Features' {
 		/* Parts that contribute to safety AND are mandatory. */
-		public import vehicle::**[@Safety and Safety::isMandatory];
+		public import vehicle::**[@Safety and (as Safety).isMandatory];
 	}
 }


### PR DESCRIPTION
This PR removes an exception made in the Pilot Implementation that allowed invalid feature references in filter expressions.

**Background**

Both the KerML Specification (in 7.4.14 Packages) and the SysML Specification (in 7.5.4 Import Filtering) show examples of referencing features using a qualified name notation. For example:
```
filter @Annotations::ApprovalAnnotation and
    Annotations::ApprovalAnnotation::approved and
    Annotations::ApprovalAnnotation::level > 1;
```
This example has subexpressions that are feature reference expressions for non-package-level features, such as `Annotations::Approval::approved`. However, filter expressions are at package level (have no featuring type), and therefore do not have access to non-package-level features. 

This should have caused a `checkConnectorTypeFeaturing` error on the implied binding connector between the referent feature and the expression result. But the Pilot Implementation had an explicit check coded in `FeatureReferenceExpressionAdapter::addReferenceConnector` to _not_ add the binding connector if the expression was in a filter, so no error was reported. There is no such exception in the normative metamodel, despite the examples given in Clause 7 of the specifications (see also [KERML11-183](https://issues.omg.org/issues/KERML11-183) on the specification inconsistency).

**Changes**

Updated `FeatureReferenceExpressionAdapter::addReferenceConnector` to remove the exception for filter expressions.

Feature expressions such as in the example above now cause errors. The corrected version of the example is:
```
filter @Annotations::ApprovalAnnotation and
    (as Annotations::ApprovalAnnotation).approved and
    (as Annotations::ApprovalAnnotation).level > 1;
```