### PR TITLE
ST6RI-941 NPE when evaluating derived properties on feature chains

### DIFF
--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/TypeUtil.java
@@ -229,12 +229,10 @@ public class TypeUtil {
 		if (type instanceof Feature) {
 			type = FeatureUtil.getBasicFeatureOf((Feature)type);
 		}
-		if (type == null) {
-			return new ArrayList<>();
-		}
-		return type.getOwnedFeature().stream().
-				filter(FeatureUtil::isParameter).
-				collect(Collectors.toList());
+		return type == null? Collections.emptyList():
+			    type.getOwnedFeature().stream().
+					filter(FeatureUtil::isParameter).
+					collect(Collectors.toList());
 	}
 	
 	public static Feature getOwnedResultParameterOf(Type type) {

--- a/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/TypeUtil.java
+++ b/org.omg.sysml.logic/src/main/java/org/omg/sysml/util/TypeUtil.java
@@ -1,7 +1,8 @@
 /*******************************************************************************
  * SysML 2 Pilot Implementation
  * Copyright (c) 2021-2022, 2024-2026 Model Driven Solutions, Inc.
- *    
+ * Copyright (c) 2026 Obeo
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by
  * the Eclipse Foundation, version 2 of the License.
@@ -227,6 +228,9 @@ public class TypeUtil {
 	public static List<Feature> getOwnedParametersOf(Type type) {
 		if (type instanceof Feature) {
 			type = FeatureUtil.getBasicFeatureOf((Feature)type);
+		}
+		if (type == null) {
+			return new ArrayList<>();
 		}
 		return type.getOwnedFeature().stream().
 				filter(FeatureUtil::isParameter).

--- a/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/TypeUtilTest.java
+++ b/org.omg.sysml.logic/src/test/java/org/omg/sysml/logic/TypeUtilTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * SysML 2 Pilot Implementation
+ * Copyright (c) 2026 Obeo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by
+ * the Eclipse Foundation, version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Eclipse Public License for more details.
+ *
+ * You should have received a copy of theEclipse Public License
+ * along with this program. If not, see <https://www.eclipse.org/legal/epl-2.0/>.
+ *  
+ * @license EPL-2.0 <http://spdx.org/licenses/EPL-2.0>
+ *
+ *******************************************************************************/
+
+package org.omg.sysml.logic;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.omg.sysml.lang.sysml.AssignmentActionUsage;
+import org.omg.sysml.lang.sysml.FeatureChaining;
+import org.omg.sysml.lang.sysml.SysMLFactory;
+
+/**
+ * Tests utility behavior reached from SysML derived properties.
+ */
+public class TypeUtilTest {
+
+	/**
+	 * Derived properties on some feature-like SysML elements ask TypeUtil for
+	 * owned parameters. When the feature is a chain whose target has not been
+	 * linked yet, the basic feature is null and the derivation must simply see no
+	 * parameters.
+	 */
+	@Test
+	public void derivedPropertyHandlesUnresolvedChainedFeatureWithoutParameters() {
+		SysMLLogicStandaloneSetup.doSetup();
+
+		AssignmentActionUsage assignment = SysMLFactory.eINSTANCE.createAssignmentActionUsage();
+		FeatureChaining unresolvedChaining = SysMLFactory.eINSTANCE.createFeatureChaining();
+		assignment.getOwnedRelationship().add(unresolvedChaining);
+
+		assertNull(assignment.getValueExpression());
+	}
+}


### PR DESCRIPTION
Evaluating some SysML derived properties can fail with a _NullPointerException_ when the model contains an unresolved feature chain.

The problem occurs in `TypeUtil.getOwnedParametersOf(Type type)`. When the provided type is a `Feature`, the method first resolves its basic feature through `FeatureUtil.getBasicFeatureOf(...)`. For a chained feature whose target has not been resolved yet, this call may return null. The method then unreferences that _null_ value by calling
`type.getOwnedFeature()`.

A concrete failing scenario is an `AssignmentActionUsage` containing an unresolved `FeatureChaining`. When its derived _valueExpression_ property is evaluated, the computation asks `TypeUtil`
for owned parameters and triggers the NPE.

Expected behavior: unresolved feature chains should be treated as having no owned parameters at this stage, so derived property evaluation should return null or an empty result instead
of crashing.

This issue prevents robust handling of partially linked SysML models and can break workflows that evaluate derived properties before all feature chain references are resolved.