### PR TITLE
ST6RI-930 Establish deployment to Maven Central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,21 @@ jobs:
       run: echo $(git diff -- sysml.library/.index.json) | grep -e '^$' || (echo "Library index in the git repository is not up to date. Please re-generate it and push changes to the repository."; exit 1)
     - name: Publish to Github Packages
       if: github.event_name != 'pull_request'
-      run: ./mvnw -B deploy -DskipTests=true
+      run: ./mvnw -B -s .mvn/settings.xml deploy -DskipTests=true
       env:
         GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+    # Snapshots reuse the central-publish profile, which signs artifacts via maven-gpg-plugin,
+    # so the runner needs the private key before deploy.
+    - name: Import GPG key for Maven Central snapshots
+      if: ${{ github.event_name != 'pull_request' && secrets.CENTRAL_TOKEN_USERNAME != '' && secrets.CENTRAL_TOKEN_PASSWORD != '' && secrets.MAVEN_GPG_PRIVATE_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
+      env:
+        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      run: |
+        printf '%s' "${MAVEN_GPG_PRIVATE_KEY}" | gpg --batch --import
+    - name: Publish org.omg.sysml.model snapshot to Maven Central
+      if: ${{ github.event_name != 'pull_request' && secrets.CENTRAL_TOKEN_USERNAME != '' && secrets.CENTRAL_TOKEN_PASSWORD != '' && secrets.MAVEN_GPG_PRIVATE_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
+      run: ./mvnw -B -s .mvn/settings.xml -f org.omg.sysml.model/pom.xml deploy -Pcentral-publish,central-snapshot -DskipTests=true -Dgpg.passphrase=${MAVEN_GPG_PASSPHRASE}
+      env:
+        CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+        CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,9 +28,24 @@ jobs:
     - name: Remove -snapshot from version
       run: ./mvnw -B versions:set -DremoveSnapshot=true
     - name: Publish to Github Packages
-      run: ./mvnw -B deploy -DskipTests=true
+      run: ./mvnw -B -s .mvn/settings.xml deploy -DskipTests=true
       env:
         GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+    # Releases reuse the central-publish profile, which signs artifacts via maven-gpg-plugin,
+    # so the runner needs the private key before deploy.
+    - name: Import GPG key for Maven Central release
+      if: ${{ secrets.CENTRAL_TOKEN_USERNAME != '' && secrets.CENTRAL_TOKEN_PASSWORD != '' && secrets.MAVEN_GPG_PRIVATE_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
+      env:
+        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      run: |
+        printf '%s' "${MAVEN_GPG_PRIVATE_KEY}" | gpg --batch --import
+    - name: Publish org.omg.sysml.model release to Maven Central
+      if: ${{ secrets.CENTRAL_TOKEN_USERNAME != '' && secrets.CENTRAL_TOKEN_PASSWORD != '' && secrets.MAVEN_GPG_PRIVATE_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
+      run: ./mvnw -B -s .mvn/settings.xml -f org.omg.sysml.model/pom.xml deploy -Pcentral-publish,central-release -DskipTests=true -Dgpg.passphrase=${MAVEN_GPG_PASSPHRASE}
+      env:
+        CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+        CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
     - name: Upload SysML Library .kpar files
       uses: actions/upload-artifact@v5
       with:

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+    <server>
+      <id>central</id>
+      <username>${env.CENTRAL_TOKEN_USERNAME}</username>
+      <password>${env.CENTRAL_TOKEN_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>default-repositories</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>Maven Central</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <name>Maven Central</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>default-repositories</activeProfile>
+  </activeProfiles>
+</settings>

--- a/org.omg.sysml.model/pom.xml
+++ b/org.omg.sysml.model/pom.xml
@@ -13,9 +13,39 @@
 	<artifactId>org.omg.sysml.model</artifactId>
 	<packaging>jar</packaging>
 
+	<name>OMG SysML Model</name>
+	<description>EMF-based SysML v2 model artifacts for the SysML v2 Pilot Implementation.</description>
+	<url>https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation</url>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License 2.0</name>
+			<url>https://www.eclipse.org/legal/epl-2.0/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Systems Modeling Team</name>
+			<organization>Object Management Group</organization>
+			<organizationUrl>https://www.omg.org/</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation.git</connection>
+		<developerConnection>scm:git:https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation.git</developerConnection>
+		<url>https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation</url>
+	</scm>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+		<maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+		<central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -30,4 +60,102 @@
 			<version>2.42.0</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<!-- Shared sources, javadocs, and signing configuration for Maven Central publication. -->
+		<profile>
+			<id>central-publish</id>
+			<build>
+				<plugins>
+					<!-- Attach source files required by Maven Central consumers. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>${maven-source-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Attach javadocs required by Maven Central publication. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>${maven-javadoc-plugin.version}</version>
+						<configuration>
+							<doclint>none</doclint>
+							<failOnError>false</failOnError>
+							<source>${java.version}</source>
+						</configuration>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Sign published artifacts so Sonatype Central accepts the bundle. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>${maven-gpg-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<!-- Allow the CI runner to supply the passphrase non-interactively. -->
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<!-- Sonatype Central snapshot repository used for -SNAPSHOT publications. -->
+		<profile>
+			<id>central-snapshot</id>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>central</id>
+					<name>Sonatype Central Snapshots</name>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+				</snapshotRepository>
+				</distributionManagement>
+		</profile>
+		<!-- Sonatype Central release publication via the central-publishing-maven-plugin. -->
+		<profile>
+			<id>central-release</id>
+			<build>
+				<plugins>
+					<!-- Upload and publish the release bundle through the Sonatype Central portal. -->
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
+						<extensions>true</extensions>
+						<configuration>
+							<publishingServerId>central</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<waitUntil>published</waitUntil>
+							<deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Configure `org.omg.sysml.model` for Sonatype Central publication with sources, javadocs, signing, and release/snapshot profiles. Update CI workflows to keep GitHub Packages deploys and add explicit Maven Central snapshot and release publication steps using a repo-managed Maven settings file.