### PR TITLE
ST6RI-919 Update derived properties to handle implied relationships

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022, 2025 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022, 2025, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,6 +24,7 @@ package org.omg.sysml.interactive.tests;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -36,6 +37,7 @@ import org.omg.sysml.lang.sysml.AcceptActionUsage;
 import org.omg.sysml.lang.sysml.ActionUsage;
 import org.omg.sysml.lang.sysml.AttributeUsage;
 import org.omg.sysml.lang.sysml.Comment;
+import org.omg.sysml.lang.sysml.ConnectionDefinition;
 import org.omg.sysml.lang.sysml.Definition;
 import org.omg.sysml.lang.sysml.Documentation;
 import org.omg.sysml.lang.sysml.Element;
@@ -350,5 +352,36 @@ public class DerivedPropertyAndOperationTest extends SysMLInteractiveTest {
 		Documentation doc = (Documentation)ownedMembers.get(1);
 		assertEquals("comment.locale", "en_US", comment.getLocale());
 		assertEquals("doc.locale", "en_US", doc.getLocale());
+	}
+	
+	public final String crossFeatureTest =
+			  "package Test {"
+			+ "    part def A {"
+			+ "        ref b : B;"
+			+ "    }"
+			+ "    part def B;"
+			+ "    connection def C {"
+			+ "        end [0..1] ref end1 : A;"
+			+ "        end ref end2 : B crosses end1.b;"
+			+ "    }"
+			+ "}";
+	
+	@Test
+	public void testCrossFeature() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		SysMLInteractiveResult result = instance.process(crossFeatureTest);
+		Element root = result.getRootElement();
+		Namespace test = (Namespace)((Namespace)root).getOwnedMember().get(0);
+		Definition a = (Definition)test.getOwnedMember().get(0);
+		Usage a_b = a.getOwnedUsage().get(0);
+		ConnectionDefinition c = (ConnectionDefinition)test.getOwnedMember().get(2);
+		List<Feature> ends = c.getAssociationEnd();
+		Usage end1 = (Usage)ends.get(0);
+		Usage end2 = (Usage)ends.get(1);
+		Feature ownedCrossFeature = end1.ownedCrossFeature();
+		
+		assertNotNull("end1 owned cross feature", ownedCrossFeature);
+		assertEquals("end1 cross feature", end1.ownedCrossFeature(), end1.getCrossFeature());
+		assertEquals("end2 cross feature", a_b, end2.getCrossFeature().getFeatureTarget());
 	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Feature_crossFeature_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Feature_crossFeature_SettingDelegate.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2024 Model Driven Solutions, Inc.
+ * Copyright (c) 2024, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,13 +21,11 @@
 
 package org.omg.sysml.delegate.setting;
 
-import java.util.List;
-
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.CrossSubsetting;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.util.FeatureUtil;
 
 public class Feature_crossFeature_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -37,17 +35,7 @@ public class Feature_crossFeature_SettingDelegate extends BasicDerivedObjectSett
 
 	@Override
 	protected EObject basicGet(InternalEObject owner) {
-		CrossSubsetting subsetting = ((Feature)owner).getOwnedCrossSubsetting();
-		if (subsetting != null) {
-			Feature crossedFeature = subsetting.getCrossedFeature();
-			if (crossedFeature != null) {
-				List<Feature> chainingFeatures = crossedFeature.getChainingFeature();
-				if (chainingFeatures.size() >=2) {
-					return chainingFeatures.get(1);
-				}
-			}
-		}
-		return null;
+		return FeatureUtil.getCrossFeatureOf((Feature)owner);
 	}
 
 }


### PR DESCRIPTION
This PR updates the derived property computation for `Feature::crossFeature` to properly account for an implied cross subsetting.

**Change**

- The code in `Feature_crossFeature_SettingDelegate::basicGet` was updated to simply call the utility method `FeatureUtil::getCrossFeatureOf`, which already computed the `crossFeature` correctly.

**Note**

After analysis, it was decided that the above change was the only update necessary to handle implied relationships. With this change, the consistent rules for derived properties are:

1. Implied relationships and binding connectors implemented implicitly are _not_ included in any derived property values. For example, `getOwnedSpecializations` does _not_ include implicit specializations, and `getOwnedMembers` does _not_ include implicit binding connectors.
2. Otherwise, derived property and operation implementations take implied relationships and binding connectors into account. So, `supertypes` includes supertypes via implied specializations and `getInheritedMemberships` includes memberships inherited via implied specializations.

To include implied relationships and binding connectors in all cases, call `ElementUtil.transformAll(root, true)` to add them physically to the abstract syntax tree (the second argument is a boolean flag to `addImplicitElements`.