### PR TITLE
ST6RI-940 ResourceSetModelLibraryProvider Implementation does not take into account the root namespace

### DIFF
--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/logic/ResourceSetModelLibraryProvider.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/logic/ResourceSetModelLibraryProvider.java
@@ -101,8 +101,10 @@ public class ResourceSetModelLibraryProvider implements IModelLibraryProvider {
 	 */
 	private Element getElement(Resource resource, String[] segments) {
 		for (EObject object : resource.getContents()) {
-			if (object instanceof Element element) {
-				Element match = resolveElement(element, segments, 0);
+			// Element not contained in a Namespace can not be access using their qualified names
+			// Section 8.3.2.1.2 Element: "If this Element does not have an owningNamespace, then its qualifiedName is null.”
+			if (object instanceof Namespace namespace) {
+				Element match = resolveElement(namespace, segments, 0);
 				if (match != null) {
 					return match;
 				}
@@ -115,51 +117,28 @@ public class ResourceSetModelLibraryProvider implements IModelLibraryProvider {
 	 * Resolves one qualified-name segment at a time by matching the current
 	 * element and then descending through namespace memberships.
 	 */
-	private Element resolveElement(Element element, String[] segments, int index) {
-		if (!matchesElementName(element, segments[index])) {
+	private Element resolveElement(Namespace namespace, String[] segments, int index) {
+		if (namespace == null || index >= segments.length) {
 			return null;
 		}
 
-		if (index == segments.length - 1) {
-			return element;
-		}
-
-		if (!(element instanceof Namespace namespace)) {
-			return null;
-		}
-
-		String nextSegment = segments[index + 1];
-		for (Membership membership : getOwnedMemberships(namespace)) {
+		String currentSegment = segments[index];
+		for (Membership membership : namespace.getOwnedMembership()) {
 			Element member = membership.getMemberElement();
-			if (member == null || !matchesMembershipName(membership, member, nextSegment)) {
-				continue;
-			}
 
-			if (index + 1 == segments.length - 1) {
-				return member;
-			}
-
-			Element nested = resolveElement(member, segments, index + 1);
-			if (nested != null) {
-				return nested;
+			if (member != null && matchesMembershipName(membership, member, currentSegment)) {
+				if (index == segments.length - 1) {
+					return member;
+				} else if (member instanceof Namespace namespaceMember) {
+					Element nested = resolveElement(namespaceMember, segments, index + 1);
+					if (nested != null) {
+						return nested;
+					}
+				}
 			}
 		}
 
 		return null;
-	}
-
-	/**
-	 * Returns the memberships owned directly by a namespace using only EMF model
-	 * state, avoiding any Xtext-specific scoping infrastructure.
-	 */
-	private List<Membership> getOwnedMemberships(Namespace namespace) {
-		List<Membership> memberships = new ArrayList<>();
-		for (EObject relationship : namespace.getOwnedRelationship()) {
-			if (relationship instanceof Membership membership) {
-				memberships.add(membership);
-			}
-		}
-		return memberships;
 	}
 
 	/**
@@ -193,6 +172,6 @@ public class ResourceSetModelLibraryProvider implements IModelLibraryProvider {
 	 * Performs an exact name comparison while tolerating missing values.
 	 */
 	private boolean matches(String expected, String actual) {
-		return expected != null && actual != null && expected.equals(actual);
+		return expected != null && expected.equals(actual);
 	}
 }

--- a/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/SysMLLogicStandaloneSetupTest.java
+++ b/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/SysMLLogicStandaloneSetupTest.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Test;
+import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Namespace;
 import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.SysMLFactory;
@@ -37,14 +38,15 @@ import org.omg.sysml.lang.sysml.Type;
 import org.omg.sysml.util.SysMLLibraryUtil;
 
 /**
- * Verifies the plain-EMF standalone bootstrap for {@link SysMLLogicStandaloneSetup}.
+ * Verifies the plain-EMF standalone bootstrap for
+ * {@link SysMLLogicStandaloneSetup}.
  */
 public class SysMLLogicStandaloneSetupTest {
 
 	/**
-	 * Checks that the standalone setup installs library lookup and delegate
-	 * support without requiring any Xtext runtime bootstrap, and that invoking
-	 * the setup multiple times remains safe for subsequent lookups.
+	 * Checks that the standalone setup installs library lookup and delegate support
+	 * without requiring any Xtext runtime bootstrap, and that invoking the setup
+	 * multiple times remains safe for subsequent lookups.
 	 */
 	@Test
 	public void standaloneSetupResolvesLibraryElementsWithoutXtext() {
@@ -59,21 +61,23 @@ public class SysMLLogicStandaloneSetupTest {
 		resourceSet.getResources().add(libraryResource);
 		resourceSet.getResources().add(modelResource);
 
-		SysMLFactory factory = SysMLFactory.eINSTANCE;
+		Namespace libraryRootNamespace = SysMLFactory.eINSTANCE.createNamespace();
+		libraryResource.getContents().add(libraryRootNamespace);
 
-		Namespace library = factory.createNamespace();
+		Namespace library = SysMLFactory.eINSTANCE.createNamespace();
 		library.setDeclaredName("Base");
-		libraryResource.getContents().add(library);
+		addAsOwnedMember(libraryRootNamespace, library);
 
-		Type anything = factory.createType();
+		Type anything = SysMLFactory.eINSTANCE.createType();
 		anything.setDeclaredName("Anything");
-		OwningMembership anythingMembership = factory.createOwningMembership();
-		anythingMembership.setOwnedMemberElement(anything);
-		library.getOwnedRelationship().add(anythingMembership);
+		addAsOwnedMember(library, anything);
 
-		Namespace context = factory.createNamespace();
+		Namespace modelRootNamespace = SysMLFactory.eINSTANCE.createNamespace();
+		modelResource.getContents().add(modelRootNamespace);
+
+		Namespace context = SysMLFactory.eINSTANCE.createNamespace();
 		context.setDeclaredName("UserModel");
-		modelResource.getContents().add(context);
+		addAsOwnedMember(modelRootNamespace, context);
 
 		assertEquals("Anything", anything.effectiveName());
 		assertEquals("Anything", anything.getName());
@@ -82,5 +86,11 @@ public class SysMLLogicStandaloneSetupTest {
 
 		SysMLLogicStandaloneSetup.doSetup();
 		assertSame(anything, SysMLLibraryUtil.getLibraryType(context, "Base::Anything"));
+	}
+
+	private void addAsOwnedMember(Element parent, Element child) {
+		OwningMembership owningMembership = SysMLFactory.eINSTANCE.createOwningMembership();
+		owningMembership.setOwnedMemberElement(child);
+		parent.getOwnedRelationship().add(owningMembership);
 	}
 }

--- a/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/SysMLLogicStandaloneSetupTest.java
+++ b/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/SysMLLogicStandaloneSetupTest.java
@@ -29,12 +29,11 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Test;
-import org.omg.sysml.lang.sysml.Element;
 import org.omg.sysml.lang.sysml.Namespace;
-import org.omg.sysml.lang.sysml.OwningMembership;
 import org.omg.sysml.lang.sysml.SysMLFactory;
 import org.omg.sysml.lang.sysml.SysMLPackage;
 import org.omg.sysml.lang.sysml.Type;
+import org.omg.sysml.util.NamespaceUtil;
 import org.omg.sysml.util.SysMLLibraryUtil;
 
 /**
@@ -66,18 +65,18 @@ public class SysMLLogicStandaloneSetupTest {
 
 		Namespace library = SysMLFactory.eINSTANCE.createNamespace();
 		library.setDeclaredName("Base");
-		addAsOwnedMember(libraryRootNamespace, library);
+		NamespaceUtil.addOwnedMemberTo(libraryRootNamespace,library);
 
 		Type anything = SysMLFactory.eINSTANCE.createType();
 		anything.setDeclaredName("Anything");
-		addAsOwnedMember(library, anything);
+		NamespaceUtil.addOwnedMemberTo(library, anything);
 
 		Namespace modelRootNamespace = SysMLFactory.eINSTANCE.createNamespace();
 		modelResource.getContents().add(modelRootNamespace);
 
 		Namespace context = SysMLFactory.eINSTANCE.createNamespace();
 		context.setDeclaredName("UserModel");
-		addAsOwnedMember(modelRootNamespace, context);
+		NamespaceUtil.addOwnedMemberTo(modelRootNamespace, context);
 
 		assertEquals("Anything", anything.effectiveName());
 		assertEquals("Anything", anything.getName());
@@ -86,11 +85,5 @@ public class SysMLLogicStandaloneSetupTest {
 
 		SysMLLogicStandaloneSetup.doSetup();
 		assertSame(anything, SysMLLibraryUtil.getLibraryType(context, "Base::Anything"));
-	}
-
-	private void addAsOwnedMember(Element parent, Element child) {
-		OwningMembership owningMembership = SysMLFactory.eINSTANCE.createOwningMembership();
-		owningMembership.setOwnedMemberElement(child);
-		parent.getOwnedRelationship().add(owningMembership);
 	}
 }


### PR DESCRIPTION
This PR fixes the `ResourceSetModelLibraryProvider` Implementation to take into account the root namespace.

**Background**

The standalone `ResourceSetModelLibraryProvider` did not correctly resolve qualified names for elements stored in standard SysML/KerML model library resources when those resources followed the structure required by the SysML/KerML specification. The previous implementation attempted to resolve a qualified name such as `Base::Anything` by matching the first segment (`Base`) directly against each root object contained in an EMF Resource. This worked only if the named library package itself was the direct root object of the resource. However, this is not the structure defined by the specification for model interchange and model libraries.

According to KerML and SysML, a model interchange file represents a single root namespace. This root namespace is implicit, unnamed, and has no owner. The actual model elements, including top-level library packages such as Base, are owned members of that root namespace.

Therefore, in a conforming resource, the structure is:
```
Resource
  Root Namespace              // implicit, unnamed
    OwningMembership
      Library Package "Base"  // top-level element
        OwningMembership
          Type "Anything"
```
The old lookup logic expected this instead:
```
Resource
  Library Package "Base"
    Type "Anything"
```
As a result, resolving `Base::Anything` failed for correctly structured resources, because the provider compared `Base` with the unnamed root namespace and stopped before inspecting the root namespace memberships.

Instead, `Base::Anything` must be resolved by entering the resource root namespace, then matching `Base` among its owned memberships, then matching `Anything` inside the `Base` namespace.

**Changes**

The model library provider now treats the resource root objects as root namespaces, not as named elements to be matched against the first qualified name segment.

The lookup algorithm:

1. Iterates over resource contents.
2. Considers only root objects that are Namespace instances.
3. Resolves the first qualified-name segment against the namespace's owned memberships.
4. Continues recursively through member elements that are themselves namespaces.
5. Matches each segment against membership names, membership short names, declared names, and declared short names, preserving alias and short-name behavior.
6. Ignore non-namespace root elements for qualified-name lookup, because an element without an owning namespace has no valid qualified name according to the metamodel rules.
