### PR TITLE
ST6RI-932 SysML 2.1 Ballot #2 - Abstract Syntax

### DIFF
--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/DerivedPropertyAndOperationTest.java
@@ -48,6 +48,7 @@ import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.ItemUsage;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.MetadataUsage;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.Relationship;
 import org.omg.sysml.lang.sysml.TriggerInvocationExpression;
@@ -486,6 +487,44 @@ public class DerivedPropertyAndOperationTest extends SysMLInteractiveTest {
 		assertSame("Test.resolve(Test::B::g)", g.getOwningMembership(), Test.resolve("Test::B::g"));
 		assertSame("Test.resolve(Test::C::f)", f.getOwningMembership(), Test.resolve("Test::C::f"));
 		assertSame("Test.resolve(Test::C::g)", g.getOwningMembership(), Test.resolve("Test::C::g"));
+	}
+	
+	public final String ownedMetadataTest =
+			  "package Test {\n"
+			+ "	   part def P {\n"
+			+ "        @M1; @M2;\n"
+			+ "        part p : P {\n"
+			+ "            @M1; @M2;\n"
+			+ "        }\n"
+			+ "    }\n"
+			+ "    metadata def M1;\n"
+			+ "    metadata def M2;\n"
+			+ "}";
+	
+	@Test
+	public void testOwnedMetadataAndNestedMetadata() throws Exception {
+		SysMLInteractive instance = createSysMLInteractiveInstance();
+		SysMLInteractiveResult result = instance.process(ownedMetadataTest);
+		Element root = result.getRootElement();
+		List<Element> elements = ((Namespace)root).getOwnedMember();
+		Namespace Test = (Namespace)elements.get(0);
+		List<Element> ownedMembers = Test.getOwnedMember();
+		Definition P = (Definition)ownedMembers.get(0);
+		List<Element> P_ownedMembers = P.getOwnedMember();
+		Usage P_M1 = (Usage)P_ownedMembers.get(0);
+		Usage P_M2 = (Usage)P_ownedMembers.get(1);
+		Usage p = (Usage)P_ownedMembers.get(2);
+		List<Element> p_ownedMembers = p.getOwnedMember();
+		Usage p_M1 = (Usage)p_ownedMembers.get(0);
+		Usage p_M2 = (Usage)p_ownedMembers.get(1);
+		
+		List<MetadataUsage> ownedMetadata = P.getOwnedMetadata();
+		assertTrue("P_M1", ownedMetadata.contains(P_M1));
+		assertTrue("P_M2", ownedMetadata.contains(P_M2));
+
+		List<MetadataUsage> nestedMetadata = p.getNestedMetadata();
+		assertTrue("p_M1", nestedMetadata.contains(p_M1));
+		assertTrue("p_M2", nestedMetadata.contains(p_M2));
 	}
 	
 }

--- a/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/SysMLInteractiveTest.java
+++ b/org.omg.sysml.interactive.tests/src/org/omg/sysml/interactive/tests/SysMLInteractiveTest.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021-2022 Model Driven Solutions, Inc.
+ * Copyright (c) 2021-2022, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/ConstraintUsageAdapter.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/ConstraintUsageAdapter.java
@@ -84,12 +84,6 @@ public class ConstraintUsageAdapter extends OccurrenceUsageAdapter {
 	}
 	
 	protected boolean isCheckedConstraint() {
-		/*
-		 * TODO: Update checkConstraintUsageCheckedConstraintSpecialization
-		 * 
-		 * OCL doesn't require composite
-		 *  
-		 */
 		ConstraintUsage target = getTarget();
 		Type owningType = target.getOwningType();
 		return target.isComposite() &&

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/IncludeUseCaseUsageAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
- * Copyright (c) 2021, 2022, 2025 Model Driven Solutions, Inc.
+ * Copyright (c) 2021, 2022, 2025, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by
@@ -37,11 +37,6 @@ public class IncludeUseCaseUsageAdapter extends UseCaseUsageAdapter {
 	public IncludeUseCaseUsage getTarget() {
 		return (IncludeUseCaseUsage)super.getTarget();
 	}
-	
-	/**
-	 * TODO: Rename checkIncludeUseCaseSpecialization
-	 * See SYSML21-299
-	 */
 	
 	/**
 	 * @satisfies checkIncludeUseCaseUsageSpecialization

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/AssignmentActionUsage_referent_SettingDelegate.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/AssignmentActionUsage_referent_SettingDelegate.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2022 Siemens AG
- * Copyright (c) 2023 Model Driven Solutions, Inc.
+ * Copyright (c) 2023, 2026 Model Driven Solutions, Inc.
  *    
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by
@@ -28,6 +28,7 @@ import org.omg.sysml.lang.sysml.AssignmentActionUsage;
 import org.omg.sysml.lang.sysml.Feature;
 import org.omg.sysml.lang.sysml.FeatureMembership;
 import org.omg.sysml.lang.sysml.Membership;
+import org.omg.sysml.lang.sysml.MetadataFeature;
 
 public class AssignmentActionUsage_referent_SettingDelegate extends BasicDerivedObjectSettingDelegate {
 
@@ -41,6 +42,7 @@ public class AssignmentActionUsage_referent_SettingDelegate extends BasicDerived
 				filter(m->!(m instanceof FeatureMembership)).
 				map(Membership::getMemberElement).
 				filter(Feature.class::isInstance).
+				filter(f->!(f instanceof MetadataFeature)).
 				findFirst().orElse(null);
 	}
 

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/Definition_ownedMetadata_SettingDelegate.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/Definition_ownedMetadata_SettingDelegate.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Eclipse Public License for more details.
+ *  
+ * You should have received a copy of the Eclipse Public License
+ * along with this program.  If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *  
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.delegate.setting;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.Definition;
+import org.omg.sysml.lang.sysml.MetadataUsage;
+import org.omg.sysml.util.NonNotifyingEObjectEList;
+
+public class Definition_ownedMetadata_SettingDelegate extends BasicDerivedListSettingDelegate {
+
+	public Definition_ownedMetadata_SettingDelegate(EStructuralFeature eStructuralFeature) {
+		super(eStructuralFeature);
+	}
+
+	@Override
+	protected EList<MetadataUsage> basicGet(InternalEObject owner) {
+		EList<MetadataUsage> ownedMetadata = new NonNotifyingEObjectEList<>(MetadataUsage.class, owner, eStructuralFeature.getFeatureID());
+		((Definition)owner).getMember().stream().
+			filter(MetadataUsage.class::isInstance).
+			map(MetadataUsage.class::cast).
+			forEachOrdered(ownedMetadata::add);
+		return ownedMetadata;
+	}
+
+}

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/Usage_nestedMetadata_SettingDelegate.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/setting/Usage_nestedMetadata_SettingDelegate.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Model Driven Solutions, Inc.
+ *    
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Eclipse Public License for more details.
+ *  
+ * You should have received a copy of the Eclipse Public License
+ * along with this program.  If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *  
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *  
+ *******************************************************************************/
+
+package org.omg.sysml.delegate.setting;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.omg.sysml.lang.sysml.MetadataUsage;
+import org.omg.sysml.lang.sysml.Usage;
+import org.omg.sysml.util.NonNotifyingEObjectEList;
+
+public class Usage_nestedMetadata_SettingDelegate extends BasicDerivedListSettingDelegate {
+
+	public Usage_nestedMetadata_SettingDelegate(EStructuralFeature eStructuralFeature) {
+		super(eStructuralFeature);
+	}
+
+	@Override
+	protected EList<MetadataUsage> basicGet(InternalEObject owner) {
+		EList<MetadataUsage> nestedMetadata = new NonNotifyingEObjectEList<>(MetadataUsage.class, owner, eStructuralFeature.getFeatureID());
+		((Usage)owner).getMember().stream().
+			filter(MetadataUsage.class::isInstance).
+			map(MetadataUsage.class::cast).
+			forEachOrdered(nestedMetadata::add);
+		return nestedMetadata;
+	}
+
+}

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/ImplicitGeneralizationMap.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/ImplicitGeneralizationMap.java
@@ -571,12 +571,6 @@ public class ImplicitGeneralizationMap {
 		//checkViewpointUsageViewpointSatisfactionSpecialization
 		put(ViewpointUsageImpl.class, "satisfied", "Views::View::viewpointSatisfactions");
 		
-		/*
-		 * TODO: Update checkViewpointDefinitionSpecialization and checkViewpointUsageSpecialization
-		 * 
-		 * See SYSML21-301
-		 */
-		
 		//checkWhileLoopActionUsageSpecialization
 		put(WhileLoopActionUsageImpl.class, "base", "Actions::whileLoopActions");
 		//checkWhileLoopActionUsageSubactionSpecialization

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/UsageUtil.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/UsageUtil.java
@@ -144,8 +144,6 @@ public class UsageUtil {
 	}
 
 	public static RequirementUsage getObjectiveRequirementOf(Type type) {
-		// TODO: Update checkRequirementUsageObjectiveRedefinition
-		// See SYSML21-309
 		if (type instanceof Feature) {
 			type = ((Feature)type).getFeatureTarget();
 		}

--- a/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/AssignmentActionUsage_invalid.sysml.xt
+++ b/org.omg.sysml.xpect.tests/src/org/omg/sysml/xpect/tests/validation/invalid/AssignmentActionUsage_invalid.sysml.xt
@@ -33,6 +33,7 @@ package AssignmentActionUsage_invalid {
         attribute a;
         protected attribute b;
         private attribute c;
+        action d;
     }
 	action def A {
         assign i.a := null;
@@ -40,5 +41,7 @@ package AssignmentActionUsage_invalid {
         assign i.b := null;
         // XPECT errors --> "Couldn't resolve reference to Element 'c'." at "c"
         assign i.c := null;
+        // XPECT errors --> "Referent must be time varying." at "d"
+        assign i.d := null;
 	}
 }

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -908,7 +908,7 @@ class SysMLValidator extends KerMLValidator {
 			warning(INVALID_SEND_ACTION_USAGE_RECEIVER_MSG, receiverArgument, null, INVALID_SEND_ACTION_USAGE_RECEIVER)
 		}
 		
-		// validateSendActionPayloadArgument
+		// validateSendActionUsagePayloadArgument
 		val featureMembership = usg.featureMembership
 		if ((featureMembership instanceof StateSubactionMembership || 
 			 featureMembership instanceof TransitionFeatureMembership) && 

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -263,6 +263,8 @@ class SysMLValidator extends KerMLValidator {
 	public static val INVALID_ASSIGNMENT_ACTION_USAGE_ARGUMENTS_MSG = "An assignment must have two arguments."
 	public static val INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT = "validateAssignmentActionUsageReferent"
 	public static val INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_MSG = "An assignment must have a referent."
+	public static val INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_IS_TIME_VARYING = "validateAssignmentActionUsageReferentIsTimeVarying"
+	public static val INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_IS_TIME_VARYING_MSG = "Referent must be time varying."
 
 	public static val INVALID_TRIGGER_INVOCATION_EXPRESSION_AFTER_ARGUMENT = "validateTriggerInvocationActionAfterArgument"
 	public static val INVALID_TRIGGER_INVOCATION_EXPRESSION_AFTER_ARGUMENT_MSG = "An after expression must be a DurationValue."
@@ -781,9 +783,14 @@ class SysMLValidator extends KerMLValidator {
 		// validateAssignmentActionUsageReferent
 		if (!usg.ownedMembership.exists[m | 
 			!(m instanceof FeatureMembership) && m.memberElement instanceof Feature && !(m.memberElement instanceof MetadataFeature)]) {
-			error(INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_MSG, usg, null, INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT)
+			error(INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_MSG, usg.ownedRelationship.get(1), null, INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT)
 		}
 		
+		// validateAssignmentActionUsageReferentIsTimeVarying
+		val referent = usg.referent
+		if (referent !== null && !referent.eIsProxy && !referent.featureTarget.isVariable) {
+			error(INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_IS_TIME_VARYING_MSG, usg.ownedRelationship.get(1), null, INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_IS_TIME_VARYING)
+		}
 	}
 	
 	@Check

--- a/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
+++ b/org.omg.sysml.xtext/src/org/omg/sysml/xtext/validation/SysMLValidator.xtend
@@ -131,6 +131,7 @@ import org.omg.sysml.lang.sysml.WhileLoopActionUsage
 import org.omg.sysml.util.SysMLLibraryUtil
 import org.omg.sysml.util.FeatureUtil
 import org.omg.sysml.util.UsageUtil
+import org.omg.sysml.lang.sysml.MetadataFeature
 
 /**
  * This class contains custom validation rules. 
@@ -778,7 +779,8 @@ class SysMLValidator extends KerMLValidator {
 	@Check
 	def checkAssignmentActionUsage(AssignmentActionUsage usg) {
 		// validateAssignmentActionUsageReferent
-		if (!usg.ownedMembership.exists[m | !(m instanceof FeatureMembership) && m.memberElement instanceof Feature]) {
+		if (!usg.ownedMembership.exists[m | 
+			!(m instanceof FeatureMembership) && m.memberElement instanceof Feature && !(m.memberElement instanceof MetadataFeature)]) {
 			error(INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT_MSG, usg, null, INVALID_ASSIGNMENT_ACTION_USAGE_REFERENT)
 		}
 		


### PR DESCRIPTION
This PR implements resolutions for the following issues that were approved on SysML 2.1 RTF Ballot 2.

- [SYSML21-15](https://issues.omg.org/issues/SYSML21-15) Error in constraint validateAssignmentActionUsageReferent
   - Fixed the derivation and validation of `AssignmentActionUsage::referent`.
- [SYSML21-17](https://issues.omg.org/issues/SYSML21-17) Error in constraint validateAssignmentActionUsage
   - Implemented a validation check for `validateAssignmentActionUsageReferentIsTimeVarying` and a corresponding Xpect test.
- [SYSML21-419](https://issues.omg.org/issues/SYSML21-419) Derivation of ownedMetadata is incorrect
   - Implemented setting delegates for computing `Definition::ownedMetadata` and `Usage::nestedMetadata` and a corresponding test in `SysMLInteractiveTest`. 
   - Note that the default would be sufficient and the new delegates unnecessary if the subsetting of these properties had been properly changed in the specification in addition to their derivation (see [SYSML21-648](https://issues.omg.org/browse/SYSML21-648)).

Resolutions for the following issues had been implemented previously. This PR removes `TODO` comments related to updating the specification for them (as has now been done).
- [SYSML21-4](https://issues.omg.org/issues/SYSML21-4) Error in constraint checkConstraintUsageCheckedConstraintSpecialization
- [SYSML21-299](https://issues.omg.org/issues/SYSML21-299) Constraint checkIncludeUseCaseSpecialization is misnamed
- [SYSML21-301](https://issues.omg.org/issues/SYSML21-301) Viewpoint specialization constraints are incorrect
- [SYSML21-309](https://issues.omg.org/issues/SYSML21-309) Constraint checkRequirementUsageObjectiveRedefinition needs to handle feature chains

Other abstract syntax issues on Ballot 2 do not require changes to the implementation in this PR. Note that updating the `.uml` and `.ecore` metamodel files was already addressed by PR #760.