### PR TITLE
ST6RI-939 Fix StackOverflow when loading a ResourceSet

### DIFF
--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/TransitionUsageAdapter.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/adapter/TransitionUsageAdapter.java
@@ -38,6 +38,8 @@ import org.omg.sysml.util.UsageUtil;
 
 public class TransitionUsageAdapter extends ActionUsageAdapter {
 
+	private boolean isComputingTransitionLinkConnectors = false;
+
 	public TransitionUsageAdapter(TransitionUsage element) {
 		super(element);
 	}
@@ -103,24 +105,32 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 	 */
 	protected Feature computeTransitionLinkConnectors() {
 		TransitionUsage transition = getTarget();
-		Feature transitionLinkFeature = UsageUtil.getTransitionLinkFeatureOf(transition);
-		if (transitionLinkFeature == null) {
-			Succession succession = transition.getSuccession();
-			if (succession != null) {
-				transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
-				TypeUtil.addOwnedFeatureTo(transition, transitionLinkFeature);			
-				addBindingConnector(succession, transitionLinkFeature);
-			}
-			
-			List<Feature> parameters = TypeUtil.getOwnedParametersOf(transition);
-			if (!parameters.isEmpty()) {
-				Feature source = transition.getSource();
-				if (source != null) {
-					addBindingConnector(source, parameters.get(0));
+		if (this.isComputingTransitionLinkConnectors) {
+			return UsageUtil.getTransitionLinkFeatureOf(transition);
+		}
+		this.isComputingTransitionLinkConnectors = true;
+		try {
+			Feature transitionLinkFeature = UsageUtil.getTransitionLinkFeatureOf(transition);
+			if (transitionLinkFeature == null) {
+				Succession succession = transition.getSuccession();
+				if (succession != null) {
+					transitionLinkFeature = SysMLFactory.eINSTANCE.createReferenceUsage();
+					TypeUtil.addOwnedFeatureTo(transition, transitionLinkFeature);
+					addBindingConnector(succession, transitionLinkFeature);
+				}
+				
+				List<Feature> parameters = TypeUtil.getOwnedParametersOf(transition);
+				if (!parameters.isEmpty()) {
+					Feature source = transition.getSource();
+					if (source != null) {
+						addBindingConnector(source, parameters.get(0));
+					}
 				}
 			}
+			return transitionLinkFeature;
+		} finally {
+			this.isComputingTransitionLinkConnectors = false;
 		}
-		return transitionLinkFeature;
 	}
 	
 	@Override
@@ -130,7 +140,7 @@ public class TransitionUsageAdapter extends ActionUsageAdapter {
 		computeSource();
 		// Note: Needs to come before clearing and recomputation of inheritance cache.
 		//checkTransitionUsageSuccessionBindingConnector
-		computeTransitionLinkConnectors();		
+		computeTransitionLinkConnectors();
 	}
 	
 }

--- a/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/TransitionUsageAdapterTest.java
+++ b/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/TransitionUsageAdapterTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Obeo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Eclipse Public License for more details.
+ *
+ * You should have received a copy of theEclipse Public License
+ * along with this program. If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *
+ *******************************************************************************/
+
+package org.omg.sysml.logic;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.omg.sysml.lang.sysml.Feature;
+import org.omg.sysml.lang.sysml.FeatureDirectionKind;
+import org.omg.sysml.lang.sysml.ParameterMembership;
+import org.omg.sysml.lang.sysml.SysMLFactory;
+import org.omg.sysml.lang.sysml.SysMLPackage;
+import org.omg.sysml.lang.sysml.TransitionUsage;
+
+/**
+ * Tests transition derived-property computations.
+ */
+public class TransitionUsageAdapterTest {
+	/**
+	 * The source derivation asks transition adapters to add implicit members. 
+	 * A transition with parameters but no source and no succession must not
+	 * recursively recompute transition link connectors while its source is being
+	 * derived.
+	 */
+	@Test
+	public void transitionSourceDerivationIsReentrantSafeWithoutSuccession() {
+		SysMLLogicStandaloneSetup.doSetup();
+		SysMLPackage.eINSTANCE.eClass();
+		SysMLFactory factory = SysMLFactory.eINSTANCE;
+		TransitionUsage transition = factory.createTransitionUsage();
+		Feature parameter = factory.createFeature();
+		parameter.setDirection(FeatureDirectionKind.IN);
+		ParameterMembership parameterMembership = factory.createParameterMembership();
+		parameterMembership.setOwnedMemberParameter(parameter);
+		transition.getOwnedRelationship().add(parameterMembership);
+		assertNull(transition.getSource());
+	}
+}


### PR DESCRIPTION
Fix a `StackOverflowError` when loading a `ResourceSet` containing `TransitionUsage` elements.

### Context

Loading a SysML-XMI `ResourceSet` can trigger a `StackOverflowError` when derived properties are evaluated on `TransitionUsage` elements.

The recursion involves the derived transition properties and the implicit member computation performed by `TransitionUsageAdapter`, especially around:

- `TransitionUsage::source`
- `TransitionUsage::sourceFeature()`
- `TransitionUsage::succession`
- Implicit transition members and binding connectors

### Observed Behavior

  The application fails with a recursive stack similar to:

```
java.lang.StackOverflowError
  at org.omg.sysml.delegate.setting.TransitionUsage_source_SettingDelegate.basicGet(...)
  at org.omg.sysml.lang.sysml.impl.TransitionUsageImpl.getSource(...)
  at org.omg.sysml.adapter.TransitionUsageAdapter.computeTransitionLinkConnectors(...)
  at org.omg.sysml.adapter.TransitionUsageAdapter.addAdditionalMembers(...)
  at org.omg.sysml.util.NamespaceUtil.addAdditionalMembersTo(...)
  at org.omg.sysml.util.UsageUtil.getSourceFeatureOf(...)
  at org.omg.sysml.lang.sysml.impl.TransitionUsageImpl.sourceFeature(...)
  at org.omg.sysml.delegate.setting.TransitionUsage_source_SettingDelegate.basicGet(...)
  ...
```

### SysML-Level Explanation

In SysML, `TransitionUsage::source` is a derived property. It is computed from `sourceFeature()`, which identifies the feature used as the source of the transition succession.

At the same time, `TransitionUsageAdapter` may add implicit members required by transition semantics, such as:

- the implicit source member;
- transition link connectors;
- binding connectors between the succession, the transition link, and parameters.

The issue is that this implicit member computation is not reentrant-safe.

### Recursion Cycle

The problematic cycle is:

1. Code reads `transition.getSource()`.
2. This evaluates the derived property `TransitionUsage::source`.
3. The derived property calls `transition.sourceFeature()`.
4. `sourceFeature()` delegates to `UsageUtil.getSourceFeatureOf(transition)`.
5. `UsageUtil.getSourceFeatureOf(...)` calls `NamespaceUtil.addAdditionalMembersTo(transition)`.
6. `TransitionUsageAdapter.addAdditionalMembers()` calls `computeTransitionLinkConnectors()`.
7. `computeTransitionLinkConnectors()` reads `transition.getSource()`.
8. The same cycle starts again.

This leads to unbounded recursion and eventually a `StackOverflowError`.

### Typical Trigger

The issue can occur when a `TransitionUsage` has parameters, but its succession-related implicit members are not fully available at the time source is evaluated.

In that state, `computeTransitionLinkConnectors()` attempts to compute source-related binding connectors and reads `transition.getSource()`, which re-enters the same implicit member computation.

### Changes

Added a Boolean `isComputingTransitionLinkConnectors` that is set to true during the computation of transition link connectors and reset to false when the computation is done. However, if `computeTransitionLinkConnectors` ends up being recursively called, it returns without calling `TransitionUsage.getSource()`.