### PR TITLE
ST6RI-938 NPE when calling "instantiatedType" on an "InstantiationExpression"

### DIFF
--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/invocation/InstantiationExpression_instantiatedType_InvocationDelegate.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/delegate/invocation/InstantiationExpression_instantiatedType_InvocationDelegate.java
@@ -1,7 +1,8 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2025 Model Driven Solutions, Inc.
- *    
+ * Copyright (c) 2026 Obeo
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by
  * the Eclipse Foundation, version 2 of the License.
@@ -21,6 +22,7 @@
 package org.omg.sysml.delegate.invocation;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EOperation;
@@ -40,11 +42,13 @@ public class InstantiationExpression_instantiatedType_InvocationDelegate extends
 	@Override
 	public Object dynamicInvoke(InternalEObject target, EList<?> arguments) throws InvocationTargetException {
 		InstantiationExpression self = (InstantiationExpression) target;
-		Element member =self.getOwnedMembership().stream().
-			filter(m->!(m instanceof FeatureMembership)).
-			map(Membership::getMemberElement).
-			findFirst().orElse(null);
-		return member instanceof Type? member: null;
+		Element member = self.getOwnedMembership().stream()
+			.filter(m->!(m instanceof FeatureMembership))
+			.map(Membership::getMemberElement)
+			.filter(Objects::nonNull)
+			.findFirst()
+			.orElse(null);
+		return member instanceof Type ? member: null;
 	}
 
 }

--- a/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/InstantiationExpression_instantiatedType_InvocationDelegateTest.java
+++ b/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/InstantiationExpression_instantiatedType_InvocationDelegateTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Obeo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Eclipse Public License for more details.
+ *
+ * You should have received a copy of theEclipse Public License
+ * along with this program. If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *
+ *******************************************************************************/
+package org.omg.sysml.logic;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.emf.ecore.InternalEObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.omg.sysml.delegate.invocation.InstantiationExpression_instantiatedType_InvocationDelegate;
+import org.omg.sysml.lang.sysml.InvocationExpression;
+import org.omg.sysml.lang.sysml.SysMLFactory;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+
+public class InstantiationExpression_instantiatedType_InvocationDelegateTest {
+
+	@BeforeClass
+	public static void setUp() {
+		SysMLLogicStandaloneSetup.doSetup();
+	}
+
+	/**
+	 * Test the call of InstantiationExpression_instantiatedType_InvocationDelegate will not throw an NPE
+	 * @throws InvocationTargetException
+	 */
+	@Test
+	public void incompleteInstantiationExpression() throws InvocationTargetException {
+		InvocationExpression invocationExpression = SysMLFactory.eINSTANCE.createInvocationExpression();
+		invocationExpression.getOwnedRelationship().add(SysMLFactory.eINSTANCE.createMembership());
+		new InstantiationExpression_instantiatedType_InvocationDelegate(SysMLPackage.eINSTANCE.getInstantiationExpression__InstantiatedType())
+			.dynamicInvoke((InternalEObject) invocationExpression,null);
+	}
+}


### PR DESCRIPTION
This PR avoids a potential `NullPointerExpression` when calling the operation `InstantiationExpression.instantiatedType()`. If an `InstantiationExpression` has an `ownedMembership` that is not a `FeatureMembership` but invalidly has no `memberElement`, then calling `InstantiationExpression.instantiatedType()` results in a `NullPointerException`. Even though the `Membership` is invalid, the system should not produce an exception when the operation is called.