### PR TITLE
ST6RI-925 Problem with deriveTypeFeatureMembership (KERML11-191)

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
@@ -43,11 +43,13 @@ import org.omg.sysml.lang.sysml.EnumerationDefinition;
 import org.omg.sysml.lang.sysml.EnumerationUsage;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.ItemUsage;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.TriggerInvocationExpression;
+import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.lang.sysml.Usage;
 import org.omg.sysml.lang.sysml.ViewUsage;
 
@@ -350,5 +352,36 @@ public class DerivedPropertyAndOperationTest extends SysMLInteractiveTest {
 		Documentation doc = (Documentation)ownedMembers.get(1);
 		assertEquals("comment.locale", "en_US", comment.getLocale());
 		assertEquals("doc.locale", "en_US", doc.getLocale());
+	}
+	
+	public final String featureMembershipTest =
+			  "package Test {\n"
+			+ "	   part def A {\n"
+			+ "		   attribute f;\n"
+			+ "	   }\n"
+			+ "	   part def B {\n"
+			+ "		   public import A::*;\n"
+			+ "        feature g;\n"
+			+ "	   }\n"
+			+ "	   part def C :> B;"
+			+ "}";
+	
+	@Test
+	public void testFeatureMembership() throws Exception {
+		SysMLInteractive instance = getSysMLInteractiveInstance();
+		SysMLInteractiveResult result = instance.process(featureMembershipTest);
+		Element root = result.getRootElement();
+		List<Element> elements = ((Namespace)root).getOwnedMember();
+		List<Element> ownedMembers = ((Namespace)elements.get(0)).getOwnedMember();
+		Definition A = (Definition)ownedMembers.get(0);
+		Definition B = (Definition)ownedMembers.get(1);
+		Definition C = (Definition)ownedMembers.get(2);
+		assertTrue("A", testFeatureOwningTypes(A));
+		assertTrue("B", testFeatureOwningTypes(B));
+		assertTrue("C", testFeatureOwningTypes(C));
+	}
+	
+	private boolean testFeatureOwningTypes(Type type) {
+		return type.getFeatureMembership().stream().map(FeatureMembership::getOwningType).allMatch(t->type.specializes(t));
 	}
 }

--- a/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml/src/org/omg/sysml/adapter/TypeAdapter.java
@@ -46,6 +46,7 @@ import org.omg.sysml.lang.sysml.Conjugation;
 import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Expression;
 import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.Specialization;
 import org.omg.sysml.lang.sysml.Membership;
 import org.omg.sysml.lang.sysml.ResultExpressionMembership;
@@ -202,18 +203,38 @@ public class TypeAdapter extends NamespaceAdapter {
 		}
 		return redefinedFeatures;		
 	}
+	
+	public EList<FeatureMembership> getFeatureMembership() {
+		if (featureMembership == null) {
+			Type target = getTarget();
+			EList<FeatureMembership> featureMemberships = new NonNotifyingEObjectEList<FeatureMembership>(FeatureMembership.class, (InternalEObject) target, SysMLPackage.TYPE__FEATURE_MEMBERSHIP);
+			featureMemberships.addAll(target.getOwnedFeatureMembership());
+			// For improved performance, compute supertypes only once.
+			List<Type> allSupertypes = target.allSupertypes();
+			for (Membership membership: target.getInheritedMembership()) {
+				if (membership instanceof FeatureMembership && 
+						allSupertypes.contains(membership.getMembershipOwningNamespace())) {
+					featureMemberships.add((FeatureMembership)membership);
+				}
+			}
+			featureMembership = featureMemberships;
+		}
+		return featureMembership;
+	}
 
 	// Caching
 	
 	private EList<Membership> inheritedMembership = null;
 	private EList<Membership> nonPrivateMembership = null;
-	private Collection<Feature> redefinedFeatures = null;	
+	private Collection<Feature> redefinedFeatures = null;
+	private EList<FeatureMembership> featureMembership = null;
 	
 	public void clearCaches() {
 		super.clearCaches();
 		inheritedMembership = null;
 		nonPrivateMembership = null;
 		redefinedFeatures = null;
+		featureMembership = null;
 	}
 	
 	// Implicit Elements

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Type_featureMembership_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Type_featureMembership_SettingDelegate.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
- * Copyright (c) 2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2022, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,13 +22,11 @@
 
 package org.omg.sysml.delegate.setting;
 
-import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.Type;
-import org.omg.sysml.util.NonNotifyingEObjectEList;
+import org.omg.sysml.util.TypeUtil;
 
 public class Type_featureMembership_SettingDelegate extends BasicDerivedListSettingDelegate {
 
@@ -38,18 +36,7 @@ public class Type_featureMembership_SettingDelegate extends BasicDerivedListSett
 
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
-		Type self = (Type)owner;
-		
-		EList<FeatureMembership> featureMemberships = new NonNotifyingEObjectEList<>(FeatureMembership.class, owner, eStructuralFeature.getFeatureID());
-		featureMemberships.addAll(self.getOwnedFeatureMembership());
-		// For improved performance, compute supertypes only once.
-		List<Type> allSupertypes = self.allSupertypes();
-		self.getInheritedMembership().stream().
-			filter(FeatureMembership.class::isInstance).
-			map(FeatureMembership.class::cast).
-			filter(membership->allSupertypes.contains(membership.getOwningType())).
-			forEachOrdered(featureMemberships::add);
-		return featureMemberships;
+		return TypeUtil.getFeatureMembershipOf((Type)owner);
 	}
 
 }

--- a/org.omg.sysml/src/org/omg/sysml/delegate/setting/Type_featureMembership_SettingDelegate.java
+++ b/org.omg.sysml/src/org/omg/sysml/delegate/setting/Type_featureMembership_SettingDelegate.java
@@ -22,6 +22,7 @@
 
 package org.omg.sysml.delegate.setting;
 
+import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -37,11 +38,16 @@ public class Type_featureMembership_SettingDelegate extends BasicDerivedListSett
 
 	@Override
 	protected EList<?> basicGet(InternalEObject owner) {
+		Type self = (Type)owner;
+		
 		EList<FeatureMembership> featureMemberships = new NonNotifyingEObjectEList<>(FeatureMembership.class, owner, eStructuralFeature.getFeatureID());
-		featureMemberships.addAll(((Type)owner).getOwnedFeatureMembership());
-		((Type)owner).getInheritedMembership().stream().
+		featureMemberships.addAll(self.getOwnedFeatureMembership());
+		// For improved performance, compute supertypes only once.
+		List<Type> allSupertypes = self.allSupertypes();
+		self.getInheritedMembership().stream().
 			filter(FeatureMembership.class::isInstance).
 			map(FeatureMembership.class::cast).
+			filter(membership->allSupertypes.contains(membership.getOwningType())).
 			forEachOrdered(featureMemberships::add);
 		return featureMemberships;
 	}

--- a/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml/src/org/omg/sysml/util/TypeUtil.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022, 2024-2025 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022, 2024-2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -103,6 +103,10 @@ public class TypeUtil {
 				filter(feature->feature != skip).
 				flatMap(feature->FeatureUtil.getRedefinedFeaturesWithComputedOf(feature).stream()).
 				toList();
+	}
+	
+	public static EList<FeatureMembership> getFeatureMembershipOf(Type type) {
+		return getTypeAdapter(type).getFeatureMembership();
 	}
 
 	// Supertypes


### PR DESCRIPTION
This PR proactively implements the resolution to the following issue, which the KerML 1.1 RTF has elevated to be a "blocker" issue.

* [KERML11-191](https://issues.omg.org/issues/KERML11-191)  Problem with deriveTypeFeatureMembership

**Background**

Currently (as of KerML 1.0), the OCL for `deriveTypeFeatureMembership` is
```
featureMembership = ownedFeatureMembership->union(
    inheritedMembership->selectByKind(FeatureMembership))
```
The intent here is clearly to not include imported feature memberships. The problem is that `inheritedMembership` _does_ include imported feature memberships from supertypes. Since `Type::feature` is derived from `featureMembership`, this means that a type may get features that are not owned features of any of its supertypes, which may have owning types incompatible with the inheriting type.

**Overview**

The proposed change to the OCL is to simply further filter the inherited feature memberships with `select(mem | self.specializes(mem.owningType))`. The implementation in `Type_featureMembership_SettingDelegate` could be similarly updated with such a filter. However, doing this naively has a notable negative effect on performance. This is because `specializes` is implemented by computing the `allSupertypes` transitive closure and then checking against that. And the set of `allSupertypes` gets recomputed on each call to `specializes`.

The performance problem can be mitigated by computing `allSupertypes` once, outside the filtering loop, and then using `allSupertypes.contains` rather than `this.specializes`. With this change (and caching), the performance is essentially unaffected by the change.

**Changes**

* `Type_featureMembership_SettingDelegate` – Revised `basicGet`to simply call `TypeUtil.getFeatureMembershipOf`.
* `TypeUtil` – Added `getFeatureMembershipOf` to provide access to `TypeAdapter.getFeatureMembership`.
* `TypeAdapter` – Implemented `getFeatureMembership` as discussed above. Implementing this in the adapter allows the computed `featureMembership` to be cached (alongside `inheritedMembership`).