### PR TITLE
ST6RI-931 Implied owner of an implicit binding connector may be shown incorrectly

### DIFF
--- a/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/outline/KerMLOutlineTreeProvider.xtend
+++ b/org.omg.kerml.xtext.ui/src/org/omg/kerml/xtext/ui/outline/KerMLOutlineTreeProvider.xtend
@@ -513,16 +513,15 @@ class KerMLOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	}
 	
 	def void _createChildren(IOutlineNode parentNode, Type type) {		
-		//ImplicitFieldAdapter.getOrCreateAdapter(type).
-		createImplicitGeneralizationNodes(parentNode, type)
+		_createChildren(parentNode, type as Namespace)
+		createImplicitBindingConnectorNodes(parentNode, type)
+		createImplicitSpecializationNodes(parentNode, type)
 		if (type instanceof Feature) {
 			createImplicitTypeFeaturingNodes(parentNode, type)
 		}
-		_createChildren(parentNode, type as Namespace)
-		createImplicitBindingConnectorNodes(parentNode, type)
 	}
 	
-	def createImplicitGeneralizationNodes(IOutlineNode parentNode, Type type) {
+	def createImplicitSpecializationNodes(IOutlineNode parentNode, Type type) {
 		TypeUtil.forEachImplicitGeneralTypeOf(type, [eClass, generalType |
 			/*
 			 * TODO here image dispatcher should be called with a type that
@@ -597,8 +596,6 @@ class KerMLOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	}
 
 	def void _createChildren(IOutlineNode parentNode, OperatorExpression expression) {
-		createImplicitGeneralizationNodes(parentNode, expression)
-		createImplicitTypeFeaturingNodes(parentNode, expression)
 		for (Relationship relationship : expression.ownedRelationship) {
 			createNode(parentNode, relationship, 
 				_image(relationship), 
@@ -608,6 +605,8 @@ class KerMLOutlineTreeProvider extends DefaultOutlineTreeProvider {
 			);
 		}
 		createImplicitBindingConnectorNodes(parentNode, expression)
+		createImplicitSpecializationNodes(parentNode, expression)
+		createImplicitTypeFeaturingNodes(parentNode, expression)
 	}
 	
 	override _createNode(DocumentRootNode parentNode, EObject modelElement) {

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/TypeAdapter.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/TypeAdapter.java
@@ -286,14 +286,14 @@ public class TypeAdapter extends NamespaceAdapter {
 	
 	/**
 	 * Executes the given consumer function with all implicit binding connectors and
-	 * their corresponding membership type (Membership or FeatureMembership)
+	 * their corresponding membership type (OwningMembership or FeatureMembership)
 	 */
 	public void forEachImplicitBindingConnector(BiConsumer<BindingConnector, EClass> consumer) {
 		for (BindingConnector connector : implicitFeatureBindingConnectors) {
 			consumer.accept(connector, SysMLPackage.Literals.FEATURE_MEMBERSHIP);
 		}
 		for (BindingConnector connector : implicitMemberBindingConnectors) {
-			consumer.accept(connector, SysMLPackage.Literals.MEMBERSHIP);
+			consumer.accept(connector, SysMLPackage.Literals.OWNING_MEMBERSHIP);
 		}
 	}
 	


### PR DESCRIPTION
This PR revises the implementation of implied binding connectors so that they are shown in the model outline as being owned by impled `OwningMembership`, rather than just `Membership`. It also revises the outline provider so that all implied (implicit) relationships are shown after explicit relationships, per the specification.

**Changes**

1. `Type Adapter` – Updated method `forEachImplicitBindingConnector` so that implicit binding connectors are considered to be owned by `OwningMembership`, not just `Membership`.
2. `KerMLOutlineTreeProvider` - Updated to list all implicit relationships after all explicit relationships (in the order `BindingConnectors`, `Specializations`, `FeatureTypings`, consistent with serialization).