### PR TITLE
ST6RI-924 Problems with TypeAdapter and AssignmentActionUsageAdapter

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/adapter/AssignmentActionUsageAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/AssignmentActionUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,6 @@
 package org.omg.sysml.adapter;
 
 import org.omg.sysml.lang.sysml.AssignmentActionUsage;
-import org.omg.sysml.util.TypeUtil;
 
 public class AssignmentActionUsageAdapter extends ActionUsageAdapter {
 
@@ -34,18 +33,4 @@ public class AssignmentActionUsageAdapter extends ActionUsageAdapter {
 		return (AssignmentActionUsage)super.getTarget();
 	}
 	
-	/**
-	 * @satisfies checkAssignmentActionUsageReferentRedefinition
-	 * @satisfies checkAssignmentActionUsageAccessedFeatureRedefinition
-	 * @satisfies checkAssignmentActionUsageStartingAtRedefinition
-	 */
-	protected void addTargetRedefinitions() {
-		AssignmentActionUsage target = getTarget();
-		addFeatureWriteTypes(TypeUtil.getOwnedParametersOf(target), target.getReferent());
-	}
-	
-	public void doTransform() {
-		super.doTransform();
-		addTargetRedefinitions();
-	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/FeatureAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2025 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.Association;
 import org.omg.sysml.lang.sysml.BindingConnector;
 import org.omg.sysml.lang.sysml.Connector;
@@ -216,7 +217,6 @@ public class FeatureAdapter extends TypeAdapter {
 	 * @satisfies checkFeatureCrossingSpecialization
 	 * @satisfies checkFeatureOwnedCrossFeatureSpecialization
 	 * @satisfies checkFeatureOwnedCrossFeatureRedefinitionSpecialization
-	 * 
 	 */
 	@Override
 	public void addDefaultGeneralType() {
@@ -592,8 +592,45 @@ public class FeatureAdapter extends TypeAdapter {
 			// NOTE: Set flag before adding redefinitions, to avoid possible infinite
 			// recursion if computeImplicitGeneralTypes is called again on this Feature.
 			isComputeRedefinitions = false;
+			addFeatureWriteTypes();
 			addRedefinitions(skip);
 		}
+	}
+	
+	/**
+	 * @satisfies checkAssignmentActionUsageReferentRedefinition
+	 * @satisfies checkAssignmentActionUsageAccessedFeatureRedefinition
+	 * @satisfies checkAssignmentActionUsageStartingAtRedefinition
+	 */
+	protected void addFeatureWriteTypes() {
+		Feature feature = getTarget();
+		if (isStartingAtFeature(feature)) {
+			addDefaultGeneralType(SysMLPackage.eINSTANCE.getRedefinition(), getDefaultSupertype("startingAt"));
+		} else if (isAccessedFeature(feature)) {
+			addDefaultGeneralType(SysMLPackage.eINSTANCE.getRedefinition(), getDefaultSupertype("accessedFeature"));
+			AssignmentActionUsage actionUsage = (AssignmentActionUsage)(feature.getOwner().getOwner().getOwner());
+			Feature referent = actionUsage.getReferent();
+			if (referent != null) {
+				addImplicitGeneralType(SysMLPackage.eINSTANCE.getRedefinition(), referent);
+			}
+		}
+	}
+	
+	public static boolean isStartingAtFeature(Feature feature) {
+		Type owningType = feature.getOwningType();
+		if (owningType instanceof Feature) {
+			Type actionUsage = ((Feature)owningType).getOwningType();
+			if (actionUsage instanceof AssignmentActionUsage) {
+				 return ((AssignmentActionUsage)actionUsage).getParameter().indexOf(owningType) == 0;
+			}
+		}
+		return false;
+	}
+	
+	public static boolean isAccessedFeature(Feature feature) {
+		Type owningType = feature.getOwningType();
+		return owningType instanceof Feature && isStartingAtFeature((Feature)owningType) &&
+			   owningType.getOwnedFeature().indexOf(feature) == 0;
 	}
 	
 	/**
@@ -787,27 +824,6 @@ public class FeatureAdapter extends TypeAdapter {
 		addImplicitMemberBindingConnector(connector);
 		FeatureUtil.addFeaturingTypesTo(connector, featuringTypes);
 		return connector;
-	}
-	
-	protected void addFeatureWriteTypes(List<Feature> parameters, Feature referent) {
-		if (!parameters.isEmpty()) {
-			Feature targetFeature = parameters.get(0);
-			List<Feature> features = targetFeature.getOwnedFeature();
-			if (!features.isEmpty()) {
-				Feature startingAtFeature = features.get(0);
-				TypeUtil.addDefaultGeneralTypeTo(startingAtFeature, SysMLPackage.eINSTANCE.getRedefinition(), getDefaultSupertype("startingAt"));
-				TypeUtil.setIsAddImplicitGeneralTypesFor(startingAtFeature, false);
-				features = startingAtFeature.getOwnedFeature();
-				if (!features.isEmpty()) {
-					Feature accessedFeature = features.get(0);
-					TypeUtil.addDefaultGeneralTypeTo(accessedFeature, SysMLPackage.eINSTANCE.getRedefinition(), getDefaultSupertype("accessedFeature"));
-					if (referent != null) {
-						TypeUtil.addImplicitGeneralTypeTo(accessedFeature, SysMLPackage.eINSTANCE.getRedefinition(), referent);
-					}
-					TypeUtil.setIsAddImplicitGeneralTypesFor(accessedFeature, false);
-				}
-			}
-		}
 	}
 	
 	/**

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -359,15 +359,17 @@ public class TypeAdapter extends NamespaceAdapter {
 		implicitGeneralTypes.values().forEach(implicitGenerals::addAll);
 		for (Object eClass: implicitGeneralTypes.keySet().toArray()) {
 			List<Type> implicitEClassGenerals = implicitGeneralTypes.get(eClass);
-			if (eClass == SysMLPackage.eINSTANCE.getRedefinition()) {
-				implicitEClassGenerals.removeAll(redefinedFeatures);
-			} else {
-				implicitEClassGenerals.removeIf(gen->
-					generals.stream().anyMatch(type->specializesExcludingTarget(type, gen)) ||
-					implicitGenerals.stream().anyMatch(type->type != gen && specializesExcludingTarget(type, gen)));
-			}
-			if (implicitEClassGenerals.isEmpty()) {
-				implicitGeneralTypes.remove(eClass);
+			if (implicitEClassGenerals != null) {
+				if (eClass == SysMLPackage.eINSTANCE.getRedefinition()) {
+					implicitEClassGenerals.removeAll(redefinedFeatures);
+				} else {
+					implicitEClassGenerals.removeIf(gen->
+						generals.stream().anyMatch(type->specializesExcludingTarget(type, gen)) ||
+						implicitGenerals.stream().anyMatch(type->type != gen && specializesExcludingTarget(type, gen)));
+				}
+				if (implicitEClassGenerals.isEmpty()) {
+					implicitGeneralTypes.remove(eClass);
+				}
 			}
 		}
 		


### PR DESCRIPTION
This PR fixes bugs in `TypeAdapter` and `AssignmentUsageAdapter`.

`TypeAdapter`

- Previously, `TypeAdapter::removeUnnecessaryImplicitGeneralTypes` could throw an `NullPointerException` if `implicitEClassGenerals` was null for a certain specialization `EClass` (which can happen during processing of an ill-formed model).
- Added a check on that `implicitEClassGenerals` is non-null before processing it further.

`AssignmentUsageAdapter`

- Previously,  `AssignmentActionUsageAdapter::addTargetRedefinition` called `FeatureAdapter::addFeatureWriteTypes` to satisfy redefinition constraints on `target::StartingAt` and `target::startingAt::accessedFeature` nested in an `AssignmentActionUsage`. However, placing this within `AssignmentActionUsageAdapter` means that the transformation is not done if `Feature::computeImplicitGeneralTypes` is called directly on these features, which can happen during Xtext editor reconciliation of text changes. The result can be spurious validation errors.
- Moved the implementation satisfying these constraints to `FeatureAdapter`, called from `addComputedRedefinitions`.

    **Note.** This change results in the KerML-level `FeatureAdapter` depending on SysML `AssignmentActionUsage`. However, in general, "on-demand" calls to `computeImplicitGeneralTypes` can only be properly handled if the satisfaction of all semantic constrains effecting a metaclass are implemented in the adapter for _that_ metaclass.