### PR TITLE
ST6RI-923 Problem with name resolution when  using Semantic metadata

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_SemanticMetadata.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/parsing/ParsingTests_SemanticMetadata.kerml.xt
@@ -1,0 +1,52 @@
+//* XPECT_SETUP org.omg.kerml.xpect.tests.parsing.KerMLParsingTest
+	ResourceSet {
+        ThisFile {}
+		File {from ="/library/Base.kerml"}
+		File {from ="/library/Links.kerml"}
+       	File {from ="/library/Occurrences.kerml"}
+       	File {from ="/library/Objects.kerml"}
+       	File {from ="/library/Performances.kerml"}
+      	File {from ="/library/Metaobjects.kerml"}
+        File {from ="/library/KerML.kerml"}
+        File {from ="/library/BaseFunctions.kerml"}
+    }
+    Workspace {
+        JavaProject {
+            SrcFolder {
+		        ThisFile {}
+				File {from ="/library/Base.kerml"}
+				File {from ="/library/Links.kerml"}
+		       	File {from ="/library/Occurrences.kerml"}
+		       	File {from ="/library/Objects.kerml"}
+		       	File {from ="/library/Performances.kerml"}
+		      	File {from ="/library/Metaobjects.kerml"}
+		        File {from ="/library/KerML.kerml"}
+                File {from ="/library/BaseFunctions.kerml"}
+            }
+    	}
+	}
+END_SETUP
+*/
+
+// XPECT noErrors ---> ""
+package SemanticMetadataTest {
+    private import Metaobjects::SemanticMetadata;
+
+    classifier P {
+        feature a;
+    }
+    feature p : P;
+
+    metaclass M :> SemanticMetadata {
+        :>> baseType = p meta KerML::Feature;
+    }
+
+    classifier Q {
+        feature a = 1;
+        #M feature p1 {
+        	// This feature should redefine P::a, not Q::a.
+        	// Redefining Q::a will causes a feature value override error.
+            feature :>> a = 2;
+        }
+    }
+}

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -436,23 +436,25 @@ public class TypeAdapter extends NamespaceAdapter {
 	protected List<Type> getBaseTypes() {
 		List<Type> baseTypes = new ArrayList<>();
 		if (isGetBaseTypes) {
-			isGetBaseTypes = false;
 			Type target = getTarget();
 			for (MetadataFeature metadataFeature : ElementUtil.getAllMetadataFeaturesOf(target)) {
+				// Resolve metaclass proxy before getting base type, to avoid problems
+				// with name resolution when applying semantic metadata.
+				metadataFeature.getMetaclass();
+				isGetBaseTypes = false;
 				metadataFeature.getFeature().stream().
 						filter(f->TypeUtil.specializes(f, getBaseTypeFeature(metadataFeature))).
 						map(FeatureUtil::getValueExpressionFor).
 						filter(expr->expr != null).
-						map(expr->
-						expr.evaluate(metadataFeature)).
+						map(expr->expr.evaluate(metadataFeature)).
 						filter(results->results != null && !results.isEmpty()).
 						map(results->results.get(0)).
 						map(EvaluationUtil::getMetaclassReferenceOf).
 						filter(Type.class::isInstance).
 						map(Type.class::cast).
 						forEachOrdered(baseTypes::add);
+				isGetBaseTypes = true;
 			}
-			isGetBaseTypes = true;
 		}
 		return baseTypes;
 	}


### PR DESCRIPTION
This PR fixes a bug that could cause an incorrect name resolution when using semantic metadata.

**Background**
The following SysML model should parse, with `p1::a` redefining `P::a`:
```
part def P {
    attribute a;
}
part p : P;

metadata def M :> Metaobjects::SemanticMetadata {
    :>> baseType = p meta SysML::Usage;
}

part def Q {
    attribute a = 1;
    part p1 {
        metadata m : M;
        attribute :>> a = 2;
    }
}
```
Previously, this worked in the Eclipse Xtext editor, but in Jupyter the model gave the errors:
```
ERROR:Cannot override a binding feature value (1.sysml line : 16 column : 29)
WARNING:Duplicate of inherited member name 'a' from P (1.sysml line : 16 column : 13)
```
In Jupyter, name resolution happens during top-down transformation of the model. During the transformation of `p1`, the reference to the semantic metadata `M` must be resolved in order to get the implied base type for `p1`. This name resolution begins in the scope of `p1`, resultin in the redefined feature name`a` being resolved early, in order to check the (effective) name of the redefining feature. But, at this point, inheritance from the implied base type is blocked, in order to avoid circular resolution of `M`. So the reference to a in `p1` resolves to `Q::a`.

In Eclipse, the Xtext reconciler proxy resolution works bottom up, resolving the proxy for `M` in the declaration of `m` before processing `m` as semantic metadata during the transformation of `p1`. When `a` is resolved, this triggers the adding of the implied subsetting of `p1` by `P`, so the reference to a resolves to `P::a` (as it should).

**Changes**

1. Created an Xpect test `ParsingTests_SemanticMetadata.kerml.xt`. Since the underlying problem is in the KerML core, it is a KerML Xpect test similar to the above SysML model. Name resolution in Xpect is similar to Jupyter, so the following model had errors previously, but does not have errors after the change below is made.
    ```
    classifier P {
        feature a;
    }
    feature p : P;
    
    metaclass M :> Metaobjects::SemanticMetadata {
        :>> baseType = p meta KerML::Feature;
    }
    
    classifier Q {
        feature a = 1;
        feature p1 {
            metadata m : M;
            feature :>> a = 2;
        }
    }
    ```
2. Add the call `metadataFeature.getMetaclass()` in the method `TypeAdapter::getBaseTypes` in the loop over the owned metadata features of a typ ethat compute the implied base types from those metadata features that are semantic metadata. The call is added such that any proxy resolution (requiring name resolution) for the metaclass will happen before the computation of the base type.