### PR TITLE
ST6RI-938 Fix NPE on InstantiationExpression.instantiatedType

### DIFF
--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/invocation/InstantiationExpression_instantiatedType_InvocationDelegate.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/invocation/InstantiationExpression_instantiatedType_InvocationDelegate.java
@@ -1,7 +1,8 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2025 Model Driven Solutions, Inc.
- *    
+ * Copyright (c) 2026 Obeo
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by
  * the Eclipse Foundation, version 2 of the License.
@@ -21,6 +22,7 @@
 package org.omg.sysml.delegate.invocation;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EOperation;
@@ -43,6 +45,7 @@ public class InstantiationExpression_instantiatedType_InvocationDelegate extends
 		Element member =self.getOwnedMembership().stream().
 			filter(m->!(m instanceof FeatureMembership)).
 			map(Membership::getMemberElement).
+			filter(Objects::nonNull).
 			findFirst().orElse(null);
 		return member instanceof Type? member: null;
 	}


### PR DESCRIPTION
Calling "instantiatedType" on an "InstantiationExpression" with its missing require membership causes an NPE

Calling "instantiatedType" on an "InstantiationExpression" might end up in a NullPointException with the "InstantiationExpression" missing its required "Membership".

```
Exception in thread "main" java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Optional.of(Optional.java:113)
	at java.base/java.util.stream.FindOps$FindSink$OfRef.get(FindOps.java:194)
	at java.base/java.util.stream.FindOps$FindSink$OfRef.get(FindOps.java:191)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at org.omg.sysml.delegate.invocation.InstantiationExpression_instantiatedType_InvocationDelegate.dynamicInvoke(InstantiationExpression_instantiatedType_InvocationDelegate.java:47)
```

This case can happen in an invalid model, however nevertheless the state of the model the application should not fail in an NullPointerException.