### PR TITLE
ST6RI-927 Automatically update `metamodel` and `version` fields for standard library releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: ./mvnw -B clean verify --file pom.xml
+      run: ./mvnw -B clean verify --file pom.xml -Dsysml.build-tag=nightly-$(date +'%Y%m%d') -Dsysml.metadata-tag=$(date +'%Y%m%d')
     - name: Upload SysML Library .kpar files
       uses: actions/upload-artifact@v5
       with:

--- a/org.omg.sysml.xtext/pom.xml
+++ b/org.omg.sysml.xtext/pom.xml
@@ -75,7 +75,7 @@
 								<argument>--build-tag</argument>
 								<argument>${sysml.build-tag}</argument>
 								<argument>--metamodel-tag</argument>
-								<argument>${sysml.metadata-tag}</argument>
+								<argument>${sysml.metamodel-tag}</argument>
 							</arguments>
 							<classpathScope>compile</classpathScope>
 						</configuration>

--- a/org.omg.sysml.xtext/pom.xml
+++ b/org.omg.sysml.xtext/pom.xml
@@ -60,6 +60,27 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>update-project-versions</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+						<configuration>
+							<mainClass>org.omg.sysml.xtext.util.StdLibVersionUtil</mainClass>
+							<arguments>
+								<argument>--workspace</argument>
+								<argument>${maven.multiModuleProjectDirectory}/sysml.library</argument>
+								<argument>--build-tag</argument>
+								<argument>${sysml.build-tag}</argument>
+								<argument>--metamodel-tag</argument>
+								<argument>${sysml.metadata-tag}</argument>
+							</arguments>
+							<classpathScope>compile</classpathScope>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/StdLibVersionUtil.java
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/StdLibVersionUtil.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Sensmetry, UAB.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Eclipse Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License
+ * along with this program.  If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *
+ *******************************************************************************/
+
+package org.omg.sysml.xtext.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.sensmetry.sysand.Sysand;
+import com.sensmetry.sysand.exceptions.SysandException;
+import com.sensmetry.sysand.model.InterchangeProject;
+import com.sensmetry.sysand.model.InterchangeProjectInfo;
+import com.sensmetry.sysand.model.InterchangeProjectMetadata;
+import com.sensmetry.sysand.model.InterchangeProjectUsage;
+
+public class StdLibVersionUtil {
+
+	private static final String DEV_SEPARATOR = "-dev.";
+
+	/** Strips any existing -dev.* suffix, then appends -dev.<buildTag>. */
+	static String withBuildTag(String version, String buildTag) {
+		int idx = version.indexOf(DEV_SEPARATOR);
+		String base = idx >= 0 ? version.substring(0, idx) : version;
+		return base + DEV_SEPARATOR + buildTag;
+	}
+
+	/** Strips any existing -dev.* suffix. */
+	static String stripBuildTag(String version) {
+		int idx = version.indexOf(DEV_SEPARATOR);
+		return idx >= 0 ? version.substring(0, idx) : version;
+	}
+
+	/** Applies build tag to a versionConstraint like "=1.0.0" → "=1.0.0-dev.<tag>". */
+	static String withBuildTagConstraint(String constraint, String buildTag) {
+		int start = 0;
+		while (start < constraint.length() && !Character.isDigit(constraint.charAt(start))) {
+			start++;
+		}
+		return constraint.substring(0, start) + withBuildTag(constraint.substring(start), buildTag);
+	}
+
+	/** Strips any existing -dev.* suffix from a versionConstraint like "=1.0.0-dev.<tag>" → "=1.0.0". */
+	static String stripBuildTagConstraint(String constraint) {
+		int start = 0;
+		while (start < constraint.length() && !Character.isDigit(constraint.charAt(start))) {
+			start++;
+		}
+		return constraint.substring(0, start) + stripBuildTag(constraint.substring(start));
+	}
+
+	/**
+	 * Replaces the date segment in a spec resource URL with buildTag.
+	 * URL structure: https://www.omg.org/spec/{lang}/{date}/{name}.kpar
+	 * Splitting by "/" yields the date at index 5.
+	 */
+	static String withBuildTagResource(String resource, String buildTag) {
+		String[] parts = resource.split("/");
+		if (parts.length >= 7) {
+			parts[5] = buildTag;
+		}
+		return String.join("/", parts);
+	}
+
+	/**
+	 * Replaces the date segment in a spec metamodel URL with buildTag.
+	 * URL structure: https://www.omg.org/spec/{lang}/{date}
+	 * Splitting by "/" yields the date at index 5.
+	 */
+	static String withBuildTagMetamodelUrl(String url, String buildTag) {
+		String[] parts = url.split("/");
+		if (parts.length >= 6) {
+			parts[5] = buildTag;
+		}
+		return String.join("/", parts);
+	}
+
+	static void updateProject(Path projectPath, String buildTag, String metamodelTag) throws SysandException {
+		InterchangeProject project = Sysand.infoPath(projectPath);
+		InterchangeProjectInfo info = project.info;
+
+		if (info.getVersion() != null) {
+			info.setVersion(buildTag != null
+					? withBuildTag(info.getVersion(), buildTag)
+					: stripBuildTag(info.getVersion()));
+		}
+
+		InterchangeProjectUsage[] usages = info.getUsage();
+		for (InterchangeProjectUsage usage : usages) {
+			if (buildTag != null && usage.getResource() != null) {
+				usage.setResource(withBuildTagResource(usage.getResource(), buildTag));
+			}
+			if (usage.getVersionConstraint() != null) {
+				usage.setVersionConstraint(buildTag != null
+						? withBuildTagConstraint(usage.getVersionConstraint(), buildTag)
+						: stripBuildTagConstraint(usage.getVersionConstraint()));
+			}
+		}
+		info.setUsage(usages);
+
+		Sysand.setProjectInfo(projectPath, info);
+
+		InterchangeProjectMetadata metadata = project.metadata;
+		if (metadata != null && metadata.getMetamodel() != null && metamodelTag != null) {
+			metadata.setMetamodel(withBuildTagMetamodelUrl(metadata.getMetamodel(), metamodelTag));
+			Sysand.setProjectMetadata(projectPath, metadata);
+		}
+	}
+
+	public static void updateWorkspace(String workspacePath, String buildTag, String metamodelTag) throws SysandException {
+		String[] projectPaths = Sysand.workspaceProjectPaths(Paths.get(workspacePath));
+		for (String projectPath : projectPaths) {
+			System.out.println("  Updating: " + projectPath);
+			updateProject(Paths.get(projectPath), buildTag, metamodelTag);
+		}
+	}
+
+	private static boolean isMavenPlaceholder(String value) {
+		return value != null && value.startsWith("${");
+	}
+
+	private static String parseTag(String value) {
+		return (value != null && !value.isEmpty() && !isMavenPlaceholder(value)) ? value : null;
+	}
+
+	private static void printUsage() {
+		System.err.println("Usage: StdLibVersionUtil --workspace WORKSPACE_PATH");
+		System.err.println("           [--build-tag BUILD_TAG] [--metamodel-tag METAMODEL_TAG]");
+		System.err.println();
+		System.err.println("  --workspace       Path to the workspace directory containing .workspace.json (required)");
+		System.err.println("  --build-tag       Stamp -dev.<tag> onto version, versionConstraint, and resource");
+		System.err.println("                    URLs in each project's .project.json");
+		System.err.println("  --metamodel-tag   Replace the date segment of the metamodel URL in each project's");
+		System.err.println("                    .meta.json");
+		System.err.println("  --help            Show this message");
+		System.err.println();
+		System.err.println("At least one of --build-tag or --metamodel-tag must be provided.");
+	}
+
+	public static void main(String[] args) throws SysandException {
+		String workspacePath = null;
+		String buildTag = null;
+		String metamodelTag = null;
+		String rawBuildTag = null;
+		String rawMetamodelTag = null;
+
+		for (int i = 0; i < args.length; i++) {
+			switch (args[i]) {
+				case "--help":
+					printUsage();
+					return;
+				case "--workspace":
+					if (++i >= args.length) { printUsage(); return; }
+					workspacePath = args[i];
+					break;
+				case "--build-tag":
+					if (++i >= args.length) { printUsage(); return; }
+					rawBuildTag = args[i];
+					buildTag = parseTag(args[i]);
+					break;
+				case "--metamodel-tag":
+					if (++i >= args.length) { printUsage(); return; }
+					rawMetamodelTag = args[i];
+					metamodelTag = parseTag(args[i]);
+					break;
+				default:
+					System.err.println("Unknown argument: " + args[i]);
+					printUsage();
+					return;
+			}
+		}
+
+		if (workspacePath == null) {
+			System.err.println("Error: --workspace is required.");
+			printUsage();
+			return;
+		}
+
+		if (buildTag == null && metamodelTag == null) {
+			if (isMavenPlaceholder(rawBuildTag) || isMavenPlaceholder(rawMetamodelTag)) {
+				System.out.println("Skipping: both --build-tag and --metamodel-tag are Maven placeholders.");
+				return;
+			}
+			System.err.println("Error: at least one of --build-tag or --metamodel-tag must be provided.");
+			printUsage();
+			return;
+		}
+
+		if (buildTag != null) {
+			System.out.println("Applying build tag '" + buildTag + "' to .project.json files in: " + workspacePath);
+		}
+		if (metamodelTag != null) {
+			System.out.println("Applying metamodel tag '" + metamodelTag + "' to .meta.json files in: " + workspacePath);
+		}
+		updateWorkspace(workspacePath, buildTag, metamodelTag);
+		System.out.println("Done.");
+	}
+}

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/StdLibVersionUtil.java
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/util/StdLibVersionUtil.java
@@ -103,8 +103,8 @@ public class StdLibVersionUtil {
 
 		InterchangeProjectUsage[] usages = info.getUsage();
 		for (InterchangeProjectUsage usage : usages) {
-			if (buildTag != null && usage.getResource() != null) {
-				usage.setResource(withBuildTagResource(usage.getResource(), buildTag));
+			if (metamodelTag != null && usage.getResource() != null) {
+				usage.setResource(withBuildTagResource(usage.getResource(), metamodelTag));
 			}
 			if (usage.getVersionConstraint() != null) {
 				usage.setVersionConstraint(buildTag != null
@@ -144,10 +144,10 @@ public class StdLibVersionUtil {
 		System.err.println("           [--build-tag BUILD_TAG] [--metamodel-tag METAMODEL_TAG]");
 		System.err.println();
 		System.err.println("  --workspace       Path to the workspace directory containing .workspace.json (required)");
-		System.err.println("  --build-tag       Stamp -dev.<tag> onto version, versionConstraint, and resource");
-		System.err.println("                    URLs in each project's .project.json");
-		System.err.println("  --metamodel-tag   Replace the date segment of the metamodel URL in each project's");
-		System.err.println("                    .meta.json");
+		System.err.println("  --build-tag       Stamp -dev.<tag> onto version and versionConstraint in each");
+		System.err.println("                    project's .project.json");
+		System.err.println("  --metamodel-tag   Replace the date segment of resource URLs in each project's");
+		System.err.println("                    .project.json and the metamodel URL in each project's .meta.json");
 		System.err.println("  --help            Show this message");
 		System.err.println();
 		System.err.println("At least one of --build-tag or --metamodel-tag must be provided.");

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,8 @@
 
   <properties>
 	<revision>0.60.0-SNAPSHOT</revision>
+    <sysml.build-tag>20260501</sysml.build-tag>
+    <sysml.metadata-tag>20250201</sysml.metadata-tag>
     <tycho-version>4.0.13</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
@@ -28,7 +30,7 @@
     <junit.version>3.5.3</junit.version>
     <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
     <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
-    <sysand.version>0.0.11</sysand.version>
+    <sysand.version>0.1.0-rc.1</sysand.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -358,14 +360,14 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
         </plugin>
-		<!-- 
+		<!--
 			From version 3.0 maven install plugin seems to be more strict about subproject outputs.
 			This is a workaround to solve the error:
 			The packaging for this project did not assign a file to the build artifact...
 			in the jupyter-sysml-kernel project.
 			Related topic:
 			https://stackoverflow.com/questions/6308162/maven-the-packaging-for-this-project-did-not-assign-a-file-to-the-build-artifac
-			
+
 			TODO: Get rid of this part once we remove gradle form the project (ST6RI-764)
 		-->
 		<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <properties>
 	<revision>0.60.0-SNAPSHOT</revision>
     <sysml.build-tag>20260501</sysml.build-tag>
-    <sysml.metadata-tag>20250201</sysml.metadata-tag>
+    <sysml.metamodel-tag>20250201</sysml.metamodel-tag>
     <tycho-version>4.0.13</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>

--- a/sysml.library/Domain Libraries/Analysis/.project.json
+++ b/sysml.library/Domain Libraries/Analysis/.project.json
@@ -4,23 +4,23 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Quantities-and-Units-Domain-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Quantities-and-Units-Domain-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Domain Libraries/Analysis/.project.json
+++ b/sysml.library/Domain Libraries/Analysis/.project.json
@@ -1,27 +1,27 @@
 {
   "name": "SysML Analysis Library",
-  "version": "2.0.0",
   "description": "Standard analysis domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Quantities-and-Units-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Quantities-and-Units-Domain-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project.json
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project.json
@@ -1,23 +1,23 @@
 {
   "name": "SysML Cause and Effect Library",
-  "version": "2.0.0",
   "description": "Standard cause-and-effect domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Cause and Effect/.project.json
+++ b/sysml.library/Domain Libraries/Cause and Effect/.project.json
@@ -4,19 +4,19 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Domain Libraries/Geometry/.project.json
+++ b/sysml.library/Domain Libraries/Geometry/.project.json
@@ -1,27 +1,27 @@
 {
   "name": "SysML Geometry Library",
-  "version": "2.0.0",
   "description": "Standard geometry domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Quantities-and-Units-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Quantities-and-Units-Domain-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Geometry/.project.json
+++ b/sysml.library/Domain Libraries/Geometry/.project.json
@@ -4,23 +4,23 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Quantities-and-Units-Domain-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Quantities-and-Units-Domain-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Domain Libraries/Metadata/.project.json
+++ b/sysml.library/Domain Libraries/Metadata/.project.json
@@ -4,15 +4,15 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Domain Libraries/Metadata/.project.json
+++ b/sysml.library/Domain Libraries/Metadata/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Metadata Library",
-  "version": "2.0.0",
   "description": "Standard metadata domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/.project.json
+++ b/sysml.library/Domain Libraries/Quantities and Units/.project.json
@@ -1,23 +1,23 @@
 {
   "name": "SysML Quantities and Units Library",
-  "version": "2.0.0",
   "description": "Standard quantities and units domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Quantities and Units/.project.json
+++ b/sysml.library/Domain Libraries/Quantities and Units/.project.json
@@ -4,19 +4,19 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Domain Libraries/Requirement Derivation/.project.json
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Requirement Derivation Library",
-  "version": "2.0.0",
   "description": "Standard requirements derivation domain library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
-      "versionConstraint": "2.0.0"
+      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "versionConstraint": "2.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Domain Libraries/Requirement Derivation/.project.json
+++ b/sysml.library/Domain Libraries/Requirement Derivation/.project.json
@@ -4,15 +4,15 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/SysML/20260501/Systems-Library.kpar",
+      "resource": "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
       "versionConstraint": "2.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
@@ -4,7 +4,7 @@
   "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Data Type Library/.project.json
@@ -1,11 +1,11 @@
 {
   "name": "Kernel Data Type Library",
-  "version": "1.0.0",
   "description": "Standard data type library for the Kernel Modeling Language (KerML)",
+  "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
@@ -4,11 +4,11 @@
   "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Function Library/.project.json
@@ -1,15 +1,15 @@
 {
   "name": "Kernel Function Library",
-  "version": "1.0.0",
   "description": "Standard function library for the Kernel Modeling Language (KerML)",
+  "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
-    }  
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
+    }
   ]
 }

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
@@ -4,11 +4,11 @@
   "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
+++ b/sysml.library/Kernel Libraries/Kernel Semantic Library/.project.json
@@ -1,15 +1,15 @@
 {
   "name": "Kernel Semantic Library",
-  "version": "1.0.0",
   "description": "Standard semantic library for the Kernel Modeling Language (KerML)",
+  "version": "1.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     }
   ]
 }

--- a/sysml.library/Systems Library/.project.json
+++ b/sysml.library/Systems Library/.project.json
@@ -4,15 +4,15 @@
   "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
       "versionConstraint": "1.1.0-dev.20260501"
     }
   ]

--- a/sysml.library/Systems Library/.project.json
+++ b/sysml.library/Systems Library/.project.json
@@ -1,19 +1,19 @@
 {
   "name": "SysML Systems Library",
-  "version": "2.0.0",
   "description": "Standard semantic library for the Systems Modeling Language (SysML)",
+  "version": "2.1.0-dev.20260501",
   "usage": [
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Semantic-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Data-Type-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     },
     {
-      "resource": "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
-      "versionConstraint": "1.0.0"
+      "resource": "https://www.omg.org/spec/KerML/20260501/Function-Library.kpar",
+      "versionConstraint": "1.1.0-dev.20260501"
     }
   ]
 }


### PR DESCRIPTION
Adds a Java program called by Maven during the build that updates metamodel and version tags of the standard library as follows:

1. If `sysml.metadata-tag` is set in `pom.xml` to `METAMODEL_TAG`, `.meta.json`'s `metamodel` field will be set to `https://www.omg.org/spec/SysML/METAMODEL_TAG`. For example, having `<sysml.metadata-tag>20250201</sysml.metadata-tag>` will result in `"metamodel": "https://www.omg.org/spec/SysML/20250201"`. Similarly, for KerML. The `resource` IRIs for usages will have its date updated to `METAMODEL_TAG`.
2. If `sysml.build-tag` is set in `pom.xml` to `BUILD_TAG`, `version` and `versionConstraint` fields will get `-dev.BUILD_TAG` suffix. For example, having `<sysml.build-tag>20260501</sysml.build-tag>` will result in the following:

    ```
    "version": "2.1.0-dev.20260501",
    "usage": [
      {
        "resource": "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
        "versionConstraint": "1.1.0-dev.20260501"
      },
    ```

For the 2026-05 release:
- `METAMODEL_TAG = 20250201` (no change from v1.0/2.0)
- `BUILD_TAG = 20260501`

This PR also updates the version of SysML KPARs to 2.1 and the version of KerML KPARs to 1.1.

**Note.** This description has been edited based on the PR discussion and additional commit.