### PR TITLE
ST6RI-966 validateFeatureOwnedCrossSubsetting throws "Error executing EValidator" on a feature with two crosses clauses

### DIFF
--- a/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_CrossFeatures_invalid.kerml.xt
+++ b/org.omg.kerml.xpect.tests/src/org/omg/kerml/xpect/tests/validation/AssociationTest_CrossFeatures_invalid.kerml.xt
@@ -57,4 +57,16 @@ package AssociationTest_CrossFeatures_invalid {
 			member feature y1 [0..1] featured by C1;
 		}
 	}
+	
+    class C3 {
+        feature x : C3;
+        feature y : C3;
+    }
+
+	assoc A4 {
+        end a : C3;
+        // XPECT errors --> "At most one cross subsetting is allowed" at "a.y"
+        end b : C3 crosses a.x crosses a.y;
+    }
+		
 }

--- a/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
+++ b/org.omg.kerml.xtext/src/org/omg/kerml/xtext/validation/KerMLValidator.xtend
@@ -646,7 +646,7 @@ class KerMLValidator extends AbstractKerMLValidator {
 		val crossSubsettings = f.ownedRelationship.filter[r | r instanceof CrossSubsetting].toList
 		if (crossSubsettings.size > 1) {
 			for (var i = 1; i < crossSubsettings.size; i++)
-				error(INVALID_FEATURE_OWNED_CROSS_SUBSETTING_MSG, refSubsettings.get(i), null, INVALID_FEATURE_OWNED_CROSS_SUBSETTING)
+				error(INVALID_FEATURE_OWNED_CROSS_SUBSETTING_MSG, crossSubsettings.get(i), null, INVALID_FEATURE_OWNED_CROSS_SUBSETTING)
 		}
 		
 		// validateFeatureEndMultiplicity


### PR DESCRIPTION
This PR resolves a bug which causd the `KerMLValidator` to throw an exception when checking invalid cross-subsettings. It closes issue #794.