### PR TITLE
ST6RI-933 SysML 2.1 Ballot #2 - Model Library

### DIFF
--- a/org.omg.sysml/src/org/omg/sysml/generation/SysMLMOF2SysMLText.xtend
+++ b/org.omg.sysml/src/org/omg/sysml/generation/SysMLMOF2SysMLText.xtend
@@ -27,7 +27,7 @@ class SysMLMOF2SysMLText extends MOF2SysMLText {
 		standard library package SysML {
 			doc 
 			/*
-			 * This package contains a reflective KerML model of the KerML abstract syntax.
+			 * This package contains a reflective SysML model of the SysML abstract syntax.
 			 */
 			 
 			private import ScalarValues::*;

--- a/sysml.library/Domain Libraries/Quantities and Units/TensorCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/TensorCalculations.sysml
@@ -13,7 +13,7 @@ standard library package TensorCalculations {
     private import MeasurementReferences::CoordinateTransformation;
     
     calc def '[' specializes BaseFunctions::'[' { 
-    	in elements: Number[1..n] ordered; 
+    	in elements: Number[1..n] ordered nonunique; 
     	in mRef: TensorMeasurementReference[1]; 
     	return quantity: TensorQuantityValue[1];
     	private attribute n = mRef.flattenedSize;

--- a/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/Time.sysml
@@ -31,7 +31,7 @@ standard library package Time {
 	part def Clock :> Clocks::Clock {
 		doc
 		/*
-		 * A Clock provides a currentTime as a TimeInstantValue that advances montonically over its lifetime.
+		 * A Clock provides a currentTime as a TimeInstantValue that advances monotonically over its lifetime.
 		 */
 	
 		attribute :>> currentTime : TimeInstantValue;

--- a/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/VectorCalculations.sysml
@@ -12,7 +12,7 @@ standard library package VectorCalculations {
     private import MeasurementReferences::CoordinateTransformation;
     
     calc def '[' :> BaseFunctions::'[' { 
-    	in elements: Number[1..n] ordered; 
+    	in elements: Number[1..n] ordered nonunique; 
     	in mRef: VectorMeasurementReference[1]; 
     	return quantity : VectorQuantityValue[1];
     	private attribute n = mRef.flattenedSize;

--- a/sysml.library/Systems Library/Actions.sysml
+++ b/sysml.library/Systems Library/Actions.sysml
@@ -187,8 +187,9 @@ standard library package Actions {
 	action def SendAction :> Action, SendPerformance {
 		doc
 		/*
-		 * A SendAction is an Action used to type SendActionUsages. It initiates an outgoingTransferFromSelf 
-		 * from a designated sender Occurrence with a given payload, optionally to a designated receiver.
+		 * A SendAction is an Action and SendPerformance used to type SendActionUsages. 
+		 * It initiates an outgoingTransferFromSelf from a designated sender Occurrence 
+		 * with a given payload, optionally to a designated receiver Occurrence.
 		 */
 	
 		in :>> payload [0..*];
@@ -207,8 +208,9 @@ standard library package Actions {
 	action def AcceptMessageAction :> Action, AcceptPerformance {
 		doc
 		/*
-		 * An AcceptMessageAction is an Action that identifies an incomingTransferToSelf
-		 * of a designated receiver Occurrence, providing its payload as output.
+		 * An AcceptMessageAction is an Action and AcceptPerformance that identifies an 
+		 * incomingTransferToSelf of a designated receiver Occurrence, providing its payload 
+		 * as output.
 		 */
 		inout :>> payload;
 		ref acceptedMessage :>> acceptedTransfer: MessageTransfer, MessageAction {
@@ -293,18 +295,21 @@ standard library package Actions {
 		 * 
 		 * Note: Incoming succession connectors to a MergeAction must have source multiplicity 
 		 * 0..1 and subset the incomingHBLink feature inherited from MergePerformance.
+		 * 
+		 * A MergeAction is the ControlAction for a MergeNode. It is a MergePerformance that 
+		 * selects exactly one incoming HappensBeforeLink. Incoming succession connectors to a 
+		 * MergeAction must have source multiplicity 0..1 and subset the incomingHBLink feature 
+		 * inherited from MergePerformance.
 		 */
 	}
 	
 	action def DecisionAction :> ControlAction, DecisionPerformance {
 		doc
 		/*
-		 * A DecisionAction is the ControlAction for a decision node.
-		 * 
-		 * Note: Outgoing succession connectors from a DecisionAction must have target multiplicity
-		 * 0..1 and subset the outgoingHBLink feature inherited from DecisionPerformance.
-		 * If an outgoing succession has a guard, it should have a transitionStep typed by 
-		 * DecisionTransition.
+		 * A DecisionAction is the ControlAction for a DecisionNode. It is a DecisionPerformance that 
+		 * selects one outgoing HappensBeforeLink. Outgoing succession connectors from a DecisionAction 
+		 * must have target multiplicity 0..1 and subset the outgoingHBLink feature inherited from 
+		 * DecisionPerformance.
 		 */
 	}
 	

--- a/sysml.library/Systems Library/SysML.sysml
+++ b/sysml.library/Systems Library/SysML.sysml
@@ -1,7 +1,7 @@
 standard library package SysML {
 	doc 
 	/*
-	 * This package contains a reflective KerML model of the KerML abstract syntax.
+	 * This package contains a reflective SysML model of the SysML abstract syntax.
 	 */
 	 
 	private import ScalarValues::*;


### PR DESCRIPTION
This PR updates several Systems and Domain Library models to correct minor errors, mostly in documentation comments, per the resolutions to the following issues approved on SysML 2.1 RTF Ballot 2.

- [SYSML21-26](https://issues.omg.org/browse/SYSML21-26) Actions::DecisionAction descriptions are different
- [SYSML21-27](https://issues.omg.org/browse/SYSML21-27) Actions::MergeAction descriptions are different
- [SYSML21-29](https://issues.omg.org/browse/SYSML21-29) Actions::AcceptMessageAction has different descriptions
- [SYSML21-30](https://issues.omg.org/browse/SYSML21-30) Actions::SendAction descriptions not the same
- [SYSML21-362](https://issues.omg.org/browse/SYSML21-362) calc defs '[' for vector and tensor quantity values missing nonunique
- [SYSML21-370](https://issues.omg.org/browse/SYSML21-370) Typo montonically in Time::Clock
- [SYSML21-526](https://issues.omg.org/browse/SYSML21-526) SysML.sysml doc wrong

The resolution to the following issue also approved on Ballot 2 was already proactively implemented in PR #660   (ST6RI-855).

- [SYSML21-6](https://issues.omg.org/browse/SYSML21-6) Remaining error in TradeStudies model

**Models Changed**

_Systems Library_
- `Actions.sysml`
- `SysML.sysml`

_Quantities and Units Domain Library_
- `VectorCalculations.sysml`
- `TensorCalculations.sysml`
- `Time.sysml`

